### PR TITLE
Fix rpmlint dbus-policy-allow-without-destination errors

### DIFF
--- a/dnf5daemon-server/dbus/org.rpm.dnf.v0.conf
+++ b/dnf5daemon-server/dbus/org.rpm.dnf.v0.conf
@@ -3,12 +3,9 @@
 <busconfig>
   <policy user="root">
     <allow own="org.rpm.dnf.v0"/>
-    <allow send_destination="org.rpm.dnf.v0"/>
-    <allow send_interface="org.rpm.dnf.v0"/>
   </policy>
   <policy context="default">
     <allow send_destination="org.rpm.dnf.v0"/>
-    <allow send_interface="org.rpm.dnf.v0"/>
   </policy>
 </busconfig>
 


### PR DESCRIPTION
Let's use simple best-practice policy file from dbus documentation.