### PR TITLE
Fix issues find by running with sanitizers

### DIFF
--- a/include/libdnf-cli/output/environmentinfo.hpp
+++ b/include/libdnf-cli/output/environmentinfo.hpp
@@ -89,6 +89,7 @@ static struct libscols_table * create_environmentinfo_table(EnvironmentType & en
     scols_symbols_set_right(sy, "  ");
     scols_symbols_set_vertical(sy, "");
     scols_table_set_symbols(table, sy);
+    scols_unref_symbols(sy);
 
     add_line_into_environmentinfo_table(table, "Id", environment.get_environmentid().c_str(), "bold");
     add_line_into_environmentinfo_table(table, "Name", environment.get_name().c_str());

--- a/include/libdnf-cli/output/groupinfo.hpp
+++ b/include/libdnf-cli/output/groupinfo.hpp
@@ -102,6 +102,7 @@ static struct libscols_table * create_groupinfo_table(GroupType & group) {
     scols_symbols_set_right(sy, "  ");
     scols_symbols_set_vertical(sy, "");
     scols_table_set_symbols(table, sy);
+    scols_unref_symbols(sy);
 
     add_line_into_groupinfo_table(table, "Id", group.get_groupid().c_str(), "bold");
     add_line_into_groupinfo_table(table, "Name", group.get_name().c_str());

--- a/libdnf-cli/output/argument_parser.hpp
+++ b/libdnf-cli/output/argument_parser.hpp
@@ -49,6 +49,7 @@ public:
         scols_symbols_set_right(sb, "  ");
         scols_symbols_set_vertical(sb, "  ");
         scols_table_set_symbols(table, sb);
+        scols_unref_symbols(sb);
 
         scols_table_set_column_separator(table, "  ");
         scols_table_new_column(table, "arg", 30, SCOLS_FL_TREE | SCOLS_FL_WRAP);

--- a/libdnf-cli/output/key_value_table.cpp
+++ b/libdnf-cli/output/key_value_table.cpp
@@ -48,6 +48,7 @@ KeyValueTable::KeyValueTable() {
     scols_symbols_set_right(sy, "  ");
     scols_symbols_set_vertical(sy, "");
     scols_table_set_symbols(tb, sy);
+    scols_unref_symbols(sy);
 }
 
 

--- a/libdnf-cli/progressbar/widgets/number.cpp
+++ b/libdnf-cli/progressbar/widgets/number.cpp
@@ -39,8 +39,8 @@ std::size_t NumberWidget::get_total_width() const noexcept {
 
 std::size_t NumberWidget::get_number_width() const {
     std::size_t result = std::max(
-        static_cast<std::size_t>(log10(get_bar()->get_number())),
-        static_cast<std::size_t>(log10(get_bar()->get_total())));
+        static_cast<std::size_t>((get_bar()->get_number() > 0) ? log10(get_bar()->get_number()) : 0),
+        static_cast<std::size_t>((get_bar()->get_total() > 0) ? log10(get_bar()->get_total()) : 0));
     return result + 1;
 }
 

--- a/libdnf/comps/environment/query.cpp
+++ b/libdnf/comps/environment/query.cpp
@@ -51,7 +51,7 @@ EnvironmentQuery::EnvironmentQuery(const BaseWeakPtr & base) : base(base) {
     std::map<std::string, std::vector<std::pair<std::string_view, Id>>> available_map;
     Id solvable_id;
     Solvable * solvable;
-    std::pair<std::string_view, std::string> solvable_name_pair;
+    std::pair<std::string, std::string> solvable_name_pair;
     std::string_view repoid;
 
     // Loop over all solvables

--- a/libdnf/comps/group/query.cpp
+++ b/libdnf/comps/group/query.cpp
@@ -51,7 +51,7 @@ GroupQuery::GroupQuery(const BaseWeakPtr & base) : base(base) {
     std::map<std::string, std::vector<std::pair<std::string_view, Id>>> available_map;
     Id solvable_id;
     Solvable * solvable;
-    std::pair<std::string_view, std::string> solvable_name_pair;
+    std::pair<std::string, std::string> solvable_name_pair;
     std::string_view repoid;
 
     // Loop over all solvables

--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -84,7 +84,8 @@ bool SolvRepo::can_use_solvfile_cache(fs::File & solvfile_cache) {
     int dnf_solv_userdata_len_read;
 
     int ret_code = solv_read_userdata(solvfile_cache.get(), &dnf_solv_userdata_read, &dnf_solv_userdata_len_read);
-    std::unique_ptr<SolvUserdata> solv_userdata(reinterpret_cast<SolvUserdata *>(dnf_solv_userdata_read));
+    std::unique_ptr<SolvUserdata, decltype(&solv_free)> solv_userdata(
+        reinterpret_cast<SolvUserdata *>(dnf_solv_userdata_read), &solv_free);
     if (ret_code != 0) {
         auto & pool = get_pool(base);
         logger.warning(

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -246,7 +246,7 @@ inline ConstMapIterator & ConstMapIterator::operator++() noexcept {
         unsigned char byte = *map_current;
 
         // reset previously seen bits to 0
-        byte >>= (current_value & 7) + 1;
+        byte = static_cast<unsigned char>(byte >> ((current_value & 7) + 1));
 
         auto bit = ffs(byte << ((current_value & 7) + 1));
         if (bit) {

--- a/test/libdnf/module/test_module.cpp
+++ b/test/libdnf/module/test_module.cpp
@@ -50,7 +50,7 @@ void ModuleTest::test_load() {
         module_yaml_file.close();
     }
 
-    auto module_item_container = new ModuleItemContainer(base);
+    auto module_item_container = std::make_unique<ModuleItemContainer>(base);
     module_item_container->add(module_yaml_string, "repomd-modules");
     module_item_container->add_modules_without_static_context();
     CPPUNIT_ASSERT_EQUAL(3lu, module_item_container->modules.size());


### PR DESCRIPTION
Even with these patches running with sanitizers still doesn't pass cleanly. However I believe the remaining reports are not problems with dnf5 or I wasn't able to figure it out at this time.

Couple of notes for future reference:

Note 1
---

Just about every run of dnf5 binary produces:
```
==16==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f2bebc2e68f in __interceptor_malloc (/lib64/libasan.so.8+0xba68f)
    #1 0x7f2be83a373c  (<unknown module>)
```
I am not sure to what does this refer to but it is somehow connected to dynamic loading of plugins (`dlopen()` - `dlclose()`) because when the `dlclose()` is commented out the reported leak disappears. I was able to find that running sanitizers with dynamic library loading is problematic but I didn't find any solutions.

Note 2
---

Similar report also happens in unittests first: (this error is correct and we do it on purpose)
```
/root/dbox/src/dnf5/test/libdnf/run_tests.cpp:70:53: runtime error: member access within address 0x608000001ea0 which does not point to an object of type 'HackTestCaller'
0x608000001ea0: note: object is of type 'CppUnit::TestCaller<AdvisoryAdvisoryTest>'
 00 00 00 00  e8 5c bd 00 00 00 00 00  78 5d bd 00 00 00 00 00  d0 20 00 00 40 60 00 00  23 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'CppUnit::TestCaller<AdvisoryAdvisoryTest>'
```
and later:
```
==86903==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 2 object(s) allocated from:
    #0 0x7fdb31ded595 in __interceptor_realloc.part.0 (/lib64/libasan.so.8+0xb9595)
    #1 0x7fdb3157e90a in d_growable_string_callback_adapter (/lib64/libstdc++.so.6+0xb090a)
```
This seems to be due to the workaround in `LogCaptureListener` for accessing the `BaseTestCase` to get logs. Not using the [`LogCaptureListener`](https://github.com/rpm-software-management/dnf5/blob/main/test/libdnf/run_tests.cpp#L66-L89) fixes the errors. I think the second error might be in fact this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80578

Note 3
---

There are also some memory leaks in `zchunk`. Either librepo is using it wrong or there are problems in the `zchunk` library itself. I haven't looked into it yet. (Detected only on rawhide host - not in a f36 container)

Note 4
---

Finally to build with `tito` I had to remove `-Werror` (otherwise it failed - complaining some std library functions may be used uninitialized) and disable the `LogCaptureListener`.