### PR TITLE
state: Store and load system repo groups metadata

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -102,6 +102,7 @@ private:
     friend class libdnf::base::Transaction;
     friend class libdnf::rpm::Package;
     friend class libdnf::advisory::AdvisoryQuery;
+    friend class libdnf::repo::SolvRepo;
 
     WeakPtrGuard<Base, false> base_guard;
 

--- a/include/libdnf/comps/environment/environment.hpp
+++ b/include/libdnf/comps/environment/environment.hpp
@@ -129,11 +129,11 @@ public:
         return get_environmentid() < rhs.get_environmentid() || get_repos() < rhs.get_repos();
     }
 
-    /// Dump the Environment into an xml file
+    /// Serialize the Environment into an xml file
     /// @param path Path of the output xml file.
     /// @exception utils::xml::XMLSaveError When saving of the file fails.
     /// @since 5.0
-    void dump(const std::string & path);
+    void serialize(const std::string & path);
 
 protected:
     explicit Environment(const libdnf::BaseWeakPtr & base);

--- a/include/libdnf/comps/group/group.hpp
+++ b/include/libdnf/comps/group/group.hpp
@@ -144,11 +144,11 @@ public:
         return get_groupid() < rhs.get_groupid() || get_repos() < rhs.get_repos();
     }
 
-    /// Dump the Group into an xml file.
+    /// Serialize the Group into an xml file.
     /// @param path Path of the output xml file.
     /// @exception utils::xml::XMLSaveError When saving of the file fails.
     /// @since 5.0
-    void dump(const std::string & path);
+    void serialize(const std::string & path);
 
 protected:
     explicit Group(const BaseWeakPtr & base);

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -374,6 +374,7 @@ private:
     void make_solv_repo();
 
     void load_available_repo(libdnf::repo::LoadFlags flags);
+    void load_system_repo(libdnf::repo::LoadFlags flags);
 
     void internalize();
 

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -1121,12 +1121,14 @@ GoalProblem Goal::Impl::add_group_install_to_goal(
     comps::GroupQuery group_query(base, true);
     if (settings.group_with_id) {
         comps::GroupQuery group_query_id(base);
+        group_query_id.filter_installed(false);
         group_query_id.filter_groupid(spec, cmp);
         group_query |= group_query_id;
     }
     // TODO(mblaha): reconsider usefulness of searching groups by names
     if (settings.group_with_name) {
         comps::GroupQuery group_query_name(base);
+        group_query_name.filter_installed(false);
         group_query_name.filter_name(spec, cmp);
         group_query |= group_query_name;
     }

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -594,6 +594,8 @@ Transaction::TransactionRunResult Transaction::Impl::run(
         }
 
         // Set correct system state for groups in the transaction
+        auto comps_xml_dir = system_state.get_group_xml_dir();
+        std::filesystem::create_directories(comps_xml_dir);
         for (const auto & tsgroup : groups) {
             auto group = tsgroup.get_group();
             if (transaction_item_action_is_inbound(tsgroup.get_action())) {
@@ -616,6 +618,8 @@ Transaction::TransactionRunResult Transaction::Impl::run(
                     }
                 }
                 system_state.set_group_state(group.get_groupid(), state);
+                // save the current xml group definition
+                group.dump(comps_xml_dir / (group.get_groupid() + ".xml"));
             }
         }
 

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -619,7 +619,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
                 }
                 system_state.set_group_state(group.get_groupid(), state);
                 // save the current xml group definition
-                group.dump(comps_xml_dir / (group.get_groupid() + ".xml"));
+                group.serialize(comps_xml_dir / (group.get_groupid() + ".xml"));
             }
         }
 

--- a/libdnf/comps/environment/environment.cpp
+++ b/libdnf/comps/environment/environment.cpp
@@ -152,7 +152,7 @@ bool Environment::get_installed() const {
 }
 
 
-void Environment::dump(const std::string & path) {
+void Environment::serialize(const std::string & path) {
     // Create doc with root node "comps"
     xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
     xmlNodePtr node_comps = xmlNewNode(NULL, BAD_CAST "comps");

--- a/libdnf/comps/group/group.cpp
+++ b/libdnf/comps/group/group.cpp
@@ -178,7 +178,7 @@ bool Group::get_installed() const {
 }
 
 
-void Group::dump(const std::string & path) {
+void Group::serialize(const std::string & path) {
     // Create doc with root node "comps"
     xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
     xmlNodePtr node_comps = xmlNewNode(NULL, BAD_CAST "comps");

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -236,7 +236,7 @@ void Repo::load(LoadFlags flags) {
     if (type == Type::AVAILABLE) {
         load_available_repo(flags);
     } else if (type == Type::SYSTEM) {
-        solv_repo->load_system_repo();
+        load_system_repo(flags);
     }
 
     solv_repo->set_needs_internalizing();
@@ -501,6 +501,15 @@ void Repo::load_available_repo(LoadFlags flags) {
 
     base->get_module_sack()->add(yaml_content, config.get_id());
 #endif
+}
+
+
+void Repo::load_system_repo(LoadFlags flags) {
+    solv_repo->load_system_repo();
+
+    if (any(flags & LoadFlags::COMPS)) {
+        solv_repo->load_system_repo_ext(RepodataType::COMPS);
+    }
 }
 
 

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -79,6 +79,9 @@ public:
     /// TODO(jrohel): Performance: Implement libsolv cache ("build_cache" argument) of system repo in future.
     void load_system_repo(const std::string & rootdir = "");
 
+    /// Loads additional system repo metadata (comps, modules)
+    void load_system_repo_ext(RepodataType type);
+
     void rewrite_repo(libdnf::solv::IdQueue & fileprovides);
 
     // Internalize repository if needed.

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -505,6 +505,11 @@ const std::map<std::string, std::set<std::string>> & State::get_package_groups_c
 }
 
 
+std::filesystem::path State::get_group_xml_dir() {
+    return path / "comps_groups";
+}
+
+
 std::filesystem::path State::get_package_state_path() {
     return path / "packages.toml";
 }

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -369,6 +369,15 @@ std::set<std::string> State::get_package_groups(const std::string & name) {
     }
 }
 
+std::vector<std::string> State::get_installed_groups() {
+    std::vector<std::string> group_ids;
+    group_ids.reserve(group_states.size());
+    for (const auto & grp : group_states) {
+        group_ids.push_back(grp.first);
+    }
+    return group_ids;
+}
+
 
 std::string State::get_module_enabled_stream(const std::string & name) {
     auto it = module_states.find(name);

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -151,6 +151,10 @@ public:
     /// @since 5.0
     std::vector<std::string> get_installed_groups();
 
+    /// @return The path to the directory containing the installed groups xml data.
+    /// @since 5.0
+    std::filesystem::path get_group_xml_dir();
+
     /// @return The state for a group id.
     /// @param id The group id to get the state for.
     /// @since 5.0

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -147,6 +147,10 @@ public:
     /// @since 5.0
     void remove_package_nevra_state(const std::string & nevra);
 
+    /// @return List of ids of installed groups.
+    /// @since 5.0
+    std::vector<std::string> get_installed_groups();
+
     /// @return The state for a group id.
     /// @param id The group id to get the state for.
     /// @since 5.0

--- a/test/libdnf/comps/test_environment.cpp
+++ b/test/libdnf/comps/test_environment.cpp
@@ -167,19 +167,19 @@ void CompsEnvironmentTest::test_merge_different_translations() {
 }
 
 
-void CompsEnvironmentTest::test_dump() {
+void CompsEnvironmentTest::test_serialize() {
     add_repo_repomd("repomd-comps-minimal-environment");
 
     EnvironmentQuery q_minimal_env(base);
     q_minimal_env.filter_environmentid("minimal-environment");
     auto minimal_env = q_minimal_env.get();
 
-    auto dump_path = std::filesystem::temp_directory_path() / "dumped-standard.xml";
-    minimal_env.dump(dump_path);
+    auto serialize_path = std::filesystem::temp_directory_path() / "serialized-standard.xml";
+    minimal_env.serialize(serialize_path);
 
-    std::ifstream dumped_stream(dump_path);
+    std::ifstream serialized_stream(serialize_path);
     std::string actual;
-    actual.assign(std::istreambuf_iterator<char>(dumped_stream), std::istreambuf_iterator<char>());
+    actual.assign(std::istreambuf_iterator<char>(serialized_stream), std::istreambuf_iterator<char>());
 
     std::filesystem::path expected_path =
         PROJECT_SOURCE_DIR "/test/data/repos-repomd/repomd-comps-minimal-environment/repodata/comps.xml";

--- a/test/libdnf/comps/test_environment.hpp
+++ b/test/libdnf/comps/test_environment.hpp
@@ -36,7 +36,7 @@ class CompsEnvironmentTest : public BaseTestCase {
     CPPUNIT_TEST(test_merge_with_empty);
     CPPUNIT_TEST(test_merge_empty_with_nonempty);
     CPPUNIT_TEST(test_merge_different_translations);
-    CPPUNIT_TEST(test_dump);
+    CPPUNIT_TEST(test_serialize);
     CPPUNIT_TEST(test_solvables);
     CPPUNIT_TEST_SUITE_END();
 
@@ -48,7 +48,7 @@ public:
     void test_merge_with_empty();
     void test_merge_empty_with_nonempty();
     void test_merge_different_translations();
-    void test_dump();
+    void test_serialize();
     void test_solvables();
 };
 

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -273,17 +273,17 @@ void CompsGroupTest::test_merge_different_translations() {
 }
 
 
-void CompsGroupTest::test_dump() {
+void CompsGroupTest::test_serialize() {
     add_repo_repomd("repomd-comps-standard");
 
     GroupQuery q_standard(base);
     q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
 
-    auto dump_path = temp->get_path() / "dumped-standard.xml";
-    standard.dump(dump_path);
+    auto serialize_path = temp->get_path() / "serialized-standard.xml";
+    standard.serialize(serialize_path);
 
-    std::string actual = libdnf::utils::fs::File(dump_path, "r").read();
+    std::string actual = libdnf::utils::fs::File(serialize_path, "r").read();
 
     std::filesystem::path expected_path =
         PROJECT_SOURCE_DIR "/test/data/repos-repomd/repomd-comps-standard/repodata/comps.xml";

--- a/test/libdnf/comps/test_group.hpp
+++ b/test/libdnf/comps/test_group.hpp
@@ -36,7 +36,7 @@ class CompsGroupTest : public BaseTestCase {
     CPPUNIT_TEST(test_merge_with_empty);
     CPPUNIT_TEST(test_merge_empty_with_nonempty);
     CPPUNIT_TEST(test_merge_different_translations);
-    CPPUNIT_TEST(test_dump);
+    CPPUNIT_TEST(test_serialize);
     CPPUNIT_TEST(test_solvables);
     CPPUNIT_TEST_SUITE_END();
 
@@ -48,7 +48,7 @@ public:
     void test_merge_with_empty();
     void test_merge_empty_with_nonempty();
     void test_merge_different_translations();
-    void test_dump();
+    void test_serialize();
     void test_solvables();
 };
 


### PR DESCRIPTION
Comps metadata for each installed group is now stored in the system state and loaded into libsolv pool from there.