### PR TITLE
Add "get_user_state_dir" func,  move non-root user log file to "~/.local/state/" ($XDG_STATE_HOME) 

### DIFF
--- a/include/libdnf/common/xdg.hpp
+++ b/include/libdnf/common/xdg.hpp
@@ -39,6 +39,10 @@ std::filesystem::path get_user_config_dir();
 /// A base directory relative to which user specific data files should be stored.
 std::filesystem::path get_user_data_dir();
 
+/// Returns user state directory.
+/// A base directory relative to which user specific state data should be stored.
+std::filesystem::path get_user_state_dir();
+
 /// Returns user runtime directory.
 /// A base directory relative to which user-specific non-essential runtime files and other file objects
 /// (such as sockets, named pipes, ...) should be stored.

--- a/libdnf/common/xdg.cpp
+++ b/libdnf/common/xdg.cpp
@@ -77,6 +77,17 @@ std::filesystem::path get_user_data_dir() {
     return std::filesystem::path(get_user_home_dir()) / ".local" / "share";
 }
 
+std::filesystem::path get_user_state_dir() {
+    const char * dir = std::getenv("XDG_STATE_HOME");
+    if (dir && *dir != '\0') {
+        auto ret = std::filesystem::path(dir);
+        if (ret.is_absolute()) {
+            return ret;
+        }
+    }
+    return std::filesystem::path(get_user_home_dir()) / ".local" / "state";
+}
+
 std::filesystem::path get_user_runtime_dir() {
     const char * dir = std::getenv("XDG_RUNTIME_DIR");
     if (dir && *dir != '\0') {

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -177,7 +177,7 @@ class ConfigMain::Impl {
     OptionPath system_cachedir{SYSTEM_CACHEDIR};
     OptionBool cacheonly{false};
     OptionBool keepcache{false};
-    OptionPath logdir{geteuid() == 0 ? "/var/log" : libdnf::xdg::get_user_data_dir() / "dnf"};
+    OptionPath logdir{geteuid() == 0 ? "/var/log" : libdnf::xdg::get_user_state_dir()};
     OptionNumber<std::int32_t> log_size{1024 * 1024, str_to_bytes};
     OptionNumber<std::int32_t> log_rotate{4, 0};
     OptionPath debugdir{"./debugdata"};


### PR DESCRIPTION
It is a question of where to save the logger files in XDG. Basically, there are 2 options - STATE category and DATA category.
Following this proposal https://wiki.debian.org/XDGBaseDirectorySpecification I moved the logger file to the STATE category.