### PR TITLE
Add setter for allow_erasing to Goal

### DIFF
--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -64,6 +64,8 @@ void RemoveCommand::run() {
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
         goal->add_rpm_remove(option->get_value());
     }
+    // To enable removal of dependenct packages it requires to use allow_erasing
+    goal->set_allow_erasing(true);
 }
 
 }  // namespace dnf5

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -608,7 +608,7 @@ int main(int argc, char * argv[]) try {
 
         command->run();
         if (auto goal = context.get_goal(false)) {
-            context.set_transaction(goal->resolve(false));
+            context.set_transaction(goal->resolve());
 
             command->goal_resolved();
 

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -69,7 +69,8 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
     session.fill_sack();
 
     auto & goal = session.get_goal();
-    auto transaction = goal.resolve(allow_erasing);
+    goal.set_allow_erasing(allow_erasing);
+    auto transaction = goal.resolve();
     session.set_transaction(transaction);
 
     std::vector<dnfdaemon::DbusTransactionItem> dbus_transaction;

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -255,15 +255,19 @@ public:
     void add_provide_install(
         const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 
+    /// When true it allows to remove installed packages to resolve dependency problems
+    void set_allow_erasing(bool value);
+
+    /// Return the currets setting of allow_erasing
+    bool get_allow_erasing() const;
 
     // TODO(jmracek) Move transaction reports to Transaction class
     /// Resolve all jobs and return a transaction object. Everytime it resolves specs (strings) to packages
     ///
-    /// @param allow_erasing    When `true`, allows to remove installed packages to resolve dependency problems
     /// @return transaction object
     // @replaces libdnf/hy-goal.h:function:hy_goal_run_flags(HyGoal goal, DnfGoalActions flags)
     // @replaces dnf:dnf/base.py:method:Base().resolve(self, allow_erasing=False)
-    base::Transaction resolve(bool allow_erasing);
+    base::Transaction resolve();
 
     /// Clean all request from the Goal instance
     void reset();

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -113,6 +113,7 @@ private:
     std::vector<std::tuple<GoalAction, std::string, GoalJobSettings>> group_specs;
 
     rpm::solv::GoalPrivate rpm_goal;
+    bool allow_erasing{false};
 };
 
 Goal::Goal(const BaseWeakPtr & base) : p_impl(new Impl(base)) {}
@@ -1133,7 +1134,15 @@ GoalProblem Goal::Impl::add_group_install_to_goal(
     return GoalProblem::NO_PROBLEM;
 }
 
-base::Transaction Goal::resolve(bool allow_erasing) {
+void Goal::set_allow_erasing(bool value) {
+    p_impl->allow_erasing = value;
+}
+
+bool Goal::get_allow_erasing() const {
+    return p_impl->allow_erasing;
+}
+
+base::Transaction Goal::resolve() {
     p_impl->rpm_goal = rpm::solv::GoalPrivate(p_impl->base);
 
     auto sack = p_impl->base->get_rpm_package_sack();
@@ -1153,7 +1162,7 @@ base::Transaction Goal::resolve(bool allow_erasing) {
     auto & cfg_main = p_impl->base->get_config();
     // Set goal flags
     p_impl->rpm_goal.set_allow_vendor_change(cfg_main.allow_vendor_change().get_value());
-    p_impl->rpm_goal.set_allow_erasing(allow_erasing);
+    p_impl->rpm_goal.set_allow_erasing(p_impl->allow_erasing);
     p_impl->rpm_goal.set_install_weak_deps(cfg_main.install_weak_deps().get_value());
 
     if (cfg_main.protect_running_kernel().get_value()) {

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -55,7 +55,7 @@ void BaseGoalTest::test_install() {
 
     libdnf::Goal goal(base);
     goal.add_rpm_install("pkg");
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
         get_pkg("pkg-0:1.2-3.x86_64"),
@@ -73,7 +73,7 @@ void BaseGoalTest::test_install_not_available() {
     base.get_config().best().set(libdnf::Option::Priority::RUNTIME, true);
     base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
     goal.add_rpm_install("not_available");
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
@@ -97,7 +97,7 @@ void BaseGoalTest::test_install_from_cmdline() {
     libdnf::Goal goal(base);
     goal.add_rpm_install(cmdline_pkg);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
         get_pkg("one-0:1-1.noarch", "@commandline"),
@@ -114,7 +114,7 @@ void BaseGoalTest::test_install_multilib_all() {
     libdnf::Goal goal(base);
     goal.add_rpm_install("multilib");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -137,7 +137,7 @@ void BaseGoalTest::test_reinstall() {
     libdnf::Goal goal(base);
     goal.add_rpm_reinstall("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -162,7 +162,7 @@ void BaseGoalTest::test_reinstall_from_cmdline() {
     libdnf::Goal goal(base);
     goal.add_rpm_reinstall(cmdline_pkg);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -185,7 +185,7 @@ void BaseGoalTest::test_reinstall_user() {
     libdnf::Goal goal(base);
     goal.add_rpm_reinstall("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -207,7 +207,7 @@ void BaseGoalTest::test_remove() {
 
     libdnf::Goal goal(base);
     goal.add_rpm_remove("one");
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
         get_pkg("one-0:1-1.noarch", true),
@@ -222,7 +222,7 @@ void BaseGoalTest::test_remove_not_installed() {
 
     libdnf::Goal goal(base);
     goal.add_rpm_remove("not_installed");
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
@@ -252,7 +252,7 @@ void BaseGoalTest::test_install_installed_pkg() {
     libdnf::Goal goal(base);
     goal.add_rpm_install(query);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 }
@@ -266,7 +266,7 @@ void BaseGoalTest::test_upgrade() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -293,7 +293,7 @@ void BaseGoalTest::test_upgrade_from_cmdline() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade(cmdline_pkg);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -322,7 +322,7 @@ void BaseGoalTest::test_upgrade_not_downgrade_from_cmdline() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade(cmdline_pkg);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
@@ -347,7 +347,7 @@ void BaseGoalTest::test_upgrade_not_available() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade("not_available");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
@@ -372,7 +372,7 @@ void BaseGoalTest::test_upgrade_all() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade();
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -397,7 +397,7 @@ void BaseGoalTest::test_upgrade_user() {
     libdnf::Goal goal(base);
     goal.add_rpm_upgrade("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -422,7 +422,7 @@ void BaseGoalTest::test_downgrade() {
     libdnf::Goal goal(base);
     goal.add_rpm_downgrade("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -449,7 +449,7 @@ void BaseGoalTest::test_downgrade_from_cmdline() {
     libdnf::Goal goal(base);
     goal.add_rpm_downgrade(cmdline_pkg);
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -474,7 +474,7 @@ void BaseGoalTest::test_downgrade_user() {
     libdnf::Goal goal(base);
     goal.add_rpm_downgrade("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -499,7 +499,7 @@ void BaseGoalTest::test_distrosync() {
     libdnf::Goal goal(base);
     goal.add_rpm_distro_sync("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -524,7 +524,7 @@ void BaseGoalTest::test_distrosync_all() {
     libdnf::Goal goal(base);
     goal.add_rpm_distro_sync();
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
@@ -550,7 +550,7 @@ void BaseGoalTest::test_install_or_reinstall() {
     query.filter_nevra({"one-0:1-1.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -82,7 +82,7 @@ void RpmTransactionTest::test_transaction() {
 
     goal.add_rpm_install("one");
 
-    auto transaction = goal.resolve(false);
+    auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
         get_pkg("one-0:2-1.noarch"),

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -14,7 +14,7 @@ goal.add_rpm_install("one");
 //
 // The argument is `allow_erasing`, a flag indicating wheter to allow removing
 // packages in the resolved transaction.
-auto transaction = goal.resolve(false);
+auto transaction = goal.resolve();
 
 // We can iterate over the resolved transction and inspect the packages.
 std::cout << "Resolved transaction:" << std::endl;


### PR DESCRIPTION
It is more transparent to have a setter then a bool argument for resolve. The setter does not accept the value because it prevents unwanted reset of already set value.