### PR TITLE
libdnf/utils/locker: Add support for read/write locking

### DIFF
--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -356,7 +356,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
     std::filesystem::create_directories(lock_file_path.parent_path());
 
     libdnf::utils::Locker locker(lock_file_path);
-    if (!locker.lock()) {
+    if (!locker.write_lock()) {
         return TransactionRunResult::ERROR_LOCK;
     }
 

--- a/libdnf/utils/locker.cpp
+++ b/libdnf/utils/locker.cpp
@@ -30,7 +30,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::utils {
 
-bool Locker::lock() {
+bool Locker::read_lock() {
+    return lock(F_RDLCK);
+}
+
+bool Locker::write_lock() {
+    return lock(F_WRLCK);
+}
+
+bool Locker::lock(short int type) {
     lock_fd = open(path.c_str(), O_CREAT | O_RDWR, 0660);
     if (lock_fd == -1) {
         throw SystemError(errno, M_("Failed to open lock file \"{}\""), path);
@@ -38,7 +46,7 @@ bool Locker::lock() {
 
     struct flock fl;
     memset(&fl, 0, sizeof(fl));
-    fl.l_type = F_WRLCK;
+    fl.l_type = type;
     fl.l_whence = SEEK_SET;
     fl.l_start = 0;
     fl.l_len = 0;

--- a/libdnf/utils/locker.hpp
+++ b/libdnf/utils/locker.hpp
@@ -28,10 +28,13 @@ class Locker {
 public:
     explicit Locker(const std::string & path) : path(path){};
     ~Locker();
-    bool lock();
+    bool read_lock();
+    bool write_lock();
     void unlock();
 
 private:
+    bool lock(short int type);
+
     std::string path;
     int lock_fd{-1};
 };


### PR DESCRIPTION
Just a small commit that adds read/write locking support to the `Locker` class I did in preparation for locking the system state.