### PR TITLE
dnf5-changes-doc: Add more structure and document dropped repoquery options

### DIFF
--- a/CHANGES-DNF-5.md
+++ b/CHANGES-DNF-5.md
@@ -31,8 +31,6 @@ The filter was replaced with `filter_latest_evr()` which has the same behavior a
 
 Changes on the command line:
 ----------------------------
-dnf upgrade-minimal -> dnf upgrade --minimal
-
 Commands cannot have optional subcommands and optional arguments. Is some cases subcommand can have the same string as
 an argument. It means there is a difficulty to find advisory for package with the name `list`, `info`, or `summary`.
 `dnf history info <transaction ID>` -> `dnf history --info <transaction ID>`
@@ -44,3 +42,7 @@ options and implemented only for related commands
 
 Renaming boolean options to format `--<option>`, and `--no-<option>`
 `--nobest` -> `--no-best`. Proposing to keep `--nobest` as a deprecated option.
+
+
+### Upgrade command
+- New dnf5 option `--minimal` (`upgrade-minimal` command still exists as a compatibility alias for `upgrade --minimal`).

--- a/CHANGES-DNF-5.md
+++ b/CHANGES-DNF-5.md
@@ -1,38 +1,36 @@
-PackageSet::operator[]
-----------------------
+# [DNF5](https://github.com/rpm-software-management/dnf5) x [DNF4](https://github.com/rpm-software-management/dnf) differences
+
+Changes on the API:
+-------------------
+### PackageSet::operator[]
 It was removed due to insufficient O(n^2) performance.
 Use PackageSet iterator to access the data instead.
 
 
-Package::get_epoch()
---------------------
+### Package::get_epoch()
 The return type was changed from `unsigned long` to `std::string`.
 
 
-DNF: Package.size, libdnf: dnf_package_get_size()
--------------------------------------------------
+### DNF: Package.size, libdnf: dnf_package_get_size()
 The return value was ambiguous, returning either package or install size.
 Use Package::get_package_size() and Package::get_install_size() instead.
 
 
-dnf_sack_set_installonly, dnf_sack_get_installonly, dnf_sack_set_installonly_limit, dnf_sack_get_installonly_limit
-------------------------------------------------------------------------------------------------------------------
+### dnf_sack_set_installonly, dnf_sack_get_installonly, dnf_sack_set_installonly_limit, dnf_sack_get_installonly_limit
 The functions were dropped as unneeded. The installonly packages are taken directly from main Conf in Base.
 
 
-Query::filter() - HY_PKG_UPGRADES_BY_PRIORITY, HY_PKG_OBSOLETES_BY_PRIORITY, HY_PKG_LATEST_PER_ARCH_BY_PRIORITY
----------------------------------------------------------------------------------------------------------------
+### Query::filter() - HY_PKG_UPGRADES_BY_PRIORITY, HY_PKG_OBSOLETES_BY_PRIORITY, HY_PKG_LATEST_PER_ARCH_BY_PRIORITY
 The priority filter was separated into a standalone method.
 Combine `query.filter_priority()` with `query.filter_latest_evr()` or another filter to achieve the original functionality.
 
 
-Query::filter() - HY_PKG_LATEST
--------------------------------
+### Query::filter() - HY_PKG_LATEST
 The filter was replaced with `filter_latest_evr()` which has the same behavior as `HY_PKG_LATEST_PER_ARCH`
 
 
-Changes on the command line
----------------------------
+Changes on the command line:
+----------------------------
 dnf upgrade-minimal -> dnf upgrade --minimal
 
 Commands cannot have optional subcommands and optional arguments. Is some cases subcommand can have the same string as

--- a/CHANGES-DNF-5.md
+++ b/CHANGES-DNF-5.md
@@ -46,3 +46,8 @@ Renaming boolean options to format `--<option>`, and `--no-<option>`
 
 ### Upgrade command
 - New dnf5 option `--minimal` (`upgrade-minimal` command still exists as a compatibility alias for `upgrade --minimal`).
+
+
+### Repoquery command
+- Dropped: `-a/--all`, `--alldeps`, `--nevra` options, their behavior is and has been the default for both dnf4 and dnf5. The options are no longer needed.
+- Dopped: `--nvr`, `--envra` options. They are no longer supported.


### PR DESCRIPTION
Add main heading with links to dnf components to be clear about the
documents subject.

Split the doc to two main sectiosn:
- Changes on the API
- Changes on the command line
to make it more readable.

Also document several Repoquery options as dropped.
For: https://github.com/rpm-software-management/dnf5/issues/122