### PR TITLE
 cli::session::Command: Added "group_id", group to which command registers

### DIFF
--- a/dnf5/commands/advisory/advisory.cpp
+++ b/dnf5/commands/advisory/advisory.cpp
@@ -33,9 +33,9 @@ void AdvisoryCommand::register_subcommands() {
     auto * query_commands_advisory = get_context().get_argument_parser().add_new_group("advisory_query_commands");
     query_commands_advisory->set_header("Query Commands:");
     get_argument_parser_command()->register_group(query_commands_advisory);
-    register_subcommand(std::make_unique<AdvisoryListCommand>(*this), query_commands_advisory);
-    register_subcommand(std::make_unique<AdvisoryInfoCommand>(*this), query_commands_advisory);
-    register_subcommand(std::make_unique<AdvisorySummaryCommand>(*this), query_commands_advisory);
+    register_subcommand(std::make_unique<AdvisoryListCommand>(*this));
+    register_subcommand(std::make_unique<AdvisoryInfoCommand>(*this));
+    register_subcommand(std::make_unique<AdvisorySummaryCommand>(*this));
 }
 
 void AdvisoryCommand::pre_configure() {

--- a/dnf5/commands/advisory/advisory.hpp
+++ b/dnf5/commands/advisory/advisory.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class AdvisoryCommand : public Command {
 public:
-    explicit AdvisoryCommand(Command & parent) : Command(parent, "advisory") {}
+    explicit AdvisoryCommand(Command & parent) : Command(parent, "advisory", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class AdvisoryInfoCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisoryInfoCommand(Command & parent) : AdvisorySubCommand(parent, "info") {}
+    explicit AdvisoryInfoCommand(Command & parent) : AdvisorySubCommand(parent, "info", "advisory_query_commands") {}
 
     void set_argument_parser() override {
         AdvisorySubCommand::set_argument_parser();

--- a/dnf5/commands/advisory/advisory_list.hpp
+++ b/dnf5/commands/advisory/advisory_list.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class AdvisoryListCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisoryListCommand(Command & parent) : AdvisorySubCommand(parent, "list") {}
+    explicit AdvisoryListCommand(Command & parent) : AdvisorySubCommand(parent, "list", "advisory_query_commands") {}
 
     void set_argument_parser() override {
         AdvisorySubCommand::set_argument_parser();

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -51,7 +51,7 @@ protected:
     std::unique_ptr<AdvisoryWithBzOption> with_bz{nullptr};
     std::unique_ptr<AdvisoryWithCveOption> with_cve{nullptr};
 
-    AdvisorySubCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    using Command::Command;
 
 protected:
     std::unique_ptr<SecurityOption> advisory_security{nullptr};

--- a/dnf5/commands/advisory/advisory_summary.hpp
+++ b/dnf5/commands/advisory/advisory_summary.hpp
@@ -26,7 +26,8 @@ namespace dnf5 {
 
 class AdvisorySummaryCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisorySummaryCommand(Command & parent) : AdvisorySubCommand(parent, "summary") {}
+    explicit AdvisorySummaryCommand(Command & parent)
+        : AdvisorySubCommand(parent, "summary", "advisory_query_commands") {}
 
     void set_argument_parser() override {
         AdvisorySubCommand::set_argument_parser();

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -35,7 +35,7 @@ namespace dnf5 {
 
 class DistroSyncCommand : public Command {
 public:
-    explicit DistroSyncCommand(Command & parent) : Command(parent, "distro-sync") {}
+    explicit DistroSyncCommand(Command & parent) : Command(parent, "distro-sync", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -34,7 +34,7 @@ namespace dnf5 {
 
 class DowngradeCommand : public Command {
 public:
-    explicit DowngradeCommand(Command & parent) : Command(parent, "downgrade") {}
+    explicit DowngradeCommand(Command & parent) : Command(parent, "downgrade", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/environment/environment.cpp
+++ b/dnf5/commands/environment/environment.cpp
@@ -32,8 +32,8 @@ void EnvironmentCommand::register_subcommands() {
     auto * query_commands_environment = get_context().get_argument_parser().add_new_group("environment_query_commands");
     query_commands_environment->set_header("Query Commands:");
     get_argument_parser_command()->register_group(query_commands_environment);
-    register_subcommand(std::make_unique<EnvironmentListCommand>(*this), query_commands_environment);
-    register_subcommand(std::make_unique<EnvironmentInfoCommand>(*this), query_commands_environment);
+    register_subcommand(std::make_unique<EnvironmentListCommand>(*this));
+    register_subcommand(std::make_unique<EnvironmentInfoCommand>(*this));
 }
 
 void EnvironmentCommand::pre_configure() {

--- a/dnf5/commands/environment/environment.hpp
+++ b/dnf5/commands/environment/environment.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class EnvironmentCommand : public Command {
 public:
-    explicit EnvironmentCommand(Command & parent) : Command(parent, "environment") {}
+    explicit EnvironmentCommand(Command & parent) : Command(parent, "environment", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/environment/environment_info.hpp
+++ b/dnf5/commands/environment/environment_info.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class EnvironmentInfoCommand : public Command {
 public:
-    explicit EnvironmentInfoCommand(Command & parent) : Command(parent, "info") {}
+    explicit EnvironmentInfoCommand(Command & parent) : Command(parent, "info", "environment_query_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/environment/environment_list.hpp
+++ b/dnf5/commands/environment/environment_list.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class EnvironmentListCommand : public Command {
 public:
-    explicit EnvironmentListCommand(Command & parent) : Command(parent, "list") {}
+    explicit EnvironmentListCommand(Command & parent) : Command(parent, "list", "environment_query_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -34,14 +34,14 @@ void GroupCommand::register_subcommands() {
     auto * query_commands_group = get_context().get_argument_parser().add_new_group("group_query_commands");
     query_commands_group->set_header("Query Commands:");
     get_argument_parser_command()->register_group(query_commands_group);
-    register_subcommand(std::make_unique<GroupListCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<GroupInfoCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<GroupListCommand>(*this));
+    register_subcommand(std::make_unique<GroupInfoCommand>(*this));
     // software management commands
     auto * software_management_commands_group =
-        get_context().get_argument_parser().add_new_group("module_software_management_commands");
+        get_context().get_argument_parser().add_new_group("group_software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     get_argument_parser_command()->register_group(software_management_commands_group);
-    register_subcommand(std::make_unique<GroupInstallCommand>(*this), software_management_commands_group);
+    register_subcommand(std::make_unique<GroupInstallCommand>(*this));
 }
 
 void GroupCommand::pre_configure() {

--- a/dnf5/commands/group/group.hpp
+++ b/dnf5/commands/group/group.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class GroupCommand : public Command {
 public:
-    explicit GroupCommand(Command & parent) : Command(parent, "group") {}
+    explicit GroupCommand(Command & parent) : Command(parent, "group", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/group/group_info.hpp
+++ b/dnf5/commands/group/group_info.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class GroupInfoCommand : public Command {
 public:
-    explicit GroupInfoCommand(Command & parent) : Command(parent, "info") {}
+    explicit GroupInfoCommand(Command & parent) : Command(parent, "info", "group_query_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/group/group_install.hpp
+++ b/dnf5/commands/group/group_install.hpp
@@ -33,17 +33,13 @@ namespace dnf5 {
 
 class GroupInstallCommand : public Command {
 public:
-    explicit GroupInstallCommand(Command & parent) : GroupInstallCommand(parent, "install") {}
+    explicit GroupInstallCommand(Command & parent) : Command(parent, "install", "group_software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;
 
     std::unique_ptr<GroupWithOptionalOption> with_optional{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
-
-protected:
-    // to be used by an alias command only
-    explicit GroupInstallCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
 

--- a/dnf5/commands/group/group_list.hpp
+++ b/dnf5/commands/group/group_list.hpp
@@ -35,7 +35,7 @@ namespace dnf5 {
 
 class GroupListCommand : public Command {
 public:
-    explicit GroupListCommand(Command & parent) : Command(parent, "list") {}
+    explicit GroupListCommand(Command & parent) : Command(parent, "list", "group_query_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/history/history.cpp
+++ b/dnf5/commands/history/history.cpp
@@ -43,18 +43,18 @@ void HistoryCommand::register_subcommands() {
     auto * query_commands_group = parser.add_new_group("history_query_commands");
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
-    register_subcommand(std::make_unique<HistoryListCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<HistoryInfoCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<HistoryListCommand>(*this));
+    register_subcommand(std::make_unique<HistoryInfoCommand>(*this));
 
     // software management commands
     auto * software_management_commands_group = parser.add_new_group("history_software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     cmd.register_group(software_management_commands_group);
-    register_subcommand(std::make_unique<HistoryUndoCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<HistoryRedoCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<HistoryRollbackCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<HistoryStoreCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<HistoryReplayCommand>(*this), software_management_commands_group);
+    register_subcommand(std::make_unique<HistoryUndoCommand>(*this));
+    register_subcommand(std::make_unique<HistoryRedoCommand>(*this));
+    register_subcommand(std::make_unique<HistoryRollbackCommand>(*this));
+    register_subcommand(std::make_unique<HistoryStoreCommand>(*this));
+    register_subcommand(std::make_unique<HistoryReplayCommand>(*this));
 }
 
 void HistoryCommand::pre_configure() {

--- a/dnf5/commands/history/history.hpp
+++ b/dnf5/commands/history/history.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class HistoryCommand : public Command {
 public:
-    explicit HistoryCommand(Command & parent) : Command(parent, "history") {}
+    explicit HistoryCommand(Command & parent) : Command(parent, "history", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/history/history_info.hpp
+++ b/dnf5/commands/history/history_info.hpp
@@ -28,7 +28,7 @@ namespace dnf5 {
 
 class HistoryInfoCommand : public Command {
 public:
-    explicit HistoryInfoCommand(Command & parent) : Command(parent, "info") {}
+    explicit HistoryInfoCommand(Command & parent) : Command(parent, "info", "history_query_commands") {}
     void set_argument_parser() override;
     void run() override;
 

--- a/dnf5/commands/history/history_list.hpp
+++ b/dnf5/commands/history/history_list.hpp
@@ -31,7 +31,7 @@ namespace dnf5 {
 
 class HistoryListCommand : public Command {
 public:
-    explicit HistoryListCommand(Command & parent) : Command(parent, "list") {}
+    explicit HistoryListCommand(Command & parent) : Command(parent, "list", "history_query_commands") {}
     void set_argument_parser() override;
     void run() override;
 

--- a/dnf5/commands/history/history_redo.hpp
+++ b/dnf5/commands/history/history_redo.hpp
@@ -29,7 +29,7 @@ namespace dnf5 {
 
 class HistoryRedoCommand : public Command {
 public:
-    explicit HistoryRedoCommand(Command & parent) : Command(parent, "redo") {}
+    explicit HistoryRedoCommand(Command & parent) : Command(parent, "redo", "history_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/history/history_replay.hpp
+++ b/dnf5/commands/history/history_replay.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryReplayCommand : public Command {
 public:
-    explicit HistoryReplayCommand(Command & parent) : Command(parent, "replay") {}
+    explicit HistoryReplayCommand(Command & parent)
+        : Command(parent, "replay", "history_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/history/history_rollback.hpp
+++ b/dnf5/commands/history/history_rollback.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryRollbackCommand : public Command {
 public:
-    explicit HistoryRollbackCommand(Command & parent) : Command(parent, "rollback") {}
+    explicit HistoryRollbackCommand(Command & parent)
+        : Command(parent, "rollback", "history_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/history/history_store.hpp
+++ b/dnf5/commands/history/history_store.hpp
@@ -29,7 +29,7 @@ namespace dnf5 {
 
 class HistoryStoreCommand : public Command {
 public:
-    explicit HistoryStoreCommand(Command & parent) : Command(parent, "store") {}
+    explicit HistoryStoreCommand(Command & parent) : Command(parent, "store", "history_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/history/history_undo.hpp
+++ b/dnf5/commands/history/history_undo.hpp
@@ -29,7 +29,7 @@ namespace dnf5 {
 
 class HistoryUndoCommand : public Command {
 public:
-    explicit HistoryUndoCommand(Command & parent) : Command(parent, "undo") {}
+    explicit HistoryUndoCommand(Command & parent) : Command(parent, "undo", "history_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class InstallCommand : public Command {
 public:
-    explicit InstallCommand(Command & parent) : Command(parent, "install") {}
+    explicit InstallCommand(Command & parent) : Command(parent, "install", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/module/module.cpp
+++ b/dnf5/commands/module/module.cpp
@@ -44,25 +44,25 @@ void ModuleCommand::register_subcommands() {
     auto * query_commands_group = parser.add_new_group("module_query_commands");
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
-    register_subcommand(std::make_unique<ModuleListCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<ModuleInfoCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<ModuleProvidesCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<ModuleListCommand>(*this));
+    register_subcommand(std::make_unique<ModuleInfoCommand>(*this));
+    register_subcommand(std::make_unique<ModuleProvidesCommand>(*this));
 
     // stream management commands
     auto * stream_management_commands_group = parser.add_new_group("module_stream_management_commands");
     stream_management_commands_group->set_header("Stream Management Commands:");
     cmd.register_group(stream_management_commands_group);
-    register_subcommand(std::make_unique<ModuleEnableCommand>(*this), stream_management_commands_group);
-    register_subcommand(std::make_unique<ModuleSwitchToCommand>(*this), stream_management_commands_group);
-    register_subcommand(std::make_unique<ModuleResetCommand>(*this), stream_management_commands_group);
-    register_subcommand(std::make_unique<ModuleDisableCommand>(*this), stream_management_commands_group);
+    register_subcommand(std::make_unique<ModuleEnableCommand>(*this));
+    register_subcommand(std::make_unique<ModuleSwitchToCommand>(*this));
+    register_subcommand(std::make_unique<ModuleResetCommand>(*this));
+    register_subcommand(std::make_unique<ModuleDisableCommand>(*this));
 
     // software management commands
     auto * software_management_commands_group = parser.add_new_group("module_software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     cmd.register_group(software_management_commands_group);
-    register_subcommand(std::make_unique<ModuleInstallCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<ModuleRemoveCommand>(*this), software_management_commands_group);
+    register_subcommand(std::make_unique<ModuleInstallCommand>(*this));
+    register_subcommand(std::make_unique<ModuleRemoveCommand>(*this));
 }
 
 void ModuleCommand::pre_configure() {

--- a/dnf5/commands/module/module.hpp
+++ b/dnf5/commands/module/module.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleCommand : public Command {
 public:
-    explicit ModuleCommand(Command & parent) : Command(parent, "module") {}
+    explicit ModuleCommand(Command & parent) : Command(parent, "module", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/module/module_disable.hpp
+++ b/dnf5/commands/module/module_disable.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleDisableCommand : public Command {
 public:
-    explicit ModuleDisableCommand(Command & parent) : Command(parent, "disable") {}
+    explicit ModuleDisableCommand(Command & parent) : Command(parent, "disable", "module_stream_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_enable.hpp
+++ b/dnf5/commands/module/module_enable.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleEnableCommand : public Command {
 public:
-    explicit ModuleEnableCommand(Command & parent) : Command(parent, "enable") {}
+    explicit ModuleEnableCommand(Command & parent) : Command(parent, "enable", "module_stream_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_info.hpp
+++ b/dnf5/commands/module/module_info.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleInfoCommand : public Command {
 public:
-    explicit ModuleInfoCommand(Command & parent) : Command(parent, "info") {}
+    explicit ModuleInfoCommand(Command & parent) : Command(parent, "info", "module_query_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_install.hpp
+++ b/dnf5/commands/module/module_install.hpp
@@ -26,7 +26,8 @@ namespace dnf5 {
 
 class ModuleInstallCommand : public Command {
 public:
-    explicit ModuleInstallCommand(Command & parent) : Command(parent, "install") {}
+    explicit ModuleInstallCommand(Command & parent)
+        : Command(parent, "install", "module_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_list.hpp
+++ b/dnf5/commands/module/module_list.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleListCommand : public Command {
 public:
-    explicit ModuleListCommand(Command & parent) : Command(parent, "list") {}
+    explicit ModuleListCommand(Command & parent) : Command(parent, "list", "module_query_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_provides.hpp
+++ b/dnf5/commands/module/module_provides.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleProvidesCommand : public Command {
 public:
-    explicit ModuleProvidesCommand(Command & parent) : Command(parent, "provides") {}
+    explicit ModuleProvidesCommand(Command & parent) : Command(parent, "provides", "module_query_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_remove.hpp
+++ b/dnf5/commands/module/module_remove.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleRemoveCommand : public Command {
 public:
-    explicit ModuleRemoveCommand(Command & parent) : Command(parent, "remove") {}
+    explicit ModuleRemoveCommand(Command & parent) : Command(parent, "remove", "module_software_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_reset.hpp
+++ b/dnf5/commands/module/module_reset.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class ModuleResetCommand : public Command {
 public:
-    explicit ModuleResetCommand(Command & parent) : Command(parent, "reset") {}
+    explicit ModuleResetCommand(Command & parent) : Command(parent, "reset", "module_stream_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/module/module_switch_to.hpp
+++ b/dnf5/commands/module/module_switch_to.hpp
@@ -26,7 +26,8 @@ namespace dnf5 {
 
 class ModuleSwitchToCommand : public Command {
 public:
-    explicit ModuleSwitchToCommand(Command & parent) : Command(parent, "switch-to") {}
+    explicit ModuleSwitchToCommand(Command & parent)
+        : Command(parent, "switch-to", "module_stream_management_commands") {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -32,7 +32,7 @@ namespace dnf5 {
 
 class ReinstallCommand : public Command {
 public:
-    explicit ReinstallCommand(Command & parent) : Command(parent, "reinstall") {}
+    explicit ReinstallCommand(Command & parent) : Command(parent, "reinstall", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class RemoveCommand : public Command {
 public:
-    explicit RemoveCommand(Command & parent) : Command(parent, "remove") {}
+    explicit RemoveCommand(Command & parent) : Command(parent, "remove", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -33,8 +33,8 @@ void RepoCommand::register_subcommands() {
     auto * query_commands_group = get_context().get_argument_parser().add_new_group("repo_query_commands");
     query_commands_group->set_header("Query Commands:");
     get_argument_parser_command()->register_group(query_commands_group);
-    register_subcommand(std::make_unique<RepoListCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<RepoInfoCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<RepoListCommand>(*this));
+    register_subcommand(std::make_unique<RepoInfoCommand>(*this));
 }
 
 void RepoCommand::pre_configure() {

--- a/dnf5/commands/repo/repo.hpp
+++ b/dnf5/commands/repo/repo.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class RepoCommand : public Command {
 public:
-    explicit RepoCommand(Command & parent) : Command(parent, "repo") {}
+    explicit RepoCommand(Command & parent) : Command(parent, "repo", "subcommands") {}
     void set_argument_parser() override;
     void register_subcommands() override;
     void pre_configure() override;

--- a/dnf5/commands/repo/repo_list.hpp
+++ b/dnf5/commands/repo/repo_list.hpp
@@ -39,7 +39,8 @@ public:
 
 protected:
     // for RepoInfoCommand
-    explicit RepoListCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    explicit RepoListCommand(Command & parent, const std::string & name)
+        : Command(parent, name, "repo_query_commands") {}
 
     virtual void print(const libdnf::repo::RepoQuery & query, bool with_status);
 };

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -35,7 +35,7 @@ namespace dnf5 {
 
 class RepoqueryCommand : public Command {
 public:
-    explicit RepoqueryCommand(Command & parent) : Command(parent, "repoquery") {}
+    explicit RepoqueryCommand(Command & parent) : Command(parent, "repoquery", "query_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class SearchCommand : public Command {
 public:
-    explicit SearchCommand(Command & parent) : Command(parent, "search") {}
+    explicit SearchCommand(Command & parent) : Command(parent, "search", "query_commands") {}
     void set_argument_parser() override;
     void run() override;
 

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -32,7 +32,7 @@ namespace dnf5 {
 //               which will allow multiple actions to be combined in one transaction.
 class SwapCommand : public Command {
 public:
-    explicit SwapCommand(Command & parent) : Command(parent, "swap") {}
+    explicit SwapCommand(Command & parent) : Command(parent, "swap", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class UpgradeCommand : public Command {
 public:
-    explicit UpgradeCommand(Command & parent) : Command(parent, "upgrade") {}
+    explicit UpgradeCommand(Command & parent) : Command(parent, "upgrade", "software_management_commands") {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -447,30 +447,30 @@ void RootCommand::register_subcommands() {
         context.get_argument_parser().add_new_group("software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     cmd.register_group(software_management_commands_group);
-    register_subcommand(std::make_unique<InstallCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<UpgradeCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<RemoveCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<DistroSyncCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<DowngradeCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<ReinstallCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<SwapCommand>(*this), software_management_commands_group);
+    register_subcommand(std::make_unique<InstallCommand>(*this));
+    register_subcommand(std::make_unique<UpgradeCommand>(*this));
+    register_subcommand(std::make_unique<RemoveCommand>(*this));
+    register_subcommand(std::make_unique<DistroSyncCommand>(*this));
+    register_subcommand(std::make_unique<DowngradeCommand>(*this));
+    register_subcommand(std::make_unique<ReinstallCommand>(*this));
+    register_subcommand(std::make_unique<SwapCommand>(*this));
 
     // query commands
     auto * query_commands_group = context.get_argument_parser().add_new_group("query_commands");
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
-    register_subcommand(std::make_unique<RepoqueryCommand>(*this), query_commands_group);
-    register_subcommand(std::make_unique<SearchCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<RepoqueryCommand>(*this));
+    register_subcommand(std::make_unique<SearchCommand>(*this));
 
     auto * subcommands_group = context.get_argument_parser().add_new_group("subcommands");
     subcommands_group->set_header("Subcommands:");
     cmd.register_group(subcommands_group);
-    register_subcommand(std::make_unique<GroupCommand>(*this), subcommands_group);
-    register_subcommand(std::make_unique<EnvironmentCommand>(*this), subcommands_group);
-    register_subcommand(std::make_unique<ModuleCommand>(*this), subcommands_group);
-    register_subcommand(std::make_unique<HistoryCommand>(*this), subcommands_group);
-    register_subcommand(std::make_unique<RepoCommand>(*this), subcommands_group);
-    register_subcommand(std::make_unique<AdvisoryCommand>(*this), subcommands_group);
+    register_subcommand(std::make_unique<GroupCommand>(*this));
+    register_subcommand(std::make_unique<EnvironmentCommand>(*this));
+    register_subcommand(std::make_unique<ModuleCommand>(*this));
+    register_subcommand(std::make_unique<HistoryCommand>(*this));
+    register_subcommand(std::make_unique<RepoCommand>(*this));
+    register_subcommand(std::make_unique<AdvisoryCommand>(*this));
 
     register_subcommand(std::make_unique<CleanCommand>(*this));
     register_subcommand(std::make_unique<DownloadCommand>(*this));

--- a/dnf5daemon-client/commands/command.hpp
+++ b/dnf5daemon-client/commands/command.hpp
@@ -28,7 +28,8 @@ namespace dnfdaemon::client {
 
 class DaemonCommand : public libdnf::cli::session::Command {
 public:
-    explicit DaemonCommand(Command & parent, const std::string & name) : Command(parent, name){};
+    explicit DaemonCommand(Command & parent, const std::string & name, const std::string & group_id = "")
+        : Command(parent, name, group_id){};
     explicit DaemonCommand(libdnf::cli::session::Session & session, const std::string & name)
         : Command(session, name){};
     virtual dnfdaemon::KeyValueMap session_config() {
@@ -39,7 +40,7 @@ public:
 
 class TransactionCommand : public DaemonCommand {
 public:
-    explicit TransactionCommand(Command & parent, const std::string & name) : DaemonCommand(parent, name){};
+    using DaemonCommand::DaemonCommand;
     void run_transaction();
 };
 

--- a/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
+++ b/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
@@ -33,7 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-DistroSyncCommand::DistroSyncCommand(Command & parent) : TransactionCommand(parent, "distro-sync") {
+DistroSyncCommand::DistroSyncCommand(Command & parent)
+    : TransactionCommand(parent, "distro-sync", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/downgrade/downgrade.cpp
+++ b/dnf5daemon-client/commands/downgrade/downgrade.cpp
@@ -33,7 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-DowngradeCommand::DowngradeCommand(Command & parent) : TransactionCommand(parent, "downgrade") {
+DowngradeCommand::DowngradeCommand(Command & parent)
+    : TransactionCommand(parent, "downgrade", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/group/group.cpp
+++ b/dnf5daemon-client/commands/group/group.cpp
@@ -26,7 +26,7 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-GroupCommand::GroupCommand(Command & parent) : DaemonCommand(parent, "group") {
+GroupCommand::GroupCommand(Command & parent) : DaemonCommand(parent, "group", "subcommands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
 
@@ -37,8 +37,8 @@ GroupCommand::GroupCommand(Command & parent) : DaemonCommand(parent, "group") {
     auto * query_commands_group = parser.add_new_group("group_query_commands");
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
-    register_subcommand(std::make_unique<GroupListCommand>(*this, "list"), query_commands_group);
-    register_subcommand(std::make_unique<GroupListCommand>(*this, "info"), query_commands_group);
+    register_subcommand(std::make_unique<GroupListCommand>(*this, "list", "group_query_commands"));
+    register_subcommand(std::make_unique<GroupListCommand>(*this, "info", "group_query_commands"));
 }
 
 void GroupCommand::pre_configure() {

--- a/dnf5daemon-client/commands/group/group_list.cpp
+++ b/dnf5daemon-client/commands/group/group_list.cpp
@@ -33,8 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-GroupListCommand::GroupListCommand(Command & parent, const char * command)
-    : DaemonCommand(parent, command),
+GroupListCommand::GroupListCommand(Command & parent, const char * command, const std::string & group_id)
+    : DaemonCommand(parent, command, group_id),
       command(command) {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();

--- a/dnf5daemon-client/commands/group/group_list.hpp
+++ b/dnf5daemon-client/commands/group/group_list.hpp
@@ -31,7 +31,7 @@ namespace dnfdaemon::client {
 
 class GroupListCommand : public DaemonCommand {
 public:
-    explicit GroupListCommand(Command & parent, const char * command);
+    explicit GroupListCommand(Command & parent, const char * command, const std::string & group_id);
     void run() override;
 
 private:

--- a/dnf5daemon-client/commands/install/install.cpp
+++ b/dnf5daemon-client/commands/install/install.cpp
@@ -33,7 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-InstallCommand::InstallCommand(Command & parent) : TransactionCommand(parent, "install") {
+InstallCommand::InstallCommand(Command & parent)
+    : TransactionCommand(parent, "install", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/reinstall/reinstall.cpp
+++ b/dnf5daemon-client/commands/reinstall/reinstall.cpp
@@ -33,7 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-ReinstallCommand::ReinstallCommand(Command & parent) : TransactionCommand(parent, "reinstall") {
+ReinstallCommand::ReinstallCommand(Command & parent)
+    : TransactionCommand(parent, "reinstall", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/remove/remove.cpp
+++ b/dnf5daemon-client/commands/remove/remove.cpp
@@ -33,7 +33,7 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-RemoveCommand::RemoveCommand(Command & parent) : TransactionCommand(parent, "remove") {
+RemoveCommand::RemoveCommand(Command & parent) : TransactionCommand(parent, "remove", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -37,7 +37,7 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-RepoqueryCommand::RepoqueryCommand(Command & parent) : DaemonCommand(parent, "repoquery") {
+RepoqueryCommand::RepoqueryCommand(Command & parent) : DaemonCommand(parent, "repoquery", "query_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/commands/upgrade/upgrade.cpp
+++ b/dnf5daemon-client/commands/upgrade/upgrade.cpp
@@ -33,7 +33,8 @@ namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
 
-UpgradeCommand::UpgradeCommand(Command & parent) : TransactionCommand(parent, "upgrade") {
+UpgradeCommand::UpgradeCommand(Command & parent)
+    : TransactionCommand(parent, "upgrade", "software_management_commands") {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -172,24 +172,24 @@ void RootCommand::register_subcommands() {
         session.get_argument_parser().add_new_group("software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     cmd.register_group(software_management_commands_group);
-    register_subcommand(std::make_unique<DistroSyncCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<DowngradeCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<InstallCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<ReinstallCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<RemoveCommand>(*this), software_management_commands_group);
-    register_subcommand(std::make_unique<UpgradeCommand>(*this), software_management_commands_group);
+    register_subcommand(std::make_unique<DistroSyncCommand>(*this));
+    register_subcommand(std::make_unique<DowngradeCommand>(*this));
+    register_subcommand(std::make_unique<InstallCommand>(*this));
+    register_subcommand(std::make_unique<ReinstallCommand>(*this));
+    register_subcommand(std::make_unique<RemoveCommand>(*this));
+    register_subcommand(std::make_unique<UpgradeCommand>(*this));
 
     // query commands
     auto * query_commands_group = session.get_argument_parser().add_new_group("query_commands");
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
-    register_subcommand(std::make_unique<RepoqueryCommand>(*this), query_commands_group);
+    register_subcommand(std::make_unique<RepoqueryCommand>(*this));
 
     // subcommands
     auto * subcommands_group = session.get_argument_parser().add_new_group("subcommands");
     subcommands_group->set_header("Subcommands:");
     cmd.register_group(subcommands_group);
-    register_subcommand(std::make_unique<GroupCommand>(*this), subcommands_group);
+    register_subcommand(std::make_unique<GroupCommand>(*this));
 }
 
 }  // namespace dnfdaemon::client

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -69,7 +69,7 @@ public:
 
 private:
     std::unique_ptr<Command> root_command;
-    Command * selected_command;
+    Command * selected_command{nullptr};
     std::unique_ptr<libdnf::cli::ArgumentParser> argument_parser;
 };
 

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -75,7 +75,7 @@ private:
 
 class Command {
 public:
-    explicit Command(Command & parent, const std::string & name);
+    explicit Command(Command & parent, const std::string & name, const std::string & group_id = "");
     explicit Command(Session & session, const std::string & program_name);
     virtual ~Command() = default;
 
@@ -133,17 +133,22 @@ public:
     /// @since 5.0
     const std::vector<std::unique_ptr<Command>> & get_subcommands() const noexcept { return subcommands; }
 
+    /// @return Group id to register this command.
+    /// @since 5.0
+    const std::string & get_group_id() const noexcept { return group_id; }
+
 protected:
     /// Register a `subcommand` to the current command.
     /// The command becomes owner of the `subcommand`.
     /// @since 5.0
-    void register_subcommand(std::unique_ptr<Command> subcommand, libdnf::cli::ArgumentParser::Group * group = nullptr);
+    void register_subcommand(std::unique_ptr<Command> subcommand);
 
 private:
     Session & session;
     Command * parent_command = nullptr;
     libdnf::cli::ArgumentParser::Command * argument_parser_command;
     std::vector<std::unique_ptr<Command>> subcommands;
+    std::string group_id;
 };
 
 


### PR DESCRIPTION
It will allow to define the group to which the command should be registered, directly in the command. Required for plugins to allow define groups for plugin commands.