### PR TITLE
MultiProgressBar: Take ownership of included ProgressBars

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -273,8 +273,9 @@ public:
     DownloadCB(libdnf::cli::progressbar::MultiProgressBar & mp_bar, const std::string & what)
         : multi_progress_bar(&mp_bar),
           what(what) {
-        progress_bar = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(-1, what);
-        multi_progress_bar->add_bar(progress_bar.get());
+        auto pb = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(-1, what);
+        progress_bar = pb.get();
+        multi_progress_bar->add_bar(std::move(pb));
     }
 
     int end(TransferStatus status, const char * msg) override {
@@ -336,7 +337,7 @@ private:
     static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
 
     libdnf::cli::progressbar::MultiProgressBar * multi_progress_bar;
-    std::unique_ptr<libdnf::cli::progressbar::DownloadProgressBar> progress_bar;
+    libdnf::cli::progressbar::DownloadProgressBar * progress_bar;
     std::string what;
 };
 
@@ -644,11 +645,10 @@ private:
         }
         auto progress_bar =
             std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), descr);
-        multi_progress_bar.add_bar(progress_bar.get());
         progress_bar->set_auto_finish(false);
         progress_bar->start();
         active_progress_bar = progress_bar.get();
-        download_progress_bars.push_back(std::move(progress_bar));
+        multi_progress_bar.add_bar(std::move(progress_bar));
     }
 
     static bool is_time_to_print() {
@@ -667,7 +667,6 @@ private:
 
     libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
-    std::vector<std::unique_ptr<libdnf::cli::progressbar::DownloadProgressBar>> download_progress_bars{};
 };
 
 std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time = std::chrono::steady_clock::now();

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -171,8 +171,8 @@ void PackageDownloadCB::start(sdbus::Signal & signal) {
         signal >> pkg_id;
         signal >> nevra;
         auto progress_bar = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(-1, nevra);
-        multi_progress_bar.add_bar(progress_bar.get());
-        package_bars.emplace(pkg_id, std::move(progress_bar));
+        package_bars.emplace(pkg_id, progress_bar.get());
+        multi_progress_bar.add_bar(std::move(progress_bar));
     }
 }
 
@@ -315,11 +315,10 @@ void TransactionCB::new_progress_bar(uint64_t total, const std::string & descrip
     }
     auto progress_bar =
         std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), description);
-    multi_progress_bar.add_bar(progress_bar.get());
     progress_bar->set_auto_finish(false);
     progress_bar->start();
     active_progress_bar = progress_bar.get();
-    progress_bars.push_back(std::move(progress_bar));
+    multi_progress_bar.add_bar(std::move(progress_bar));
 }
 
 void TransactionCB::verify_start(sdbus::Signal & signal) {

--- a/dnf5daemon-client/callbacks.hpp
+++ b/dnf5daemon-client/callbacks.hpp
@@ -72,11 +72,11 @@ public:
 private:
     libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
     // map {package id: progressbar}
-    std::map<int, std::unique_ptr<libdnf::cli::progressbar::DownloadProgressBar>> package_bars;
+    std::map<int, libdnf::cli::progressbar::DownloadProgressBar *> package_bars;
 
     libdnf::cli::progressbar::DownloadProgressBar * find_progress_bar(const int pkg_id) {
         if (package_bars.find(pkg_id) != package_bars.end()) {
-            return package_bars.at(pkg_id).get();
+            return package_bars.at(pkg_id);
         } else {
             return nullptr;
         }
@@ -112,7 +112,6 @@ public:
 private:
     libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
-    std::vector<std::unique_ptr<libdnf::cli::progressbar::DownloadProgressBar>> progress_bars;
 
     void new_progress_bar(uint64_t total, const std::string & description);
 };

--- a/include/libdnf-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/multi_progress_bar.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "progress_bar.hpp"
 
 #include <iostream>
+#include <memory>
 #include <vector>
 
 
@@ -37,8 +38,7 @@ public:
     explicit MultiProgressBar();
     ~MultiProgressBar();
 
-    // TODO(dmach): use std::unique_ptr instead of the raw pointer?
-    void add_bar(ProgressBar * bar);
+    void add_bar(std::unique_ptr<ProgressBar> && bar);
     void print() {
         std::cout << *this;
         std::cout << std::flush;
@@ -46,7 +46,7 @@ public:
     friend std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar);
 
 private:
-    std::vector<ProgressBar *> bars_all;
+    std::vector<std::unique_ptr<ProgressBar>> bars_all;
     std::vector<ProgressBar *> bars_todo;
     std::vector<ProgressBar *> bars_done;
     DownloadProgressBar total;

--- a/libdnf-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf-cli/progressbar/multi_progress_bar.cpp
@@ -47,10 +47,8 @@ MultiProgressBar::~MultiProgressBar() {
 }
 
 
-void MultiProgressBar::add_bar(ProgressBar * bar) {
-    bars_all.push_back(bar);
-    bars_todo.push_back(bar);
-    total.set_total(static_cast<int>(bars_all.size()));
+void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
+    bars_todo.push_back(bar.get());
 
     // if the number is not set, automatically find and set the next available
     if (bar->get_number() == 0) {
@@ -61,8 +59,11 @@ void MultiProgressBar::add_bar(ProgressBar * bar) {
         bar->set_number(number + 1);
     }
 
+    bars_all.push_back(std::move(bar));
+    total.set_total(static_cast<int>(bars_all.size()));
+
     // update total (in [num/total]) in all bars
-    for (auto i : bars_all) {
+    for (auto & i : bars_all) {
         i->set_total(total.get_total());
     }
 }


### PR DESCRIPTION
In current implementation MultiProgressBar only keeps raw pointers to its encapsulated ProgressBar instances.
I think the ownership of progress bars should be transfered to MultiProgressBar and their lifecycles kept tied together.