### PR TITLE
[dnf5] Fix: Handling of unknown exceptions

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -721,7 +721,7 @@ int main(int argc, char * argv[]) try {
         return ex.get_exit_code();
     } catch (std::exception & ex) {
         std::cerr << ex.what() << std::endl;
-        log_router.error(fmt::format("Command returned error: {}", ex.what()));
+        log_router.error("Command returned error: {}", ex.what());
         return static_cast<int>(libdnf::cli::ExitCode::ERROR);
     }
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -719,7 +719,7 @@ int main(int argc, char * argv[]) try {
     } catch (libdnf::cli::CommandExitError & ex) {
         std::cerr << ex.what() << std::endl;
         return ex.get_exit_code();
-    } catch (std::exception & ex) {
+    } catch (std::runtime_error & ex) {
         std::cerr << ex.what() << std::endl;
         log_router.error("Command returned error: {}", ex.what());
         return static_cast<int>(libdnf::cli::ExitCode::ERROR);


### PR DESCRIPTION
- Fix: Do not pass formatted message as the first parameter to the logger
  fixes "terminate called after throwing an instance of 'fmt::v9::format_error'". 

- Catch only exceptions inherited from std::runtime_error