### PR TITLE
Run clang-format check on vanilla Fedora 35

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,8 +6,17 @@ jobs:
   clang-format:
     name: Clang Format
     runs-on: ubuntu-latest
-    container: ghcr.io/rpm-software-management/dnf-ci-host
+    # TODO(mblaha) temporarily lock to Fedora 35 due to bugged
+    # clang-format (clang-tools-extra-0:14.0.0-1.fc36):
+    # https://github.com/llvm/llvm-project/issues/55260
+    # change back to ghcr.io/rpm-software-management/dnf-ci-host when fixed
+    container: registry.fedoraproject.org/fedora:35
     steps:
+      # TODO(mblaha) remove this step when dnf-ci-host image is used again
+      - name: Install clang-tools-extra and git
+        run: |
+          dnf install -y git clang-tools-extra
+
       - name: Check out sources
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Currently the workaround for Fedora 36 clang-format issue
(https://github.com/llvm/llvm-project/issues/55260) is in the
dnf-ci-host container (see
https://github.com/rpm-software-management/ci-dnf-stack/commit/23e4400f4f66441f1c604e4aa4ce37d7fc814050
for details).

This PR makes the workaround local to "Clang Format" job. It enables us
to move "DNF Integration Tests" job back to the latest Fedora.