### PR TITLE
Workflow: integration-tests now support build type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,4 @@ jobs:
         with:
           package-urls: ${{needs.copr-build.outputs.package-urls}}
           extra-run-args: ${{matrix.extra-run-args}}
+          build-type: dnf5


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1197