### PR TITLE
[unit tests] Support accessing overloaded private members, unnamed namespace

### DIFF
--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -176,10 +176,13 @@ libdnf::rpm::Package BaseTestCase::get_pkg_i(const std::string & nevra, size_t i
     return *it;
 }
 
+namespace {
 
 // Accessor of private Base::p_impl, see private_accessor.hpp
+create_private_getter_template;
 create_getter(priv_impl, &libdnf::Base::p_impl);
 
+}  // namespace
 
 libdnf::rpm::Package BaseTestCase::add_system_pkg(
     const std::string & relative_path, libdnf::transaction::TransactionItemReason reason) {

--- a/test/libdnf/private_accessor.hpp
+++ b/test/libdnf/private_accessor.hpp
@@ -23,16 +23,23 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 // A getter generating structure
-template <typename AccessTag, auto value>
-struct CreateGetter {
-    friend constexpr auto get(AccessTag) { return value; }
-};
+#define create_private_getter_template                         \
+    template <typename AccessTag, typename T, T value>         \
+    struct PrivateGetter {                                     \
+        friend constexpr auto get(AccessTag) { return value; } \
+    }
 
-// Helper macro
+// Helper macro with automatic member type deduction
 #define create_getter(AccessTag, class_member_ptr) \
     struct AccessTag {};                           \
     constexpr auto get(AccessTag);                 \
-    template struct CreateGetter<AccessTag, class_member_ptr>;
+    template struct PrivateGetter<AccessTag, decltype(class_member_ptr), class_member_ptr>
+
+// Helper macro with member type as argument. Needed in case of overloaded members.
+#define create_getter_type(AccessTag, class_member_type, class_member_ptr) \
+    struct AccessTag {};                                                   \
+    constexpr auto get(AccessTag);                                         \
+    template struct PrivateGetter<AccessTag, class_member_type, class_member_ptr>
 
 
 #endif  // TEST_LIBDNF_PRIVATE_ACCESSOR_HPP


### PR DESCRIPTION
There are now two macros available to create a getter:
* `create_getter` - A macro that uses automatic member type deduction.
* `create_getter_type` - Macro that gets the type of a member as an argument. Needed in case of overloaded members.

The getter generating structure is now also created by the macro. This makes the structure no longer global. The user can create it in their own namespace or in an unnamed namespace.