### PR TITLE
libdnf: handle unknown events in the rpm transaction callback

### DIFF
--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -553,11 +553,6 @@ void * Transaction::ts_callback(
                 callbacks->uninstall_stop(*item, amount, total);
             }
             break;
-        case RPMCALLBACK_REPACKAGE_PROGRESS:  // obsolete, unused
-        case RPMCALLBACK_REPACKAGE_START:     // obsolete, unused
-        case RPMCALLBACK_REPACKAGE_STOP:      // obsolete, unused
-            logger.warning("Got RPMCALLBACK_REPACKAGE_* obsolete callback");
-            break;
         case RPMCALLBACK_UNPACK_ERROR:
             libdnf_assert_transaction_item_set();
             logger.error(
@@ -651,8 +646,9 @@ void * Transaction::ts_callback(
                 callbacks->verify_stop(total);
             }
             break;
-        case RPMCALLBACK_UNKNOWN:
-            logger.warning("Unknown RPM Transaction callback type: RPMCALLBACK_UNKNOWN");
+        default:
+            logger.warning("Unknown RPM Transaction callback type {}", what);
+            break;
     }
 
     return rc;


### PR DESCRIPTION
The repackage callbacks are 15 years gone upstream, they are best treated as unknown events. As for RPMCALLBACK_UNKNOWN, this is a nice little rpm-side WTF: an enum whose value is 0 isn't exactly unknown, so the value doesn't make any sense whatsoever.

Replace these with a default case to warn on all actually unknown events.