### PR TITLE
Disable irrelevant clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,readability-*,-google-runtime-references,-modernize-use-trailing-return-type,-hicpp-signed-bitwise,-fuchsia*,-modernize-use-nodiscard'
+Checks:          'bugprone-*,cert-*,concurrency-*,cppcoreguidelines-*,misc-*,modernize-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,performance-*,portability-*,readability-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
Previously, the clang-tidy configuration enables all checks and then disables a few undesired ones. This enables a lot of checks that are specific to certain kinds of code and aren't relevant for this project. For example, I noticed several errors from checks specific to LLVM libc. It makes more sense to enable only the checks that we want instead of enabling everything and then disabling the checks that we don't want.