### PR TITLE
HistoryDB: Rename tables "pkg_names" and "archs" to singular form

### DIFF
--- a/libdnf/transaction/db/arch.cpp
+++ b/libdnf/transaction/db/arch.cpp
@@ -17,13 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "archs.hpp"
+#include "arch.hpp"
 
 namespace libdnf::transaction {
 
 static constexpr const char * SQL_NAME_INSERT_IF_NOT_EXISTS = R"**(
     INSERT INTO
-        "archs" (
+        "arch" (
             "name"
         )
     VALUES
@@ -32,11 +32,11 @@ static constexpr const char * SQL_NAME_INSERT_IF_NOT_EXISTS = R"**(
     RETURNING "id"
 )**";
 
-std::unique_ptr<utils::SQLite3::Statement> archs_insert_if_not_exists_new_query(utils::SQLite3 & conn) {
+std::unique_ptr<utils::SQLite3::Statement> arch_insert_if_not_exists_new_query(utils::SQLite3 & conn) {
     return std::make_unique<utils::SQLite3::Statement>(conn, SQL_NAME_INSERT_IF_NOT_EXISTS);
 }
 
-int64_t archs_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name) {
+int64_t arch_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name) {
     int64_t result = 0;
 
     query.bindv(name);

--- a/libdnf/transaction/db/arch.hpp
+++ b/libdnf/transaction/db/arch.hpp
@@ -17,8 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF_TRANSACTION_DB_ARCHS_HPP
-#define LIBDNF_TRANSACTION_DB_ARCHS_HPP
+#ifndef LIBDNF_TRANSACTION_DB_ARCH_HPP
+#define LIBDNF_TRANSACTION_DB_ARCH_HPP
 
 #include "utils/sqlite3/sqlite3.hpp"
 
@@ -26,12 +26,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::transaction {
 
-/// Create a query (statement) that inserts new records to the 'archs' table
-std::unique_ptr<utils::SQLite3::Statement> archs_insert_if_not_exists_new_query(utils::SQLite3 & conn);
+/// Create a query (statement) that inserts new records to the 'arch' table
+std::unique_ptr<utils::SQLite3::Statement> arch_insert_if_not_exists_new_query(utils::SQLite3 & conn);
 
-/// Use a query to insert a new record to the 'archs' table
-int64_t archs_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name);
+/// Use a query to insert a new record to the 'arch' table
+int64_t arch_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name);
 
 }  // namespace libdnf::transaction
 
-#endif  // LIBDNF_TRANSACTION_DB_ARCHS_HPP
+#endif  // LIBDNF_TRANSACTION_DB_ARCH_HPP

--- a/libdnf/transaction/db/comps_group_package.cpp
+++ b/libdnf/transaction/db/comps_group_package.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "comps_group_package.hpp"
 
-#include "pkg_names.hpp"
+#include "pkg_name.hpp"
 
 #include "libdnf/transaction/transaction.hpp"
 
@@ -34,12 +34,12 @@ namespace libdnf::transaction {
 static constexpr const char * SQL_COMPS_GROUP_PACKAGE_SELECT = R"**(
     SELECT
         "cgp"."id",
-        "pkg_names"."name",
+        "pkg_name"."name",
         "cgp"."installed",
         "cgp"."pkg_type"
     FROM
         "comps_group_package" "cgp"
-    LEFT JOIN "pkg_names" ON "cgp"."name_id" = "pkg_names"."id"
+    LEFT JOIN "pkg_name" ON "cgp"."name_id" = "pkg_name"."id"
     WHERE
         "cgp"."group_id" = ?
     ORDER BY
@@ -77,7 +77,7 @@ static constexpr const char * SQL_COMPS_GROUP_PACKAGE_INSERT = R"**(
             "pkg_type"
         )
     VALUES
-        (?, (SELECT "id" FROM "pkg_names" WHERE "name" = ?), ?, ?)
+        (?, (SELECT "id" FROM "pkg_name" WHERE "name" = ?), ?, ?)
 )**";
 
 
@@ -89,11 +89,11 @@ static std::unique_ptr<libdnf::utils::SQLite3::Statement> comps_group_package_in
 
 
 void comps_group_packages_insert(libdnf::utils::SQLite3 & conn, CompsGroup & group) {
-    auto query_pkg_name_insert_if_not_exists = pkg_names_insert_if_not_exists_new_query(conn);
+    auto query_pkg_name_insert_if_not_exists = pkg_name_insert_if_not_exists_new_query(conn);
     auto query = comps_group_package_insert_new_query(conn);
     for (auto & pkg : group.get_packages()) {
-        // insert package name into 'pkg_names' table if not exists
-        pkg_names_insert_if_not_exists(*query_pkg_name_insert_if_not_exists, pkg.get_name());
+        // insert package name into 'pkg_name' table if not exists
+        pkg_name_insert_if_not_exists(*query_pkg_name_insert_if_not_exists, pkg.get_name());
         query->bindv(
             group.get_item_id(), pkg.get_name(), pkg.get_installed(), static_cast<int>(pkg.get_package_type()));
         query->step();

--- a/libdnf/transaction/db/pkg_name.cpp
+++ b/libdnf/transaction/db/pkg_name.cpp
@@ -17,13 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "pkg_names.hpp"
+#include "pkg_name.hpp"
 
 namespace libdnf::transaction {
 
 static constexpr const char * SQL_NAME_INSERT_IF_NOT_EXISTS = R"**(
     INSERT INTO
-        "pkg_names" (
+        "pkg_name" (
             "name"
         )
     VALUES
@@ -32,11 +32,11 @@ static constexpr const char * SQL_NAME_INSERT_IF_NOT_EXISTS = R"**(
     RETURNING "id"
 )**";
 
-std::unique_ptr<utils::SQLite3::Statement> pkg_names_insert_if_not_exists_new_query(utils::SQLite3 & conn) {
+std::unique_ptr<utils::SQLite3::Statement> pkg_name_insert_if_not_exists_new_query(utils::SQLite3 & conn) {
     return std::make_unique<utils::SQLite3::Statement>(conn, SQL_NAME_INSERT_IF_NOT_EXISTS);
 }
 
-int64_t pkg_names_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name) {
+int64_t pkg_name_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name) {
     int64_t result = 0;
 
     query.bindv(name);

--- a/libdnf/transaction/db/pkg_name.hpp
+++ b/libdnf/transaction/db/pkg_name.hpp
@@ -17,8 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF_TRANSACTION_DB_PKG_NAMES_HPP
-#define LIBDNF_TRANSACTION_DB_PKG_NAMES_HPP
+#ifndef LIBDNF_TRANSACTION_DB_PKG_NAME_HPP
+#define LIBDNF_TRANSACTION_DB_PKG_NAME_HPP
 
 #include "utils/sqlite3/sqlite3.hpp"
 
@@ -26,12 +26,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::transaction {
 
-/// Create a query (statement) that inserts new records to the 'pkg_names' table
-std::unique_ptr<utils::SQLite3::Statement> pkg_names_insert_if_not_exists_new_query(utils::SQLite3 & conn);
+/// Create a query (statement) that inserts new records to the 'pkg_name' table
+std::unique_ptr<utils::SQLite3::Statement> pkg_name_insert_if_not_exists_new_query(utils::SQLite3 & conn);
 
-/// Use a query to insert a new record to the 'pkg_names' table
-int64_t pkg_names_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name);
+/// Use a query to insert a new record to the 'pkg_name' table
+int64_t pkg_name_insert_if_not_exists(utils::SQLite3::Statement & query, const std::string & name);
 
 }  // namespace libdnf::transaction
 
-#endif  // LIBDNF_TRANSACTION_DB_PKG_NAMES_HPP
+#endif  // LIBDNF_TRANSACTION_DB_PKG_NAME_HPP

--- a/libdnf/transaction/db/sql/create_tables.sql
+++ b/libdnf/transaction/db/sql/create_tables.sql
@@ -20,7 +20,7 @@ R"**(
         "comment" TEXT,                                   /* An arbitrary comment */
         "state_id" INTEGER,                               /* (enum) */
         PRIMARY KEY("id" AUTOINCREMENT),
-	FOREIGN KEY("state_id") REFERENCES "trans_state"("id")
+        FOREIGN KEY("state_id") REFERENCES "trans_state"("id")
     );
 
     CREATE TABLE "repo" (
@@ -29,13 +29,13 @@ R"**(
         PRIMARY KEY("id")
     );
 
-    CREATE TABLE "pkg_names" (
+    CREATE TABLE "pkg_name" (
         "id" INTEGER,
         "name" TEXT NOT NULL UNIQUE,
         PRIMARY KEY("id")
     );
 
-    CREATE TABLE "archs" (
+    CREATE TABLE "arch" (
         "id" INTEGER,
         "name" TEXT NOT NULL UNIQUE,
         PRIMARY KEY("id")
@@ -110,8 +110,8 @@ R"**(
         "release" TEXT NOT NULL,
         "arch_id" INTEGER NOT NULL,
         FOREIGN KEY("item_id") REFERENCES "item"("id"),
-        FOREIGN KEY("name_id") REFERENCES "pkg_names"("id"),
-        FOREIGN KEY("arch_id") REFERENCES "archs"("id"),
+        FOREIGN KEY("name_id") REFERENCES "pkg_name"("id"),
+        FOREIGN KEY("arch_id") REFERENCES "arch"("id"),
         CONSTRAINT "rpm_unique_nevra" UNIQUE ("name_id", "epoch", "version", "release", "arch_id")
     );
 
@@ -132,7 +132,7 @@ R"**(
         "installed" INTEGER NOT NULL,
         "pkg_type" INTEGER NOT NULL,
         FOREIGN KEY("group_id") REFERENCES "comps_group"("item_id"),
-        FOREIGN KEY("name_id") REFERENCES "pkg_names"("id"),
+        FOREIGN KEY("name_id") REFERENCES "pkg_name"("id"),
         CONSTRAINT "comps_group_package_unique_name" UNIQUE ("group_id", "name_id"),
         PRIMARY KEY("id" AUTOINCREMENT)
     );
@@ -167,7 +167,7 @@ R"**(
 
     DELETE FROM "sqlite_sequence";
 
-    CREATE INDEX "pkg_name" ON "pkg_names"("name");
+    CREATE INDEX "pkg_name_name" ON "pkg_name"("name");
     CREATE INDEX "trans_item_trans_id" ON "trans_item"("trans_id");
     CREATE INDEX "trans_item_item_id" ON "trans_item"("item_id");
 


### PR DESCRIPTION
To be consistent with other table names.