### PR TITLE
Base: Hide "pool" from public

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -34,8 +34,6 @@
 %template(BaseWeakPtr) libdnf::WeakPtr<libdnf::Base, false>;
 %template(VarsWeakPtr) libdnf::WeakPtr<libdnf::Vars, false>;
 
-%ignore libdnf::get_pool;
-
 %include "libdnf/base/base.hpp"
 %ignore libdnf::base::TransactionError;
 %include "libdnf/base/transaction.hpp"

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -41,13 +41,7 @@ namespace libdnf {
 using LogRouterWeakPtr = WeakPtr<LogRouter, false>;
 using VarsWeakPtr = WeakPtr<Vars, false>;
 
-namespace solv {
-
-class Pool;
-
-}
-
-solv::Pool & get_pool(const libdnf::BaseWeakPtr & base);
+class InternalBaseUser;
 
 /// Instances of :class:`libdnf::Base` are the central point of functionality supplied by libdnf.
 /// An application will typically create a single instance of this class which it will keep for the run-time needed to accomplish its packaging tasks.
@@ -106,7 +100,7 @@ public:
     class Impl;
 
 private:
-    friend solv::Pool & get_pool(const libdnf::BaseWeakPtr & base);
+    friend class libdnf::InternalBaseUser;
     friend class libdnf::base::Transaction;
     friend class libdnf::rpm::Package;
     friend class libdnf::advisory::AdvisoryQuery;

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -131,7 +131,6 @@ private:
     void load_config_from_dir();
 
     LogRouter log_router;
-    std::unique_ptr<solv::Pool> pool;
     ConfigMain config;
     repo::RepoSack repo_sack;
     rpm::PackageSack rpm_package_sack;

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -131,6 +131,7 @@ void Base::load_plugins() {
 }
 
 void Base::setup() {
+    auto & pool = p_impl->pool;
     libdnf_assert(!pool, "Base was already initialized");
 
     load_plugins();

--- a/libdnf/base/base_impl.hpp
+++ b/libdnf/base/base_impl.hpp
@@ -37,9 +37,16 @@ public:
     libdnf::system::State & get_system_state() { return *system_state; }
     libdnf::advisory::AdvisorySackWeakPtr get_rpm_advisory_sack() { return rpm_advisory_sack.get_weak_ptr(); }
 
+    solv::Pool & get_pool() {
+        libdnf_assert(pool, "Base instance was not fully initialized by Base::setup()");
+        return *pool;
+    }
+
 private:
     friend class Base;
     Impl(const libdnf::BaseWeakPtr & base);
+
+    std::unique_ptr<solv::Pool> pool;
 
     std::optional<libdnf::system::State> system_state;
     libdnf::advisory::AdvisorySack rpm_advisory_sack;

--- a/libdnf/base/base_impl.hpp
+++ b/libdnf/base/base_impl.hpp
@@ -29,6 +29,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+namespace solv {
+
+class Pool;
+
+}
 
 class Base::Impl {
 public:
@@ -52,6 +57,11 @@ private:
     libdnf::advisory::AdvisorySack rpm_advisory_sack;
 };
 
+
+class InternalBaseUser {
+public:
+    static solv::Pool & get_pool(const libdnf::BaseWeakPtr & base) { return base->p_impl->get_pool(); }
+};
 
 }  // namespace libdnf
 

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -245,8 +245,8 @@ private:
 
 namespace libdnf {
 
-inline solv::Pool & get_pool(const libdnf::BaseWeakPtr & base) {
-    return base->p_impl->get_pool();
+static inline solv::Pool & get_pool(const libdnf::BaseWeakPtr & base) {
+    return InternalBaseUser::get_pool(base);
 }
 
 }  // namespace libdnf

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -20,9 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_SOLV_POOL_HPP
 #define LIBDNF_SOLV_POOL_HPP
 
+#include "base/base_impl.hpp"
 #include "id_queue.hpp"
 
-#include "libdnf/base/base.hpp"
 #include "libdnf/repo/repo.hpp"
 
 #include <climits>
@@ -246,8 +246,7 @@ private:
 namespace libdnf {
 
 inline solv::Pool & get_pool(const libdnf::BaseWeakPtr & base) {
-    libdnf_assert(base->pool, "Base instance was not fully initialized by Base::setup()");
-    return *base->pool;
+    return base->p_impl->get_pool();
 }
 
 }  // namespace libdnf


### PR DESCRIPTION
The "get_pool(const libdnf::BaseWeakPtr & base)" function is only intended for internal use within the libdnf library. That's why the Base class didn't have a public "get_pool()" method. Which didn't solve anything. The "get_pool" is still on the public API, only it is not a method of the Base class, but a function in the "libdnf" namespace. And disallowing the export of this function for other languages in SWIG is just a crutch. It does not address the C++ API.

This PR moves "pool" to p_impl and removes the "get_pool" function from the public API.