### PR TITLE
Add dnf5-devel package

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -246,6 +246,23 @@ Library for working with a terminal in a command-line package manager.
 %license lgpl-2.1.txt
 %endif
 
+# ========== dnf5-devel ==========
+
+%package -n dnf5-devel
+Summary:        Development files for dnf5
+License:        LGPL-2.1-or-later
+Requires:       dnf5%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-devel%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-cli-devel%{?_isa} = %{version}-%{release}
+
+%description -n dnf5-devel
+Develpment files for dnf5.
+
+%files -n dnf5-devel
+%{_includedir}/dnf5/
+%license COPYING.md
+%license lgpl-2.1.txt
+
 
 # ========== libdnf5-devel ==========
 

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -47,3 +47,4 @@ install(DIRECTORY "config/etc/" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 
 
 add_subdirectory(po)
+add_subdirectory("include")

--- a/dnf5/include/CMakeLists.txt
+++ b/dnf5/include/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory("dnf5")

--- a/dnf5/include/dnf5/CMakeLists.txt
+++ b/dnf5/include/dnf5/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE DNF5_HEADERS *.hpp)
+
+# preserve relative paths of the header files
+foreach(abspath ${DNF5_HEADERS})
+    # relative path to the header file
+    file(RELATIVE_PATH relpath ${CMAKE_CURRENT_SOURCE_DIR} ${abspath})
+    # dirname of the relative path
+    get_filename_component(relpath_dir ${relpath} DIRECTORY)
+    install(FILES ${abspath} DESTINATION include/dnf5/${relpath_dir})
+endforeach()


### PR DESCRIPTION
Files in dnf5/include are necessary to build plugins. This commit adds header files to cmake installed files and dnf5-devel package in the dnf5 specfile.