### PR TITLE
Fix: RepoDownloader::get_cache_handle: Don't set callbacks in LibrepoHandle

### DIFF
--- a/libdnf/repo/repo_downloader.hpp
+++ b/libdnf/repo/repo_downloader.hpp
@@ -76,7 +76,7 @@ private:
     friend class Repo;
 
     LibrepoHandle init_local_handle();
-    LibrepoHandle init_remote_handle(const char * destdir, bool mirror_setup = true);
+    LibrepoHandle init_remote_handle(const char * destdir, bool mirror_setup = true, bool set_callbacks = true);
     void common_handle_setup(LibrepoHandle & h);
 
     void apply_http_headers(LibrepoHandle & handle);


### PR DESCRIPTION
Before downloading files (packages) from the repository, Librepo itself downloads a metalink/mirrorlist file to a temporary file (if the metalink/mirrorlist url was defined in the configuration) and parses it. An unexpected call to the progress callback occurred while doing so. This fix ensures that the progress callback will not be called.

This fix is not ideal. We should know that librepo is downloading an extra file in the background. For example, in case of network problems, the program may hang for some time and we will not know why. It's just a quick fix for the crash.

The question is, do we even want librepo to download metalink/mirrorlist files itself every time before downloading files from the repository? Why are the metalink/mirrorlist files in the cache?