### PR TITLE
Fix formating of solv_userdata->checksum in logging message

### DIFF
--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -136,10 +136,11 @@ bool SolvRepo::can_use_solvfile_cache(fs::File & solvfile_cache) {
 
     // check solvfile checksum
     if (memcmp(solv_userdata->checksum, checksum, CHKSUM_BYTES) != 0) {
+        auto & pool = get_pool(base);
         logger.debug(
             "Solvfile's repomd checksum doesn't match, read: \"{}\" vs. expected repomd checksum: \"{}\" for: {}",
-            solv_userdata->checksum,
-            checksum,
+            pool_bin2hex(*pool, solv_userdata->checksum, sizeof solv_userdata->checksum),
+            pool_bin2hex(*pool, checksum, sizeof checksum),
             solvfile_cache.get_path().native());
         return false;
     }


### PR DESCRIPTION
The checksum is not a string, but a byte array.
Convert it to a hexadecimal string.