### PR TITLE
Load updateinfo when needed + filelists in upgrade command

### DIFF
--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -77,7 +77,7 @@ void AdvisorySubCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.set_available_repos_load_flags(libdnf::repo::LoadFlags::UPDATEINFO);
+    context.set_available_repos_load_flags(libdnf::repo::LoadFlags::PRIMARY | libdnf::repo::LoadFlags::UPDATEINFO);
 }
 
 void AdvisorySubCommand::run() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -56,6 +56,15 @@ void InstallCommand::configure() {
     auto & context = get_context();
     context.update_repo_load_flags_from_specs(pkg_specs);
     context.set_load_system_repo(true);
+    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
+                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
+                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
+                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
+    if (updateinfo_needed) {
+        context.set_available_repos_load_flags(
+            context.get_available_repos_load_flags() | libdnf::repo::LoadFlags::UPDATEINFO);
+    }
+
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -119,6 +119,14 @@ void RepoqueryCommand::configure() {
     auto & context = get_context();
     context.update_repo_load_flags_from_specs(pkg_specs);
     context.set_load_system_repo(installed_option->get_value());
+    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
+                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
+                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
+                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
+    if (updateinfo_needed) {
+        context.set_available_repos_load_flags(
+            context.get_available_repos_load_flags() | libdnf::repo::LoadFlags::UPDATEINFO);
+    }
     context.set_load_available_repos(
         available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value()
             ? Context::LoadAvailableRepos::ENABLED

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -67,6 +67,14 @@ void UpgradeCommand::configure() {
     auto & context = get_context();
     context.update_repo_load_flags_from_specs(pkg_specs);
     context.set_load_system_repo(true);
+    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
+                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
+                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
+                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
+    if (updateinfo_needed) {
+        context.set_available_repos_load_flags(
+            context.get_available_repos_load_flags() | libdnf::repo::LoadFlags::UPDATEINFO);
+    }
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -65,6 +65,7 @@ void UpgradeCommand::set_argument_parser() {
 
 void UpgradeCommand::configure() {
     auto & context = get_context();
+    context.update_repo_load_flags_from_specs(pkg_specs);
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }


### PR DESCRIPTION
Follow up for: https://github.com/rpm-software-management/libdnf/pull/1556

I discovered this while working on enabling advisory CI tests.