### PR TITLE
dnf5: Create MemoryBufferLogger before Context 

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -170,7 +170,9 @@ std::chrono::time_point<std::chrono::steady_clock> ProgressAndKeyImportRepoCB::p
 
 }  // namespace
 
-Context::Context() : plugins(std::make_unique<Plugins>(*this)) {}
+Context::Context(std::vector<std::unique_ptr<libdnf::Logger>> && loggers)
+    : base(std::move(loggers)),
+      plugins(std::make_unique<Plugins>(*this)) {}
 
 Context::~Context() {
     // "Session", which is the parent of "Context", owns objects from dnf5 plugins (command arguments).

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -46,7 +46,9 @@ public:
     enum class LoadAvailableRepos { NONE, ENABLED, ALL };
     enum class ImportRepoKeys { KEY_IMPORTED, IMPORT_FAILED, NO_KEYS, ALREADY_PRESENT };
 
-    Context();
+    /// Constructs a new Context instance and sets the destination loggers.
+    Context(std::vector<std::unique_ptr<libdnf::Logger>> && loggers = {});
+
     ~Context();
 
     void apply_repository_setopts();

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -47,7 +47,7 @@ public:
     enum class ImportRepoKeys { KEY_IMPORTED, IMPORT_FAILED, NO_KEYS, ALREADY_PRESENT };
 
     /// Constructs a new Context instance and sets the destination loggers.
-    Context(std::vector<std::unique_ptr<libdnf::Logger>> && loggers = {});
+    Context(std::vector<std::unique_ptr<libdnf::Logger>> && loggers);
 
     ~Context();
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -495,17 +495,20 @@ void RootCommand::register_subcommands() {
 }  // namespace dnf5
 
 int main(int argc, char * argv[]) try {
-    dnf5::Context context;
+    // Creates a vector of loggers with one circular memory buffer logger
+    std::vector<std::unique_ptr<libdnf::Logger>> loggers;
+    const std::size_t max_log_items_to_keep = 10000;
+    const std::size_t prealloc_log_items = 256;
+    loggers.emplace_back(std::make_unique<libdnf::MemoryBufferLogger>(max_log_items_to_keep, prealloc_log_items));
+
+    loggers.front()->info("DNF5 start");
+
+    // Creates a context and passes the loggers to it. We want to capture all messages from the context in the log.
+    dnf5::Context context(std::move(loggers));
+
     libdnf::Base & base = context.base;
 
     auto & log_router = *base.get_logger();
-
-    // Add circular memory buffer logger
-    const std::size_t max_log_items_to_keep = 10000;
-    const std::size_t prealloc_log_items = 256;
-    log_router.add_logger(std::make_unique<libdnf::MemoryBufferLogger>(max_log_items_to_keep, prealloc_log_items));
-
-    log_router.info("DNF5 start");
 
     context.set_prg_arguments(static_cast<size_t>(argc), argv);
 

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -51,6 +51,7 @@ protected:
 class Session {
 public:
     Session(
+        std::vector<std::unique_ptr<libdnf::Logger>> && loggers,
         sdbus::IConnection & connection,
         dnfdaemon::KeyValueMap session_configuration,
         std::string object_path,

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -54,7 +54,9 @@ solv::Pool & get_pool(const libdnf::BaseWeakPtr & base);
 /// :class:`.Base` instances are stateful objects owning various data.
 class Base {
 public:
-    Base();
+    /// Constructs a new Base instance and sets the destination loggers.
+    Base(std::vector<std::unique_ptr<Logger>> && loggers = {});
+
     ~Base();
 
     /// Sets the pointer to the locked instance "Base" to "this" instance. Blocks if the pointer is already set.
@@ -128,9 +130,9 @@ private:
     /// The files in the directory are read in alphabetical order.
     void load_config_from_dir();
 
+    LogRouter log_router;
     std::unique_ptr<solv::Pool> pool;
     ConfigMain config;
-    LogRouter log_router;
     repo::RepoSack repo_sack;
     rpm::PackageSack rpm_package_sack;
     comps::Comps comps{*this};

--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -32,6 +32,12 @@ namespace libdnf {
 /// Loggers can be addressed via index. Index is serial number of the logger starting from zero.
 class LogRouter : public Logger {
 public:
+    /// Constructs a new LogRouter instance with an empty set of destination loggers.
+    LogRouter() = default;
+
+    /// Constructs a new LogRouter instance and sets the destination loggers.
+    LogRouter(std::vector<std::unique_ptr<Logger>> && loggers) : loggers(std::move(loggers)) {}
+
     /// Moves (registers) the "logger" into the log router. It gets next free index number.
     void add_logger(std::unique_ptr<Logger> && logger) { loggers.push_back(std::move(logger)); }
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -39,8 +39,9 @@ namespace libdnf {
 static std::atomic<Base *> locked_base{nullptr};
 static std::mutex locked_base_mutex;
 
-Base::Base()
-    : repo_sack(get_weak_ptr()),
+Base::Base(std::vector<std::unique_ptr<Logger>> && loggers)
+    : log_router(std::move(loggers)),
+      repo_sack(get_weak_ptr()),
       rpm_package_sack(get_weak_ptr()),
       transaction_history(get_weak_ptr()),
       vars(get_weak_ptr()),


### PR DESCRIPTION
We want to capture all messages from the context in the log.