### PR TITLE
Write output of RPM scriptlets to logger

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -433,34 +433,6 @@ namespace {
 
 class RpmTransCB : public libdnf::rpm::TransactionCallbacks {
 public:
-    static const char * script_type_to_string(ScriptType type) noexcept {
-        switch (type) {
-            case ScriptType::PRE_INSTALL:
-                return "pre-install";
-            case ScriptType::POST_INSTALL:
-                return "post-install";
-            case ScriptType::PRE_UNINSTALL:
-                return "pre-uninstall";
-            case ScriptType::POST_UNINSTALL:
-                return "post-uninstall";
-            case ScriptType::PRE_TRANSACTION:
-                return "pre-transaction";
-            case ScriptType::POST_TRANSACTION:
-                return "post-transaction";
-            case ScriptType::TRIGGER_PRE_INSTALL:
-                return "trigger-pre-install";
-            case ScriptType::TRIGGER_INSTALL:
-                return "trigger-install";
-            case ScriptType::TRIGGER_UNINSTALL:
-                return "trigger-uninstall";
-            case ScriptType::TRIGGER_POST_UNINSTALL:
-                return "trigger-post-uninstall";
-            case ScriptType::UNKNOWN:
-                return "unknown";
-        }
-        return "unknown";
-    }
-
     ~RpmTransCB() {
         if (active_progress_bar &&
             active_progress_bar->get_state() != libdnf::cli::progressbar::ProgressBarState::ERROR) {

--- a/include/libdnf/rpm/transaction_callbacks.hpp
+++ b/include/libdnf/rpm/transaction_callbacks.hpp
@@ -56,6 +56,10 @@ public:
         TRIGGER_POST_UNINSTALL  // "%triggerpostun"
     };
 
+    /// @param type  scriptlet type
+    /// @return  string representation of the scriptlet type
+    static const char * script_type_to_string(ScriptType type) noexcept;
+
     virtual ~TransactionCallbacks() = default;
 
     virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}


### PR DESCRIPTION
The output of the RPM scriptlets was  written to the "scriptlet.out" file in the current working directory and was owerwritten every time dnf5 was run.
Now there is a thread that processes output from the RPM scriptlets and writes it to the logger.

Logging of RPM transaction callbacks was also added. It is possible to read from the log which scriptlet the given output is from.