### PR TITLE
Group remove command

### DIFF
--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "group_info.hpp"
 #include "group_install.hpp"
 #include "group_list.hpp"
+#include "group_remove.hpp"
 
 namespace dnf5 {
 
@@ -45,10 +46,11 @@ void GroupCommand::register_subcommands() {
     register_subcommand(std::make_unique<GroupInfoCommand>(get_context()), query_commands_group);
     // software management commands
     auto * software_management_commands_group =
-        get_context().get_argument_parser().add_new_group("module_software_management_commands");
+        get_context().get_argument_parser().add_new_group("group_software_management_commands");
     software_management_commands_group->set_header("Software Management Commands:");
     get_argument_parser_command()->register_group(software_management_commands_group);
     register_subcommand(std::make_unique<GroupInstallCommand>(get_context()), software_management_commands_group);
+    register_subcommand(std::make_unique<GroupRemoveCommand>(get_context()), software_management_commands_group);
 }
 
 void GroupCommand::pre_configure() {

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -56,7 +56,7 @@ void GroupInstallCommand::run() {
         *settings.group_package_types |= libdnf::comps::PackageType::OPTIONAL;
     }
     for (const auto & spec : group_specs->get_value()) {
-        goal->add_group_install(spec, settings);
+        goal->add_group_install(spec, libdnf::transaction::TransactionItemReason::USER, settings);
     }
 }
 

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -1,0 +1,57 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "group_remove.hpp"
+
+#include <libdnf/comps/comps.hpp>
+#include <libdnf/comps/group/group.hpp>
+#include <libdnf/comps/group/query.hpp>
+#include <libdnf/conf/const.hpp>
+
+#include <iostream>
+
+namespace dnf5 {
+
+using namespace libdnf::cli;
+
+void GroupRemoveCommand::set_argument_parser() {
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_description("Remove comp groups, including their packages");
+
+    group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
+}
+
+void GroupRemoveCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.base.get_config().optional_metadata_types().add_item(libdnf::METADATA_TYPE_COMPS);
+}
+
+void GroupRemoveCommand::run() {
+    auto & ctx = get_context();
+    auto goal = ctx.get_goal();
+
+    libdnf::GoalJobSettings settings;
+    for (const auto & spec : group_specs->get_value()) {
+        goal->add_group_remove(spec, libdnf::transaction::TransactionItemReason::USER, settings);
+    }
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/group/group_remove.hpp
+++ b/dnf5/commands/group/group_remove.hpp
@@ -1,0 +1,49 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_COMMANDS_GROUP_GROUP_REMOVE_HPP
+#define DNF5_COMMANDS_GROUP_GROUP_REMOVE_HPP
+
+#include "arguments.hpp"
+
+#include <dnf5/context.hpp>
+
+
+namespace dnf5 {
+
+
+class GroupRemoveCommand : public Command {
+public:
+    explicit GroupRemoveCommand(Context & context) : GroupRemoveCommand(context, "remove") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+
+    std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
+
+protected:
+    // to be used by an alias command only
+    explicit GroupRemoveCommand(Context & context, const std::string & name) : Command(context, name) {}
+};
+
+
+}  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_GROUP_GROUP_REMOVE_HPP

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -99,6 +99,7 @@ public:
 private:
     friend class libdnf::InternalBaseUser;
     friend class libdnf::base::Transaction;
+    friend class libdnf::Goal;
     friend class libdnf::rpm::Package;
     friend class libdnf::advisory::AdvisoryQuery;
     friend class libdnf::module::ModuleSack;

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -256,9 +256,12 @@ public:
     /// Also packages of the types specified in setting.group_package_types be installed.
     ///
     /// @param spec      A string describing the Goal group install request.
+    /// @param reason    Reason why the group is installed (USER/DEPENDENCY)
     /// @param settings  A structure to override default goal settings.
     void add_group_install(
-        const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+        const std::string & spec,
+        const libdnf::transaction::TransactionItemReason reason,
+        const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 
     /// Request to install providers of the `spec`. Useful to install package
     /// using rich dependencies.  The `spec` (e.g. "(depA and depB)") is not

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -263,6 +263,17 @@ public:
         const libdnf::transaction::TransactionItemReason reason,
         const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 
+    /// Add group remove request to the goal. The `spec` will be resolved to groups in the resolve() call.
+    /// Also packages not belonging to another group and not explicitly user-installed will get removed.
+    ///
+    /// @param spec      A string describing the Goal group remove request.
+    /// @param reason    Reason why the group is removed.
+    /// @param settings  A structure to override default goal settings.
+    void add_group_remove(
+        const std::string & spec,
+        const libdnf::transaction::TransactionItemReason reason,
+        const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+
     /// Request to install providers of the `spec`. Useful to install package
     /// using rich dependencies.  The `spec` (e.g. "(depA and depB)") is not
     /// parsed but directly passed to the solver to install package(s) which

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -125,8 +125,9 @@ private:
         rpm_reason_change_specs;
     /// <libdnf::GoalAction, rpm Ids, libdnf::GoalJobSettings settings>
     std::vector<std::tuple<GoalAction, libdnf::solv::IdQueue, GoalJobSettings>> rpm_ids;
-    /// <libdnf::GoalAction, std::string group_spec, GoalJobSettings settings>
-    std::vector<std::tuple<GoalAction, std::string, GoalJobSettings>> group_specs;
+    /// <libdnf::GoalAction, TransactionItemReason reason, std::string group_spec, GoalJobSettings settings>
+    std::vector<std::tuple<GoalAction, libdnf::transaction::TransactionItemReason, std::string, GoalJobSettings>>
+        group_specs;
 
     rpm::solv::GoalPrivate rpm_goal;
     bool allow_erasing{false};
@@ -334,8 +335,11 @@ void Goal::Impl::filter_candidates_for_advisory_upgrade(
         candidates, latest_unresolved_adv_pkgs, libdnf::sack::QueryCmp::GTE);
 }
 
-void Goal::add_group_install(const std::string & spec, const GoalJobSettings & settings) {
-    p_impl->group_specs.push_back(std::make_tuple(GoalAction::INSTALL, spec, settings));
+void Goal::add_group_install(
+    const std::string & spec,
+    const libdnf::transaction::TransactionItemReason reason,
+    const GoalJobSettings & settings) {
+    p_impl->group_specs.push_back(std::make_tuple(GoalAction::INSTALL, reason, spec, settings));
 }
 
 GoalProblem Goal::Impl::add_specs_to_goal(base::Transaction & transaction) {

--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -72,7 +72,7 @@ public:
     /// @param action Action to be commited - INSTALL, REMOVE, UPGRADE
     /// @param reason Reason for the group action - USER, DEPENDENCY
     void add_group(
-        libdnf::comps::Group & group,
+        const libdnf::comps::Group & group,
         transaction::TransactionItemAction action,
         transaction::TransactionItemReason reason);
 
@@ -310,7 +310,7 @@ inline void GoalPrivate::add_distro_sync(libdnf::solv::IdQueue & queue, bool str
 }
 
 inline void GoalPrivate::add_group(
-    libdnf::comps::Group & group,
+    const libdnf::comps::Group & group,
     transaction::TransactionItemAction action,
     transaction::TransactionItemReason reason) {
     groups.emplace_back(group, action, reason);


### PR DESCRIPTION
Implement the `dnf5 group remove` command.
While removing the group also packages that meet all following criteria are removed from the system:

- package is installed with GROUP reason
- package is not part of any other installed group
- package is not required by any other package. In such case the package is left on the system, but its reason is changed to DEPENDENCY.
