### PR TITLE
PGP: Use new librepo PGP API, remove gpgme dependency

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -54,7 +54,7 @@ Recommends:     bash-completion
 # ========== versions of dependencies ==========
 
 %global libmodulemd_version 2.5.0
-%global librepo_version 1.13.0
+%global librepo_version 1.15.0
 %global libsolv_version 0.7.21
 %global swig_version 4
 %global zchunk_version 0.9.11
@@ -68,7 +68,6 @@ BuildRequires:  doxygen
 BuildRequires:  gettext
 BuildRequires:  pkgconfig(check)
 BuildRequires:  pkgconfig(fmt)
-BuildRequires:  (pkgconfig(gpgme) or gpgme-devel)
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(librepo) >= %{librepo_version}

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -71,7 +71,7 @@ public:
         }
 
         auto tmp_id = id.size() > 8 ? id.substr(id.size() - 8) : id;
-        std::cout << "Importing GPG key 0x" << id << ":\n";
+        std::cout << "Importing PGP key 0x" << id << ":\n";
         std::cout << " Userid     : \"" << user_id << "\"\n";
         std::cout << " Fingerprint: " << fingerprint << "\n";
         std::cout << " From       : " << url << std::endl;
@@ -670,7 +670,7 @@ private:
 std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time = std::chrono::steady_clock::now();
 
 static bool user_confirm_key(libdnf::ConfigMain & config, const libdnf::rpm::KeyInfo & key_info) {
-    std::cout << "Importing GPG key 0x" << key_info.get_short_key_id() << std::endl;
+    std::cout << "Importing PGP key 0x" << key_info.get_short_key_id() << std::endl;
     std::cout << " UserId     : \"" << key_info.get_user_id() << "\"" << std::endl;
     std::cout << " Fingerprint: " << key_info.get_fingerprint() << std::endl;
     std::cout << " From       : " << key_info.get_url() << std::endl;
@@ -779,7 +779,7 @@ bool Context::check_gpg_signatures(const libdnf::base::Transaction & transaction
                             retval = false;
                             break;
                         case ImportRepoKeys::NO_KEYS:
-                            std::cerr << err_msg << "the repository does not have any gpg key configured." << std::endl;
+                            std::cerr << err_msg << "the repository does not have any pgp key configured." << std::endl;
                             retval = false;
                             break;
                         case ImportRepoKeys::IMPORT_FAILED:
@@ -799,7 +799,7 @@ bool Context::check_gpg_signatures(const libdnf::base::Transaction & transaction
 void Context::download_and_run(libdnf::base::Transaction & transaction) {
     download_packages(transaction, nullptr);
 
-    std::cout << std::endl << "Verifying GPG signatures" << std::endl;
+    std::cout << std::endl << "Verifying PGP signatures" << std::endl;
     if (!check_gpg_signatures(transaction)) {
         throw libdnf::cli::CommandExitError(1, M_("Signature verification failed"));
     }

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -60,7 +60,7 @@ public:
 
     bool repokey_import(
         const std::string & id,
-        const std::string & user_id,
+        const std::vector<std::string> & user_ids,
         const std::string & fingerprint,
         const std::string & url,
         [[maybe_unused]] long int timestamp) override {
@@ -72,7 +72,9 @@ public:
 
         auto tmp_id = id.size() > 8 ? id.substr(id.size() - 8) : id;
         std::cout << "Importing PGP key 0x" << id << ":\n";
-        std::cout << " Userid     : \"" << user_id << "\"\n";
+        for (auto & user_id : user_ids) {
+            std::cout << " Userid     : \"" << user_id << "\"\n";
+        }
         std::cout << " Fingerprint: " << fingerprint << "\n";
         std::cout << " From       : " << url << std::endl;
 
@@ -671,7 +673,9 @@ std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time =
 
 static bool user_confirm_key(libdnf::ConfigMain & config, const libdnf::rpm::KeyInfo & key_info) {
     std::cout << "Importing PGP key 0x" << key_info.get_short_key_id() << std::endl;
-    std::cout << " UserId     : \"" << key_info.get_user_id() << "\"" << std::endl;
+    for (auto & user_id : key_info.get_user_ids()) {
+        std::cout << " UserId     : \"" << user_id << "\"" << std::endl;
+    }
     std::cout << " Fingerprint: " << key_info.get_fingerprint() << std::endl;
     std::cout << " From       : " << key_info.get_url() << std::endl;
     return libdnf::cli::utils::userconfirm::userconfirm(config);

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -692,7 +692,7 @@ int main(int argc, char * argv[]) try {
             for (const auto & tsflag : base.get_config().tsflags().get_value()) {
                 if (tsflag == "test") {
                     std::cout
-                        << "Test mode enabled: Only package downloads, gpg key installations and transaction checks "
+                        << "Test mode enabled: Only package downloads, pgp key installations and transaction checks "
                            "will be performed."
                         << std::endl;
                 }

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -117,7 +117,7 @@ void RepoCB::key_import(sdbus::Signal & signal) {
         std::string fingerprint;
         std::string url;
         signal >> key_id >> user_id >> fingerprint >> url;
-        progress_bar.add_message(libdnf::cli::progressbar::MessageType::INFO, "Importing GPG key: " + key_id);
+        progress_bar.add_message(libdnf::cli::progressbar::MessageType::INFO, "Importing PGP key: " + key_id);
         progress_bar.add_message(libdnf::cli::progressbar::MessageType::INFO, " Userid     : " + user_id);
         progress_bar.add_message(libdnf::cli::progressbar::MessageType::INFO, " Fingerprint: " + fingerprint);
         progress_bar.add_message(libdnf::cli::progressbar::MessageType::INFO, " From       : " + url);

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -148,14 +148,14 @@ int DbusRepoCB::progress(double total_to_download, double downloaded) {
 
 bool DbusRepoCB::repokey_import(
     const std::string & id,
-    const std::string & user_id,
+    const std::vector<std::string> & user_ids,
     const std::string & fingerprint,
     const std::string & url,
     long int timestamp) {
     bool confirmed;
     try {
         auto signal = create_signal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST);
-        signal << id << user_id << fingerprint << url << static_cast<int64_t>(timestamp);
+        signal << id << (user_ids.empty() ? "" : user_ids[0]) << fingerprint << url << static_cast<int64_t>(timestamp);
         // wait for client's confirmation
         confirmed = session.wait_for_key_confirmation(id, signal);
     } catch (...) {

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -80,7 +80,7 @@ public:
 
     bool repokey_import(
         const std::string & id,
-        const std::string & user_id,
+        const std::vector<std::string> & user_ids,
         const std::string & fingerprint,
         const std::string & url,
         long int timestamp) override;

--- a/include/libdnf-cli/output/repo_info.hpp
+++ b/include/libdnf-cli/output/repo_info.hpp
@@ -61,7 +61,7 @@ void RepoInfo::add_repo(Repo & repo, bool verbose, bool show_sack_data) {
     */
 
     // GPG
-    auto group_gpg = add_line("GPG", "", nullptr);
+    auto group_gpg = add_line("PGP", "", nullptr);
     add_line("Keys", "", nullptr, group_gpg);
     add_line("Verify repodata", "", nullptr, group_gpg);
     add_line("Verify packages", "", nullptr, group_gpg);

--- a/include/libdnf/repo/repo_callbacks.hpp
+++ b/include/libdnf/repo/repo_callbacks.hpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_REPO_REPO_CALLBACKS_HPP
 #define LIBDNF_REPO_REPO_CALLBACKS_HPP
 
+#include <string>
+#include <vector>
 
 namespace libdnf::repo {
 
@@ -90,14 +92,14 @@ public:
 
     /// GPG key import callback. Allows to confirm or deny the import.
     /// @param id the key id
-    /// @param user_id the user id of the key
+    /// @param user_ids the list of the key user IDs
     /// @param fingerprint the fingerprint of the key
     /// @param url the URL from which the key was downloaded
     /// @param timestamp the timestamp of the key
     /// @return `true` to import the key, `false` to not import
     virtual bool repokey_import(
         const std::string & id,
-        const std::string & user_id,
+        const std::vector<std::string> & user_ids,
         const std::string & fingerprint,
         const std::string & url,
         long int timestamp) {

--- a/include/libdnf/repo/repo_errors.hpp
+++ b/include/libdnf/repo/repo_errors.hpp
@@ -39,10 +39,10 @@ public:
 };
 
 
-class RepoGpgError : public RepoError {
+class RepoPgpError : public RepoError {
 public:
     using RepoError::RepoError;
-    const char * get_name() const noexcept override { return "RepoGpgError"; }
+    const char * get_name() const noexcept override { return "RepoPgpError"; }
 };
 
 

--- a/include/libdnf/rpm/rpm_signature.hpp
+++ b/include/libdnf/rpm/rpm_signature.hpp
@@ -47,12 +47,12 @@ using RpmKeyPktPtr = std::unique_ptr<uint8_t, std::function<void(uint8_t * pkt)>
 
 class KeyInfo {
 public:
-    std::string get_key_id() const { return key_id; }
+    const std::string & get_key_id() const noexcept { return key_id; }
     std::string get_short_key_id() const;
-    std::string get_user_id() const { return user_id; }
-    std::string get_fingerprint() const { return fingerprint; }
-    std::string get_url() const { return key_url; }
-    std::string get_path() const { return key_path; }
+    const std::vector<std::string> & get_user_ids() const noexcept { return user_ids; }
+    const std::string & get_fingerprint() const noexcept { return fingerprint; }
+    const std::string & get_url() const noexcept { return key_url; }
+    const std::string & get_path() const noexcept { return key_path; }
 
 private:
     friend class RpmSignature;
@@ -60,13 +60,13 @@ private:
         const std::string & key_url,
         const std::string & key_path,
         const std::string & key_id,
-        const std::string & user_id,
+        const std::vector<std::string> & user_ids,
         const std::string & fingerprint,
         std::string raw_key);
     std::string key_url;
     std::string key_path;
     std::string key_id;
-    std::string user_id;
+    std::vector<std::string> user_ids;
     std::string fingerprint;
     std::string raw_key;
 };

--- a/include/libdnf/rpm/rpm_signature.hpp
+++ b/include/libdnf/rpm/rpm_signature.hpp
@@ -62,13 +62,13 @@ private:
         const std::string & key_id,
         const std::string & user_id,
         const std::string & fingerprint,
-        std::vector<char> raw_key);
+        std::string raw_key);
     std::string key_url;
     std::string key_path;
     std::string key_id;
     std::string user_id;
     std::string fingerprint;
-    std::vector<char> raw_key;
+    std::string raw_key;
 };
 
 class RpmSignature {

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -84,17 +84,7 @@ pkg_check_modules (GLIB2 glib-2.0>=2.46.0)
 include_directories(${GLIB2_INCLUDE_DIRS})
 target_link_libraries(libdnf ${GLIB2_LIBRARIES})
 
-# GPGME
-pkg_check_modules(GPGME gpgme)
-if(NOT GPGME_FOUND)
-    # gpgme.pc is not available on RHEL 8 / CentOS Stream 8
-    set(GPGME_MODULE_NAME gpgme)
-    set(GPGME_LIBRARIES gpgme)
-endif()
-list(APPEND LIBDNF5_PC_REQUIRES "${GPGME_MODULE_NAME}")
-target_link_libraries(libdnf ${GPGME_LIBRARIES})
-
-pkg_check_modules(LIBREPO REQUIRED librepo>=1.13.0)
+pkg_check_modules(LIBREPO REQUIRED librepo>=1.15.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
 target_link_libraries(libdnf ${LIBREPO_LIBRARIES})
 

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -131,7 +131,7 @@ LibrepoError::LibrepoError(std::unique_ptr<GError> && lr_error)
 RepoDownloader::RepoDownloader(const libdnf::BaseWeakPtr & base, const ConfigRepo & config)
     : base(base),
       config(config),
-      gpgme(base, config) {}
+      pgp(base, config) {}
 
 RepoDownloader::~RepoDownloader() = default;
 
@@ -337,7 +337,7 @@ LibrepoHandle & RepoDownloader::get_cached_handle() {
 
 void RepoDownloader::set_callbacks(std::unique_ptr<libdnf::repo::RepoCallbacks> && cbs) noexcept {
     callbacks = std::move(cbs);
-    gpgme.set_callbacks(callbacks.get());
+    pgp.set_callbacks(callbacks.get());
 }
 
 
@@ -518,7 +518,7 @@ void RepoDownloader::apply_http_headers(LibrepoHandle & handle) {
 LibrepoResult RepoDownloader::perform(
     LibrepoHandle & handle, const std::string & dest_directory, bool set_gpg_home_dir) {
     if (set_gpg_home_dir) {
-        auto pubringdir = gpgme.get_keyring_dir();
+        auto pubringdir = pgp.get_keyring_dir();
         handle.set_opt(LRO_GNUPGHOMEDIR, pubringdir.c_str());
     }
 
@@ -610,7 +610,7 @@ void RepoDownloader::import_repo_keys() {
         download_url(gpgkey_url.c_str(), tmp_file.get_fd());
 
         lseek(tmp_file.get_fd(), SEEK_SET, 0);
-        gpgme.import_key(tmp_file.get_fd(), gpgkey_url);
+        pgp.import_key(tmp_file.get_fd(), gpgkey_url);
     }
 }
 

--- a/libdnf/repo/repo_downloader.hpp
+++ b/libdnf/repo/repo_downloader.hpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/repo/load_flags.hpp"
 #include "libdnf/repo/repo_callbacks.hpp"
 
-#include <gpgme.h>
 #include <librepo/librepo.h>
 
 #include <map>

--- a/libdnf/repo/repo_downloader.hpp
+++ b/libdnf/repo/repo_downloader.hpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_REPO_REPO_DOWNLOADER_HPP
 
 #include "librepo.hpp"
-#include "repo_gpgme.hpp"
+#include "repo_pgp.hpp"
 
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
@@ -95,7 +95,7 @@ private:
 
     libdnf::BaseWeakPtr base;
     const ConfigRepo & config;
-    RepoGpgme gpgme;
+    RepoPgp pgp;
 
     std::unique_ptr<RepoCallbacks> callbacks;
 

--- a/libdnf/repo/repo_pgp.cpp
+++ b/libdnf/repo/repo_pgp.cpp
@@ -35,8 +35,9 @@ Key::Key(const LrGpgKey * key, const LrGpgSubkey * subkey)
       fingerprint{lr_gpg_subkey_get_fingerprint(subkey)},
       timestamp{lr_gpg_subkey_get_timestamp(subkey)},
       raw_key{lr_gpg_key_get_raw_key(key)} {
-    auto * userid_c = lr_gpg_key_get_userids(key)[0];
-    userid = userid_c ? userid_c : "";
+    for (auto * const * item = lr_gpg_key_get_userids(key); *item; ++item) {
+        user_ids.push_back(*item);
+    }
 }
 
 
@@ -124,7 +125,7 @@ void RepoPgp::import_key(int fd, const std::string & url) {
         if (callbacks) {
             if (!callbacks->repokey_import(
                     key_info.get_id(),
-                    key_info.get_user_id(),
+                    key_info.get_user_ids(),
                     key_info.get_fingerprint(),
                     url,
                     key_info.get_timestamp()))

--- a/libdnf/repo/repo_pgp.cpp
+++ b/libdnf/repo/repo_pgp.cpp
@@ -33,11 +33,10 @@ namespace libdnf::repo {
 Key::Key(const LrGpgKey * key, const LrGpgSubkey * subkey)
     : id{lr_gpg_subkey_get_id(subkey)},
       fingerprint{lr_gpg_subkey_get_fingerprint(subkey)},
-      timestamp{lr_gpg_subkey_get_timestamp(subkey)} {
+      timestamp{lr_gpg_subkey_get_timestamp(subkey)},
+      raw_key{lr_gpg_key_get_raw_key(key)} {
     auto * userid_c = lr_gpg_key_get_userids(key)[0];
     userid = userid_c ? userid_c : "";
-    std::string_view raw_key_str = lr_gpg_key_get_raw_key(key);
-    std::copy(raw_key_str.begin(), raw_key_str.end(), std::back_inserter(raw_key));
 }
 
 
@@ -140,7 +139,7 @@ void RepoPgp::import_key(int fd, const std::string & url) {
 
         GError * err = NULL;
         if (!lr_gpg_import_key_from_memory(
-                key_info.raw_key.data(), key_info.raw_key.size(), keyring_dir.c_str(), &err)) {
+                key_info.get_raw_key().c_str(), key_info.get_raw_key().size(), keyring_dir.c_str(), &err)) {
             throw_repo_pgp_error(M_("Failed to import pgp keys: {}"), err);
         }
 

--- a/libdnf/repo/repo_pgp.cpp
+++ b/libdnf/repo/repo_pgp.cpp
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "repo_gpgme.hpp"
+#include "repo_pgp.hpp"
 
 #include "utils/bgettext/bgettext-mark-domain.h"
 #include "utils/fs/temp.hpp"
@@ -44,11 +44,11 @@ Key::Key(const LrGpgKey * key, const LrGpgSubkey * subkey)
 [[noreturn]] static void throw_repo_pgp_error(const BgettextMessage & msg, GError * err) {
     std::string err_msg = err->message;
     g_error_free(err);
-    throw RepoGpgError(msg, err_msg);
+    throw RepoPgpError(msg, err_msg);
 }
 
 
-std::vector<Key> RepoGpgme::rawkey2infos(int fd) {
+std::vector<Key> RepoPgp::rawkey2infos(int fd) {
     std::vector<Key> key_infos;
 
     libdnf::utils::fs::TempDir tmpdir("tmpdir");
@@ -79,7 +79,7 @@ std::vector<Key> RepoGpgme::rawkey2infos(int fd) {
 }
 
 
-std::vector<std::string> RepoGpgme::load_keys_ids_from_keyring() {
+std::vector<std::string> RepoPgp::load_keys_ids_from_keyring() {
     std::vector<std::string> keys_ids;
 
     auto keyring_dir = get_keyring_dir();
@@ -107,10 +107,10 @@ std::vector<std::string> RepoGpgme::load_keys_ids_from_keyring() {
 }
 
 
-RepoGpgme::RepoGpgme(const BaseWeakPtr & base, const ConfigRepo & config) : base(base), config(config) {}
+RepoPgp::RepoPgp(const BaseWeakPtr & base, const ConfigRepo & config) : base(base), config(config) {}
 
 
-void RepoGpgme::import_key(int fd, const std::string & url) {
+void RepoPgp::import_key(int fd, const std::string & url) {
     auto & logger = *base->get_logger();
 
     auto key_infos = rawkey2infos(fd);

--- a/libdnf/repo/repo_pgp.hpp
+++ b/libdnf/repo/repo_pgp.hpp
@@ -17,8 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF_REPO_REPO_GPGME_HPP
-#define LIBDNF_REPO_REPO_GPGME_HPP
+#ifndef LIBDNF_REPO_REPO_PGP_HPP
+#define LIBDNF_REPO_REPO_PGP_HPP
 
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
@@ -53,10 +53,10 @@ private:
 };
 
 /// Wraps pgp in a higher-level interface.
-/// @exception RepoGpgError (public) Thrown on any pgp-related error.
-class RepoGpgme {
+/// @exception RepoPgpError (public) Thrown on any pgp-related error.
+class RepoPgp {
 public:
-    RepoGpgme(const BaseWeakPtr & base, const ConfigRepo & config);
+    RepoPgp(const BaseWeakPtr & base, const ConfigRepo & config);
 
     void set_callbacks(RepoCallbacks * callbacks) noexcept { this->callbacks = callbacks; }
 
@@ -74,4 +74,4 @@ private:
 
 }  // namespace libdnf::repo
 
-#endif  // LIBDNF_REPO_REPO_GPGME_HPP
+#endif  // LIBDNF_REPO_REPO_PGP_HPP

--- a/libdnf/repo/repo_pgp.hpp
+++ b/libdnf/repo/repo_pgp.hpp
@@ -39,7 +39,7 @@ public:
     Key(const LrGpgKey * key, const LrGpgSubkey * subkey);
 
     const std::string & get_id() const noexcept { return id; }
-    const std::string & get_user_id() const noexcept { return userid; }
+    const std::vector<std::string> & get_user_ids() const noexcept { return user_ids; }
     const std::string & get_fingerprint() const noexcept { return fingerprint; }
     long int get_timestamp() const noexcept { return timestamp; }
     const std::string & get_raw_key() const noexcept { return raw_key; }
@@ -48,7 +48,7 @@ public:
 private:
     std::string id;
     std::string fingerprint;
-    std::string userid;
+    std::vector<std::string> user_ids;
     long int timestamp;
     std::string raw_key;
 };

--- a/libdnf/repo/repo_pgp.hpp
+++ b/libdnf/repo/repo_pgp.hpp
@@ -42,14 +42,15 @@ public:
     const std::string & get_user_id() const noexcept { return userid; }
     const std::string & get_fingerprint() const noexcept { return fingerprint; }
     long int get_timestamp() const noexcept { return timestamp; }
+    const std::string & get_raw_key() const noexcept { return raw_key; }
 
-    std::vector<char> raw_key;
 
 private:
     std::string id;
     std::string fingerprint;
     std::string userid;
     long int timestamp;
+    std::string raw_key;
 };
 
 /// Wraps pgp in a higher-level interface.

--- a/libdnf/rpm/rpm_signature.cpp
+++ b/libdnf/rpm/rpm_signature.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/rpm_signature.hpp"
 
-#include "repo/repo_gpgme.hpp"
+#include "repo/repo_pgp.hpp"
 #include "rpm/rpm_log_guard.hpp"
 #include "utils/bgettext/bgettext-lib.h"
 #include "utils/bgettext/bgettext-mark-domain.h"
@@ -218,7 +218,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
 
     std::vector<KeyInfo> keys;
     utils::fs::File key_file(key_path, "r");
-    for (auto & key_info : repo::RepoGpgme::rawkey2infos(key_file.get_fd())) {
+    for (auto & key_info : repo::RepoPgp::rawkey2infos(key_file.get_fd())) {
         key_info.raw_key.insert(key_info.raw_key.end(), '\0');
         KeyInfo key{
             key_url,

--- a/libdnf/rpm/rpm_signature.cpp
+++ b/libdnf/rpm/rpm_signature.cpp
@@ -75,13 +75,13 @@ KeyInfo::KeyInfo(
     const std::string & key_url,
     const std::string & key_path,
     const std::string & key_id,
-    const std::string & user_id,
+    const std::vector<std::string> & user_ids,
     const std::string & fingerprint,
     std::string raw_key)
     : key_url(key_url),
       key_path(key_path),
       key_id(key_id),
-      user_id(user_id),
+      user_ids(user_ids),
       fingerprint(fingerprint),
       raw_key(raw_key) {}
 
@@ -223,7 +223,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
             key_url,
             key_path,
             key_info.get_id(),
-            key_info.get_user_id(),
+            key_info.get_user_ids(),
             key_info.get_fingerprint(),
             key_info.get_raw_key()};
         keys.emplace_back(std::move(key));

--- a/test/libdnf/repo/test_repo.cpp
+++ b/test/libdnf/repo/test_repo.cpp
@@ -66,7 +66,7 @@ public:
 
     bool repokey_import(
         [[maybe_unused]] const std::string & id,
-        [[maybe_unused]] const std::string & user_id,
+        [[maybe_unused]] const std::vector<std::string> & user_ids,
         [[maybe_unused]] const std::string & fingerprint,
         [[maybe_unused]] const std::string & url,
         [[maybe_unused]] long int timestamp) override {


### PR DESCRIPTION
Librepo internally uses gpgme to work with PGP keys. Libdnf used the librepo keyring directly via gpgme instead of using the librepo API. It had to, the librepo API was insufficient.

Librepo in version 1.15.0 extended the PGP API.
This commmit uses the extended librepo PGP API and removes libdnf's dependency on gpgme.

PR also adds support for any number of user IDs in a PGP key.

This PR requires new librepo PGP API PR https://github.com/rpm-software-management/librepo/pull/266 .