### PR TITLE
Base: Load default (distribution-specific) configuration

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -12,6 +12,7 @@
 %include <shared.i>
 
 %import "common.i"
+%import "logger.i"
 
 %exception {
     try {
@@ -26,6 +27,8 @@
     #include "libdnf/conf/config_main.hpp"
     #include "libdnf/conf/config_parser.hpp"
     #include "libdnf/common/weak_ptr.hpp"
+    #include "libdnf/logger/log_router.hpp"
+    #include "libdnf/logger/memory_buffer_logger.hpp"
 %}
 
 #define CV __perl_CV
@@ -78,12 +81,13 @@
 %ignore libdnf::OptionBinds::find;
 %include "libdnf/conf/option_binds.hpp"
 
-%include "libdnf/conf/config.hpp"
-%include "libdnf/conf/config_main.hpp"
-
 %ignore libdnf::ConfigParserError;
 %ignore ConfigParserSectionNotFoundError;
 %ignore ConfigParserOptionNotFoundError;
 %include "libdnf/conf/config_parser.hpp"
 
 %include "libdnf/conf/vars.hpp"
+
+%include "libdnf/conf/config.hpp"
+%include "libdnf/conf/config_main.hpp"
+

--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -24,6 +24,8 @@
 }
 
 %{
+    #include "libdnf/logger/log_router.hpp"
+    #include "libdnf/logger/memory_buffer_logger.hpp"
     #include "libdnf/repo/config_repo.hpp"
     #include "libdnf/repo/download_callbacks.hpp"
     #include "libdnf/repo/file_downloader.hpp"

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -111,6 +111,9 @@ private:
 
     WeakPtrGuard<Base, false> base_guard;
 
+    /// Loads the default configuration. To load distribution-specific configuration.
+    void load_defaults();
+
     //TODO(jrohel): Make public?
     /// Loads main configuration from file defined by path.
     void load_config_from_file(const std::string & path);

--- a/include/libdnf/conf/config.hpp
+++ b/include/libdnf/conf/config.hpp
@@ -31,7 +31,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 /// Base class for configurations objects
-template <Option::Priority default_priority>
 class Config {
 public:
     OptionBinds & opt_binds() noexcept { return binds; }
@@ -39,14 +38,16 @@ public:
     virtual ~Config() = default;
 
     virtual void load_from_parser(
-        const ConfigParser & parser, const std::string & section, const Vars & vars, Logger & logger);
+        const ConfigParser & parser,
+        const std::string & section,
+        const Vars & vars,
+        Logger & logger,
+        Option::Priority priority);
 
 private:
     OptionBinds binds;
 };
 
-extern template class Config<Option::Priority::MAINCONFIG>;
-extern template class Config<Option::Priority::REPOCONFIG>;
 
 }  // namespace libdnf
 

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -37,7 +37,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 /// Holds global configuration
-class ConfigMain : public Config<Option::Priority::MAINCONFIG> {
+class ConfigMain : public Config {
 public:
     ConfigMain();
     ~ConfigMain();
@@ -276,11 +276,12 @@ public:
     OptionBool & skip_if_unavailable();
     const OptionBool & skip_if_unavailable() const;
 
-    virtual void load_from_parser(
+    void load_from_parser(
         const libdnf::ConfigParser & parser,
         const std::string & section,
         const libdnf::Vars & vars,
-        libdnf::Logger & logger) override;
+        libdnf::Logger & logger,
+        Option::Priority priority = Option::Priority::MAINCONFIG) override;
 
 private:
     class Impl;

--- a/include/libdnf/repo/config_repo.hpp
+++ b/include/libdnf/repo/config_repo.hpp
@@ -29,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::repo {
 
 /// Holds repo configuration options. Default values of some options are inherited from ConfigMain.
-class ConfigRepo : public Config<Option::Priority::REPOCONFIG> {
+class ConfigRepo : public Config {
 public:
     ConfigRepo(ConfigMain & main_config, const std::string & id);
     ~ConfigRepo();
@@ -156,6 +156,13 @@ public:
     /// @return The path to the repository's perisistent directory, where its
     /// persistent data are stored.
     std::string get_persistdir() const;
+
+    void load_from_parser(
+        const libdnf::ConfigParser & parser,
+        const std::string & section,
+        const libdnf::Vars & vars,
+        libdnf::Logger & logger,
+        Option::Priority priority = Option::Priority::REPOCONFIG) override;
 
 private:
     class Impl;

--- a/libdnf/conf/config.cpp
+++ b/libdnf/conf/config.cpp
@@ -22,16 +22,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-template <Option::Priority default_priority>
-void Config<default_priority>::load_from_parser(
-    const ConfigParser & parser, const std::string & section, const Vars & vars, Logger & logger) {
+void Config::load_from_parser(
+    const ConfigParser & parser,
+    const std::string & section,
+    const Vars & vars,
+    Logger & logger,
+    Option::Priority priority) {
     auto cfg_parser_data_iter = parser.get_data().find(section);
     if (cfg_parser_data_iter != parser.get_data().end()) {
         for (const auto & opt : cfg_parser_data_iter->second) {
             auto opt_binds_iter = binds.find(opt.first);
             if (opt_binds_iter != binds.end()) {
                 try {
-                    opt_binds_iter->second.new_string(default_priority, vars.substitute(opt.second));
+                    opt_binds_iter->second.new_string(priority, vars.substitute(opt.second));
                 } catch (const OptionError & ex) {
                     logger.warning("Config error in section \"{}\" key \"{}\": {}", section, opt.first, ex.what());
                 }
@@ -39,8 +42,5 @@ void Config<default_priority>::load_from_parser(
         }
     }
 }
-
-template class Config<Option::Priority::MAINCONFIG>;
-template class Config<Option::Priority::REPOCONFIG>;
 
 }  // namespace libdnf

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -1335,8 +1335,12 @@ const OptionBool & ConfigMain::skip_if_unavailable() const {
 }
 
 void ConfigMain::load_from_parser(
-    const ConfigParser & parser, const std::string & section, const Vars & vars, Logger & logger) {
-    Config::load_from_parser(parser, section, vars, logger);
+    const ConfigParser & parser,
+    const std::string & section,
+    const Vars & vars,
+    Logger & logger,
+    Option::Priority priority) {
+    Config::load_from_parser(parser, section, vars, logger, priority);
 
     if (geteuid() == 0) {
         p_impl->cachedir.set(Option::Priority::MAINCONFIG, p_impl->system_cachedir.get_value());

--- a/libdnf/config.h.in
+++ b/libdnf/config.h.in
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef _LIBDNF_CONFIG_H_
 #define _LIBDNF_CONFIG_H_
 
+#define LIBDNF5_DISTRIBUTION_CONFIG_FILE "@CMAKE_INSTALL_PREFIX@/lib/dnf5/libdnf.conf"
 #define DEFAULT_LIBDNF5_PLUGINS_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/libdnf5/plugins/"
 
 #endif // _LIBDNF_CONFIG_H_

--- a/libdnf/repo/config_repo.cpp
+++ b/libdnf/repo/config_repo.cpp
@@ -587,4 +587,13 @@ std::string ConfigRepo::get_persistdir() const {
     return main_persistdir / "repos" / get_unique_id();
 }
 
+void ConfigRepo::load_from_parser(
+    const ConfigParser & parser,
+    const std::string & section,
+    const Vars & vars,
+    Logger & logger,
+    Option::Priority priority) {
+    Config::load_from_parser(parser, section, vars, logger, priority);
+}
+
 }  // namespace libdnf::repo


### PR DESCRIPTION
The default configuration is loaded from "INSTALL_PREFIX/lib/dnf5/libdnf.conf" file.