### PR TITLE
modules: Remove default from module state

### DIFF
--- a/include/libdnf/module/module_sack.hpp
+++ b/include/libdnf/module/module_sack.hpp
@@ -44,9 +44,8 @@ namespace libdnf::module {
 // TODO(pkratoch): Make this a docstring.
 // ENABLED - a module that has an enabled stream.
 // DISABLED - a module that is disabled.
-// DEFAULT - a module that has a default stream (but isn't ENABLED nor DISABLED).
 // AVAILABLE - otherwise.
-enum class ModuleState { AVAILABLE, DEFAULT, ENABLED, DISABLED };
+enum class ModuleState { AVAILABLE, ENABLED, DISABLED };
 
 
 /// Container with data and methods related to modules

--- a/libdnf/module/module_sack.cpp
+++ b/libdnf/module/module_sack.cpp
@@ -359,8 +359,6 @@ std::string module_state_to_string(ModuleState state) {
     switch (state) {
         case ModuleState::AVAILABLE:
             return "Available";
-        case ModuleState::DEFAULT:
-            return "Default";
         case ModuleState::ENABLED:
             return "Enabled";
         case ModuleState::DISABLED:
@@ -373,8 +371,6 @@ std::string module_state_to_string(ModuleState state) {
 ModuleState module_state_from_string(const std::string & state) {
     if (state == "Available") {
         return ModuleState::AVAILABLE;
-    } else if (state == "Default") {
-        return ModuleState::DEFAULT;
     } else if (state == "Enabled") {
         return ModuleState::ENABLED;
     } else if (state == "Disabled") {


### PR DESCRIPTION
Enabled and disabled values are taken from a different source (etc) then module `default` (METADATA). In some cases it is possible to have module disabled but it has still default stream. It can be seen in `module info` command when default information is provided together with enable state.

Therefore it is not good to have an Enum that cannot provide both states (enable, default) together.