### PR TITLE
Throw Exception if alldeps used without resolve

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "download.hpp"
 
+#include "utils/bgettext/bgettext-mark-domain.h"
+
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
@@ -86,6 +88,9 @@ void DownloadCommand::configure() {
     context.update_repo_load_flags_from_specs(pkg_specs);
     if (resolve_option->get_value() && !alldeps_option->get_value()) {
         context.set_load_system_repo(true);
+    } else if (!resolve_option->get_value() && alldeps_option->get_value()) {
+        throw libdnf::cli::ArgumentParserMissingDependentArgumentError(
+            M_("Option alldeps should be used with resolve"));
     } else {
         context.set_load_system_repo(false);
     }

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -709,6 +709,10 @@ int main(int argc, char * argv[]) try {
         std::cerr << ex.what() << std::endl;
         context.get_argument_parser().get_selected_command()->help();
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
+    } catch (libdnf::cli::ArgumentParserMissingDependentArgumentError & ex) {
+        std::cerr << ex.what() << std::endl;
+        context.get_argument_parser().get_selected_command()->help();
+        return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
     } catch (libdnf::cli::ArgumentParserError & ex) {
         std::cerr << ex.what() << std::endl;
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -117,6 +117,13 @@ public:
     const char * get_name() const noexcept override { return "ArgumentParserIdAlreadyRegisteredError"; }
 };
 
+/// Exception is thrown when the command, named argument, positiona argument, or group needs an additional argument.
+class ArgumentParserMissingDependentArgumentError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingDependentArgumentError"; }
+};
+
 /// Base class for user data used in ArgumentParser::Argument
 class ArgumentParserUserData {};
 


### PR DESCRIPTION
Add catch condition in main for
libdnf::cli::ArgumentParserConflictingArgumentsError. When exception is caught the help should be printed to show the correct arguments usage.