### PR TITLE
modules: Move code to private section or Impl

### DIFF
--- a/include/libdnf/module/module_sack.hpp
+++ b/include/libdnf/module/module_sack.hpp
@@ -33,6 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::repo {
 
+class Repo;
 class RepoSack;
 
 }  // namespace libdnf::repo
@@ -58,20 +59,6 @@ public:
     /// Return module items in container
     const std::vector<std::unique_ptr<ModuleItem>> & get_modules();
 
-    // TODO(pkratoch): Maybe make this private later
-    void add(const std::string & file_content, const std::string & repo_id);
-    // Compute static context for older modules and move these modules to `ModuleSack.modules`.
-    void add_modules_without_static_context();
-
-    // TODO(pkratoch): Implement adding defaults from "/etc/dnf/modules.defaults.d/", which are defined by user.
-    //                 They are added with priority 1000 after everything else is loaded.
-    /// Add and resolve defaults.
-    /// @since 5.0
-    //
-    // @replaces libdnf:ModulePackageContainer.hpp:method:ModulePackageContainer.addDefaultsFromDisk()
-    // @replaces libdnf:ModulePackageContainer.hpp:method:ModulePackageContainer.moduleDefaultsResolve()
-    void add_defaults_from_disk();
-
     // TODO(pkratoch): Implement getting default streams and profiles.
     /// @return Default stream for given module.
     /// @since 5.0
@@ -82,20 +69,28 @@ public:
 
 private:
     friend class libdnf::Base;
+    friend class libdnf::repo::Repo;
     friend class libdnf::repo::RepoSack;
     friend ModuleItem;
 
     ModuleSack(const BaseWeakPtr & base);
 
-    void create_module_solvables();
     BaseWeakPtr get_base() const;
 
-    WeakPtrGuard<ModuleSack, false> data_guard;
+    /// Load information about modules from file to ModuleSack. It is critical to load all module information from
+    /// all available repositories when modular metadata are available.
+    void add(const std::string & file_content, const std::string & repo_id);
 
-    // Older ModuleItems that don't have static context. After all metadata are loaded, static contexts are assigned
-    // also to these ModuleItems and they are removed from this vector and added to `ModuleSack.modules`.
-    // This is done in `ModuleSack::add_modules_without_static_context`.
-    std::vector<std::unique_ptr<ModuleItem>> modules_without_static_context;
+    // TODO(pkratoch): Implement adding defaults from "/etc/dnf/modules.defaults.d/", which are defined by user.
+    //                 They are added with priority 1000 after everything else is loaded.
+    /// Add and resolve defaults.
+    /// @since 5.0
+    //
+    // @replaces libdnf:ModulePackageContainer.hpp:method:ModulePackageContainer.addDefaultsFromDisk()
+    // @replaces libdnf:ModulePackageContainer.hpp:method:ModulePackageContainer.moduleDefaultsResolve()
+    void add_defaults_from_disk();
+
+    WeakPtrGuard<ModuleSack, false> data_guard;
 
     class Impl;
     std::unique_ptr<Impl> p_impl;

--- a/libdnf/module/module_sack_impl.hpp
+++ b/libdnf/module/module_sack_impl.hpp
@@ -56,6 +56,11 @@ public:
         rpm::ReldepList>
     collect_data_for_modular_filtering();
 
+    // Compute static context for older modules and move these modules to `ModuleSack.modules`.
+    void add_modules_without_static_context();
+
+    void create_module_solvables();
+
 private:
     friend ModuleSack;
     friend ModuleItem;
@@ -66,10 +71,15 @@ private:
     // Repositories containing any modules. Key is repoid, value is Id of the repo in libsolv.
     // This is needed in `ModuleItem::create_solvable` for creating solvable in the correct repository.
     std::map<std::string, Id> repositories;
+
+    // Older ModuleItems that don't have static context. After all metadata are loaded, static contexts are assigned
+    // also to these ModuleItems and they are removed from this vector and added to `ModuleSack.modules`.
+    // This is done in `ModuleSack::add_modules_without_static_context`.
+    std::vector<std::unique_ptr<ModuleItem>> modules_without_static_context;
 };
 
 inline const std::vector<std::unique_ptr<ModuleItem>> & ModuleSack::Impl::get_modules() {
-    // TODO(mracek) What about to call add_modules_without_static_context before returning the vector?
+    add_modules_without_static_context();
     return modules;
 }
 

--- a/test/libdnf/module/test_module.cpp
+++ b/test/libdnf/module/test_module.cpp
@@ -43,7 +43,6 @@ void ModuleTest::test_load() {
     add_repo_repomd("repomd-modules");
 
     auto module_sack = base.get_module_sack();
-    module_sack->add_modules_without_static_context();
     CPPUNIT_ASSERT_EQUAL(3lu, module_sack->get_modules().size());
 
     auto & meson = module_sack->get_modules()[0];


### PR DESCRIPTION
Removal supporting and unnecessary functions from API will improve clarity of API and allows further modifications in future.

As an consequence of movement and resolving accessing private methods, the movement resolves auto processing of modules without static context.