### PR TITLE
Fix build with LLVM/clang

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SWIG_COMPILE_OPTIONS
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
         -Wno-deprecated-volatile
+        -Wno-unknown-warning-option
     )
 else()
     set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}


### PR DESCRIPTION
Workarounds error with C++20 and latest LLVM/clang

```
FAILED: bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx.o 
/usr/bin/clang++ -DPROJECT_BINARY_DIR=\"/builddir/build/BUILD/dnf5-5.0.0/build\" -DPROJECT_SOURCE_DIR=\"/builddir/build/BUILD/dnf5-5.0.0\" -Dperl5_base_EXPORTS -I/builddir/build/BUILD/dnf5-5.0.0/include -I/builddir/build/BUILD/dnf5-5.0.0/common -I/usr/lib64/perl5/CORE -Os -fomit-frame-pointer -g3 -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-all --param=ssp-buffer-size=4 -flto -Os -fomit-frame-pointer -g3 -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-all --param=ssp-buffer-size=4 -flto -fPIC -fmacro-prefix-map=/builddir/build/BUILD/dnf5-5.0.0/= -Wall -Wextra -Werror -Wcast-align -Wformat-nonliteral -Wmissing-format-attribute -Wredundant-decls -Wsign-compare -Wtype-limits -Wuninitialized -Wwrite-strings -Werror=unused-result -Wodr -Wconversion -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wno-cast-align -Wno-conversion -Wno-deprecated-copy -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-missing-declarations -Wno-missing-field-initializers -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-strict-aliasing -Wno-unused-function -Wno-unused-parameter -Wno-deprecated-volatile -Wno-unknown-pragmas -std=gnu++20 -MD -MT bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx.o -MF bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx.o.d -o bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx.o -c /builddir/build/BUILD/dnf5-5.0.0/build/bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx
/builddir/build/BUILD/dnf5-5.0.0/build/bindings/perl5/libdnf5/CMakeFiles/perl5_base.dir/basePERL_wrap.cxx:746:32: error: unknown warning group '-Wvolatile', ignored [-Werror,-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wvolatile"
                               ^
1 error generated.
```