### PR TITLE
Repoquery: show all packages that resolve selected advisories

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -148,7 +148,7 @@ void RepoqueryCommand::run() {
         advisory_bz->get_value(),
         advisory_cve->get_value());
     if (advisories.has_value()) {
-        full_package_query.filter_advisories(advisories.value(), libdnf::sack::QueryCmp::EQ);
+        full_package_query.filter_advisories(advisories.value(), libdnf::sack::QueryCmp::GTE);
     }
 
     if (pkg_specs.empty() && pkg_file_paths.empty()) {


### PR DESCRIPTION
Instead of the exact versions that match advisory packages show all
exact matches plus higher versions (which also resolve the advisory).

dnf4 shows equal or if there is none then the first higher. Given that
this is not documented anywhere I think we could change it to show equal
plus all higher. Which seems to make more sense to me for repoquery.

For: https://github.com/rpm-software-management/ci-dnf-stack/pull/1101