### PR TITLE
Repoquery: Add --duplicates option

### DIFF
--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -43,6 +43,8 @@ public:
     void run() override;
 
 private:
+    bool only_system_repo_needed = false;
+
     libdnf::OptionBool * available_option{nullptr};
     libdnf::OptionBool * installed_option{nullptr};
     libdnf::OptionBool * info_option{nullptr};
@@ -50,6 +52,8 @@ private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<libdnf::cli::session::BoolOption> duplicates{nullptr};
 
     std::unique_ptr<AdvisoryOption> advisory_name{nullptr};
     std::unique_ptr<SecurityOption> advisory_security{nullptr};

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -594,6 +594,9 @@ public:
 
     void swap(PackageQuery & other) noexcept;
 
+    /// Filter packages to keep only duplicates of installed packages. Packages are duplicate if they have the same `name` and `arch` but different `evr`.
+    void filter_duplicates();
+
 private:
     friend libdnf::Goal;
     class PQImpl;


### PR DESCRIPTION
Adds `filter_duplicates()` method to `PackageQuery`.

For: https://github.com/rpm-software-management/dnf5/issues/122

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1187