### PR TITLE
Move call to load libdnf plugins from application to base.setup()

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -633,10 +633,6 @@ int main(int argc, char * argv[]) try {
         // Write messages from memory buffer logger to stream logger
         dynamic_cast<libdnf::MemoryBufferLogger &>(*logger).write_to_logger(log_router);
 
-        context.base.load_plugins();
-        auto & plugins = context.base.get_plugins();
-        plugins.init();
-
         base.setup();
 
         base.get_repo_sack()->create_repos_from_system_configuration();

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -643,10 +643,6 @@ int main(int argc, char * argv[]) try {
 
         context.apply_repository_setopts();
 
-        //configure_plugins
-        //configure_from_options(context);
-        plugins.hook(libdnf::plugin::HookId::LOAD_CONFIG_FROM_FILE);
-
         // Run selected command
         command->configure();
         {

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -76,10 +76,12 @@ public:
     repo::RepoSackWeakPtr get_repo_sack() { return repo_sack.get_weak_ptr(); }
     rpm::PackageSackWeakPtr get_rpm_package_sack() { return rpm_package_sack.get_weak_ptr(); }
 
-    /// Load vars from environment, varsdirs and installroot (releasever, arch). To prevent differences between
-    /// configuration and internal Base settings, following configurations will be locked: installroot, varsdir.
-    /// The method is supposed to be called after configuration is updated, plugins applied their pre configuration
-    /// modification in configuration, but before repositories are loaded or any Package or Advisory query created.
+    /// Loads libdnf plugins, vars from environment, varsdirs and installroot (releasever, arch).
+    /// To prevent differences between configuration and internal Base settings, following configurations
+    /// will be locked: installroot, varsdir.
+    /// The method is supposed to be called after configuration is updated, application plugins applied
+    /// their pre configuration modification in configuration, but before repositories are loaded or any Package
+    /// or Advisory query created.
     void setup();
 
     transaction::TransactionHistoryWeakPtr get_transaction_history() { return transaction_history.get_weak_ptr(); }

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -108,6 +108,9 @@ void Base::load_plugins() {
 void Base::setup() {
     libdnf_assert(!pool, "Base was already initialized");
 
+    load_plugins();
+    plugins.init();
+
     plugins.pre_base_setup();
 
     pool.reset(new libdnf::solv::Pool);


### PR DESCRIPTION
We want the libdnf library to load the plugins automatically without the need for a call in the application.