### PR TITLE
Initial version of the dnf5 man pages

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -184,6 +184,33 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %license COPYING.md
 %license gpl-2.0.txt
 %{_mandir}/man8/dnf5.8.*
+%{_mandir}/man8/dnf5-advisory.8.*
+%{_mandir}/man8/dnf5-clean.8.*
+%{_mandir}/man8/dnf5-distro-sync.8.*
+%{_mandir}/man8/dnf5-downgrade.8.*
+%{_mandir}/man8/dnf5-download.8.*
+%{_mandir}/man8/dnf5-environment.8.*
+%{_mandir}/man8/dnf5-group.8.*
+# TODO(jkolarik): history is not ready yet
+# %{_mandir}/man8/dnf5-history.8.*
+%{_mandir}/man8/dnf5-install.8.*
+%{_mandir}/man8/dnf5-makecache.8.*
+%{_mandir}/man8/dnf5-mark.8.*
+# TODO(jkolarik): module is not ready yet
+# %{_mandir}/man8/dnf5-module.8.*
+%{_mandir}/man8/dnf5-reinstall.8.*
+%{_mandir}/man8/dnf5-remove.8.*
+%{_mandir}/man8/dnf5-repo.8.*
+%{_mandir}/man8/dnf5-repoquery.8.*
+%{_mandir}/man8/dnf5-swap.8.*
+%{_mandir}/man8/dnf5-upgrade.8.*
+%{_mandir}/man7/dnf5-comps.7.*
+# TODO(jkolarik): filtering is not ready yet
+# %{_mandir}/man7/dnf5-filtering.7.*
+%{_mandir}/man7/dnf5-installroot.7.*
+# TODO(jkolarik): modularity is not ready yet
+# %{_mandir}/man7/dnf5-modularity.7.*
+%{_mandir}/man7/dnf5-specs.7.*
 
 # ========== libdnf5 ==========
 %package -n libdnf5

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -28,7 +28,7 @@ namespace dnf5 {
 using namespace libdnf::cli;
 
 void MakeCacheCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Generate the metadada cache");
+    get_argument_parser_command()->set_description("Generate the metadata cache");
 }
 
 void MakeCacheCommand::run() {

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -64,7 +64,7 @@ void RemoveCommand::run() {
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
         goal->add_rpm_remove(option->get_value());
     }
-    // To enable removal of dependenct packages it requires to use allow_erasing
+    // To enable removal of dependency packages it requires to use allow_erasing
     goal->set_allow_erasing(true);
 }
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,6 +48,33 @@ if(WITH_MAN)
 
     if(WITH_DNF5)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-advisory.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-clean.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-distro-sync.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-downgrade.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-download.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-environment.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-group.8 DESTINATION share/man/man8)
+        # TODO(jkolarik): history is not ready yet
+        # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-history.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-install.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-makecache.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-mark.8 DESTINATION share/man/man8)
+        # TODO(jkolarik): module is not ready yet
+        # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-module.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-reinstall.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-remove.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-repo.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-repoquery.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-swap.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-upgrade.8 DESTINATION share/man/man8)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-comps.7 DESTINATION share/man/man7)
+        # TODO(jkolarik): filtering is not ready yet
+        # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-filtering.7 DESTINATION share/man/man7)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-installroot.7 DESTINATION share/man/man7)
+        # TODO(jkolarik): modularity is not ready yet
+        # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-modularity.7 DESTINATION share/man/man7)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-specs.7 DESTINATION share/man/man7)
     endif()
 
 endif()

--- a/doc/commands/advisory.8.rst
+++ b/doc/commands/advisory.8.rst
@@ -1,0 +1,118 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _advisory_command_ref-label:
+
+#################
+ Advisory Command
+#################
+
+Synopsis
+========
+
+``dnf5 advisory <subcommand> [options] [<advisory-spec>...]``
+
+
+Description
+===========
+
+The ``advisory`` command in ``DNF5`` offers several queries for getting information about 
+advisories and packages related to them.
+
+Optional ``advisory-spec`` arguments could be passed to filter only advisories with given names.
+
+
+Subcommands
+===========
+
+``list``
+    | List available advisories.
+
+``info``
+    | Print details about advisories.
+
+``summary``
+    | Print a summary of advisories.
+
+
+Options
+=======
+
+``--all``
+    | Show advisories containing any version of installed packages.
+
+``--available``
+    | Show advisories containing newer versions of installed packages.
+
+``--installed``
+    | Show advisories containing equal and older versions of installed packages.
+
+``--updates``
+    | Show advisories containing newer versions of installed packages for which a newer version is available.
+
+``--contains-pkgs=PACKAGE_NAME,...``
+    | Show only advisories containing packages with specified names.
+    | This is a list option.
+    | Only installed packages are matched. Globs are supported.
+
+``--security``
+    | Consider only content contained in security advisories.
+
+``--bugfix``
+    | Consider only content contained in bugfix advisories.
+
+``--enhancement``
+    | Consider only content contained in enhancement advisories.
+
+``--newpackage``
+    | Consider only content contained in newpackage advisories.
+
+``--advisory-severities=ADVISORY_SEVERITY,...``
+    | Consider only content contained in advisories with specified severity. 
+    | This is a list option. 
+    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+
+``--bzs=BUGZILLA_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID. 
+    | This is a list option.
+    | Expected values are numeric IDs, e.g. `123123`.
+
+``--cves=CVE_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
+    | This is a list option.
+    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`. 
+
+``--with-bz``
+    | Show only advisories referencing a Bugzilla ticket.
+
+``--with-cve``
+    | Show only advisories referencing a CVE ticket.
+
+
+Examples
+========
+
+``dnf5 advisory info FEDORA-2022-07aa56297a``
+    | Show detailed info about advisory with given name.
+
+``dnf5 advisory summary --contains-pkgs=kernel,kernel-core --with-bz``
+    | Show a summary of advisories containing ``kernel`` or ``kernel-core`` packages and referencing any Bugzilla ticket.
+
+``dnf5 advisory list --security --advisory-severities=important``
+    | Show a list of security advisories or advisories with ``important`` severity.
+

--- a/doc/commands/clean.8.rst
+++ b/doc/commands/clean.8.rst
@@ -1,0 +1,67 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _clean_command_ref-label:
+
+##############
+ Clean Command
+##############
+
+Synopsis
+========
+
+``dnf5 clean [options] <cache_types>...``
+
+
+Description
+===========
+
+The ``clean`` command in ``DNF5`` is used to delete temporarily kept repository metadata 
+or marking the cache expired.
+
+Arguments in ``cache_types`` specify which types of the cached data to cleanup:
+
+`all`
+    | Delete all temporary repository data from the system.
+
+`packages`
+    | Delete any cached packages.
+
+`metadata`
+    | Delete repository metadata.
+    | This will delete the files which ``DNF5`` uses to determine the remote availability of packages. 
+    | Using this option will make ``DNF5`` download all the metadata the next time it is run.
+
+`dbcache`
+    | Delete cache files generated from the repository metadata. 
+    | This forces ``DNF5`` to regenerate the cache files the next time it is run.
+
+`expire-cache`
+    | Mark the repository metadata expired. 
+    | This forces ``DNF5`` to check the validity of the cache the next time it is run.
+
+
+Examples
+========
+
+``dnf5 clean all``
+    | Cleanup all repository cached data.
+
+``dnf5 clean packages dbcache``
+    | Cleanup all cached packages and dbcache metadata.
+

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -1,0 +1,62 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _distro-sync_command_ref-label:
+
+####################
+ Distro-Sync Command
+####################
+
+Synopsis
+========
+
+``dnf5 distro-sync [options] [<package-spec>...]``
+
+
+Description
+===========
+
+The ``distro-sync`` command in ``DNF5`` serves to synchronize the installed packages 
+with their latest available version from any enabled repository. It upgrades, downgrades 
+or keeps packages as needed.
+
+Optional ``package-spec`` arguments could be passed to select only specific packages to be synced.
+
+
+Options
+=======
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+
+Examples
+========
+
+``dnf5 distro-sync``
+    | Sync the whole system to the latest available version of packages.
+
+``dnf5 distro-sync vim``
+    | Sync the ``vim`` package to the latest available version.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -1,0 +1,60 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _downgrade_command_ref-label:
+
+##################
+ Downgrade Command
+##################
+
+Synopsis
+========
+
+``dnf5 downgrade [options] <package-spec>...``
+
+
+Description
+===========
+
+The ``downgrade`` command in ``DNF5`` is used to downgrade each package specified in ``package-spec`` list to the 
+highest installable version of all known lower versions if possible. When the version is explicitly given
+in the argument and it is lower than the version of the installed package then it downgrades to this one.
+
+
+Options
+=======
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+
+Examples
+========
+
+``dnf5 downgrade nano-0:6.0-2.fc36``
+    | Downgrade the ``nano`` package to the given version.
+
+``dnf5 downgrade gcc glibc --allowerasing``
+    | Downgrade ``gcc``, ``glibc`` packages and allow erasing of installed packages when needed.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -1,0 +1,65 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _download_command_ref-label:
+
+#################
+ Download Command
+#################
+
+Synopsis
+========
+
+``dnf5 download [options] <package-spec>...``
+
+
+Description
+===========
+
+The ``download`` command in ``DNF5`` is used for downloading binary and source packages 
+defined in ``package-spec`` arguments.
+
+
+Options
+=======
+
+``--resolve``
+    | Resolve dependencies of specified packages and download missing ones.
+
+``--alldeps``
+    | To be used together with ``--resolve``, it downloads all dependencies, not skipping the already installed ones.
+
+
+Examples
+========
+
+``dnf5 download kernel-headers-0:5.17.0-300.fc36.i686``
+    | Download the ``kernel-headers`` package using the full NEVRA format.
+
+``dnf5 download rpm rpm-devel``
+    | Download all packages having the name of ``rpm`` or ``rpm-devel``.
+
+``dnf5 download maven-compiler-plugin --resolve --alldeps``
+    | Download the ``maven-compiler-plugin`` package with all its dependencies.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/environment.8.rst
+++ b/doc/commands/environment.8.rst
@@ -1,0 +1,78 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): Still some subcommands missing in the upstream (install, ...)
+
+.. _environment_command_ref-label:
+
+####################
+ Environment Command
+####################
+
+Synopsis
+========
+
+``dnf5 environment <subcommand> [options] [<environment-spec>...]``
+
+
+Description
+===========
+
+The ``environment`` command in ``DNF5`` offers several queries for getting information 
+about environments and groups related to them.
+
+Optional ``environment-spec`` arguments could be passed to filter only environments with given names.
+
+
+Subcommands
+===========
+
+``list``
+    | List available environments.
+
+``info``
+    | Print details about environments.
+
+
+Options
+=======
+
+``--available``
+    | Show only available environments. Those which are not installed, but known to ``DNF5``.
+
+``--installed``
+    | Show only installed environments.
+
+
+Examples
+========
+
+``dnf5 environment list``
+    | Show list of all environments.
+
+``dnf5 environment info "KDE Plasma Workspaces"``
+    | Show detailed info about the ``KDE`` environment.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-comps(7)`, :ref:`Comps groups and environments <comps_misc_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -1,0 +1,86 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _group_command_ref-label:
+
+##############
+ Group Command
+##############
+
+Synopsis
+========
+
+``dnf5 group <subcommand> [options] [<group-spec>...]``
+
+
+Description
+===========
+
+The ``group`` command in ``DNF5`` offers several queries for getting information about groups, packages
+related to them and it is also used for groups installation.
+
+Optional ``group-spec`` arguments could be passed to filter only groups with given names.
+
+
+Subcommands
+===========
+
+``install``
+    | Install comps groups, including their packages.
+
+``list``
+    | List available groups.
+
+``info``
+    | Print details about groups.
+
+
+Options
+=======
+
+``--available``
+    | Show only available groups. Those which are not installed, but known to ``DNF5``.
+
+``--installed``
+    | Show only installed groups.
+
+``--hidden``
+    | Show also hidden groups.
+
+``--with-optional``
+    | Used with ``install`` command to include optional packages from the groups.
+
+Examples
+========
+
+``dnf5 group list --hidden``
+    | Show list of all groups, including hidden ones.
+
+``dnf5 group info *xfce*``
+    | Show detailed info about all groups related to ``Xfce``.
+
+``dnf5 group install mysql --with-optional``
+    | Install the ``mysql`` group including optional packages.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-comps(7)`, :ref:`Comps groups and environments <comps_misc_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/history.8.rst
+++ b/doc/commands/history.8.rst
@@ -1,0 +1,83 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): Command not ready yet in upstream ...
+
+.. _history_command_ref-label:
+
+################
+ History Command
+################
+
+Synopsis
+========
+
+``dnf5 history <subcommand> [options] [<transaction-spec>]``
+
+
+Description
+===========
+
+The ``history`` command in ``DNF5`` allows the user to view what has happened in past transactions
+and offers several operations on these transactions, like undoing and redoing them. In order to
+use the transactions in these commands, it is assumed that they were committed while using the
+``history_record`` configuration option.
+
+
+Subcommands
+===========
+
+``list``
+    | List info about recorded transactions in the system.
+
+``info``
+    | Print details about specific transactions.
+
+``undo``
+    | Revert all actions from the specified transaction.
+
+``redo``
+    | Repeat the specified transaction.
+
+``rollback``
+    | Undo all transactions performed after the specified transaction.
+
+``store``
+    | Store the transaction into the file.
+
+``replay``
+    | Replay the transaction that was previously stored into the file.
+
+
+Options
+=======
+
+``--reverse``
+    | Reverse the order of transactions in the output.
+
+
+Examples
+========
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/index.rst
+++ b/doc/commands/index.rst
@@ -1,0 +1,32 @@
+=============
+DNF5 Commands
+=============
+
+
+.. toctree::
+    :maxdepth: 1
+
+    advisory.8
+    clean.8
+    distro-sync.8
+    downgrade.8
+    download.8
+    environment.8
+    group.8
+    install.8
+    makecache.8
+    mark.8
+    reinstall.8
+    remove.8
+    repo.8
+    repoquery.8
+    swap.8
+    upgrade.8
+
+..
+    # TODO(jkolarik): history not ready yet
+    history.8
+
+    # TODO(jkolarik): module not ready yet
+    module.8
+

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -1,0 +1,100 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _install_command_ref-label:
+
+################
+ Install Command
+################
+
+Synopsis
+========
+
+``dnf5 install [options] <package-spec>...``
+
+
+Description
+===========
+
+The ``install`` command in ``DNF5`` is used for installing packages. It makes sure that
+all given packages defined in ``package-spec`` arguments and their dependencies are installed
+on the system.
+
+
+Options
+=======
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+``--advisories=ADVISORY_NAME,...``
+    | Consider only content contained in advisories with specified name.
+    | This is a list option.
+    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+
+``--advisory-severities=ADVISORY_SEVERITY,...``
+    | Consider only content contained in advisories with specified severity. 
+    | This is a list option. 
+    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+
+``--bzs=BUGZILLA_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID. 
+    | This is a list option.
+    | Expected values are numeric IDs, e.g. `123123`.
+
+``--cves=CVE_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
+    | This is a list option.
+    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`. 
+
+``--security``
+    | Consider only content contained in security advisories.
+
+``--bugfix``
+    | Consider only content contained in bugfix advisories.
+
+``--enhancement``
+    | Consider only content contained in enhancement advisories.
+
+``--newpackage``
+    | Consider only content contained in newpackage advisories.
+
+
+Examples
+========
+
+``dnf5 install tito``
+    | Install the ``tito`` package.
+
+``dnf5 install ~/Downloads/tito-0.6.21-1.fc36.noarch.rpm``
+    | Install the local rpm file from the given location.
+
+``dnf5 install tito-0.6.21-1.fc36``
+    | Install the ``tito`` package in defined version. 
+    | If the package is already installed, it will automatically try to downgrade or upgrade to the given version.
+
+``dnf5 install --advisory=FEDORA-2022-07aa56297a \*``
+    | Install all the packages that belong to the ``FEDORA-2022-07aa56297a`` advisory.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-advisory(8)`, :ref:`Advisory command <advisory_command_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/makecache.8.rst
+++ b/doc/commands/makecache.8.rst
@@ -1,0 +1,39 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _makecache_command_ref-label:
+
+##################
+ Makecache Command
+##################
+
+Synopsis
+========
+
+``dnf5 makecache [global options]``
+
+
+Description
+===========
+
+The ``makecache`` command in ``DNF5`` is used for creating and downloading metadata
+for enabled repositories.
+
+It tries to avoid downloading whenever possible, e.g. when the local metadata hasn't 
+expired yet or when the metadata timestamp hasn't changed.
+

--- a/doc/commands/mark.8.rst
+++ b/doc/commands/mark.8.rst
@@ -1,0 +1,86 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _mark_command_ref-label:
+
+#############
+ Mark Command
+#############
+
+Synopsis
+========
+
+``dnf5 mark <subcommand> [global options] [<group-id>] <package-spec>...``
+
+
+Description
+===========
+
+The ``mark`` command in ``DNF5`` is used to change reason of installed packages 
+defined in ``package-spec`` arguments.
+
+
+Subcommands
+===========
+
+``user``
+    | Mark the package as user-installed.
+
+    This can be useful if any package was installed as a dependency and is desired 
+    to stay on the system when ``remove`` command along with ``clean_requirements_on_remove`` 
+    configuration option set to ``True`` is executed.
+
+``dependency``
+    | Mark the package as a dependency.
+
+    This can be useful if you as the user don't need a specific package. The package stays 
+    installed on the system, but will be removed when ``remove`` command along with 
+    ``clean_requirements_on_remove`` configuration option set to ``True`` is executed.
+
+    You should use this operation instead of ``remove`` command if you're not sure whether 
+    the package is a requirement of other user installed package on the system.
+
+``weak``
+    | Mark the package as a weak dependency.
+
+..
+    # TODO(jkolarik): weak - What is the purpose of doing this?
+
+``group``
+    | Mark the package as installed by the group defined in ``group-id`` argument.
+    
+    This can be useful if any package was installed as a dependency or the user and 
+    is desired to be protected and handled as a group member like during ``group remove`` command.
+
+
+Examples
+========
+
+``dnf5 mark user fuse-devel``
+    | Mark the ``fuse-devel`` package as user-installed.
+
+``dnf5 mark group xfce-desktop vim-enhanced``
+    | Mark the ``vim-enhanced`` package as installed by the ``xfce-desktop`` group.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-comps(7)`, :ref:`Comps groups and environments <comps_misc_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/module.8.rst
+++ b/doc/commands/module.8.rst
@@ -1,0 +1,75 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): Command not ready yet in upstream ...
+
+.. _module_command_ref-label:
+
+###############
+ Module Command
+###############
+
+Synopsis
+========
+
+``dnf5 module <subcommand> [options] [<module-spec>]``
+
+
+Description
+===========
+
+
+Subcommands
+===========
+
+``list``
+    | List module streams.
+
+``info``
+    | Print details about module streams.
+
+``provides``
+    | Print module and module profile the specified packages come from.
+
+``enable``
+    | Enable module streams and make their packages available.
+
+``disable``
+    | Disable modules including all their streams.
+
+``switch-to``
+    | Enable different module streams, upgrade their profiles and distro-sync packages.
+
+``reset``
+    | Reset module state so it's no longer enabled or disabled.
+
+``install``
+    | Install module profiles, including their packages.
+
+``remove``
+    | Remove installed module profiles including their packages.
+
+
+Options
+=======
+
+
+Examples
+========
+

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -1,0 +1,53 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _reinstall_command_ref-label:
+
+##################
+ Reinstall Command
+##################
+
+Synopsis
+========
+
+``dnf5 reinstall [global options] <package-spec>...``
+
+
+Description
+===========
+
+The ``reinstall`` command in ``DNF5`` is used for reinstalling packages defined in
+``package-spec`` arguments.
+
+
+Examples
+========
+
+``dnf5 reinstall tito``
+    | Reinstall the ``tito`` package.
+
+``dnf5 reinstall ~/Downloads/tito-0.6.21-1.fc36.noarch.rpm``
+    | Reinstall the ``tito`` package from the local rpm file.
+    | This can be useful f.e. when the given package is not available in any enabled repository.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -1,0 +1,50 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _remove_command_ref-label:
+
+###############
+ Remove Command
+###############
+
+Synopsis
+========
+
+``dnf5 remove [options] <package-spec>...``
+
+
+Description
+===========
+
+The ``remove`` command in ``DNF5`` is used for removing installed packages from the system.
+If you want to remove also all dependencies that are no longer needed by any other package,
+set the ``clean_requirements_on_remove`` configuration parameter to ``True``.
+
+
+Examples
+========
+
+``dnf5 remove tito``
+    | Remove the ``tito`` package.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -1,0 +1,70 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _repo_command_ref-label:
+
+#############
+ Repo Command
+#############
+
+Synopsis
+========
+
+``dnf5 repo <subcommand> [options] [<repo-spec>...]``
+
+
+Description
+===========
+
+The ``repo`` command in ``DNF5`` offers several queries for getting information 
+about repositories configured on the system.
+
+
+Subcommands
+===========
+
+``list``
+    | List available repositories.
+
+``info``
+    | Show detailed info about repositories.
+
+
+Options
+=======
+
+``--all``
+    | Show information about all known repositories.
+
+``--enabled``
+    | Show information only about enabled repositories.
+    | This is the default behavior.
+
+``--disabled``
+    | Show information only about disabled repositories.
+
+
+Examples
+========
+
+``dnf5 repo info --all``
+    | Print detailed info about all known repositories.
+
+``dnf5 repo list --disabled *-debuginfo``
+    | Print disabled repositories related to debugging.
+

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -1,0 +1,108 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _repoquery_command_ref-label:
+
+##################
+ Repoquery Command
+##################
+
+Synopsis
+========
+
+``dnf5 repoquery [options] [<spec>...]``
+
+
+Description
+===========
+
+The ``repoquery`` command in ``DNF5`` is used for querying packages by matching
+various input criteria from the user. Arguments defined in ``spec`` list could be
+either file paths or package specs.
+
+
+Options
+=======
+
+``--advisories=ADVISORY_NAME,...``
+    | Consider only content contained in advisories with specified name.
+    | This is a list option.
+    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+
+``--advisory-severities=ADVISORY_SEVERITY,...``
+    | Consider only content contained in advisories with specified severity. 
+    | This is a list option. 
+    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+
+``--bzs=BUGZILLA_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID. 
+    | This is a list option.
+    | Expected values are numeric IDs, e.g. `123123`.
+
+``--cves=CVE_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
+    | This is a list option.
+    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`. 
+
+``--security``
+    | Consider only content contained in security advisories.
+
+``--bugfix``
+    | Consider only content contained in bugfix advisories.
+
+``--enhancement``
+    | Consider only content contained in enhancement advisories.
+
+``--newpackage``
+    | Consider only content contained in newpackage advisories.
+
+``--available``
+    | Display all available packages.
+    | This is the default behavior.
+
+``--installed``
+    | Display only installed packages.
+
+``--nevra``
+    | Use the `NEVRA` format for the output.
+    | This is the default behavior.
+    | This can be useful for scripting or automation as the output is in machine-readable format.
+
+``--info``
+    | Use the verbose format for the output.
+
+
+Examples
+========
+
+``dnf5 repoquery /etc/koji.conf``
+    | List packages which provide the given file.
+
+``dnf5 repoquery *http*``
+    | List packages containing the ``http`` inside their name.
+
+``dnf5 repoquery --installed --security``
+    | List installed packages included in any security advisories.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-advisory(8)`, :ref:`Advisory command <advisory_command_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -1,0 +1,50 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _swap_command_ref-label:
+
+#############
+ Swap Command
+#############
+
+Synopsis
+========
+
+``dnf5 swap [options] <remove-spec> <install-spec>``
+
+
+Description
+===========
+
+The ``swap`` command in ``DNF5`` is used for removing a package while installing
+a different one in a single transaction.
+
+
+Options
+=======
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+
+Examples
+========
+
+``dnf5 swap mlocate plocate``
+    | Remove the ``mlocate`` package and install the ``plocate`` instead in the single transaction.
+

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -1,0 +1,96 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _upgrade_command_ref-label:
+
+################
+ Upgrade Command
+################
+
+Synopsis
+========
+
+``dnf5 upgrade [options] [<package-spec>...]``
+
+
+Description
+===========
+
+The ``upgrade`` command in ``DNF5`` is used for upgrading installed packages to the
+newer available version.
+
+
+Options
+=======
+
+``--minimal``
+    Update packages only to the lowest higher available version that provides a bugfix, 
+    enhancement or a fix for a security issue.
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+``--advisories=ADVISORY_NAME,...``
+    | Consider only content contained in advisories with specified name.
+    | This is a list option.
+    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+
+``--advisory-severities=ADVISORY_SEVERITY,...``
+    | Consider only content contained in advisories with specified severity. 
+    | This is a list option. 
+    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+
+``--bzs=BUGZILLA_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID. 
+    | This is a list option.
+    | Expected values are numeric IDs, e.g. `123123`.
+
+``--cves=CVE_ID,...``
+    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
+    | This is a list option.
+    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`. 
+
+``--security``
+    | Consider only content contained in security advisories.
+
+``--bugfix``
+    | Consider only content contained in bugfix advisories.
+
+``--enhancement``
+    | Consider only content contained in enhancement advisories.
+
+``--newpackage``
+    | Consider only content contained in newpackage advisories.
+
+
+Examples
+========
+
+``dnf5 upgrade``
+    | Upgrade all installed packages to the newest available version.
+
+``dnf5 upgrade tito``
+    | Upgrade the ``tito`` package.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-advisory(8)`, :ref:`Advisory command <advisory_command_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -23,11 +23,11 @@ sys.path.insert(0, os.path.join(libdnf_docdir, "sphinx"))
 
 # -- Project information -----------------------------------------------------
 
-project = 'libdnf'
-copyright = 'Contributors to the libdnf project.'
+project = 'dnf5'
+copyright = 'Contributors to the dnf5 project.'
 author = 'RPM Software Management <rpm-ecosystem@lists.rpm.org>'
 
-AUTHORS=['See AUTHORS.md in libdnf source distribution.']
+AUTHORS=['See AUTHORS.md in dnf5 source distribution.']
 
 
 # -- General configuration ---------------------------------------------------
@@ -40,8 +40,8 @@ needs_sphinx = '4.1.2'
 extensions = [
     'breathe'
 ]
-breathe_projects = {'libdnf': '@CMAKE_CURRENT_BINARY_DIR@/xml/'}
-breathe_default_project = 'libdnf'
+breathe_projects = {'dnf5': '@CMAKE_CURRENT_BINARY_DIR@/xml/'}
+breathe_default_project = 'dnf5'
 
 if sphinx.version_info[:3] > (4, 0, 0):
     tags.add('sphinx4')
@@ -82,8 +82,36 @@ html_static_path = ['_static']
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('dnf5.8', 'dnf5', 'DNF5 Command-line Package Manager', AUTHORS, 8),
+    ('dnf5.8', 'dnf5', 'DNF5 Package Management Utility', AUTHORS, 8),
+    ('commands/advisory.8', 'dnf5-advisory', 'Advisory Command', AUTHORS, 8),
+    ('commands/clean.8', 'dnf5-clean', 'Clean Command', AUTHORS, 8),
+    ('commands/distro-sync.8', 'dnf5-distro-sync', 'Distro-Sync Command', AUTHORS, 8),
+    ('commands/downgrade.8', 'dnf5-downgrade', 'Downgrade Command', AUTHORS, 8),
+    ('commands/download.8', 'dnf5-download', 'Download Command', AUTHORS, 8),
+    ('commands/environment.8', 'dnf5-environment', 'Environment Command', AUTHORS, 8),
+    ('commands/group.8', 'dnf5-group', 'Group Command', AUTHORS, 8),
+    ('commands/history.8', 'dnf5-history', 'History Command', AUTHORS, 8),
+    ('commands/install.8', 'dnf5-install', 'Install Command', AUTHORS, 8),
+    ('commands/makecache.8', 'dnf5-makecache', 'Makecache Command', AUTHORS, 8),
+    ('commands/mark.8', 'dnf5-mark', ' Mark Command', AUTHORS, 8),
+    ('commands/module.8', 'dnf5-module', ' Module Command', AUTHORS, 8),
+    ('commands/reinstall.8', 'dnf5-reinstall', 'Reinstall Command', AUTHORS, 8),
+    ('commands/remove.8', 'dnf5-remove', 'Remove Command', AUTHORS, 8),
+    ('commands/repo.8', 'dnf5-repo', 'Repo Command', AUTHORS, 8),
+    ('commands/repoquery.8', 'dnf5-repoquery', 'Repoquery Command', AUTHORS, 8),
+    ('commands/swap.8', 'dnf5-swap', 'Swap Command', AUTHORS, 8),
+    ('commands/upgrade.8', 'dnf5-upgrade', 'Upgrade Command', AUTHORS, 8),
+    ('misc/comps.7', 'dnf5-comps', 'Comps Groups And Environments', AUTHORS, 7),
+    ('misc/filtering.7', 'dnf5-filtering', 'Packages Filtering', AUTHORS, 7),
+    ('misc/installroot.7', 'dnf5-installroot', 'Installroot Parameter', AUTHORS, 7),
+    ('misc/modularity.7', 'dnf5-modularity', 'Modularity Overview', AUTHORS, 7),
+    ('misc/specs.7', 'dnf5-specs', 'Patterns Specification', AUTHORS, 7),
     ('dnf_daemon/dnf5daemon_client.8', 'dnf5daemon-client', 'Command-line interface for Dnf5daemon', AUTHORS, 8),
     ('dnf_daemon/dnf5daemon_server.8', 'dnf5daemon-server', 'Package management service with a DBus interface', AUTHORS, 8),
     ('dnf_daemon/dnf5daemon_dbus_api.8', 'dnf5daemon-dbus-api', 'DBus API Reference for Dnf5daemon', AUTHORS, 8),
 ]
+
+rst_prolog = """
+.. _DNF: https://github.com/rpm-software-management/dnf/
+.. _DNF5: https://github.com/rpm-software-management/dnf5/
+"""

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -16,17 +16,309 @@
     You should have received a copy of the GNU General Public License
     along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
+################################
+ DNF5 Package Management Utility
+################################
 
-#######################################
- DNF5 Command-line Package Manager
-#######################################
-
+..
+    # TODO(jkolarik): unify first man page structure with the help output, especially the commands 
+                      grouping - think about it, some groups and related commands don't make much sense
+    # TODO(jkolarik): add notes about mutually exclusive options
+    # TODO(jkolarik): add crosslinks where possible
+    # TODO(jkolarik): review against DNF4 if nothing important is missing
+    # TODO(jkolarik): add misc page about advisories?
 
 Synopsis
 ========
 
-``dnf5 [options] <command> [<args>...]``
+``dnf5 <command> [options] [<args>...]``
 
 
 Description
 ===========
+
+`DNF5`_ is the new version of `DNF`_, a package manager for RPM-based Linux distributions. It has been completely 
+rewritten in C++ aiming for better performance and reducing external dependencies.
+
+
+Commands
+========
+
+Here is the list of the available commands.
+For more details see the separate man page for the specific command, f.e. ``man dnf5 install``.
+
+:ref:`advisory <advisory_command_ref-label>`
+    | Manage advisories.
+
+:ref:`clean <clean_command_ref-label>`
+    | Remove or invalidate cached data.
+
+:ref:`distro-sync <distro-sync_command_ref-label>`
+    | Upgrade or downgrade installed packages to the latest available version.
+
+:ref:`downgrade <downgrade_command_ref-label>`
+    | Downgrade packages.
+
+:ref:`download <download_command_ref-label>`
+    | Download packages. 
+
+:ref:`environment <environment_command_ref-label>`
+    | Manage comps environments. 
+
+:ref:`group <group_command_ref-label>`
+    | Manage comps groups.
+
+:ref:`install <install_command_ref-label>`
+    | Install packages.
+
+:ref:`makecache <makecache_command_ref-label>`
+    | Generate the metadata cache.
+
+:ref:`mark <mark_command_ref-label>`
+    | Change the reason of an installed package.
+
+:ref:`reinstall <reinstall_command_ref-label>`
+    | Reinstall packages.
+
+:ref:`remove <remove_command_ref-label>`
+    | Remove packages.
+
+:ref:`repo <repo_command_ref-label>`
+    | Manage repositories. 
+
+:ref:`repoquery <repoquery_command_ref-label>`
+    | Search for packages in repositories.
+
+:ref:`swap <swap_command_ref-label>`
+    | Remove software and install another in the single transaction.
+
+:ref:`upgrade <upgrade_command_ref-label>`
+    | Upgrade packages.
+
+..
+    # TODO(jkolarik): History command is not ready yet
+    :ref:`history <history_command_ref-label>`
+        | Manage transaction history.
+
+    # TODO(jkolarik): Module command is not ready yet
+    :ref:`module <module_command_ref-label>`
+        | Manage modules. 
+
+
+Options
+=======
+
+Following options are applicable in the general context for any ``dnf5`` command:
+
+``--assumeno``
+    | Automatically answer no for all questions.
+
+``--best``
+    | Try the best available package versions in transactions. 
+
+    Specifically during dnf upgrade, which by default skips over updates that can not be 
+    installed for dependency reasons, the switch forces ``DNF5`` to only consider the latest 
+    packages. When running into packages with broken dependencies, ``DNF5`` will fail giving 
+    the reason why the latest version can not be installed.
+
+    Note that the use of the newest available version is only guaranteed for the packages 
+    directly requested (e.g. as a command line arguments), and the solver may use older 
+    versions of dependencies to meet their requirements.
+
+``--comment=COMMENT``
+    | Add a comment to the transaction history.
+
+``--config=CONFIG_FILE_PATH``
+    | Define configuration file location.
+
+``--debugsolver``
+    | Dump additional data from solver for debugging purposes.
+    | Data are saved in ``./debugdata``.
+
+``--disable-plugin=PLUGIN_NAME,...``
+    | Disable specified plugins for the purpose of the current ``DNF5`` command.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are names, or a glob of names.
+
+``--disable-repo=REPO_ID,...``
+    | Temporarily disable active repositories for the purpose of the current ``DNF5`` command.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are ids, or a glob of ids.
+
+``--enable-plugin=PLUGIN_NAME,...``
+    | Enable specified plugins for the purpose of the current ``DNF5`` command.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are names, or a glob of names.
+
+``--enable-repo=REPO_ID,...``
+    | Temporarily enable additional repositories for the purpose of the current ``DNF5`` command.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are ids, or a glob of ids.
+
+``-h, --help``
+    | Show the help.
+
+``--installroot=ABSOLUTE_PATH``
+    | Setup installroot path.
+    | Absolute path is required.
+    | :ref:`See <installroot_misc_ref-label>` :manpage:`dnf5-installroot(7)` for more info.
+
+``--no-best``
+    | Do not limit the transaction to the best candidates only.
+
+``--no-docs``
+    | Do not install any files that are marked as a documentation (which includes man pages and texinfo documents).
+    | It sets the ``RPMTRANS_FLAG_NODOCS`` flag.
+
+``--no-gpgchecks``
+    | Skip checking GPG signatures on packages (if ``RPM`` policy allows that).
+
+``--no-plugins``
+    | Disable all plugins.
+
+``-q, --quiet``
+    In combination with a non-interactive command, shows just the relevant content. 
+    Suppresses messages notifying about the current state or actions of ``DNF5``.
+
+``--repo=REPO_ID,...``
+    | Enable just specified repositories.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are ids, or a glob of ids.
+
+``--releasever=RELEASEVER``
+    | Override the value of the distribution release in configuration files. 
+    | This can affect cache paths, values in configuration files and mirrorlist URLs.
+
+``--setopt=[REPO_ID.]OPTION=VALUE``
+    | Override a configuration option from the configuration file. 
+    | The ``REPO_ID`` parameter is used to override options for repositories.
+    
+    Values for the options like ``excludepkgs``, ``includepkgs``, ``installonlypkgs`` and ``tsflags`` 
+    are appended to the original value, they do not override it. However, specifying an empty 
+    value (e.g. ``--setopt=tsflags=``) will clear the option.
+
+``--setvar=VAR_NAME=VALUE``
+    | Override a ``DNF5`` variable value, like ``arch``, ``releasever``, etc.
+
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
+``-y, --assumeyes``
+    | Automatically answer yes for all questions.
+
+``-x PACKAGE-SPEC,..., --exclude=PACKAGE-SPEC,...``
+    | Exclude packages specified in ``PACKAGE-SPEC`` arguments from the transaction.
+    | This is a list option.
+
+
+Metadata Synchronization
+========================
+
+Correct operation of ``DNF5`` depends on having an access to up-to-date data from the all enabled 
+repositories, but contacting remote mirrors on every operation considerably slows it down and costs 
+bandwidth for both the client and the repository provider. The ``metadata_expire`` repository configuration 
+option is used by ``DNF5`` to determine whether a particular local copy of repository data is due 
+to be re-synced. It is crucial that the repository providers set the option well, namely to a value 
+where it is guaranteed that if particular metadata was available in time ``T`` on the server, 
+then all packages it references will still be available for download from the server 
+in time ``T + metadata_expire``.
+
+To further reduce the bandwidth load, some of the commands where having up-to-date metadata 
+is not critical (e.g. the ``group list`` command) do not look at whether a repository is expired 
+and whenever any version of it is locally available to the user's account, it will be used. 
+
+For non-root usages it can be also useful running entirely from the system cache, don't update the 
+cache and use it even in case it is expired by setting the ``cacheonly`` configuration option.
+``DNF5`` uses a separate cache for each user under which it executes. The cache for the root user 
+is called the system cache. This option allows a regular user read-only access to the system cache, 
+which usually is more fresh than the user's and thus he does not have to wait for metadata sync.
+
+Configuration Files Replacement Policy
+======================================
+
+The updated packages could replace the old modified configuration files with the new ones or keep 
+the older files. Neither of the files are actually replaced. To the conflicting ones ``RPM`` 
+gives additional suffix to the origin name. Which file should maintain the true name after 
+transaction is not controlled by package manager, but is specified by each package itself, 
+following packaging guideline.
+
+
+Exit Codes
+==========
+
+The ``dnf5`` command in general exits with the following return values:
+
+`0`
+    | Operation was successful.
+
+`1`
+    | An error occurred during processing of the command.
+
+`2`
+    | An error occurred during parsing the arguments.
+
+Other exit codes could be returned by the specific command itself, see its documentation for more info.
+
+
+Files
+=====
+
+``Cache Files``
+    /var/cache/libdnf5/
+
+``Main Configuration``
+    /etc/dnf/dnf.conf
+
+``Repository Metadata``
+    /etc/yum.repos.d/
+
+``Repository Persistence``
+    /var/lib/dnf/
+
+``System state``
+    /usr/lib/sysimage/libdnf5/
+
+
+See Also
+========
+
+Commands in detail:
+    | :manpage:`dnf5-advisory(8)`, :ref:`Advisory command <advisory_command_ref-label>`
+    | :manpage:`dnf5-clean(8)`, :ref:`Clean command <clean_command_ref-label>`
+    | :manpage:`dnf5-distro-sync(8)`, :ref:`Distro-Sync command <distro-sync_command_ref-label>`
+    | :manpage:`dnf5-downgrade(8)`, :ref:`Downgrade command <downgrade_command_ref-label>`
+    | :manpage:`dnf5-download(8)`, :ref:`Download command <download_command_ref-label>`
+    | :manpage:`dnf5-environment(8)`, :ref:`Environment command <environment_command_ref-label>`
+    | :manpage:`dnf5-group(8)`, :ref:`Group command <group_command_ref-label>`
+    | :manpage:`dnf5-install(8)`, :ref:`Install command <install_command_ref-label>`
+    | :manpage:`dnf5-makecache(8)`, :ref:`Makecache command <makecache_command_ref-label>`
+    | :manpage:`dnf5-mark(8)`, :ref:`Mark command <mark_command_ref-label>`
+    | :manpage:`dnf5-reinstall(8)`, :ref:`Reinstall command <reinstall_command_ref-label>`
+    | :manpage:`dnf5-remove(8)`, :ref:`Remove command <remove_command_ref-label>`
+    | :manpage:`dnf5-repo(8)`, :ref:`Repo command <repo_command_ref-label>`
+    | :manpage:`dnf5-repoquery(8)`, :ref:`Repoquery command <repoquery_command_ref-label>`
+    | :manpage:`dnf5-swap(8)`, :ref:`Swap command <swap_command_ref-label>`
+    | :manpage:`dnf5-upgrade(8)`, :ref:`Upgrade command <upgrade_command_ref-label>`
+
+..
+    # TODO(jkolarik): History command is not ready yet
+    | :manpage:`dnf5-history(8)`, :ref:`History command, <history_command_ref-label>`
+
+    # TODO(jkolarik): Module command is not ready yet
+    | :manpage:`dnf5-module(8)`, :ref:`Module command, <module_command_ref-label>`
+
+Miscellaneous:
+    | :manpage:`dnf5-comps(7)`, :ref:`Comps groups and environments <comps_misc_ref-label>`
+    | :manpage:`dnf5-installroot(7)`, :ref:`Installroot parameter <installroot_misc_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+
+..
+    # TODO(jkolarik): Filtering is not ready yet
+    | :manpage:`dnf5-filtering(7)`, :ref:`Packages filtering, <filtering_misc_ref-label>`
+
+    # TODO(jkolarik): Modularity is not ready yet
+    | :manpage:`dnf5-modularity(7)`, :ref:`Modularity overview, <modularity_misc_ref-label>`
+
+Project homepage:
+    | https://github.com/rpm-software-management/dnf5
+

--- a/doc/dnf_daemon/index.rst
+++ b/doc/dnf_daemon/index.rst
@@ -1,5 +1,5 @@
 ===========
-Dnf5 Daemon
+DNF5 Daemon
 ===========
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 Welcome to DNF5's documentation!
-==================================
+================================
 
 
 .. toctree::
@@ -8,8 +8,10 @@ Welcome to DNF5's documentation!
     about
     tutorial/index
     api/index
+    commands/index
     dnf5.8
     dnf_daemon/index
+    misc/index
     contributing/index
     templates/index
     migration_guide

--- a/doc/misc/comps.7.rst
+++ b/doc/misc/comps.7.rst
@@ -1,0 +1,64 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _comps_misc_ref-label:
+
+##############################
+ Comps Groups And Environments
+##############################
+
+Description
+===========
+
+Comps files are used for grouping of packages into functional groups. They are stored
+in repository metadata files under the ``comps.xml`` filename. 
+
+There are two types of structures that can be used for grouping. The first is a 
+`group` which is composed of lists of packages. The second one is an `environment` 
+that is composed from the groups.
+
+Each `environment` is made of mandatory and optional groups. All mandatory groups have
+to be installed, so the `environment` is marked as `installed`. Optional groups are
+not installed by default, they have to be added using the ``--with-optional`` argument.
+
+In the `group`, there are four levels of packages:
+
+`mandatory`
+    | These are the essential packages for the functionality of the group.
+    | These have to be installed for the group to be considered ``installed``.
+
+`default`
+    | These are packages installed together with mandatory packages.
+    | They can be excluded, f.e. using the ``--exclude=PACKAGE-SPEC,...`` argument.
+
+`optional`
+    | These packages are not installed by default.
+    | They can be included using the ``--with-optional`` argument.
+
+`conditional`
+    | These packages are brought in the transaction if their required package is to be installed.
+
+For commands operating with groups and environments, see references below.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-group(8)`, :ref:`Group command <group_command_ref-label>`
+    | :manpage:`dnf5-environment(8)`, :ref:`Environment command <environment_command_ref-label>`
+

--- a/doc/misc/filtering.7.rst
+++ b/doc/misc/filtering.7.rst
@@ -1,0 +1,70 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): review, fix according to DNF5 state
+
+.. _filtering_misc_ref-label:
+
+###################
+ Packages Filtering
+###################
+
+Description
+===========
+
+Package filtering filters packages out from the available package set, making them invisible to most
+of the ``DNF5`` commands. They cannot be used in a transaction. Packages can be filtered out by either
+`Exclude Filtering` or `Modular Filtering`.
+
+
+Exclude Filtering
+=================
+
+Exclude Filtering is a mechanism used by a user or by the ``DNF5`` plugin to modify the set of available
+packages. Exclude Filtering can be modified by either ``includepkgs`` or ``excludepkgs`` configuration options in
+configuration files. In addition to user-configured excludes, plugins can also extend the set of excluded packages. 
+To disable excludes from the ``DNF5`` plugin you can use the ``--disable-plugin`` command line option.
+
+To disable all excludes for e.g. the install command you can use the following combination
+of command line options:
+
+``dnf5 --disableexcludes=all --disable-plugin="*" install bash``
+
+
+Modular Filtering
+=================
+
+Please see `the modularity documentation` for details on how Modular Filtering works.
+
+With modularity, only RPM packages from ``active`` module streams are included in the available
+package set. RPM packages from ``inactive`` module streams, as well as non-modular packages with
+the same name or provides as a package from an ``active`` module stream, are filtered out. Modular
+filtering is not applied to packages added from the command line, installed packages, or packages
+from repositories with ``module_hotfixes=true`` in their ``.repo`` file.
+
+Disabling of modular filtering is not recommended, because it could cause the system to get into
+a broken state. To disable modular filtering for a particular repository, specify
+``module_hotfixes=true`` in the ``.repo`` file or use ``--setopt=<repo_id>.module_hotfixes=true``.
+
+To discover the module which contains an excluded package use ``dnf5 module provides``.
+
+
+Examples
+========
+

--- a/doc/misc/index.rst
+++ b/doc/misc/index.rst
@@ -1,0 +1,18 @@
+=============
+Miscellaneous
+=============
+
+
+.. toctree::
+    :maxdepth: 1
+
+    comps.7
+    installroot.7
+    specs.7
+
+..
+    # TODO(jkolarik): Filtering is not ready yet
+    filtering.7
+
+    # TODO(jkolarik): Modularity is not ready yet
+    modularity.7

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -1,0 +1,73 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _installroot_misc_ref-label:
+
+######################
+ Installroot Parameter
+######################
+
+Description
+===========
+
+The ``--installroot`` parameter is used to specify an alternative installroot, 
+relative to where all packages will be installed. Think of it like doing 
+``chroot <root> dnf``, except using ``--installroot`` allows ``DNF5`` to work 
+before the chroot is created.
+
+`cachedir`, `log` files, `releasever`, and `gpgkey` are taken from or stored in 
+the installroot. Gpgkeys are imported into the installroot from a path relative 
+to the host which can be specified in the repository section of configuration files.
+
+`configuration` file and `reposdir` are searched inside the installroot first. 
+If they are not present, they are taken from the host system. 
+
+Note: When a path is specified within a command line argument (``--config=CONFIG_FILE_PATH`` 
+in case of `configuration` file and ``--setopt=reposdir=REPO_DIR_PATH`` for `reposdir`), then 
+this path is always relative to the host with no exceptions.
+
+`vars` are taken from the host system or installroot according to `reposdir`. When `reposdir` 
+path is specified within a command line argument, vars are taken from the installroot. 
+When `varsdir` paths are specified within the command line argument (``--setopt=varsdir=<reposdir>``) 
+then those path are always relative to the host with no exceptions.
+
+`pluginpath` and `pluginconfpath` are relative to the host. 
+
+Note: You may also want to use the command-line option ``--releasever=RELEASEVER`` when creating 
+the installroot, otherwise the $releasever value is taken from the rpmdb within the installroot 
+(and thus it is empty at the time of creation and the transaction will fail). If ``--releasever=/`` 
+is used, the releasever will be detected from the host (/) system. The new installroot path at the 
+time of creation does not contain the repository, releasever and dnf.conf files.
+
+On a modular system you may also want to use the ``--setopt=module_platform_id=<module_platform_name:stream>`` 
+command-line option when creating the installroot, otherwise the ``module_platform_id`` value will be 
+taken from the ``/etc/os-release`` file within the installroot (and thus it will be empty at the time of 
+creation, the modular dependency could be unsatisfied and modules content could be excluded).
+
+
+Examples
+========
+
+``dnf5 --installroot=INSTALLROOT --releasever=RELEASEVER install system-release``
+    Permanently sets the ``releasever`` of the system in the ``INSTALLROOT`` directory 
+    to ``RELEASEVER``.
+
+``dnf5 --installroot=INSTALLROOT --setopt=reposdir=PATH --config /path/dnf.conf upgrade``
+    Upgrades packages inside the installroot from a repository described by ``--setopt`` 
+    using configuration from ``/path/dnf.conf``.
+

--- a/doc/misc/modularity.7.rst
+++ b/doc/misc/modularity.7.rst
@@ -1,0 +1,32 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): Command not ready yet in upstream ...
+
+.. _modularity_misc_ref-label:
+
+####################
+ Modularity Overview
+####################
+
+Description
+===========
+
+Modularity is a new way of building, organizing and delivering packages.
+

--- a/doc/misc/specs.7.rst
+++ b/doc/misc/specs.7.rst
@@ -1,0 +1,190 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+..
+    # TODO(jkolarik): Add more specs info (advisory-spec, repo-spec, ...)
+
+.. _specs_misc_ref-label:
+
+#######################
+ Patterns Specification
+#######################
+
+Description
+===========
+
+Different pattern matching rules for arguments in ``*-spec`` form are defined 
+for operation with each entity type in ``DNF5``. In this section all rules are 
+described and explained in detail, with examples.
+
+
+Globs
+=====
+
+Pattern specification supports the same glob pattern matching that shell does.
+The following patterns are supported:
+
+``*``
+    Matches any number of characters.
+``?``
+    Matches any single character.
+``[]``
+    Matches any one of the enclosed characters. A pair of characters separated
+    by a hyphen denotes a range expression; any character that falls between
+    those two characters, inclusive, is matched. If the first character
+    following the ``[`` is a ``!`` or a ``^`` then any character not enclosed
+    is matched.
+
+Note: Curly brackets (``{}``) are not supported. You can still use them in
+shells that support them and let the shell do the expansion, but if quoted or
+escaped, ``DNF5`` will not expand them.
+
+NEVRA matching
+==============
+
+Each package can be uniquely identified by the `NEVRA` string. It consists of
+5 parts of information:
+
+`Name`
+    | Package name.
+
+`Epoch`
+    | Epoch number.
+    | It is not always included.
+
+    The epoch number overrides other version checking, so it can be used to 
+    force the package upgrade over some other one.
+
+`Version`
+    | Version string.
+    | It is not strictly numeric.
+    | It is intended to match the upstream software version.
+
+`Release`
+    | Edition string.
+
+    It is an information about the particular package build, usually a number 
+    increased with the newer build. It is not connected with the upstream software.
+
+`Architecture`
+    | Target architecture string.
+    | Defines the processor type the package is intended to be installed on.
+
+    It can be also a package containing source files (``src``) or architecture-independent 
+    package (``noarch``).
+
+When matching against NEVRAs, partial matching is supported. ``DNF5`` tries to match
+the spec against the following list of NEVRA forms (in decreasing order of
+priority):
+
+    |
+    | ``NAME-[EPOCH:]VERSION-RELEASE.ARCH``
+    | ``NAME.ARCH``
+    | ``NAME``
+    | ``NAME-[EPOCH:]VERSION-RELEASE``
+    | ``NAME-[EPOCH:]VERSION``
+    |
+
+Note that `name` can in general contain dashes (e.g. ``package-with-dashes``).
+
+The first form that matches any packages is used and the remaining forms are
+not tried. If none of the forms match any packages, an attempt is made to match
+the ``<package-spec>`` against full package NEVRAs. This is only relevant
+if globs are present in the ``<package-spec>``.
+
+``<package-spec>`` matches NEVRAs the same way ``<package-name-spec>`` does,
+but in case matching NEVRAs fails, it attempts to match against provides and
+file provides of packages as well.
+
+You can specify globs as part of any of the five NEVRA components. You can also
+specify a glob pattern to match over multiple NEVRA components (in other words,
+to match across the NEVRA separators). In that case, however, you need to write
+the spec to match against full package NEVRAs, as it is not possible to split
+such spec into NEVRA forms.
+
+
+Packages
+========
+
+Many commands take a ``<package-spec>`` parameter that selects a package for
+the operation. The ``<package-spec>`` argument is matched against package
+NEVRAs, provides and file provides.
+
+``<package-file-spec>`` is similar to ``<package-spec>``, except provides
+matching is not performed. Therefore, ``<package-file-spec>`` is matched only
+against NEVRAs and file provides.
+
+``<package-name-spec>`` is matched against NEVRAs only.
+
+
+Provides
+========
+
+``<provide-spec>`` in command descriptions means the command operates on
+packages providing the given spec. This can either be an explicit provide, an
+implicit provide (i.e. name of the package) or a file provide. The selection is
+case-sensitive and globbing is supported.
+
+
+Specifying File Provides
+------------------------
+
+If a ``spec`` starts with either ``/`` or ``*/``, it is considered as a potential file provide.
+
+
+Groups
+======
+
+``<group-spec>`` allows one to select (environment) groups a particular operation should work
+on. It is a case insensitive string (supporting globbing characters) that is
+matched against a group's ID, canonical name and name translated into the
+current ``LC_MESSAGES`` locale (if possible).
+
+
+Modules
+=======
+
+``<module-spec>`` allows one to select modules or profiles a particular operation should work
+on.
+
+Since `NEVRA` matching form is insufficient for modules, they are uniquely identified by the
+`NSVCA` format (``NAME:STREAM:VERSION:CONTEXT:ARCH/PROFILE``). Supported partial forms are the following:
+
+    |
+    | ``NAME``
+    | ``NAME:STREAM``
+    | ``NAME:STREAM:VERSION``
+    | ``NAME:STREAM:VERSION:CONTEXT``
+    | All above combinations with ``::ARCH`` (e.g. ``NAME::ARCH``)
+    | ``NAME:STREAM:VERSION:CONTEXT:ARCH``
+    | All above combinations with ``/PROFILE`` (e.g. ``NAME/PROFILE``)
+    |
+
+In case stream is not specified, the enabled or the default stream is used, in this order. 
+In case profile is not specified, the system default profile or the 'default' profile is used.
+
+
+Transactions
+============
+
+``<transaction-spec>`` can be in one of several forms. If it is an integer, it
+specifies a transaction ID. Specifying ``last`` is the same as specifying the ID
+of the most recent transaction. The last form is ``last-<offset>``, where
+``<offset>`` is a positive integer. It specifies offset-th transaction preceding
+the most recent transaction.
+


### PR DESCRIPTION
Created initial version of new `dnf5` man pages. Most of the content is based on the `dnf` man pages.

The main intent was to make the first page shorter, so the user won't be overwhelmed with information at the first look. Each command has its own man page. Also some concepts and terms referenced within man pages were moved into separate pages and described here in more detail.

Commands that are not completed are skipped for now. Also many `#TODO`s are included, so the work is not forgotten in the future.

Tested was both `man` and `HTML` output.