### PR TITLE
Unify matching file patterns

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -37,6 +37,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
 #include <libdnf/rpm/rpm_signature.hpp>
+#include <libdnf/utils/patterns.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -239,12 +240,10 @@ void Context::print_info(const char * msg) {
 
 
 void Context::update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs) {
-    // TODO(jkolarik): unify this behavior with internal libdnf detection of file specs
-    // if a pkg_spec contains '/', it's a path and we need to load filelists
     for (auto & spec : pkg_specs) {
-        if (spec.find("/") != std::string::npos) {
+        if (libdnf::utils::is_file_pattern(spec)) {
             base.get_config().optional_metadata_types().add_item(libdnf::METADATA_TYPE_FILELISTS);
-            break;
+            return;
         }
     }
 }
@@ -950,8 +949,8 @@ std::vector<std::string> match_specs(
     base.load_config_from_file();
     base.setup();
 
-    // optimization - if pattern contain '/', disable the search for matching installed and available packages
-    if (pattern.find('/') != std::string::npos) {
+    // optimization - disable the search for matching installed and available packages for file patterns
+    if (libdnf::utils::is_file_pattern(pattern)) {
         installed = available = false;
     }
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -159,7 +159,7 @@ private:
     Actions action;
 };
 
-/// Downoad packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
+/// Download packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
 void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir);
 void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir);
 
@@ -176,6 +176,8 @@ void parse_add_specs(
 /// Returns the names of matching packages and paths of matching package file names and directories.
 /// If `nevra_for_same_name` is true, it returns a full nevra for packages with the same name.
 /// Only files whose names match `file_name_regex` are returned.
+/// NOTE: This function is intended to be used only for autocompletion purposes as the argument parser's
+/// complete hook argument. It does the base setup and repos loading inside.
 std::vector<std::string> match_specs(
     Context & ctx,
     const std::string & pattern,

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -53,7 +53,7 @@ public:
     void apply_repository_setopts();
 
     /// Update required metadata types according to the provided `pkg_specs`.
-    /// If a pkg_spec contains '/' then assume it's a path and file lists need to be loaded.
+    /// If a `pkg_spec` is a file pattern, the file lists need to be loaded.
     void update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs);
 
     /// Sets callbacks for repositories and loads them, updating metadata if necessary.

--- a/include/libdnf/utils/patterns.hpp
+++ b/include/libdnf/utils/patterns.hpp
@@ -17,41 +17,29 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#ifndef LIBDNF_UTILS_UTILS_INTERNAL_HPP
-#define LIBDNF_UTILS_UTILS_INTERNAL_HPP
-
-
-#include <ctype.h>
-
-#include <cstring>
-#include <string>
-
+#ifndef LIBDNF_UTILS_PATTERNS_HPP
+#define LIBDNF_UTILS_PATTERNS_HPP
 
 namespace libdnf::utils {
 
+/// @brief Check if a given pattern is a GLOB.
+///
+/// @param pattern Text pattern to be test
+/// @return True if a given pattern is a GLOB
 inline bool is_glob_pattern(const char * pattern) {
     return strpbrk(pattern, "*[?") != nullptr;
 }
 
-/// @brief Test if pattern is file path
-/// Return true if pattern start with "/" or pattern[0] == '*' && pattern[1] == '/'
-static inline bool is_file_pattern(const std::string & pattern) {
+/// Return true if given pattern is a file path
+
+/// @brief Check if a given pattern is a file path.
+///
+/// @param pattern Text pattern to be test
+/// @return True if a given pattern is a file path
+inline bool is_file_pattern(const std::string & pattern) {
     return pattern[0] == '/' || (pattern[0] == '*' && pattern[1] == '/');
 }
 
-inline std::string to_lowercase(const std::string & source) {
-    auto length = source.size();
-    std::string result;
-    result.reserve(length);
-    for (unsigned index = 0; index < length; ++index) {
-        result += static_cast<char>(tolower(source[index]));
-    }
-    return result;
-}
-
-
 }  // namespace libdnf::utils
 
-
-#endif  // LIBDNF_UTILS_UTILS_INTERNAL_HPP
+#endif  // LIBDNF_UTILS_PATTERNS_HPP

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -25,10 +25,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "common/sack/query_cmp_private.hpp"
 #include "solv/pool.hpp"
 #include "solv/solv_map.hpp"
-#include "utils/utils_internal.hpp"
 
 #include "libdnf/advisory/advisory_set.hpp"
 #include "libdnf/rpm/package_set.hpp"
+#include "libdnf/utils/patterns.hpp"
 
 #include <solv/evr.h>
 

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -30,12 +30,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "transaction_impl.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
 #include "utils/string.hpp"
-#include "utils/utils_internal.hpp"
 
 #include "libdnf/common/exception.hpp"
 #include "libdnf/comps/group/query.hpp"
 #include "libdnf/rpm/package_query.hpp"
 #include "libdnf/rpm/reldep.hpp"
+#include "libdnf/utils/patterns.hpp"
 
 #include <filesystem>
 #include <iostream>

--- a/libdnf/module/module_query.cpp
+++ b/libdnf/module/module_query.cpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/module/module_query.hpp"
 
 #include "module/module_sack_impl.hpp"
-#include "utils/utils_internal.hpp"
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/module/module_item.hpp"

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -22,11 +22,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "common/sack/query_cmp_private.hpp"
 #include "package_query_impl.hpp"
 #include "package_set_impl.hpp"
-#include "utils/utils_internal.hpp"
+#include "utils/convert.hpp"
 
 #include "libdnf/advisory/advisory_query.hpp"
 #include "libdnf/base/base.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/utils/patterns.hpp"
 
 extern "C" {
 #include <solv/evr.h>

--- a/libdnf/utils/convert.hpp
+++ b/libdnf/utils/convert.hpp
@@ -1,0 +1,45 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_UTILS_CONVERT_HPP
+#define LIBDNF_UTILS_CONVERT_HPP
+
+#include <ctype.h>
+
+#include <string>
+
+namespace libdnf::utils {
+
+/// @brief Convert an input text to a lowercase version.
+///
+/// @param source Input text to be converted
+/// @return New string containing the input text in lowercase
+inline std::string to_lowercase(const std::string & source) {
+    auto length = source.size();
+    std::string result;
+    result.reserve(length);
+    for (unsigned index = 0; index < length; ++index) {
+        result += static_cast<char>(tolower(source[index]));
+    }
+    return result;
+}
+
+}  // namespace libdnf::utils
+
+#endif  // LIBDNF_UTILS_CONVERT_HPP


### PR DESCRIPTION
Move the function for detecting file patterns to the API and use it consistently across the codebase. Also other functions for the `utils_internal.hpp` were moved to the API as I think we can consider them generic.