### PR TITLE
dnf5: Add option "--allowerasing"

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -40,6 +40,8 @@ void DistroSyncCommand::set_argument_parser() {
         patterns_to_distro_sync_options);
     patterns_arg->set_description("Patterns");
     cmd.register_positional_arg(patterns_arg);
+
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
 }
 
 void DistroSyncCommand::configure() {
@@ -50,6 +52,7 @@ void DistroSyncCommand::configure() {
 
 void DistroSyncCommand::run() {
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
     if (patterns_to_distro_sync_options->empty()) {
         goal->add_rpm_distro_sync();
     } else {

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -40,6 +40,8 @@ void DowngradeCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, true, false); });
     cmd.register_positional_arg(keys);
+
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
 }
 
 void DowngradeCommand::configure() {
@@ -54,6 +56,7 @@ void DowngradeCommand::load_additional_packages() {
 
 void DowngradeCommand::run() {
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
     for (const auto & pkg : cmdline_packages) {
         goal->add_rpm_downgrade(pkg);
     }

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 #define DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 
+#include "../shared_options.hpp"
+
 #include <dnf5/context.hpp>
 
 #include <memory>
@@ -42,6 +44,8 @@ private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 };
 
 

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -40,6 +40,8 @@ void InstallCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, false, true, true, false); });
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
+
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);
     advisory_bugfix = std::make_unique<BugfixOption>(*this);
@@ -75,6 +77,7 @@ void InstallCommand::load_additional_packages() {
 void InstallCommand::run() {
     auto & ctx = get_context();
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf::GoalJobSettings();
     auto advisories = advisory_query_from_cli_input(
         ctx.base,

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_INSTALL_INSTALL_HPP
 
 #include "../advisory_shared.hpp"
+#include "../shared_options.hpp"
 
 #include <dnf5/context.hpp>
 #include <libdnf/rpm/package.hpp>
@@ -42,6 +43,8 @@ private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 
     std::unique_ptr<AdvisoryOption> advisory_name;
     std::unique_ptr<SecurityOption> advisory_security;

--- a/dnf5/commands/shared_options.hpp
+++ b/dnf5/commands/shared_options.hpp
@@ -17,36 +17,22 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#ifndef DNF5_COMMANDS_SHARED_OPTIONS_HPP
+#define DNF5_COMMANDS_SHARED_OPTIONS_HPP
 
-#ifndef DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
-#define DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
+#include "utils/bgettext/bgettext-lib.h"
 
-#include "../shared_options.hpp"
-
-#include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
-
-#include <memory>
-#include <vector>
-
+#include <libdnf-cli/session.hpp>
 
 namespace dnf5 {
 
-
-class DistroSyncCommand : public Command {
+class AllowErasingOption : public libdnf::cli::session::BoolOption {
 public:
-    explicit DistroSyncCommand(Command & parent) : Command(parent, "distro-sync") {}
-    void set_argument_parser() override;
-    void configure() override;
-    void run() override;
-
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_distro_sync_options{nullptr};
-
-    std::unique_ptr<AllowErasingOption> allow_erasing;
+    explicit AllowErasingOption(libdnf::cli::session::Command & command)
+        : BoolOption(
+              command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
 };
-
 
 }  // namespace dnf5
 
-
-#endif  // DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
+#endif  // DNF5_COMMANDS_SHARED_OPTIONS_HPP

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -55,6 +55,8 @@ void SwapCommand::set_argument_parser() {
     install_spec_arg->set_complete_hook_func(
         [&ctx](const char * arg) { return match_specs(ctx, arg, false, true, true, false); });
     cmd.register_positional_arg(install_spec_arg);
+
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
 }
 
 void SwapCommand::configure() {
@@ -69,6 +71,7 @@ void SwapCommand::load_additional_packages() {
 
 void SwapCommand::run() {
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
     for (const auto & pkg : cmdline_packages) {
         goal->add_rpm_install(pkg);
     }

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_SWAP_SWAP_HPP
 #define DNF5_COMMANDS_SWAP_SWAP_HPP
 
+#include "../shared_options.hpp"
+
 #include <dnf5/context.hpp>
 
 #include <vector>
@@ -41,6 +43,8 @@ private:
     std::vector<std::string> install_pkg_specs;
     std::vector<std::string> install_pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -51,6 +51,8 @@ void UpgradeCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, true, false); });
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
+
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);
     advisory_bugfix = std::make_unique<BugfixOption>(*this);
@@ -85,6 +87,7 @@ void UpgradeCommand::load_additional_packages() {
 void UpgradeCommand::run() {
     auto & ctx = get_context();
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
 
     auto settings = libdnf::GoalJobSettings();
 

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 
 #include "../advisory_shared.hpp"
+#include "../shared_options.hpp"
 
 #include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
@@ -43,6 +44,8 @@ protected:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 
     std::unique_ptr<AdvisoryOption> advisory_name;
     std::unique_ptr<SecurityOption> advisory_security;


### PR DESCRIPTION
The option was added to commands for which it makes sense.
This was a global option in dnf4, though it was ignored for many commands.