### PR TITLE
Support for specifying set of allowed proxy authentication methods

### DIFF
--- a/CHANGES-DNF-5.md
+++ b/CHANGES-DNF-5.md
@@ -29,6 +29,12 @@ Combine `query.filter_priority()` with `query.filter_latest_evr()` or another fi
 The filter was replaced with `filter_latest_evr()` which has the same behavior as `HY_PKG_LATEST_PER_ARCH`
 
 
+### ConfigMain::proxy_auth_method() and ConfigRepo::proxy_auth_method()
+The return types were changed. `OptionEnum<std::string>` was replaced by `OptionStringSet`.
+A combination of several authentication methods (for example "basic" and "digest") can now be used.
+This allows using a list of authentication methods in configuration files and the DNF5 command line "--setopt=proxy_auth_method=".
+
+
 Changes on the command line:
 ----------------------------
 Commands cannot have optional subcommands and optional arguments. Is some cases subcommand can have the same string as

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -225,8 +225,8 @@ public:
     const OptionString & proxy_username() const;
     OptionString & proxy_password();
     const OptionString & proxy_password() const;
-    OptionEnum<std::string> & proxy_auth_method();
-    const OptionEnum<std::string> & proxy_auth_method() const;
+    OptionStringSet & proxy_auth_method();
+    const OptionStringSet & proxy_auth_method() const;
     OptionStringList & protected_packages();
     const OptionStringList & protected_packages() const;
     OptionString & username();

--- a/include/libdnf/repo/config_repo.hpp
+++ b/include/libdnf/repo/config_repo.hpp
@@ -70,8 +70,8 @@ public:
     const OptionChild<OptionString> & proxy_username() const;
     OptionChild<OptionString> & proxy_password();
     const OptionChild<OptionString> & proxy_password() const;
-    OptionChild<OptionEnum<std::string>> & proxy_auth_method();
-    const OptionChild<OptionEnum<std::string>> & proxy_auth_method() const;
+    OptionChild<OptionStringSet> & proxy_auth_method();
+    const OptionChild<OptionStringSet> & proxy_auth_method() const;
     OptionChild<OptionString> & username();
     const OptionChild<OptionString> & username() const;
     OptionChild<OptionString> & password();

--- a/libdnf/conf/option_string.cpp
+++ b/libdnf/conf/option_string.cpp
@@ -62,10 +62,12 @@ void OptionString::test(const std::string & value) const {
     if (regex.empty()) {
         return;
     }
-    std::regex re(
-        regex,
-        std::regex::nosubs | std::regex::extended | (icase ? std::regex::icase : std::regex_constants::ECMAScript));
-    if (!std::regex_match(value, re)) {
+
+    auto flags = std::regex::ECMAScript | std::regex::nosubs;
+    if (icase) {
+        flags |= std::regex::icase;
+    }
+    if (!std::regex_match(value, std::regex(regex, flags))) {
         throw OptionValueNotAllowedError(
             M_("Input value \"{}\" not allowed, allowed values for this option are defined by regular expression "
                "\"{}\""),

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -102,9 +102,11 @@ void OptionStringContainer<T>::init_regex_matcher() {
         return;
     }
 
-    regex_matcher = std::regex(
-        regex,
-        std::regex::nosubs | std::regex::extended | (icase ? std::regex::icase : std::regex_constants::ECMAScript));
+    auto flags = std::regex::ECMAScript | std::regex::nosubs;
+    if (icase) {
+        flags |= std::regex::icase;
+    }
+    regex_matcher = std::regex(regex, flags);
 }
 
 template <typename T>

--- a/libdnf/repo/config_repo.cpp
+++ b/libdnf/repo/config_repo.cpp
@@ -54,7 +54,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> proxy{main_config.proxy()};
     OptionChild<OptionString> proxy_username{main_config.proxy_username()};
     OptionChild<OptionString> proxy_password{main_config.proxy_password()};
-    OptionChild<OptionEnum<std::string>> proxy_auth_method{main_config.proxy_auth_method()};
+    OptionChild<OptionStringSet> proxy_auth_method{main_config.proxy_auth_method()};
     OptionChild<OptionString> username{main_config.username()};
     OptionChild<OptionString> password{main_config.password()};
     OptionChild<OptionStringList> protected_packages{main_config.protected_packages()};
@@ -151,7 +151,20 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
 
     owner.opt_binds().add("proxy_username", proxy_username);
     owner.opt_binds().add("proxy_password", proxy_password);
-    owner.opt_binds().add("proxy_auth_method", proxy_auth_method);
+
+    owner.opt_binds().add(
+        "proxy_auth_method",
+        proxy_auth_method,
+        [&](Option::Priority priority, const std::string & value) {
+            if (priority >= proxy_auth_method.get_priority()) {
+                auto tmp = value;
+                std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+                proxy_auth_method.set(priority, tmp);
+            }
+        },
+        nullptr,
+        false);
+
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
     owner.opt_binds().add("protected_packages", protected_packages);
@@ -305,10 +318,10 @@ const OptionChild<OptionString> & ConfigRepo::proxy_password() const {
     return p_impl->proxy_password;
 }
 
-OptionChild<OptionEnum<std::string>> & ConfigRepo::proxy_auth_method() {
+OptionChild<OptionStringSet> & ConfigRepo::proxy_auth_method() {
     return p_impl->proxy_auth_method;
 }
-const OptionChild<OptionEnum<std::string>> & ConfigRepo::proxy_auth_method() const {
+const OptionChild<OptionStringSet> & ConfigRepo::proxy_auth_method() const {
     return p_impl->proxy_auth_method;
 }
 

--- a/libdnf/repo/librepo.cpp
+++ b/libdnf/repo/librepo.cpp
@@ -165,15 +165,20 @@ static void init_remote(LibrepoHandle & handle, const C & config) {
         handle.set_opt(LRO_PROXY, config.proxy().get_value().c_str());
     }
 
-    const std::string proxy_auth_method_str = config.proxy_auth_method().get_value();
-    auto proxy_auth_method = LR_AUTH_ANY;
-    for (auto & auth : PROXYAUTHMETHODS) {
-        if (proxy_auth_method_str == auth.name) {
-            proxy_auth_method = auth.code;
-            break;
+    long proxy_auth_methods = 0;
+    if (config.proxy_auth_method().empty()) {
+        proxy_auth_methods = LR_AUTH_ANY;
+    } else {
+        for (const auto & proxy_auth_method_str : config.proxy_auth_method().get_value()) {
+            for (auto & auth : PROXYAUTHMETHODS) {
+                if (proxy_auth_method_str == auth.name) {
+                    proxy_auth_methods |= auth.code;
+                    break;
+                }
+            }
         }
     }
-    handle.set_opt(LRO_PROXYAUTHMETHODS, static_cast<long>(proxy_auth_method));
+    handle.set_opt(LRO_PROXYAUTHMETHODS, proxy_auth_methods);
 
     if (!config.proxy_username().empty()) {
         auto userpwd = config.proxy_username().get_value();


### PR DESCRIPTION
The "proxy_auth_method" option accepted exactly one value from the enum "none", "basic", "digest", "negotiate", "ntlm", "digest_ie", "ntlm_wb", "any".

It is now possible to enter a combination of several authentication methods, for example "basic, digest".