### PR TITLE
Depend on toml11 via toml11-static

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -72,7 +72,7 @@ BuildRequires:  clang
 BuildRequires:  gcc-c++
 %endif
 
-BuildRequires:  toml11-devel
+BuildRequires:  toml11-static
 BuildRequires:  pkgconfig(check)
 %if %{with tests}
 BuildRequires:  pkgconfig(cppunit)


### PR DESCRIPTION
According to Fedora packaging guidelines
<https://docs.fedoraproject.org/en-US/packaging-guidelines/#_packaging_header_only_libraries>,
header-only libraries must be pulled in with a -static RPM dependency
symbol. A rationale is that this form of static linking must be
tracked for security purposes.

This patch fixes it.