### PR TITLE
Cast std::tolower() argument to unsigned char to avoid possible UB

### DIFF
--- a/common/utils/url.cpp
+++ b/common/utils/url.cpp
@@ -28,7 +28,7 @@ bool is_url(std::string path) {
         if (ch == ':' || ch == '/') {
             break;
         }
-        ch = static_cast<char>(std::tolower(ch));
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
     }
     return path.starts_with("file://") || path.starts_with("http://") || path.starts_with("ftp://") ||
            path.starts_with("https://");


### PR DESCRIPTION
`std::tolower()` takes an `int` instead of a `char`, and it's undefined behavior if the `int` value is not representable as an `unsigned char` or equal to `EOF`. Therefore, casting the argument to `unsigned char` is necessary to avoid potential UB if `char` is signed and `ch` is not an ASCII character. See https://en.cppreference.com/w/cpp/string/byte/tolower#Notes.