### PR TITLE
commands: Remove unimplemented unneeded option

### DIFF
--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -41,15 +41,16 @@ void RemoveCommand::set_argument_parser() {
     cmd.register_positional_arg(keys);
 
     // TODO(dmach): implement the option; should work as `dnf autoremove`
-    unneeded = dynamic_cast<libdnf::OptionBool *>(
-        parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));
+    // TODO(jkolarik): commented out as it is not implemented now
+    // unneeded = dynamic_cast<libdnf::OptionBool *>(
+    //     parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));
 
-    auto unneeded_opt = parser.add_new_named_arg("unneeded");
-    unneeded_opt->set_long_name("unneeded");
-    unneeded_opt->set_description("Remove unneeded packages that were installed as dependencies");
-    unneeded_opt->set_const_value("false");
-    unneeded_opt->link_value(unneeded);
-    cmd.register_named_arg(unneeded_opt);
+    // auto unneeded_opt = parser.add_new_named_arg("unneeded");
+    // unneeded_opt->set_long_name("unneeded");
+    // unneeded_opt->set_description("Remove unneeded packages that were installed as dependencies");
+    // unneeded_opt->set_const_value("false");
+    // unneeded_opt->link_value(unneeded);
+    // cmd.register_named_arg(unneeded_opt);
 }
 
 void RemoveCommand::configure() {

--- a/dnf5/config/usr/lib/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/lib/dnf5/aliases.d/compatibility.conf
@@ -71,15 +71,16 @@ group_id = 'options-compatibility-aliases'
 type = 'group'
 header = "Compatibility Aliases:"
 
-['autoremove']
-type = 'command'
-attached_command = 'remove'
-descr = "Alias for 'remove --unneeded'"
-group_id = 'commands-compatibility-aliases'
-complete = true
-attached_named_args = [
- { id_path = 'remove.unneeded' }
-]
+# TODO(jkolarik): Uncomment when unneeded argument is ready
+# ['autoremove']
+# type = 'command'
+# attached_command = 'remove'
+# descr = "Alias for 'remove --unneeded'"
+# group_id = 'commands-compatibility-aliases'
+# complete = true
+# attached_named_args = [
+#  { id_path = 'remove.unneeded' }
+# ]
 
 ['groupinfo']
 type = 'command'


### PR DESCRIPTION
`--unneeded` option is not yet implemented in `remove` command, therefore commenting it out for now.