### PR TITLE
Do not set explicit Fedora release for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
         uses: ./.github/actions/copr-build
         with:
           copr-user: ${{steps.setup-ci.outputs.copr-user}}
-          chroot: fedora-35-x86_64
           overlay: dnf5-ci
 
   integration-tests:
@@ -109,4 +108,3 @@ jobs:
         with:
           package-urls: ${{needs.copr-build.outputs.package-urls}}
           extra-run-args: ${{matrix.extra-run-args}}
-          base-image: fedora:35


### PR DESCRIPTION
Let's use the default taken from ci-dnf-stack Dockerfile.