### PR TITLE
Implement history transaction ID ranges and `last`

### DIFF
--- a/dnf5/commands/history/arguments.hpp
+++ b/dnf5/commands/history/arguments.hpp
@@ -36,6 +36,13 @@ public:
 };
 
 
+class ReverseOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit ReverseOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "reverse", '\0', _("Reverse the order of transactions."), false) {}
+};
+
+
 }  // namespace dnf5
 
 

--- a/dnf5/commands/history/history_info.cpp
+++ b/dnf5/commands/history/history_info.cpp
@@ -33,11 +33,18 @@ void HistoryInfoCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Print details about transactions");
 
     transaction_specs = std::make_unique<TransactionSpecArguments>(*this);
+    reverse = std::make_unique<ReverseOption>(*this);
 }
 
 void HistoryInfoCommand::run() {
     auto transactions =
         list_transactions_from_specs(*get_context().base.get_transaction_history(), transaction_specs->get_value());
+
+    if (reverse->get_value()) {
+        std::sort(transactions.begin(), transactions.end(), std::greater{});
+    } else {
+        std::sort(transactions.begin(), transactions.end());
+    }
 
     for (auto ts : transactions) {
         libdnf::cli::output::print_transaction_info(ts);

--- a/dnf5/commands/history/history_info.cpp
+++ b/dnf5/commands/history/history_info.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_info.hpp"
 
+#include "transaction_id.hpp"
+
 #include <libdnf-cli/output/transactioninfo.hpp>
 
 #include <iostream>
@@ -34,21 +36,10 @@ void HistoryInfoCommand::set_argument_parser() {
 }
 
 void HistoryInfoCommand::run() {
-    auto & ctx = get_context();
+    auto transactions =
+        list_transactions_from_specs(*get_context().base.get_transaction_history(), transaction_specs->get_value());
 
-    auto specs_str = transaction_specs->get_value();
-
-    std::vector<int64_t> spec_ids;
-
-    // TODO(lukash) proper transaction id parsing
-    std::transform(specs_str.begin(), specs_str.end(), std::back_inserter(spec_ids), [](const std::string & spec) {
-        return std::stol(spec);
-    });
-
-    auto ts_hist = ctx.base.get_transaction_history();
-    auto ts_list = spec_ids.empty() ? ts_hist->list_all_transactions() : ts_hist->list_transactions(spec_ids);
-
-    for (auto ts : ts_list) {
+    for (auto ts : transactions) {
         libdnf::cli::output::print_transaction_info(ts);
         std::cout << std::endl;
     }

--- a/dnf5/commands/history/history_info.hpp
+++ b/dnf5/commands/history/history_info.hpp
@@ -33,6 +33,7 @@ public:
     void run() override;
 
     std::unique_ptr<TransactionSpecArguments> transaction_specs{nullptr};
+    std::unique_ptr<ReverseOption> reverse{nullptr};
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -37,8 +37,15 @@ void HistoryListCommand::set_argument_parser() {
 }
 
 void HistoryListCommand::run() {
-    auto transactions =
-        list_transactions_from_specs(*get_context().base.get_transaction_history(), transaction_specs->get_value());
+    auto ts_specs = transaction_specs->get_value();
+    auto & history = *get_context().base.get_transaction_history();
+    std::vector<libdnf::transaction::Transaction> transactions;
+
+    if (ts_specs.empty()) {
+        transactions = history.list_all_transactions();
+    } else {
+        transactions = list_transactions_from_specs(history, transaction_specs->get_value());
+    }
 
     libdnf::cli::output::print_transaction_list(transactions);
 }

--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -34,6 +34,7 @@ void HistoryListCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("List transactions");
 
     transaction_specs = std::make_unique<TransactionSpecArguments>(*this);
+    reverse = std::make_unique<ReverseOption>(*this);
 }
 
 void HistoryListCommand::run() {
@@ -45,6 +46,12 @@ void HistoryListCommand::run() {
         transactions = history.list_all_transactions();
     } else {
         transactions = list_transactions_from_specs(history, transaction_specs->get_value());
+    }
+
+    if (reverse->get_value()) {
+        std::sort(transactions.begin(), transactions.end(), std::greater{});
+    } else {
+        std::sort(transactions.begin(), transactions.end());
     }
 
     libdnf::cli::output::print_transaction_list(transactions);

--- a/dnf5/commands/history/history_list.hpp
+++ b/dnf5/commands/history/history_list.hpp
@@ -36,6 +36,7 @@ public:
     void run() override;
 
     std::unique_ptr<TransactionSpecArguments> transaction_specs{nullptr};
+    std::unique_ptr<ReverseOption> reverse{nullptr};
 };
 
 

--- a/dnf5/commands/history/transaction_id.cpp
+++ b/dnf5/commands/history/transaction_id.cpp
@@ -1,0 +1,134 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "transaction_id.hpp"
+
+#include "utils/bgettext/bgettext-mark-domain.h"
+#include "utils/string.hpp"
+
+
+namespace dnf5 {
+
+
+InvalidIdRangeError::InvalidIdRangeError(const std::string & id_range)
+    : libdnf::Error(
+          M_("Invalid transaction ID range \"{}\", \"ID\" or \"ID..ID\" expected, where ID is \"NUMBER\", \"last\" or "
+             "\"last-NUMBER\"."),
+          id_range) {}
+
+
+int64_t parse_id(const std::string & id) {
+    if (id == "last") {
+        return -1;
+    }
+
+    if (id.rfind("last-", 0) == 0) {
+        // shift by -1. we return -1 for "last", -2 for "last-1" etc.
+        return std::stol(id.substr(4), nullptr, 10) - 1;
+    }
+
+    // prevent ambiguity
+    if (id[0] == '-' || id[0] == '+') {
+        throw std::runtime_error("Invalid ID");  // gets replaced with a proper exception up the stack
+    }
+
+    return stol(id);
+}
+
+
+std::pair<int64_t, int64_t> parse_transaction_id_range(const std::string & id_range) {
+    auto splitted = libdnf::utils::string::split(id_range, "..");
+
+    if (splitted.size() > 2 || splitted.size() < 1) {
+        throw InvalidIdRangeError(id_range);
+    }
+
+    try {
+        std::pair<int64_t, int64_t> res;
+
+        res.first = parse_id(splitted[0]);
+        if (splitted.size() == 2) {
+            res.second = parse_id(splitted[1]);
+        }
+
+        return res;
+    } catch (const std::exception & e) {
+        throw InvalidIdRangeError(id_range);
+    }
+}
+
+
+std::vector<libdnf::transaction::Transaction> list_transactions_from_specs(
+    libdnf::transaction::TransactionHistory & ts_history, const std::vector<std::string> & specs) {
+    std::vector<int64_t> trans_id_cache;
+    std::vector<int64_t> single_ids_to_get;
+    std::vector<libdnf::transaction::Transaction> result;
+
+    for (auto & i : specs) {
+        auto id_range = parse_transaction_id_range(i);
+
+        if (id_range.first < 0 || id_range.second < 0) {
+            if (trans_id_cache.empty()) {
+                trans_id_cache = ts_history.list_transaction_ids();
+            }
+
+            if (id_range.first < 0) {
+                if (static_cast<uint64_t>(std::abs(id_range.first)) <= trans_id_cache.size()) {
+                    id_range.first = trans_id_cache.end()[id_range.first];
+                } else {
+                    // X in last-X goes out of range; we start with ID 0 if
+                    // spec is a range, or search for ID 0 (which shouldn't
+                    // exist, so we don't find anything)
+                    id_range.first = 0;
+                }
+            }
+
+            if (id_range.second < 0) {
+                if (static_cast<uint64_t>(std::abs(id_range.second)) <= trans_id_cache.size()) {
+                    id_range.second = trans_id_cache.end()[id_range.second];
+                } else {
+                    // X in last-X goes out of range for a range upper
+                    // boundary, we shouldn't match anything
+                    id_range.first = 0;
+                    id_range.second = 0;
+                }
+            }
+        }
+
+        // The ID range is just a single ID; accumulate into a vector and fetch them all at once
+        if (id_range.second == 0) {
+            single_ids_to_get.push_back(id_range.first);
+            continue;
+        }
+
+        auto transactions = ts_history.list_transactions(id_range.first, id_range.second);
+        result.insert(result.end(), transactions.begin(), transactions.end());
+    }
+
+    if (!single_ids_to_get.empty()) {
+        auto transactions = ts_history.list_transactions(single_ids_to_get);
+        result.insert(result.end(), transactions.begin(), transactions.end());
+    }
+
+    std::sort(result.begin(), result.end());
+
+    return result;
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/history/transaction_id.cpp
+++ b/dnf5/commands/history/transaction_id.cpp
@@ -117,6 +117,10 @@ std::vector<libdnf::transaction::Transaction> list_transactions_from_specs(
             continue;
         }
 
+        if (id_range.first > id_range.second) {
+            std::swap(id_range.first, id_range.second);
+        }
+
         auto transactions = ts_history.list_transactions(id_range.first, id_range.second);
         result.insert(result.end(), transactions.begin(), transactions.end());
     }

--- a/dnf5/commands/history/transaction_id.cpp
+++ b/dnf5/commands/history/transaction_id.cpp
@@ -126,8 +126,6 @@ std::vector<libdnf::transaction::Transaction> list_transactions_from_specs(
         result.insert(result.end(), transactions.begin(), transactions.end());
     }
 
-    std::sort(result.begin(), result.end());
-
     return result;
 }
 

--- a/dnf5/commands/history/transaction_id.hpp
+++ b/dnf5/commands/history/transaction_id.hpp
@@ -17,30 +17,35 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "history_list.hpp"
 
-#include "transaction_id.hpp"
+#ifndef DNF5_COMMANDS_HISTORY_TRANSACTION_ID_HPP
+#define DNF5_COMMANDS_HISTORY_TRANSACTION_ID_HPP
 
-#include <libdnf-cli/output/transactionlist.hpp>
+#include "libdnf/common/exception.hpp"
+#include "libdnf/transaction/transaction_history.hpp"
 
-#include <iostream>
+#include <cstdint>
+#include <string>
+#include <utility>
 
 
 namespace dnf5 {
 
-using namespace libdnf::cli;
 
-void HistoryListCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("List transactions");
+class InvalidIdRangeError : public libdnf::Error {
+public:
+    InvalidIdRangeError(const std::string & id_range);
 
-    transaction_specs = std::make_unique<TransactionSpecArguments>(*this);
-}
+    const char * get_domain_name() const noexcept override { return "dnf5"; }
+    const char * get_name() const noexcept override { return "InvalidIdRangeError"; }
+};
 
-void HistoryListCommand::run() {
-    auto transactions =
-        list_transactions_from_specs(*get_context().base.get_transaction_history(), transaction_specs->get_value());
 
-    libdnf::cli::output::print_transaction_list(transactions);
-}
+std::vector<libdnf::transaction::Transaction> list_transactions_from_specs(
+    libdnf::transaction::TransactionHistory & ts_history, const std::vector<std::string> & specs);
+
 
 }  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_HISTORY_TRANSACTION_ID_HPP

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -538,6 +538,11 @@ int main(int argc, char * argv[]) try {
         const auto & help = context.get_argument_parser().get_named_arg("help", false);
         try {
             context.get_argument_parser().parse(argc, argv);
+        } catch (libdnf::cli::ArgumentParserUnknownArgumentError & ex) {
+            // print help if an unknown command is provided
+            std::cerr << ex.what() << std::endl;
+            context.get_argument_parser().get_selected_command()->help();
+            return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
         } catch (const std::exception & ex) {
             if (help.get_parse_count() == 0) {
                 std::cout << ex.what() << std::endl;

--- a/include/libdnf/transaction/comps_environment.hpp
+++ b/include/libdnf/transaction/comps_environment.hpp
@@ -40,7 +40,7 @@ class Transction;
 /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentItem
 class CompsEnvironment : public TransactionItem {
 public:
-    explicit CompsEnvironment(Transaction & trans);
+    explicit CompsEnvironment(const Transaction & trans);
 
     /// Get text id of the environment (xml element: <comps><environment><id>VALUE</id>...)
     ///
@@ -115,8 +115,6 @@ private:
 /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentGroup
 class CompsEnvironmentGroup {
 public:
-    explicit CompsEnvironmentGroup(CompsEnvironment & environment);
-
     /// Get database id (primary key)
     ///
     /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getId()
@@ -157,17 +155,11 @@ public:
     /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupType(libdnf::CompsPackageType value)
     void set_group_type(libdnf::comps::PackageType value) { group_type = value; }
 
-    /// Get the environment the group is part of
-    ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getEnvironment()
-    const CompsEnvironment & get_environment() const noexcept { return environment; }
-
 private:
     int64_t id = 0;
     std::string group_id;
     bool installed = false;
     libdnf::comps::PackageType group_type;
-    CompsEnvironment & environment;
 };
 
 }  // namespace libdnf::transaction

--- a/include/libdnf/transaction/comps_group.hpp
+++ b/include/libdnf/transaction/comps_group.hpp
@@ -40,7 +40,7 @@ class Transaction;
 /// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupItem
 class CompsGroup : public TransactionItem {
 public:
-    explicit CompsGroup(Transaction & trans);
+    explicit CompsGroup(const Transaction & trans);
 
     /// Get text id of the group (xml element: <comps><group><id>VALUE</id>...)
     ///
@@ -116,8 +116,6 @@ private:
 /// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupPackage
 class CompsGroupPackage {
 public:
-    explicit CompsGroupPackage(CompsGroup & group);
-
     /// Get database id (primary key)
     ///
     /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getId()
@@ -162,17 +160,11 @@ public:
     /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setPackageType(libdnf::PackageType value)
     void set_package_type(libdnf::comps::PackageType value) { package_type = value; }
 
-    /// Get the group the package is part of
-    ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getGroup()
-    const CompsGroup & get_group() const noexcept { return group; }
-
 private:
     int64_t id = 0;
     std::string name;
     bool installed = false;
     libdnf::comps::PackageType package_type = libdnf::comps::PackageType::DEFAULT;
-    CompsGroup & group;
 };
 
 }  // namespace libdnf::transaction

--- a/include/libdnf/transaction/rpm_package.hpp
+++ b/include/libdnf/transaction/rpm_package.hpp
@@ -38,7 +38,7 @@ class Transaction;
 /// @replaces libdnf:transaction/RPMItem.hpp:class:RPMItem
 class Package : public TransactionItem {
 public:
-    explicit Package(Transaction & trans);
+    explicit Package(const Transaction & trans);
 
     /// Get package name
     ///

--- a/include/libdnf/transaction/transaction_history.hpp
+++ b/include/libdnf/transaction/transaction_history.hpp
@@ -43,6 +43,12 @@ public:
 
     TransactionHistoryWeakPtr get_weak_ptr() { return TransactionHistoryWeakPtr(this, &guard); }
 
+    /// Lists all transaction IDs from the transaction history database. The
+    /// result is sorted in ascending order.
+    ///
+    /// @return The list of transaction IDs.
+    std::vector<int64_t> list_transaction_ids();
+
     /// Lists transactions from the transaction history for transaction ids in `ids`.
     ///
     /// @param ids The ids to list.

--- a/include/libdnf/transaction/transaction_item.hpp
+++ b/include/libdnf/transaction/transaction_item.hpp
@@ -38,7 +38,7 @@ public:
     using Reason = TransactionItemReason;
     using State = TransactionItemState;
 
-    explicit TransactionItem(Transaction & trans);
+    explicit TransactionItem(const Transaction & trans);
 
     /// Get database id (primary key) of the transaction item (table 'trans_item')
     int64_t get_id() const noexcept { return id; }
@@ -124,7 +124,7 @@ public:
     // TODO(dmach): Review and bring back if needed
     //void saveState();
 
-    Transaction & get_transaction() { return trans; }
+    const Transaction & get_transaction() const;
 
 protected:
     int64_t id = 0;
@@ -135,7 +135,12 @@ protected:
 
     int64_t item_id = 0;
 
-    Transaction & trans;
+    // TODO(lukash) this won't be safe in bindings (or in general when a
+    // TransactionItem is kept around after a Transaction is destroyed), but we
+    // can't easily use a WeakPtr here, since the Transactions are expected to
+    // be at least movable, and the WeakPtrGuard would make the Transaction
+    // unmovable
+    const Transaction * trans = nullptr;
 
     // TODO(dmach): Reimplement in Package class; it's most likely not needed in Comps{Group,Environment}
     // std::vector< TransactionItemPtr > replacedBy;

--- a/libdnf/transaction/comps_environment.cpp
+++ b/libdnf/transaction/comps_environment.cpp
@@ -30,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::transaction {
 
 
-CompsEnvironment::CompsEnvironment(Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+CompsEnvironment::CompsEnvironment(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
 
 
 /*
@@ -70,11 +70,8 @@ CompsEnvironmentItem::getTransactionItemsByPattern(libdnf::utils::SQLite3Ptr con
 */
 
 
-CompsEnvironmentGroup::CompsEnvironmentGroup(CompsEnvironment & environment) : environment(environment) {}
-
-
 CompsEnvironmentGroup & CompsEnvironment::new_group() {
-    return groups.emplace_back(*this);
+    return groups.emplace_back();
 }
 
 

--- a/libdnf/transaction/comps_group.cpp
+++ b/libdnf/transaction/comps_group.cpp
@@ -32,7 +32,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::transaction {
 
 
-CompsGroup::CompsGroup(Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+CompsGroup::CompsGroup(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
 
 
 /*
@@ -72,11 +72,8 @@ CompsGroup::getTransactionItemsByPattern(libdnf::utils::SQLite3Ptr conn, const s
 */
 
 CompsGroupPackage & CompsGroup::new_package() {
-    return packages.emplace_back(*this);
+    return packages.emplace_back();
 }
-
-
-CompsGroupPackage::CompsGroupPackage(CompsGroup & group) : group(group) {}
 
 
 }  // namespace libdnf::transaction

--- a/libdnf/transaction/db/trans.cpp
+++ b/libdnf/transaction/db/trans.cpp
@@ -45,6 +45,21 @@ static constexpr const char * select_sql = R"**(
 )**";
 
 
+std::vector<int64_t> select_transaction_ids(const BaseWeakPtr & base) {
+    auto conn = transaction_db_connect(*base);
+
+    auto query = libdnf::utils::SQLite3::Query(*conn, "SELECT \"id\" FROM \"trans\" ORDER BY \"id\"");
+
+    std::vector<int64_t> res;
+
+    while (query.step() == libdnf::utils::SQLite3::Statement::StepResult::ROW) {
+        res.push_back(query.get<int64_t>("id"));
+    }
+
+    return res;
+}
+
+
 static std::vector<Transaction> load_from_select(const BaseWeakPtr & base, libdnf::utils::SQLite3::Query & query) {
     std::vector<Transaction> res;
 

--- a/libdnf/transaction/db/trans.hpp
+++ b/libdnf/transaction/db/trans.hpp
@@ -35,6 +35,10 @@ namespace libdnf::transaction {
 class Transaction;
 
 
+/// Selects all transaction IDs, sorting in ascending order.
+std::vector<int64_t> select_transaction_ids(const BaseWeakPtr & base);
+
+
 /// Selects transactions using a list of ids, in case `ids` is empty, selects all transactions.
 std::vector<Transaction> select_transactions_by_ids(const BaseWeakPtr & base, const std::vector<int64_t> & ids);
 

--- a/libdnf/transaction/rpm_package.cpp
+++ b/libdnf/transaction/rpm_package.cpp
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::transaction {
 
 
-Package::Package(Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+Package::Package(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
 
 
 uint32_t Package::get_epoch_int() const {

--- a/libdnf/transaction/transaction_history.cpp
+++ b/libdnf/transaction/transaction_history.cpp
@@ -38,6 +38,10 @@ Transaction TransactionHistory::new_transaction() {
     return Transaction(base);
 }
 
+std::vector<int64_t> TransactionHistory::list_transaction_ids() {
+    return select_transaction_ids(base);
+}
+
 std::vector<Transaction> TransactionHistory::list_transactions(const std::vector<int64_t> & ids) {
     return select_transactions_by_ids(base, ids);
 }

--- a/libdnf/transaction/transaction_item.cpp
+++ b/libdnf/transaction/transaction_item.cpp
@@ -39,7 +39,7 @@ std::string TransactionItem::get_action_short() {
 }
 
 
-TransactionItem::TransactionItem(Transaction & trans) : trans{trans} {}
+TransactionItem::TransactionItem(const Transaction & trans) : trans{&trans} {}
 
 
 bool TransactionItem::is_inbound_action() const {
@@ -51,6 +51,11 @@ bool TransactionItem::is_outbound_action() const {
     return transaction_item_action_is_outbound(action);
 }
 
+
+const Transaction & TransactionItem::get_transaction() const {
+    libdnf_assert(trans, "Transaction in TransactionItem was not set.");
+    return *trans;
+}
 
 /*
 void


### PR DESCRIPTION
Comes without tests as of now, they'll require parsing the `history list` output, which is not that easy, as column separators are spaces, which can also appear in a lot of the column values.