### PR TITLE
Better consistency of libdnf5 library file locations

### DIFF
--- a/include/libdnf/conf/const.hpp
+++ b/include/libdnf/conf/const.hpp
@@ -27,8 +27,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 constexpr const char * PERSISTDIR = "/var/lib/dnf";
-constexpr const char * SYSTEM_STATE_DIR = "/usr/lib/sysimage/dnf";
-constexpr const char * SYSTEM_CACHEDIR = "/var/cache/libdnf";
+constexpr const char * SYSTEM_STATE_DIR = "/usr/lib/sysimage/libdnf5";
+constexpr const char * SYSTEM_CACHEDIR = "/var/cache/libdnf5";
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 constexpr const char * CONF_DIRECTORY = "/etc/dnf/conf.d";

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -280,7 +280,7 @@ class ConfigMain::Impl {
     // Repo main config
 
     OptionNumber<std::uint32_t> retries{10};
-    OptionPath cachedir{geteuid() == 0 ? SYSTEM_CACHEDIR : libdnf::xdg::get_user_cache_dir() / "dnf"};
+    OptionPath cachedir{geteuid() == 0 ? SYSTEM_CACHEDIR : libdnf::xdg::get_user_cache_dir() / "libdnf5"};
     OptionBool fastestmirror{false};
     OptionStringList excludepkgs{std::vector<std::string>{}};
     OptionStringList includepkgs{std::vector<std::string>{}};


### PR DESCRIPTION
/usr/lib/sysimage/dnf/ -> /usr/lib/sysimage/libdnf5/
/var/cache/libdnf/ -> /var/cache/libdnf5/
~/.cache/dnf/ -> ~/.cache/libdnf5/

Requests a change in the CI. PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1165