### PR TITLE
Make `TransactionItem` parts unused from outside `private`

### DIFF
--- a/include/libdnf/transaction/comps_group.hpp
+++ b/include/libdnf/transaction/comps_group.hpp
@@ -43,6 +43,7 @@ class CompsGroupPackageDbUtils;
 class CompsGroup : public TransactionItem {
 private:
     friend Transaction;
+    friend CompsGroupPackage;
     friend CompsGroupDbUtils;
     friend CompsGroupPackageDbUtils;
 
@@ -107,7 +108,6 @@ private:
     /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.toStr()
     std::string to_string() const { return get_group_id(); }
 
-    friend class CompsGroupPackage;
     std::string group_id;
     std::string name;
     std::string translated_name;

--- a/include/libdnf/transaction/transaction_item.hpp
+++ b/include/libdnf/transaction/transaction_item.hpp
@@ -30,6 +30,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::transaction {
 
 class Transaction;
+class CompsEnvironment;
+class CompsGroup;
+class RpmDbUtils;
+class Package;
+class TransItemDbUtils;
+class CompsGroupDbUtils;
+class CompsEnvironmentDbUtils;
+class CompsGroupPackageDbUtils;
+class CompsEnvironmentGroupDbUtils;
 
 
 class TransactionItem {
@@ -38,6 +47,38 @@ public:
     using Reason = TransactionItemReason;
     using State = TransactionItemState;
 
+    /// Get action associated with the transaction item in the transaction
+    ///
+    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
+    Action get_action() const noexcept { return action; }
+
+    /// Get reason of the action associated with the transaction item in the transaction
+    ///
+    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
+    Reason get_reason() const noexcept { return reason; }
+
+    /// Get transaction item repoid (text identifier of a repository)
+    ///
+    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getRepoid()
+    const std::string & get_repoid() const noexcept { return repoid; }
+
+    /// Get transaction item state
+    ///
+    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
+    State get_state() const noexcept { return state; }
+
+private:
+    friend RpmDbUtils;
+    friend Transaction;
+    friend CompsEnvironment;
+    friend CompsGroup;
+    friend Package;
+    friend TransItemDbUtils;
+    friend CompsGroupDbUtils;
+    friend CompsEnvironmentDbUtils;
+    friend CompsGroupPackageDbUtils;
+    friend CompsEnvironmentGroupDbUtils;
+
     explicit TransactionItem(const Transaction & trans);
 
     /// Get database id (primary key) of the transaction item (table 'trans_item')
@@ -45,11 +86,6 @@ public:
 
     /// Set database id (primary key) of the transaction item (table 'trans_item')
     void set_id(int64_t value) { id = value; }
-
-    /// Get action associated with the transaction item in the transaction
-    ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
 
     /// Set action associated with the transaction item in the transaction
     ///
@@ -66,30 +102,15 @@ public:
     /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getActionShort()
     std::string get_action_short();
 
-    /// Get reason of the action associated with the transaction item in the transaction
-    ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
-
     /// Set reason of the action associated with the transaction item in the transaction
     ///
     /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setReason(libdnf::TransactionItemReason value)
     void set_reason(Reason value) { reason = value; }
 
-    /// Get transaction item state
-    ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
-
     /// Set transaction item state
     ///
     /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setState(libdnf::TransactionItemState value)
     void set_state(State value) { state = value; }
-
-    /// Get transaction item repoid (text identifier of a repository)
-    ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getRepoid()
-    const std::string & get_repoid() const noexcept { return repoid; }
 
     /// Get transaction item repoid (text identifier of a repository)
     ///
@@ -106,15 +127,9 @@ public:
     /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.isBackwardAction()
     bool is_outbound_action() const;
 
-    /// Get database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
-    int64_t get_item_id() const noexcept { return item_id; }
-
-    /// Set database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
-    void set_item_id(int64_t value) { item_id = value; }
-
-    // TODO(dmach): move to sack, resolve for all packages; return the user who initially installed the package
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItem.getInstalledBy()
-    uint32_t getInstalledBy() const;
+    // TODO(dmach): Reimplement in Package class; it's most likely not needed in Comps{Group,Environment}
+    // std::vector< TransactionItemPtr > replacedBy;
+    const Transaction & get_transaction() const;
 
     // TODO(dmach): Reimplement in Package class
     //const std::vector< TransactionItemPtr > &getReplacedBy() const noexcept { return replacedBy; }
@@ -124,9 +139,15 @@ public:
     // TODO(dmach): Review and bring back if needed
     //void saveState();
 
-    const Transaction & get_transaction() const;
+    // TODO(dmach): move to sack, resolve for all packages; return the user who initially installed the package
+    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItem.getInstalledBy()
+    uint32_t getInstalledBy() const;
 
-protected:
+    /// Get database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
+    int64_t get_item_id() const noexcept { return item_id; }
+
+    /// Set database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
+    void set_item_id(int64_t value) { item_id = value; }
     int64_t id = 0;
     Action action = Action::INSTALL;
     Reason reason = Reason::NONE;
@@ -141,9 +162,6 @@ protected:
     // be at least movable, and the WeakPtrGuard would make the Transaction
     // unmovable
     const Transaction * trans = nullptr;
-
-    // TODO(dmach): Reimplement in Package class; it's most likely not needed in Comps{Group,Environment}
-    // std::vector< TransactionItemPtr > replacedBy;
 };
 
 }  // namespace libdnf::transaction

--- a/libdnf/transaction/db/comps_environment.cpp
+++ b/libdnf/transaction/db/comps_environment.cpp
@@ -70,7 +70,7 @@ std::vector<CompsEnvironment> CompsEnvironmentDbUtils::get_transaction_comps_env
     auto query = comps_environment_transaction_item_select_new_query(conn, trans.get_id());
     while (query->step() == libdnf::utils::SQLite3::Statement::StepResult::ROW) {
         CompsEnvironment ti(trans);
-        transaction_item_select(*query, ti);
+        TransItemDbUtils::transaction_item_select(*query, ti);
         ti.set_environment_id(query->get<std::string>("environmentid"));
         ti.set_name(query->get<std::string>("name"));
         ti.set_translated_name(query->get<std::string>("translated_name"));
@@ -127,11 +127,11 @@ int64_t CompsEnvironmentDbUtils::comps_environment_insert(
 void CompsEnvironmentDbUtils::insert_transaction_comps_environments(
     libdnf::utils::SQLite3 & conn, Transaction & trans) {
     auto query_comps_environment_insert = comps_environment_insert_new_query(conn);
-    auto query_trans_item_insert = trans_item_insert_new_query(conn);
+    auto query_trans_item_insert = TransItemDbUtils::trans_item_insert_new_query(conn);
 
     for (auto & env : trans.get_comps_environments()) {
         comps_environment_insert(*query_comps_environment_insert, env);
-        transaction_item_insert(*query_trans_item_insert, env);
+        TransItemDbUtils::transaction_item_insert(*query_trans_item_insert, env);
         CompsEnvironmentGroupDbUtils::comps_environment_groups_insert(conn, env);
     }
 }

--- a/libdnf/transaction/db/comps_group.cpp
+++ b/libdnf/transaction/db/comps_group.cpp
@@ -71,7 +71,7 @@ std::vector<CompsGroup> CompsGroupDbUtils::get_transaction_comps_groups(
 
     while (query->step() == libdnf::utils::SQLite3::Statement::StepResult::ROW) {
         CompsGroup ti(trans);
-        transaction_item_select(*query, ti);
+        TransItemDbUtils::transaction_item_select(*query, ti);
         //        auto trans_item = std::make_shared< TransactionItem >(trans);
         //        auto item = std::make_shared< CompsGroup >(trans);
         //        trans_item->setItem(item);
@@ -128,11 +128,11 @@ int64_t CompsGroupDbUtils::comps_group_insert(libdnf::utils::SQLite3::Statement 
 
 void CompsGroupDbUtils::insert_transaction_comps_groups(libdnf::utils::SQLite3 & conn, Transaction & trans) {
     auto query_comps_group_insert = comps_group_insert_new_query(conn);
-    auto query_trans_item_insert = trans_item_insert_new_query(conn);
+    auto query_trans_item_insert = TransItemDbUtils::trans_item_insert_new_query(conn);
 
     for (auto & grp : trans.get_comps_groups()) {
         comps_group_insert(*query_comps_group_insert, grp);
-        transaction_item_insert(*query_trans_item_insert, grp);
+        TransItemDbUtils::transaction_item_insert(*query_trans_item_insert, grp);
         CompsGroupPackageDbUtils::comps_group_packages_insert(conn, grp);
     }
 }

--- a/libdnf/transaction/db/rpm.cpp
+++ b/libdnf/transaction/db/rpm.cpp
@@ -67,7 +67,7 @@ static std::unique_ptr<libdnf::utils::SQLite3::Query> rpm_transaction_item_selec
 
 
 int64_t RpmDbUtils::rpm_transaction_item_select(libdnf::utils::SQLite3::Query & query, Package & pkg) {
-    transaction_item_select(query, pkg);
+    TransItemDbUtils::transaction_item_select(query, pkg);
     pkg.set_name(query.get<std::string>("name"));
     pkg.set_epoch(std::to_string(query.get<uint32_t>("epoch")));
     pkg.set_version(query.get<std::string>("version"));
@@ -183,7 +183,7 @@ void RpmDbUtils::insert_transaction_packages(libdnf::utils::SQLite3 & conn, Tran
     auto query_pkg_name_insert_if_not_exists = pkg_name_insert_if_not_exists_new_query(conn);
     auto query_arch_insert_if_not_exists = arch_insert_if_not_exists_new_query(conn);
     auto query_rpm_insert = rpm_insert_new_query(conn);
-    auto query_trans_item_insert = trans_item_insert_new_query(conn);
+    auto query_trans_item_insert = TransItemDbUtils::trans_item_insert_new_query(conn);
 
     for (auto & pkg : trans.get_packages()) {
         pkg.set_item_id(rpm_select_pk(*query_rpm_select_pk, pkg));
@@ -197,7 +197,7 @@ void RpmDbUtils::insert_transaction_packages(libdnf::utils::SQLite3 & conn, Tran
             // insert into 'rpm' table
             rpm_insert(*query_rpm_insert, pkg);
         }
-        transaction_item_insert(*query_trans_item_insert, pkg);
+        TransItemDbUtils::transaction_item_insert(*query_trans_item_insert, pkg);
     }
 }
 

--- a/libdnf/transaction/db/trans_item.cpp
+++ b/libdnf/transaction/db/trans_item.cpp
@@ -29,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::transaction {
 
 
-void transaction_item_select(libdnf::utils::SQLite3::Query & query, TransactionItem & ti) {
+void TransItemDbUtils::transaction_item_select(libdnf::utils::SQLite3::Query & query, TransactionItem & ti) {
     ti.set_id(query.get<int64_t>("id"));
     ti.set_action(transaction_item_action_from_string(query.get<std::string>("action")));
     ti.set_reason(transaction_item_reason_from_string(query.get<std::string>("reason")));
@@ -62,13 +62,14 @@ static constexpr const char * SQL_TRANS_ITEM_INSERT = R"**(
 )**";
 
 
-std::unique_ptr<libdnf::utils::SQLite3::Statement> trans_item_insert_new_query(libdnf::utils::SQLite3 & conn) {
+std::unique_ptr<libdnf::utils::SQLite3::Statement> TransItemDbUtils::trans_item_insert_new_query(
+    libdnf::utils::SQLite3 & conn) {
     auto query = std::make_unique<libdnf::utils::SQLite3::Statement>(conn, SQL_TRANS_ITEM_INSERT);
     return query;
 }
 
 
-int64_t transaction_item_insert(libdnf::utils::SQLite3::Statement & query, TransactionItem & ti) {
+int64_t TransItemDbUtils::transaction_item_insert(libdnf::utils::SQLite3::Statement & query, TransactionItem & ti) {
     // try to find an existing repo
     auto query_repo_select_pkg = repo_select_pk_new_query(query.get_db());
     auto repo_id = repo_select_pk(*query_repo_select_pkg, ti.get_repoid());

--- a/libdnf/transaction/db/trans_item.hpp
+++ b/libdnf/transaction/db/trans_item.hpp
@@ -32,17 +32,20 @@ namespace libdnf::transaction {
 
 class TransactionItem;
 
-
-/// Copy 'trans_item' fields from a query to TransactionItem or an object that inherits from it
-void transaction_item_select(libdnf::utils::SQLite3::Query & query, TransactionItem & ti);
-
-
-/// Create a query (statement) that inserts new records to the 'trans_item' table
-std::unique_ptr<libdnf::utils::SQLite3::Statement> trans_item_insert_new_query(libdnf::utils::SQLite3 & conn);
+class TransItemDbUtils {
+public:
+    /// Copy 'trans_item' fields from a query to TransactionItem or an object that inherits from it
+    static void transaction_item_select(libdnf::utils::SQLite3::Query & query, TransactionItem & ti);
 
 
-/// Use a query to insert a new record to the 'trans_item' table
-int64_t transaction_item_insert(libdnf::utils::SQLite3::Statement & query, TransactionItem & ti);
+    /// Create a query (statement) that inserts new records to the 'trans_item' table
+    static std::unique_ptr<libdnf::utils::SQLite3::Statement> trans_item_insert_new_query(
+        libdnf::utils::SQLite3 & conn);
+
+
+    /// Use a query to insert a new record to the 'trans_item' table
+    static int64_t transaction_item_insert(libdnf::utils::SQLite3::Statement & query, TransactionItem & ti);
+};
 
 
 }  // namespace libdnf::transaction

--- a/test/libdnf/transaction/test_comps_group.cpp
+++ b/test/libdnf/transaction/test_comps_group.cpp
@@ -53,6 +53,11 @@ create_getter(set_name_pkg, &libdnf::transaction::CompsGroupPackage::set_name);
 create_getter(set_installed, &libdnf::transaction::CompsGroupPackage::set_installed);
 create_getter(set_package_type, &libdnf::transaction::CompsGroupPackage::set_package_type);
 
+create_getter(set_repoid, &libdnf::transaction::TransactionItem::set_repoid);
+create_getter(set_action, &libdnf::transaction::TransactionItem::set_action);
+create_getter(set_reason, &libdnf::transaction::TransactionItem::set_reason);
+create_getter(set_state, &libdnf::transaction::TransactionItem::set_state);
+
 }  // namespace
 
 static CompsGroup & create_comps_group(Transaction & trans) {
@@ -63,10 +68,10 @@ static CompsGroup & create_comps_group(Transaction & trans) {
     (grp.*get(set_translated_name{}))("translated(Smallest possible installation)");
     (grp.*get(set_package_types{}))(libdnf::comps::PackageType::DEFAULT);
 
-    grp.set_repoid("repoid");
-    grp.set_action(TransactionItemAction::INSTALL);
-    grp.set_reason(TransactionItemReason::USER);
-    grp.set_state(TransactionItemState::OK);
+    (grp.*get(set_repoid{}))("repoid");
+    (grp.*get(set_action{}))(TransactionItemAction::INSTALL);
+    (grp.*get(set_reason{}))(TransactionItemReason::USER);
+    (grp.*get(set_state{}))(TransactionItemState::OK);
 
     auto & pkg1 = (grp.*get(new_package{}))();
     (pkg1.*get(set_name_pkg{}))("bash");

--- a/test/libdnf/transaction/test_workflow.cpp
+++ b/test/libdnf/transaction/test_workflow.cpp
@@ -93,7 +93,7 @@ create_getter(set_reason, &libdnf::transaction::CompsEnvironment::set_reason);
 create_getter(new_group, &libdnf::transaction::CompsEnvironment::new_group);
 
 }  // namespace CompsEnvironmentPrivates
-   //
+
 namespace CompsEnvironmentGroupPrivates {
 
 create_private_getter_template;
@@ -102,6 +102,13 @@ create_getter(set_installed, &libdnf::transaction::CompsEnvironmentGroup::set_in
 create_getter(set_group_type, &libdnf::transaction::CompsEnvironmentGroup::set_group_type);
 
 }  // namespace CompsEnvironmentGroupPrivates
+
+namespace TransactionItemPrivates {
+
+create_private_getter_template;
+create_getter(set_state, &libdnf::transaction::TransactionItem::set_state);
+
+}  // namespace TransactionItemPrivates
 
 void TransactionWorkflowTest::test_default_workflow() {
     auto base = new_base();
@@ -192,15 +199,15 @@ void TransactionWorkflowTest::test_default_workflow() {
     (trans.*get(start{}))();
 
     for (auto & env : trans.get_comps_environments()) {
-        env.set_state(TransactionItemState::OK);
+        (env.*get(TransactionItemPrivates::set_state{}))(TransactionItemState::OK);
     }
 
     for (auto & grp : trans.get_comps_groups()) {
-        grp.set_state(TransactionItemState::OK);
+        (grp.*get(TransactionItemPrivates::set_state{}))(TransactionItemState::OK);
     }
 
     for (auto & pkg : trans.get_packages()) {
-        pkg.set_state(TransactionItemState::OK);
+        (pkg.*get(TransactionItemPrivates::set_state{}))(TransactionItemState::OK);
     }
 
     // finish transaction


### PR DESCRIPTION
I wanted to include this in https://github.com/rpm-software-management/dnf5/pull/106 but I was too slow and I didn't properly mark the PR.