### PR TITLE
[dnf5] Fix progress bars during downloading packages

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -121,6 +121,7 @@ public:
             progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
             print_progress_bar();
         }
+        std::cout << std::endl;
     }
 
     int progress([[maybe_unused]] double total_to_download, [[maybe_unused]] double downloaded) override {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -83,10 +83,6 @@ public:
         return libdnf::cli::utils::userconfirm::userconfirm(*config);
     }
 
-    // Quiet empty implementation.
-    virtual void add_message(
-        [[maybe_unused]] libdnf::cli::progressbar::MessageType type, [[maybe_unused]] const std::string & message) {}
-
 private:
     libdnf::ConfigMain * config;
 };
@@ -112,15 +108,15 @@ public:
 
         if (error_message) {
             progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
-            add_message(libdnf::cli::progressbar::MessageType::ERROR, error_message);
+            progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, error_message);
         } else {
             // Correction of the total data size for the download.
             // Sometimes Librepo returns a larger data size for download than the actual file size.
             progress_bar->set_total_ticks(progress_bar->get_ticks());
 
             progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
-            print_progress_bar();
         }
+        print_progress_bar();
         std::cout << std::endl;
     }
 
@@ -153,13 +149,9 @@ public:
         [[maybe_unused]] const char * metadata) override {
         libdnf_assert(progress_bar != nullptr, "Called \"handle_mirror_failure\" callback before \"start\" callback");
 
-        add_message(libdnf::cli::progressbar::MessageType::WARNING, msg);
-        return 0;
-    }
-
-    void add_message(libdnf::cli::progressbar::MessageType type, const std::string & message) override {
-        progress_bar->add_message(type, message);
+        progress_bar->add_message(libdnf::cli::progressbar::MessageType::WARNING, msg);
         print_progress_bar();
+        return 0;
     }
 
 private:

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -280,6 +280,7 @@ public:
     int end(TransferStatus status, const char * msg) override {
         switch (status) {
             case TransferStatus::SUCCESSFUL:
+                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
             case TransferStatus::ALREADYEXISTS:
                 // skipping the download -> downloading 0 bytes
@@ -317,6 +318,7 @@ public:
         //std::cout << "Mirror failure: " << msg << " " << url << std::endl;
         std::string message = std::string(msg) + " - " + url;
         progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, message);
+        multi_progress_bar->print();
         return 0;
     }
 

--- a/libdnf-cli/progressbar/download_progress_bar.cpp
+++ b/libdnf-cli/progressbar/download_progress_bar.cpp
@@ -213,10 +213,6 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
             stream << tty::reset;
         }
     }
-
-    if (is_finished()) {
-        stream << std::endl;
-    }
 }
 
 


### PR DESCRIPTION
- Moves finished (downloaded) packages up (fixes/removes repeating download progress bars of currently downloaded packages).
- Removes empty lines between progress bars. 