### PR TITLE
Fix showing full percentage progress before metadata download start

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -125,13 +125,16 @@ public:
         // "total_to_download" and "downloaded" are related to the currently downloaded file.
         // We add the size of previously downloaded files.
         auto total_ticks = static_cast<std::int64_t>(total_to_download);
-        if (total_ticks != prev_total_tick) {
-            prev_total_tick = total_ticks;
-            sum_prev_downloaded += prev_downloaded;
+        // ignore zero progress events at the beginning of the download, so we don't start with 100% progress
+        if (total_ticks != 0 || prev_total_tick != -1) {
+            if (total_ticks != prev_total_tick) {
+                prev_total_tick = total_ticks;
+                sum_prev_downloaded += prev_downloaded;
+            }
+            prev_downloaded = static_cast<std::int64_t>(downloaded);
+            progress_bar->set_total_ticks(sum_prev_downloaded + total_ticks);
+            progress_bar->set_ticks(sum_prev_downloaded + prev_downloaded);
         }
-        prev_downloaded = static_cast<std::int64_t>(downloaded);
-        progress_bar->set_total_ticks(sum_prev_downloaded + total_ticks);
-        progress_bar->set_ticks(sum_prev_downloaded + prev_downloaded);
 
         if (is_time_to_print()) {
             print_progress_bar();

--- a/include/libdnf-cli/progressbar/progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/progress_bar.hpp
@@ -117,8 +117,8 @@ protected:
 
 private:
     // ticks
-    int64_t ticks = 0;
-    int64_t total_ticks = 0;
+    int64_t ticks = -1;
+    int64_t total_ticks = -1;
 
     // numbers
     int32_t number = 0;
@@ -132,7 +132,7 @@ private:
 
     ProgressBarState state = ProgressBarState::READY;
 
-    int32_t percent_done = 0;
+    int32_t percent_done = -1;
     int64_t elapsed_seconds = 0;
     int64_t remaining_seconds = 0;
     int64_t average_speed = 0;

--- a/libdnf-cli/progressbar/progress_bar.cpp
+++ b/libdnf-cli/progressbar/progress_bar.cpp
@@ -33,14 +33,14 @@ ProgressBar::ProgressBar(int64_t total_ticks, const std::string & description)
 
 
 void ProgressBar::reset() {
-    ticks = 0;
-    total_ticks = 0;
+    ticks = -1;
+    total_ticks = -1;
     number = 0;
     total = 0;
     description = "";
     messages.clear();
     state = ProgressBarState::READY;
-    percent_done = 0;
+    percent_done = -1;
     elapsed_seconds = 0;
     remaining_seconds = 0;
     average_speed = 0;
@@ -88,16 +88,16 @@ void ProgressBar::update() {
         return;
     }
 
-    if (ticks >= total_ticks) {
-        percent_done = 100;
+    if (total_ticks < 0) {
+        // unknown total ticks
+        percent_done = -1;
     } else if (total_ticks == 0) {
         // can't divide by zero, consider progressbar 100% complete
         percent_done = 100;
-    } else if (total_ticks > 0) {
-        percent_done = static_cast<int32_t>(static_cast<float>(ticks) / static_cast<float>(total_ticks) * 100);
+    } else if (ticks >= total_ticks) {
+        percent_done = 100;
     } else {
-        // unknown total ticks
-        percent_done = -1;
+        percent_done = static_cast<int32_t>(static_cast<float>(ticks) / static_cast<float>(total_ticks) * 100);
     }
 
     auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
There are some uninteresting progress events with zero values coming at the beginning of the metadata download which causes the percent widget to show `100%` before the actual downloading starts.

As there is already implemented showing the `???%`, I assume this was the original intention, so I fixed the incorrectly initialized members in the `ProgressBar` class.

This is a follow-up of https://github.com/rpm-software-management/dnf5/pull/130