### PR TITLE
Remove set_reason() from transaction public API

### DIFF
--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -25,14 +25,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/goal_elements.hpp"
 #include "libdnf/base/log_event.hpp"
 #include "libdnf/base/solver_problems.hpp"
-#include "libdnf/base/transaction_group.hpp"
-#include "libdnf/base/transaction_package.hpp"
 #include "libdnf/rpm/transaction_callbacks.hpp"
 
 #include <optional>
 
 
 namespace libdnf::base {
+
+class TransactionGroup;
+class TransactionPackage;
 
 /// Error related to processing transaction
 class TransactionError : public Error {
@@ -101,6 +102,8 @@ public:
     std::vector<std::string> get_transaction_problems() const noexcept;
 
 private:
+    friend class TransactionGroup;
+    friend class TransactionPackage;
     friend class libdnf::Goal;
 
     Transaction(const libdnf::BaseWeakPtr & base);

--- a/include/libdnf/base/transaction_group.hpp
+++ b/include/libdnf/base/transaction_group.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_BASE_TRANSACTION_GROUP_HPP
 
 #include "libdnf/base/goal_elements.hpp"
+#include "libdnf/base/transaction.hpp"
 #include "libdnf/comps/group/group.hpp"
 #include "libdnf/rpm/package.hpp"
 #include "libdnf/transaction/transaction_item_action.hpp"
@@ -57,8 +58,8 @@ public:
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
     Reason get_reason() const noexcept { return reason; }
 
-public:
-    friend class Transaction;
+private:
+    friend class Transaction::Impl;
 
     TransactionGroup(const libdnf::comps::Group & grp, Action action, Reason reason)
         : group(grp),

--- a/include/libdnf/base/transaction_package.hpp
+++ b/include/libdnf/base/transaction_package.hpp
@@ -60,13 +60,6 @@ public:
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
     Reason get_reason() const noexcept { return reason; }
 
-    /// Set the reason of the action being performed on the transaction package.
-    ///
-    /// @param reason The reason to set.
-    //
-    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setReason(libdnf::TransactionItemReason value)
-    void set_reason(Reason reason) { this->reason = reason; }
-
     /// @return packages replaced by this transaction package.
     const std::vector<rpm::Package> get_replaces() const noexcept { return replaces; }
 
@@ -101,6 +94,7 @@ private:
           reason(reason),
           reason_change_group_id(group_id) {}
 
+    void set_reason(Reason value) noexcept { reason = value; }
     void set_state(State value) noexcept { state = value; }
 
     libdnf::rpm::Package package;

--- a/include/libdnf/base/transaction_package.hpp
+++ b/include/libdnf/base/transaction_package.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_BASE_TRANSACTION_PACKAGE_HPP
 
 #include "libdnf/base/goal_elements.hpp"
+#include "libdnf/base/transaction.hpp"
 #include "libdnf/rpm/package.hpp"
 #include "libdnf/transaction/transaction_item_action.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
@@ -29,6 +30,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <optional>
 
+class BaseGoalTest;
+class RpmTransactionTest;
 
 namespace libdnf::base {
 
@@ -75,13 +78,21 @@ public:
     /// @return id of group the package belongs to
     const std::optional<std::string> & get_reason_change_group_id() const noexcept { return reason_change_group_id; }
 
-public:
-    friend class Transaction;
+private:
+    friend class Transaction::Impl;
+    friend class ::BaseGoalTest;
+    friend class ::RpmTransactionTest;
 
     TransactionPackage(const libdnf::rpm::Package & pkg, Action action, Reason reason)
         : package(pkg),
           action(action),
           reason(reason) {}
+
+    TransactionPackage(const libdnf::rpm::Package & pkg, Action action, Reason reason, State state)
+        : package(pkg),
+          action(action),
+          reason(reason),
+          state(state) {}
 
     TransactionPackage(
         const libdnf::rpm::Package & pkg, Action action, Reason reason, std::optional<std::string> group_id)

--- a/include/libdnf/rpm/transaction_callbacks.hpp
+++ b/include/libdnf/rpm/transaction_callbacks.hpp
@@ -21,9 +21,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_TRANSACTION_CALLBACKS_HPP
 #define LIBDNF_RPM_TRANSACTION_CALLBACKS_HPP
 
-#include "libdnf/base/transaction_package.hpp"
+#include "libdnf/rpm/nevra.hpp"
 
 #include <cstdint>
+
+namespace libdnf::base {
+
+class TransactionGroup;
+class TransactionPackage;
+
+}  // namespace libdnf::base
 
 namespace libdnf::rpm {
 

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -288,12 +288,14 @@ void Transaction::Impl::set_transaction(rpm::solv::GoalPrivate & solved_goal, Go
 
     // Add groups to the transaction
     for (auto & [group, action, reason] : solved_goal.list_groups()) {
-        groups.emplace_back(group, action, reason);
+        TransactionGroup tsgrp(group, action, reason);
+        groups.emplace_back(std::move(tsgrp));
     }
 
     // Add reason change actions to the transaction
     for (auto & [pkg, reason, group_id] : solved_goal.list_reason_changes()) {
-        packages.emplace_back(pkg, TransactionPackage::Action::REASON_CHANGE, reason, group_id);
+        TransactionPackage tspkg(pkg, TransactionPackage::Action::REASON_CHANGE, reason, group_id);
+        packages.emplace_back(std::move(tspkg));
     }
 }
 

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/transaction.hpp"
 #include "libdnf/base/transaction_group.hpp"
+#include "libdnf/base/transaction_package.hpp"
 
 #include <solv/transaction.h>
 

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -23,28 +23,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 
 #include "libdnf/base/goal.hpp"
+#include "libdnf/base/transaction_package.hpp"
 
 #include <libdnf/rpm/package_query.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(BaseGoalTest);
 
-
-namespace {
-
 using namespace libdnf::transaction;
-
-// make constructor public so we can create Package instances in the tests
-class TransactionPackage : public libdnf::base::TransactionPackage {
-public:
-    TransactionPackage(const libdnf::rpm::Package & pkg, Action action, Reason reason, State state)
-        : libdnf::base::TransactionPackage(pkg, action, reason) {
-        this->state = state;
-    }
-};
-
-}  // namespace
-
 
 void BaseGoalTest::setUp() {
     BaseTestCase::setUp();
@@ -57,7 +43,7 @@ void BaseGoalTest::test_install() {
     goal.add_rpm_install("pkg");
     auto transaction = goal.resolve();
 
-    std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
+    std::vector<libdnf::base::TransactionPackage> expected = {libdnf::base::TransactionPackage(
         get_pkg("pkg-0:1.2-3.x86_64"),
         TransactionItemAction::INSTALL,
         TransactionItemReason::USER,
@@ -99,7 +85,7 @@ void BaseGoalTest::test_install_from_cmdline() {
 
     auto transaction = goal.resolve();
 
-    std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
+    std::vector<libdnf::base::TransactionPackage> expected = {libdnf::base::TransactionPackage(
         get_pkg("one-0:1-1.noarch", "@commandline"),
         TransactionItemAction::INSTALL,
         TransactionItemReason::USER,
@@ -117,12 +103,12 @@ void BaseGoalTest::test_install_multilib_all() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("multilib-0:1.2-4.i686"),
             TransactionItemAction::INSTALL,
             TransactionItemReason::USER,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("multilib-0:1.2-4.x86_64"),
             TransactionItemAction::INSTALL,
             TransactionItemReason::USER,
@@ -140,12 +126,12 @@ void BaseGoalTest::test_reinstall() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -165,12 +151,12 @@ void BaseGoalTest::test_reinstall_from_cmdline() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", "@commandline"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -188,12 +174,12 @@ void BaseGoalTest::test_reinstall_user() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::USER,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::USER,
@@ -209,7 +195,7 @@ void BaseGoalTest::test_remove() {
     goal.add_rpm_remove("one");
     auto transaction = goal.resolve();
 
-    std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
+    std::vector<libdnf::base::TransactionPackage> expected = {libdnf::base::TransactionPackage(
         get_pkg("one-0:1-1.noarch", true),
         TransactionItemAction::REMOVE,
         TransactionItemReason::USER,
@@ -269,12 +255,12 @@ void BaseGoalTest::test_upgrade() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -296,12 +282,12 @@ void BaseGoalTest::test_upgrade_from_cmdline() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", "@commandline"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -375,12 +361,12 @@ void BaseGoalTest::test_upgrade_all() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -400,12 +386,12 @@ void BaseGoalTest::test_upgrade_user() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::USER,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::USER,
@@ -425,12 +411,12 @@ void BaseGoalTest::test_downgrade() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -452,12 +438,12 @@ void BaseGoalTest::test_downgrade_from_cmdline() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", "@commandline"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -477,12 +463,12 @@ void BaseGoalTest::test_downgrade_user() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::USER,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::USER,
@@ -502,12 +488,12 @@ void BaseGoalTest::test_distrosync() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -527,12 +513,12 @@ void BaseGoalTest::test_distrosync_all() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,
@@ -553,12 +539,12 @@ void BaseGoalTest::test_install_or_reinstall() {
     auto transaction = goal.resolve();
 
     std::vector<libdnf::base::TransactionPackage> expected = {
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::DEPENDENCY,
             TransactionItemState::STARTED),
-        TransactionPackage(
+        libdnf::base::TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REPLACED,
             TransactionItemReason::DEPENDENCY,

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 
 #include "libdnf/base/goal.hpp"
+#include "libdnf/base/transaction_package.hpp"
 #include "libdnf/repo/package_downloader.hpp"
 #include "libdnf/rpm/transaction_callbacks.hpp"
 
@@ -30,21 +31,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmTransactionTest);
 
 
-namespace {
-
-// make constructor public so we can create instances in the tests
-class TransactionPackage : public libdnf::base::TransactionPackage {
-public:
-    TransactionPackage(const libdnf::rpm::Package & pkg, Action action, Reason reason, State state)
-        : libdnf::base::TransactionPackage(pkg, action, reason) {
-        this->state = state;
-    }
-};
-
-}  // namespace
-
-
 using namespace libdnf::rpm;
+using namespace libdnf::transaction;
 
 
 class PackageDownloadCallbacks : public libdnf::repo::DownloadCallbacks {
@@ -84,11 +72,11 @@ void RpmTransactionTest::test_transaction() {
 
     auto transaction = goal.resolve();
 
-    std::vector<libdnf::base::TransactionPackage> expected = {TransactionPackage(
+    std::vector<libdnf::base::TransactionPackage> expected = {libdnf::base::TransactionPackage(
         get_pkg("one-0:2-1.noarch"),
-        libdnf::transaction::TransactionItemAction::INSTALL,
-        libdnf::transaction::TransactionItemReason::USER,
-        libdnf::transaction::TransactionItemState::STARTED)};
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::USER,
+        TransactionItemState::STARTED)};
     CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 
     libdnf::repo::PackageDownloader downloader;

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/advisory/advisory_set.hpp"
 #include "libdnf/base/transaction.hpp"
+#include "libdnf/base/transaction_package.hpp"
 #include "libdnf/comps/environment/environment.hpp"
 #include "libdnf/comps/environment/query.hpp"
 #include "libdnf/comps/group/group.hpp"


### PR DESCRIPTION
Method `set_reason()` was removed from the public API and also a visibility of related members was fixed to (hopefully) originally planned level. Due to these changes also some header includes reordering and other small refactoring was necessary.