### PR TITLE
Centralize download callbacks setting to Base

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -137,7 +137,7 @@ void DownloadCommand::run() {
     }
 
     if (!download_pkgs.empty()) {
-        download_packages(download_pkgs, ".");
+        download_packages(ctx.base.get_weak_ptr(), download_pkgs, ".");
     }
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dnf5/context.hpp"
 
+#include "download_cb.hpp"
 #include "plugins.hpp"
 #include "utils.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
@@ -258,87 +259,6 @@ void Context::load_repos(bool load_system) {
     print_info("Repositories loaded.");
 }
 
-
-namespace {
-
-class DownloadCB : public libdnf::repo::DownloadCallbacks {
-public:
-    DownloadCB(libdnf::cli::progressbar::MultiProgressBar & mp_bar, const std::string & what)
-        : multi_progress_bar(&mp_bar),
-          what(what) {
-        auto pb = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(-1, what);
-        progress_bar = pb.get();
-        multi_progress_bar->add_bar(std::move(pb));
-    }
-
-    int end(TransferStatus status, const char * msg) override {
-        switch (status) {
-            case TransferStatus::SUCCESSFUL:
-                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
-                break;
-            case TransferStatus::ALREADYEXISTS:
-                // skipping the download -> downloading 0 bytes
-                progress_bar->set_ticks(0);
-                progress_bar->set_total_ticks(0);
-                progress_bar->add_message(libdnf::cli::progressbar::MessageType::SUCCESS, msg);
-                progress_bar->start();
-                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
-                break;
-            case TransferStatus::ERROR:
-                progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, msg);
-                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
-                break;
-        }
-        multi_progress_bar->print();
-        return 0;
-    }
-
-    int progress(double total_to_download, double downloaded) override {
-        auto total = static_cast<int64_t>(total_to_download);
-        if (total > 0) {
-            progress_bar->set_total_ticks(total);
-        }
-        if (progress_bar->get_state() == libdnf::cli::progressbar::ProgressBarState::READY) {
-            progress_bar->start();
-        }
-        progress_bar->set_ticks(static_cast<int64_t>(downloaded));
-        if (is_time_to_print()) {
-            multi_progress_bar->print();
-        }
-        return 0;
-    }
-
-    int mirror_failure(const char * msg, const char * url) override {
-        //std::cout << "Mirror failure: " << msg << " " << url << std::endl;
-        std::string message = std::string(msg) + " - " + url;
-        progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, message);
-        multi_progress_bar->print();
-        return 0;
-    }
-
-private:
-    static bool is_time_to_print() {
-        auto now = std::chrono::steady_clock::now();
-        auto delta = now - prev_print_time;
-        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-        if (ms > 100) {
-            // 100ms equals to 10 FPS and that seems to be smooth enough
-            prev_print_time = now;
-            return true;
-        }
-        return false;
-    }
-
-    static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
-
-    libdnf::cli::progressbar::MultiProgressBar * multi_progress_bar;
-    libdnf::cli::progressbar::DownloadProgressBar * progress_bar;
-    std::string what;
-};
-
-std::chrono::time_point<std::chrono::steady_clock> DownloadCB::prev_print_time = std::chrono::steady_clock::now();
-
-}  // namespace
 
 void Context::download_urls(
     std::vector<std::pair<std::string, std::filesystem::path>> url_to_dest_path, bool fail_fast, bool resume) {

--- a/dnf5/download_cb.cpp
+++ b/dnf5/download_cb.cpp
@@ -1,0 +1,93 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "download_cb.hpp"
+
+#include <libdnf-cli/progressbar/download_progress_bar.hpp>
+#include <libdnf-cli/progressbar/multi_progress_bar.hpp>
+
+#include <chrono>
+#include <memory>
+
+std::chrono::time_point<std::chrono::steady_clock> DownloadCB::prev_print_time = std::chrono::steady_clock::now();
+
+DownloadCB::DownloadCB(libdnf::cli::progressbar::MultiProgressBar & mp_bar, const std::string & what)
+    : multi_progress_bar(&mp_bar),
+      what(what) {
+    auto pb = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(-1, what);
+    progress_bar = pb.get();
+    multi_progress_bar->add_bar(std::move(pb));
+}
+
+
+int DownloadCB::end(TransferStatus status, const char * msg) {
+    switch (status) {
+        case TransferStatus::SUCCESSFUL:
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
+            break;
+        case TransferStatus::ALREADYEXISTS:
+            // skipping the download -> downloading 0 bytes
+            progress_bar->set_ticks(0);
+            progress_bar->set_total_ticks(0);
+            progress_bar->add_message(libdnf::cli::progressbar::MessageType::SUCCESS, msg);
+            progress_bar->start();
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
+            break;
+        case TransferStatus::ERROR:
+            progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, msg);
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
+            break;
+    }
+    multi_progress_bar->print();
+    return 0;
+}
+
+int DownloadCB::progress(double total_to_download, double downloaded) {
+    auto total = static_cast<int64_t>(total_to_download);
+    if (total > 0) {
+        progress_bar->set_total_ticks(total);
+    }
+    if (progress_bar->get_state() == libdnf::cli::progressbar::ProgressBarState::READY) {
+        progress_bar->start();
+    }
+    progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    if (is_time_to_print()) {
+        multi_progress_bar->print();
+    }
+    return 0;
+}
+
+int DownloadCB::mirror_failure(const char * msg, const char * url) {
+    std::string message = std::string(msg) + " - " + url;
+    progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->print();
+    return 0;
+}
+
+bool DownloadCB::is_time_to_print() {
+    auto now = std::chrono::steady_clock::now();
+    auto delta = now - prev_print_time;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
+    if (ms > 100) {
+        // 100ms equals to 10 FPS and that seems to be smooth enough
+        prev_print_time = now;
+        return true;
+    }
+    return false;
+}

--- a/dnf5/download_cb.cpp
+++ b/dnf5/download_cb.cpp
@@ -91,3 +91,27 @@ bool DownloadCB::is_time_to_print() {
     }
     return false;
 }
+
+
+DownloadCBFactory::DownloadCBFactory()
+    : multi_progress_bar(std::make_unique<libdnf::cli::progressbar::MultiProgressBar>()) {}
+
+std::unique_ptr<libdnf::repo::DownloadCallbacks> DownloadCBFactory::create_callbacks(const std::string & url) {
+    progressbar_created = true;
+    return std::make_unique<DownloadCB>(*multi_progress_bar, url);
+}
+
+std::unique_ptr<libdnf::repo::DownloadCallbacks> DownloadCBFactory::create_callbacks(
+    const libdnf::rpm::Package & package) {
+    progressbar_created = true;
+    return std::make_unique<DownloadCB>(*multi_progress_bar, package.get_full_nevra());
+}
+
+DownloadCBFactory::~DownloadCBFactory() {
+    if (progressbar_created) {
+        // print a completed progress bar
+        multi_progress_bar->print();
+        std::cout << std::endl;
+        // TODO(dmach): if a download gets interrupted, the "Total" bar should show reasonable data
+    }
+}

--- a/dnf5/download_cb.hpp
+++ b/dnf5/download_cb.hpp
@@ -44,4 +44,21 @@ private:
     std::string what;
 };
 
+
+class DownloadCBFactory : public libdnf::repo::DownloadCallbacksFactory {
+public:
+    DownloadCBFactory();
+    ~DownloadCBFactory();
+
+    std::unique_ptr<libdnf::repo::DownloadCallbacks> create_callbacks(const std::string & url) override;
+
+    std::unique_ptr<libdnf::repo::DownloadCallbacks> create_callbacks(const libdnf::rpm::Package & package) override;
+
+    // true if a new progressbar was added to the multi_progress_bar
+    bool progressbar_created{false};
+
+private:
+    std::unique_ptr<libdnf::cli::progressbar::MultiProgressBar> multi_progress_bar;
+};
+
 #endif  // DNF5_DOWNLOAD_CB_HPP

--- a/dnf5/download_cb.hpp
+++ b/dnf5/download_cb.hpp
@@ -1,0 +1,47 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_DOWNLOAD_CB_HPP
+#define DNF5_DOWNLOAD_CB_HPP
+
+#include <libdnf-cli/progressbar/download_progress_bar.hpp>
+#include <libdnf-cli/progressbar/multi_progress_bar.hpp>
+#include <libdnf/repo/download_callbacks.hpp>
+
+#include <memory>
+
+class DownloadCB : public libdnf::repo::DownloadCallbacks {
+public:
+    DownloadCB(libdnf::cli::progressbar::MultiProgressBar & mp_bar, const std::string & what);
+
+    int end(TransferStatus status, const char * msg) override;
+    int progress(double total_to_download, double downloaded) override;
+    int mirror_failure(const char * msg, const char * url) override;
+
+private:
+    static bool is_time_to_print();
+
+    static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
+
+    libdnf::cli::progressbar::MultiProgressBar * multi_progress_bar;
+    libdnf::cli::progressbar::DownloadProgressBar * progress_bar;
+    std::string what;
+};
+
+#endif  // DNF5_DOWNLOAD_CB_HPP

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -160,8 +160,10 @@ private:
 };
 
 /// Download packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
-void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir);
-void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir);
+void download_packages(
+    const libdnf::BaseWeakPtr & base, const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir);
+void download_packages(
+    const libdnf::BaseWeakPtr & base, libdnf::base::Transaction & transaction, const char * dest_dir);
 
 void run_transaction(libdnf::rpm::Transaction & transaction);
 

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -106,6 +106,14 @@ sdbus::Signal DbusPackageCB::create_signal(std::string interface, std::string si
 }
 
 
+DbusPackageCBFactory::DbusPackageCBFactory(Session & session) : session(session) {}
+DbusPackageCBFactory::~DbusPackageCBFactory() {}
+std::unique_ptr<libdnf::repo::DownloadCallbacks> DbusPackageCBFactory::create_callbacks(
+    const libdnf::rpm::Package & package) {
+    return std::make_unique<DbusPackageCB>(session, package);
+}
+
+
 void DbusRepoCB::start(const char * what) {
     try {
         auto signal = create_signal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_LOAD_START);

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5DAEMON_SERVER_CALLBACKS_HPP
 #define DNF5DAEMON_SERVER_CALLBACKS_HPP
 
+#include <libdnf/repo/download_callbacks.hpp>
 #include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/repo/repo_callbacks.hpp>
 #include <libdnf/rpm/transaction_callbacks.hpp>
@@ -67,6 +68,17 @@ private:
     double total = 0;
 
     sdbus::Signal create_signal(std::string interface, std::string signal_name) override;
+};
+
+class DbusPackageCBFactory : public libdnf::repo::DownloadCallbacksFactory {
+public:
+    DbusPackageCBFactory(Session & session);
+    ~DbusPackageCBFactory();
+
+    std::unique_ptr<libdnf::repo::DownloadCallbacks> create_callbacks(const libdnf::rpm::Package & package) override;
+
+private:
+    Session & session;
 };
 
 class DbusRepoCB : public libdnf::repo::RepoCallbacks, public DbusCallback {

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -154,7 +154,7 @@ sdbus::MethodReply Goal::get_transaction_problems(sdbus::MethodCall & call) {
 // TODO (mblaha) shared download_packages with dnf5 / libdnf
 // TODO (mblaha) callbacks to report the status
 void download_packages(Session & session, libdnf::base::Transaction & transaction) {
-    libdnf::repo::PackageDownloader downloader;
+    libdnf::repo::PackageDownloader downloader(session.get_base()->get_weak_ptr());
 
     for (auto & tspkg : transaction.get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action())) {

--- a/include/libdnf/repo/download_callbacks.hpp
+++ b/include/libdnf/repo/download_callbacks.hpp
@@ -20,6 +20,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_REPO_DOWNLOAD_CALLBACKS_HPP
 #define LIBDNF_REPO_DOWNLOAD_CALLBACKS_HPP
 
+#include <libdnf/rpm/package.hpp>
+
+#include <memory>
+#include <string>
+
 namespace libdnf::repo {
 
 /// Base class for download callbacks.
@@ -49,6 +54,31 @@ public:
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
     virtual int mirror_failure(const char * msg, const char * url);
 };
+
+
+/// Interface of DownloadCallbacks factory class.
+/// User of API is supposed to create a subclass of this class and register the
+/// instance in the Base.  This will be then used to create instances of concrete
+/// DownloadCallbacks subclass.
+/// For download callbacks we have two, kind of contradicting, requirements:
+/// 1. callbacks need to be instantiated by libdnf5 library, they cannot be instantiated
+/// by the user and passed to the library. The reason is duplicating the download
+/// code in several parts of client applications.
+/// 2. callbacks need access to some elements created in the client application -
+/// for example instance of libdnf::cli::progressbar::MultiProgressBar.
+class DownloadCallbacksFactory {
+public:
+    virtual ~DownloadCallbacksFactory(){};
+
+    // Create a DownloadCallbacks (or it's subclass) instance based on the string description.
+    // @param what  String which describes what is being downloaded (URL, package name...)
+    virtual std::unique_ptr<DownloadCallbacks> create_callbacks(const std::string & what);
+
+    // Create a DownloadCallbacks (or it's subclass) instance based on the rpm package object.
+    // @param package  rpm::Package object that is being downloaded
+    virtual std::unique_ptr<DownloadCallbacks> create_callbacks(const libdnf::rpm::Package & package);
+};
+
 
 }  // namespace libdnf::repo
 

--- a/include/libdnf/repo/file_downloader.hpp
+++ b/include/libdnf/repo/file_downloader.hpp
@@ -22,7 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/exception.hpp"
 #include "libdnf/conf/config_main.hpp"
-#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/repo/repo_weak.hpp"
 
 #include <memory>
@@ -38,26 +37,19 @@ class FileDownloadError : public Error {
 
 class FileDownloader {
 public:
-    explicit FileDownloader(ConfigMain & config);
+    explicit FileDownloader(const libdnf::BaseWeakPtr & base);
     ~FileDownloader();
 
     /// Adds a file (URL) to download.
     /// @param repo The repository whose settings are to be used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
-    /// @param callbacks (optional) A pointer to an instance of the `FileDownloadCallbacks` class.
-    void add(
-        libdnf::repo::RepoWeakPtr & repo,
-        const std::string & url,
-        const std::string & destination,
-        std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(libdnf::repo::RepoWeakPtr & repo, const std::string & url, const std::string & destination);
 
     /// Adds a file (URL) to download. The settings from ConfigMain passed in the FileDownloader constructor are used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
-    /// @param callbacks (optional) A pointer to an instance of the `FileDownloadCallbacks` class.
-    void add(
-        const std::string & url, const std::string & destination, std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const std::string & url, const std::string & destination);
 
     /// Download the previously added files (URLs).
     /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.
@@ -67,6 +59,7 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
+    BaseWeakPtr base;
 };
 
 }  // namespace libdnf::repo

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_REPO_PACKAGE_DOWNLOADER_HPP
 
 #include "libdnf/conf/config_main.hpp"
-#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/rpm/package.hpp"
 
 #include <memory>
@@ -37,22 +36,17 @@ class PackageDownloadError : public Error {
 
 class PackageDownloader {
 public:
-    PackageDownloader();
+    explicit PackageDownloader(const libdnf::BaseWeakPtr & base);
     ~PackageDownloader();
 
     /// Adds a package to download to the standard location of repo cachedir/packages.
     /// @param package The package to download.
-    /// @param callbacks (optional) A pointer to an instance of the `PackageDownloadCallbacks` class.
-    void add(const libdnf::rpm::Package & package, std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const libdnf::rpm::Package & package);
 
     /// Adds a package to download to a specific destination directory.
     /// @param package The package to download.
     /// @param destination The directory to which to download the package.
-    /// @param callbacks (optional) A pointer to an instance of the `PackageDownloadCallbacks` class.
-    void add(
-        const libdnf::rpm::Package & package,
-        const std::string & destination,
-        std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const libdnf::rpm::Package & package, const std::string & destination);
 
     /// Download the previously added packages.
     /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.
@@ -62,6 +56,7 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
+    BaseWeakPtr base;
 };
 
 /// Wraps librepo PackageTarget

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -131,6 +131,27 @@ void Base::load_plugins() {
     }
 }
 
+void Base::set_download_callbacks_factory(
+    std::unique_ptr<libdnf::repo::DownloadCallbacksFactory> && callbacks_factory) {
+    download_callbacks_factory = std::move(callbacks_factory);
+}
+
+std::unique_ptr<libdnf::repo::DownloadCallbacks> Base::create_download_callbacks(const std::string & what) {
+    if (download_callbacks_factory) {
+        return download_callbacks_factory->create_callbacks(what);
+    } else {
+        return nullptr;
+    }
+}
+
+std::unique_ptr<libdnf::repo::DownloadCallbacks> Base::create_download_callbacks(const libdnf::rpm::Package & package) {
+    if (download_callbacks_factory) {
+        return download_callbacks_factory->create_callbacks(package);
+    } else {
+        return nullptr;
+    }
+}
+
 void Base::setup() {
     auto & pool = p_impl->pool;
     libdnf_assert(!pool, "Base was already initialized");

--- a/libdnf/repo/download_callbacks.cpp
+++ b/libdnf/repo/download_callbacks.cpp
@@ -31,4 +31,13 @@ int DownloadCallbacks::mirror_failure([[maybe_unused]] const char * msg, [[maybe
     return 0;
 }
 
+std::unique_ptr<DownloadCallbacks> DownloadCallbacksFactory::create_callbacks(
+    [[maybe_unused]] const std::string & what) {
+    return nullptr;
+}
+
+std::unique_ptr<DownloadCallbacks> DownloadCallbacksFactory::create_callbacks(const libdnf::rpm::Package & package) {
+    return create_callbacks(package.get_full_nevra());
+}
+
 }  // namespace libdnf::repo

--- a/libdnf/rpm/rpm_signature.cpp
+++ b/libdnf/rpm/rpm_signature.cpp
@@ -207,7 +207,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
         } else {
             // download the remote key
             downloaded_key = std::make_unique<libdnf::utils::fs::TempFile>("rpmkey");
-            libdnf::repo::FileDownloader downloader(base->get_config());
+            libdnf::repo::FileDownloader downloader(base);
             downloader.add(key_url, downloaded_key->get_path());
             downloader.download(true, true);
             key_path = downloaded_key->get_path();

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "test_transaction.hpp"
 
 #include "utils.hpp"
+#include "utils/string.hpp"
 
 #include "libdnf/base/goal.hpp"
 #include "libdnf/base/transaction_package.hpp"
@@ -35,31 +36,47 @@ using namespace libdnf::rpm;
 using namespace libdnf::transaction;
 
 
-class PackageDownloadCallbacks : public libdnf::repo::DownloadCallbacks {
+class CallbacksStats {
 public:
-    int end(libdnf::repo::DownloadCallbacks::TransferStatus status, const char * msg) override {
-        ++end_cnt;
-        end_status = status;
-        end_msg = msg ? msg : "";
+    int end_cnt = 0;
+    libdnf::repo::DownloadCallbacks::TransferStatus end_status = libdnf::repo::DownloadCallbacks::TransferStatus::ERROR;
+    std::string end_msg;
+
+    int progress_cnt = 0;
+    int mirror_failure_cnt = 0;
+};
+
+class DownloadCallbacks : public libdnf::repo::DownloadCallbacks {
+public:
+    DownloadCallbacks(CallbacksStats * stats) : stats(stats) {}
+    int end(TransferStatus status, const char * msg) override {
+        ++stats->end_cnt;
+        stats->end_status = status;
+        stats->end_msg = libdnf::utils::string::c_to_str(msg);
         return 0;
     }
 
     int progress([[maybe_unused]] double total_to_download, [[maybe_unused]] double downloaded) override {
-        ++progress_cnt;
+        ++stats->progress_cnt;
         return 0;
     }
 
     int mirror_failure([[maybe_unused]] const char * msg, [[maybe_unused]] const char * url) override {
-        ++mirror_failure_cnt;
+        ++stats->mirror_failure_cnt;
         return 0;
     }
 
-    int end_cnt{0};
-    TransferStatus end_status{TransferStatus::ERROR};
-    std::string end_msg;
+    CallbacksStats * stats;
+};
 
-    int progress_cnt{0};
-    int mirror_failure_cnt{0};
+class DownloadCallbacksFactory : public libdnf::repo::DownloadCallbacksFactory {
+public:
+    DownloadCallbacksFactory(CallbacksStats * stats) : stats(stats) {}
+    std::unique_ptr<libdnf::repo::DownloadCallbacks> create_callbacks(
+        [[maybe_unused]] const libdnf::rpm::Package & package) override {
+        return std::make_unique<DownloadCallbacks>(stats);
+    }
+    CallbacksStats * stats;
 };
 
 
@@ -79,25 +96,24 @@ void RpmTransactionTest::test_transaction() {
         TransactionItemState::STARTED)};
     CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 
-    libdnf::repo::PackageDownloader downloader;
-
-    auto dl_callbacks = std::make_unique<PackageDownloadCallbacks>();
-    auto dl_callbacks_ptr = dl_callbacks.get();
+    CallbacksStats stats;
+    auto downloader = libdnf::repo::PackageDownloader(base.get_weak_ptr());
+    base.set_download_callbacks_factory(std::make_unique<DownloadCallbacksFactory>(&stats));
 
     for (auto & tspkg : transaction.get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action())) {
-            downloader.add(tspkg.get_package(), std::move(dl_callbacks));
+            downloader.add(tspkg.get_package());
         }
     }
 
     downloader.download(true, true);
 
-    CPPUNIT_ASSERT_EQUAL(1, dl_callbacks_ptr->end_cnt);
-    CPPUNIT_ASSERT_EQUAL(PackageDownloadCallbacks::TransferStatus::SUCCESSFUL, dl_callbacks_ptr->end_status);
-    CPPUNIT_ASSERT_EQUAL(std::string(), dl_callbacks_ptr->end_msg);
+    CPPUNIT_ASSERT_EQUAL(1, stats.end_cnt);
+    CPPUNIT_ASSERT_EQUAL(DownloadCallbacks::TransferStatus::SUCCESSFUL, stats.end_status);
+    CPPUNIT_ASSERT_EQUAL(std::string(), stats.end_msg);
 
-    CPPUNIT_ASSERT_GREATEREQUAL(1, dl_callbacks_ptr->progress_cnt);
-    CPPUNIT_ASSERT_EQUAL(0, dl_callbacks_ptr->mirror_failure_cnt);
+    CPPUNIT_ASSERT_GREATEREQUAL(1, stats.progress_cnt);
+    CPPUNIT_ASSERT_EQUAL(0, stats.mirror_failure_cnt);
 
     // TODO(lukash) test transaction callbacks
     libdnf::base::Transaction::TransactionRunResult res = transaction.run(


### PR DESCRIPTION
This PR introduces centralized setting of download callbacks. Callbacks are not set using `*Downloader.add()` API any more, there is a new `base::set_download_callbacks_factory()` API for setting a callback factory class and `base.create_download_callbacks()` to get a callback using this factory.

Resolves https://github.com/rpm-software-management/dnf5/issues/203