### PR TITLE
Extend LogEvent with new attribute spec_type

### DIFF
--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -252,6 +252,11 @@ public:
         const std::optional<std::string> & group_id,
         const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 
+    /// Add group install request to the goal. The `spec` will be resolved to groups in the resolve() call.
+    /// Also packages of the types specified in setting.group_package_types be installed.
+    ///
+    /// @param spec      A string describing the Goal group install request.
+    /// @param settings  A structure to override default goal settings.
     void add_group_install(
         const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 

--- a/include/libdnf/base/log_event.hpp
+++ b/include/libdnf/base/log_event.hpp
@@ -34,11 +34,15 @@ namespace libdnf::base {
 /// Contain information, hint, or a problem created during libdnf::Goal::resolve()
 class LogEvent {
 public:
+    /// What object type is the spec supposed to describe
+    enum class SpecType { PACKAGE, GROUP, ENVIRONMENT, MODULE };
+
     /// Public constructor
     LogEvent(
         libdnf::GoalAction action,
         libdnf::GoalProblem problem,
         const libdnf::GoalJobSettings & settings,
+        const SpecType spec_type,
         const std::string & spec,
         const std::set<std::string> & additional_data);
     LogEvent(libdnf::GoalProblem problem, const SolverProblems & solver_problems);
@@ -62,13 +66,14 @@ public:
         libdnf::GoalAction action,
         libdnf::GoalProblem problem,
         const std::optional<libdnf::GoalJobSettings> & settings,
+        const std::optional<SpecType> & spec_type,
         const std::optional<std::string> & spec,
         const std::optional<std::set<std::string>> & additional_data,
         const std::optional<SolverProblems> & solver_problems);
 
     /// Convert an element from resolve log to string;
     std::string to_string() const {
-        return to_string(action, problem, job_settings, spec, additional_data, solver_problems);
+        return to_string(action, problem, job_settings, spec_type, spec, additional_data, solver_problems);
     };
 
 private:
@@ -77,6 +82,7 @@ private:
     libdnf::GoalAction action;
     libdnf::GoalProblem problem;
     std::optional<libdnf::GoalJobSettings> job_settings;
+    std::optional<SpecType> spec_type;
     std::optional<std::string> spec;
     std::optional<std::set<std::string>> additional_data;
     std::optional<SolverProblems> solver_problems;

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -479,7 +479,13 @@ std::pair<GoalProblem, libdnf::solv::IdQueue> Goal::Impl::add_install_to_goal(
     installed.filter_installed();
     for (auto package_id : *installed.p_impl) {
         transaction.p_impl->add_resolve_log(
-            action, GoalProblem::ALREADY_INSTALLED, settings, spec, {pool.get_nevra(package_id)}, false);
+            action,
+            GoalProblem::ALREADY_INSTALLED,
+            settings,
+            base::LogEvent::SpecType::PACKAGE,
+            spec,
+            {pool.get_nevra(package_id)},
+            false);
     }
 
     if (multilib_policy == "all" || utils::is_glob_pattern(nevra_pair.second.get_arch().c_str())) {
@@ -487,7 +493,13 @@ std::pair<GoalProblem, libdnf::solv::IdQueue> Goal::Impl::add_install_to_goal(
             query.filter_repo_id(settings.to_repo_ids, sack::QueryCmp::GLOB);
             if (query.empty()) {
                 transaction.p_impl->add_resolve_log(
-                    action, GoalProblem::NOT_FOUND_IN_REPOSITORIES, settings, spec, {}, strict);
+                    action,
+                    GoalProblem::NOT_FOUND_IN_REPOSITORIES,
+                    settings,
+                    base::LogEvent::SpecType::PACKAGE,
+                    spec,
+                    {},
+                    strict);
                 return {GoalProblem::NOT_FOUND_IN_REPOSITORIES, result_queue};
             }
             query |= installed;
@@ -570,7 +582,13 @@ std::pair<GoalProblem, libdnf::solv::IdQueue> Goal::Impl::add_install_to_goal(
                 query.filter_repo_id(settings.to_repo_ids, sack::QueryCmp::GLOB);
                 if (query.empty()) {
                     transaction.p_impl->add_resolve_log(
-                        action, GoalProblem::NOT_FOUND_IN_REPOSITORIES, settings, spec, {}, strict);
+                        action,
+                        GoalProblem::NOT_FOUND_IN_REPOSITORIES,
+                        settings,
+                        base::LogEvent::SpecType::PACKAGE,
+                        spec,
+                        {},
+                        strict);
                     return {GoalProblem::NOT_FOUND_IN_REPOSITORIES, result_queue};
                 }
                 query |= installed;
@@ -639,7 +657,13 @@ std::pair<GoalProblem, libdnf::solv::IdQueue> Goal::Impl::add_install_to_goal(
                 query.filter_repo_id(settings.to_repo_ids, sack::QueryCmp::GLOB);
                 if (query.empty()) {
                     transaction.p_impl->add_resolve_log(
-                        action, GoalProblem::NOT_FOUND_IN_REPOSITORIES, settings, spec, {}, strict);
+                        action,
+                        GoalProblem::NOT_FOUND_IN_REPOSITORIES,
+                        settings,
+                        base::LogEvent::SpecType::PACKAGE,
+                        spec,
+                        {},
+                        strict);
                     return {GoalProblem::NOT_FOUND_IN_REPOSITORIES, result_queue};
                 }
                 query |= installed;
@@ -688,7 +712,13 @@ GoalProblem Goal::Impl::add_reinstall_to_goal(
     query_installed.filter_installed();
     if (query_installed.empty()) {
         transaction.p_impl->add_resolve_log(
-            GoalAction::REINSTALL, GoalProblem::NOT_INSTALLED, settings, spec, {}, strict);
+            GoalAction::REINSTALL,
+            GoalProblem::NOT_INSTALLED,
+            settings,
+            base::LogEvent::SpecType::PACKAGE,
+            spec,
+            {},
+            strict);
         return strict ? GoalProblem::NOT_INSTALLED : GoalProblem::NO_PROBLEM;
     }
 
@@ -696,7 +726,13 @@ GoalProblem Goal::Impl::add_reinstall_to_goal(
     query -= query_installed;
     if (query.empty()) {
         transaction.p_impl->add_resolve_log(
-            GoalAction::REINSTALL, GoalProblem::NOT_AVAILABLE, settings, spec, {}, strict);
+            GoalAction::REINSTALL,
+            GoalProblem::NOT_AVAILABLE,
+            settings,
+            base::LogEvent::SpecType::PACKAGE,
+            spec,
+            {},
+            strict);
         return strict ? GoalProblem::NOT_AVAILABLE : GoalProblem::NO_PROBLEM;
     }
 
@@ -708,18 +744,36 @@ GoalProblem Goal::Impl::add_reinstall_to_goal(
         relevant_available_na.filter_name_arch(query_installed);
         if (!relevant_available_na.empty()) {
             transaction.p_impl->add_resolve_log(
-                GoalAction::REINSTALL, GoalProblem::INSTALLED_IN_DIFFERENT_VERSION, settings, spec, {}, strict);
+                GoalAction::REINSTALL,
+                GoalProblem::INSTALLED_IN_DIFFERENT_VERSION,
+                settings,
+                base::LogEvent::SpecType::PACKAGE,
+                spec,
+                {},
+                strict);
             return strict ? GoalProblem::INSTALLED_IN_DIFFERENT_VERSION : GoalProblem::NO_PROBLEM;
         } else {
             rpm::PackageQuery relevant_available_n(query);
             relevant_available_n.filter_name(query_installed);
             if (relevant_available_n.empty()) {
                 transaction.p_impl->add_resolve_log(
-                    GoalAction::REINSTALL, GoalProblem::NOT_INSTALLED, settings, spec, {}, strict);
+                    GoalAction::REINSTALL,
+                    GoalProblem::NOT_INSTALLED,
+                    settings,
+                    base::LogEvent::SpecType::PACKAGE,
+                    spec,
+                    {},
+                    strict);
                 return strict ? GoalProblem::NOT_INSTALLED : GoalProblem::NO_PROBLEM;
             } else {
                 transaction.p_impl->add_resolve_log(
-                    GoalAction::REINSTALL, GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE, settings, spec, {}, strict);
+                    GoalAction::REINSTALL,
+                    GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
+                    settings,
+                    base::LogEvent::SpecType::PACKAGE,
+                    spec,
+                    {},
+                    strict);
                 return strict ? GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE : GoalProblem::NO_PROBLEM;
             }
         }
@@ -731,7 +785,13 @@ GoalProblem Goal::Impl::add_reinstall_to_goal(
         relevant_available.filter_repo_id(settings.to_repo_ids, sack::QueryCmp::GLOB);
         if (relevant_available.empty()) {
             transaction.p_impl->add_resolve_log(
-                GoalAction::REINSTALL, GoalProblem::NOT_FOUND_IN_REPOSITORIES, settings, spec, {}, strict);
+                GoalAction::REINSTALL,
+                GoalProblem::NOT_FOUND_IN_REPOSITORIES,
+                settings,
+                base::LogEvent::SpecType::PACKAGE,
+                spec,
+                {},
+                strict);
             return strict ? GoalProblem::NOT_FOUND_IN_REPOSITORIES : GoalProblem::NO_PROBLEM;
         }
     }
@@ -793,7 +853,13 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                 //  report aready installed packages with the same NEVRA
                 for (auto package_id : *query.p_impl) {
                     transaction.p_impl->add_resolve_log(
-                        action, GoalProblem::ALREADY_INSTALLED, settings, {}, {pool.get_nevra(package_id)}, strict);
+                        action,
+                        GoalProblem::ALREADY_INSTALLED,
+                        settings,
+                        base::LogEvent::SpecType::PACKAGE,
+                        {},
+                        {pool.get_nevra(package_id)},
+                        strict);
                     ids.push_back(package_id);
                 }
                 rpm_goal.add_install(ids, strict, best, clean_requirements_on_remove);
@@ -817,7 +883,13 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                     if (query.empty()) {
                         // Report when package with the same NEVRA is not installed
                         transaction.p_impl->add_resolve_log(
-                            action, GoalProblem::NOT_INSTALLED, settings, {pool.get_nevra(id)}, {}, strict);
+                            action,
+                            GoalProblem::NOT_INSTALLED,
+                            settings,
+                            base::LogEvent::SpecType::PACKAGE,
+                            {pool.get_nevra(id)},
+                            {},
+                            strict);
                     } else {
                         // Only installed packages can be reinstalled
                         ids_nevra_installed.push_back(id);
@@ -843,7 +915,13 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                     if (query.empty()) {
                         // Report when package with the same name is not installed
                         transaction.p_impl->add_resolve_log(
-                            action, GoalProblem::NOT_INSTALLED, settings, {pool.get_nevra(id)}, {}, false);
+                            action,
+                            GoalProblem::NOT_INSTALLED,
+                            settings,
+                            base::LogEvent::SpecType::PACKAGE,
+                            {pool.get_nevra(id)},
+                            {},
+                            false);
                         continue;
                     }
                     std::string arch = pool.get_arch(id);
@@ -856,6 +934,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                                 action,
                                 GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
                                 settings,
+                                base::LogEvent::SpecType::PACKAGE,
                                 {pool.get_nevra(id)},
                                 {},
                                 false);
@@ -869,6 +948,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             action,
                             GoalProblem::ALREADY_INSTALLED,
                             settings,
+                            base::LogEvent::SpecType::PACKAGE,
                             {pool.get_nevra(id)},
                             {pool.get_name(id) + ("." + arch)},
                             false);
@@ -891,7 +971,13 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                     if (query.empty()) {
                         // Report when package with the same name is not installed
                         transaction.p_impl->add_resolve_log(
-                            action, GoalProblem::NOT_INSTALLED, settings, {pool.get_nevra(id)}, {}, strict);
+                            action,
+                            GoalProblem::NOT_INSTALLED,
+                            settings,
+                            base::LogEvent::SpecType::PACKAGE,
+                            {pool.get_nevra(id)},
+                            {},
+                            strict);
                         continue;
                     }
                     query.filter_arch({pool.get_arch(id)});
@@ -901,6 +987,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             action,
                             GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
                             settings,
+                            base::LogEvent::SpecType::PACKAGE,
                             {pool.get_nevra(id)},
                             {},
                             strict);
@@ -916,6 +1003,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             action,
                             GoalProblem::INSTALLED_LOWEST_VERSION,
                             settings,
+                            base::LogEvent::SpecType::PACKAGE,
                             {pool.get_nevra(id)},
                             {name_arch},
                             strict);
@@ -1006,10 +1094,17 @@ void Goal::Impl::add_up_down_distrosync_to_goal(
             rpm::PackageQuery relevant_installed_n(all_installed);
             relevant_installed_n.filter_name(query);
             if (relevant_installed_n.empty()) {
-                transaction.p_impl->add_resolve_log(action, GoalProblem::NOT_INSTALLED, settings, spec, {}, false);
+                transaction.p_impl->add_resolve_log(
+                    action, GoalProblem::NOT_INSTALLED, settings, base::LogEvent::SpecType::PACKAGE, spec, {}, false);
             } else {
                 transaction.p_impl->add_resolve_log(
-                    action, GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE, settings, spec, {}, false);
+                    action,
+                    GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
+                    settings,
+                    base::LogEvent::SpecType::PACKAGE,
+                    spec,
+                    {},
+                    false);
             }
             return;
         }
@@ -1041,7 +1136,13 @@ void Goal::Impl::add_up_down_distrosync_to_goal(
         query.filter_repo_id(settings.to_repo_ids, sack::QueryCmp::GLOB);
         if (query.empty()) {
             transaction.p_impl->add_resolve_log(
-                action, GoalProblem::NOT_FOUND_IN_REPOSITORIES, settings, spec, {}, false);
+                action,
+                GoalProblem::NOT_FOUND_IN_REPOSITORIES,
+                settings,
+                base::LogEvent::SpecType::PACKAGE,
+                spec,
+                {},
+                false);
             return;
         }
         query |= installed;
@@ -1107,7 +1208,13 @@ void Goal::Impl::add_up_down_distrosync_to_goal(
                         name_arch.append(".");
                         name_arch.append(pool.get_arch(installed_id));
                         transaction.p_impl->add_resolve_log(
-                            action, GoalProblem::INSTALLED_LOWEST_VERSION, settings, spec, {name_arch}, false);
+                            action,
+                            GoalProblem::INSTALLED_LOWEST_VERSION,
+                            settings,
+                            base::LogEvent::SpecType::PACKAGE,
+                            spec,
+                            {name_arch},
+                            false);
                     } else {
                         rpm_goal.add_install(tmp_queue, strict, best, clean_requirements_on_remove);
                     }
@@ -1142,9 +1249,10 @@ GoalProblem Goal::Impl::add_group_install_to_goal(
         group_query |= group_query_name;
     }
     if (group_query.empty()) {
-        auto problem = transaction.p_impl->report_not_found(GoalAction::INSTALL, spec, GoalJobSettings(), strict);
+        transaction.p_impl->add_resolve_log(
+            GoalAction::INSTALL, GoalProblem::NOT_FOUND, settings, base::LogEvent::SpecType::GROUP, spec, {}, strict);
         if (strict) {
-            return problem;
+            return GoalProblem::NOT_FOUND;
         } else {
             return GoalProblem::NO_PROBLEM;
         }
@@ -1219,6 +1327,7 @@ GoalProblem Goal::Impl::add_reason_change_to_goal(
                 GoalAction::REASON_CHANGE,
                 GoalProblem::ALREADY_INSTALLED,
                 settings,
+                base::LogEvent::SpecType::PACKAGE,
                 pkg.get_nevra(),
                 {libdnf::transaction::transaction_item_reason_to_string(reason)},
                 false);
@@ -1308,7 +1417,13 @@ base::Transaction Goal::resolve() {
         p_impl->rpm_goal.write_debugdata(abs_debug_dir);
 
         transaction.p_impl->add_resolve_log(
-            GoalAction::RESOLVE, GoalProblem::WRITE_DEBUG, {}, "", {abs_debug_dir}, false);
+            GoalAction::RESOLVE,
+            GoalProblem::WRITE_DEBUG,
+            {},
+            base::LogEvent::SpecType::PACKAGE,
+            "",
+            {abs_debug_dir},
+            false);
     }
 
     transaction.p_impl->set_transaction(p_impl->rpm_goal, ret);

--- a/libdnf/base/log_event.cpp
+++ b/libdnf/base/log_event.cpp
@@ -32,11 +32,13 @@ LogEvent::LogEvent(
     libdnf::GoalAction action,
     libdnf::GoalProblem problem,
     const libdnf::GoalJobSettings & settings,
+    const SpecType spec_type,
     const std::string & spec,
     const std::set<std::string> & additional_data)
     : action(action),
       problem(problem),
       job_settings(settings),
+      spec_type(spec_type),
       spec(spec),
       additional_data(additional_data) {
     libdnf_assert(
@@ -63,6 +65,7 @@ std::string LogEvent::to_string(
     libdnf::GoalAction action,
     libdnf::GoalProblem problem,
     const std::optional<libdnf::GoalJobSettings> & settings,
+    const std::optional<LogEvent::SpecType> & spec_type,
     const std::optional<std::string> & spec,
     const std::optional<std::set<std::string>> & additional_data,
     const std::optional<SolverProblems> & solver_problems) {
@@ -71,7 +74,22 @@ std::string LogEvent::to_string(
         // TODO(jmracek) Improve messages => Each message can contain also an action
         case GoalProblem::NOT_FOUND:
             if (action == GoalAction::REMOVE) {
-                return ret.append(utils::sformat(_("No packages to remove for argument: {}"), *spec));
+                std::string spec_type_str;
+                switch (*spec_type) {
+                    case LogEvent::SpecType::PACKAGE:
+                        spec_type_str = _("packages");
+                        break;
+                    case LogEvent::SpecType::GROUP:
+                        spec_type_str = _("groups");
+                        break;
+                    case LogEvent::SpecType::ENVIRONMENT:
+                        spec_type_str = _("environmental groups");
+                        break;
+                    case LogEvent::SpecType::MODULE:
+                        spec_type_str = _("modules");
+                        break;
+                }
+                return ret.append(utils::sformat(_("No {} to remove for argument: {}"), spec_type_str, *spec));
             } else if (action == GoalAction::INSTALL_BY_GROUP) {
                 return ret.append(utils::sformat(_("No match for group package: {}"), *spec));
             }

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -64,6 +64,7 @@ public:
         GoalAction action,
         GoalProblem problem,
         const GoalJobSettings & settings,
+        const LogEvent::SpecType spec_type,
         const std::string & spec,
         const std::set<std::string> & additional_data,
         bool strict);


### PR DESCRIPTION
To correctly print LogEvent messages we need to distinguish what object type the `spec` attibute was matched against.