### PR TITLE
Fix clang rawhide build by removing unused variable

### DIFF
--- a/libdnf-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf-cli/progressbar/multi_progress_bar.cpp
@@ -122,14 +122,12 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     // then print the "total" progress bar
-    int32_t number = 0;
     int32_t total_numbers = 0;
     int64_t ticks = 0;
     int64_t total_ticks = 0;
 
     for (auto & bar : mbar.bars_done) {
         total_numbers = std::max(total_numbers, bar->get_total());
-        number++;
         // completed bars can be unfinished
         // add only processed ticks to both values
         total_ticks += bar->get_ticks();

--- a/libdnf/module/module_item_container_impl.hpp
+++ b/libdnf/module/module_item_container_impl.hpp
@@ -32,7 +32,7 @@ namespace libdnf::module {
 class ModuleItemContainer::Impl {
 public:
     Impl() : pool(pool_create()) {}
-    ~Impl() {}
+    ~Impl() { pool_free(pool); }
 
 private:
     friend ModuleItemContainer;


### PR DESCRIPTION
Also fixes a memory leak of `pool`.