### PR TITLE
SWIG: drop the std::optional from the public API

### DIFF
--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -101,10 +101,10 @@ void AdvisorySubCommand::run() {
     auto advisories = advisories_opt.value_or(libdnf::advisory::AdvisoryQuery(ctx.base));
 
     if (with_bz->get_value()) {
-        advisories.filter_reference("*", libdnf::sack::QueryCmp::IGLOB, {"bugzilla"});
+        advisories.filter_reference("*", {"bugzilla"}, libdnf::sack::QueryCmp::IGLOB);
     }
     if (with_cve->get_value()) {
-        advisories.filter_reference("*", libdnf::sack::QueryCmp::IGLOB, {"cve"});
+        advisories.filter_reference("*", {"cve"}, libdnf::sack::QueryCmp::IGLOB);
     }
 
     process_and_print_queries(ctx, advisories, package_query);

--- a/dnf5/commands/advisory_shared.hpp
+++ b/dnf5/commands/advisory_shared.hpp
@@ -87,14 +87,14 @@ inline std::optional<libdnf::advisory::AdvisoryQuery> advisory_query_from_cli_in
         // Filter by advisory bz
         if (!advisory_bzs.empty()) {
             auto advisories_bzs = libdnf::advisory::AdvisoryQuery(base);
-            advisories_bzs.filter_reference(advisory_bzs, libdnf::sack::QueryCmp::EQ, {"bugzilla"});
+            advisories_bzs.filter_reference(advisory_bzs, {"bugzilla"});
             advisories |= advisories_bzs;
         }
 
         // Filter by advisory cve
         if (!advisory_cves.empty()) {
             auto advisories_cves = libdnf::advisory::AdvisoryQuery(base);
-            advisories_cves.filter_reference(advisory_cves, libdnf::sack::QueryCmp::EQ, {"cve"});
+            advisories_cves.filter_reference(advisory_cves, {"cve"});
             advisories |= advisories_cves;
         }
 

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -51,9 +51,9 @@ void GroupInstallCommand::run() {
 
     libdnf::GoalJobSettings settings;
     if (with_optional->get_value()) {
-        settings.group_package_types =
+        auto group_package_types =
             libdnf::comps::package_type_from_string(ctx.base.get_config().group_package_types().get_value());
-        *settings.group_package_types |= libdnf::comps::PackageType::OPTIONAL;
+        settings.set_group_package_types(group_package_types | libdnf::comps::PackageType::OPTIONAL);
     }
     for (const auto & spec : group_specs->get_value()) {
         goal->add_group_install(spec, libdnf::transaction::TransactionItemReason::USER, settings);

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -94,7 +94,7 @@ void InstallCommand::run() {
         advisory_bz->get_value(),
         advisory_cve->get_value());
     if (advisories.has_value()) {
-        settings.advisory_filter = advisories;
+        settings.set_advisory_filter(std::move(advisories.value()));
     }
     for (const auto & spec : pkg_specs) {
         goal->add_install(spec, settings);

--- a/dnf5/commands/mark/mark.cpp
+++ b/dnf5/commands/mark/mark.cpp
@@ -76,7 +76,7 @@ void MarkUserCommand::run() {
     auto goal = get_context().get_goal();
     for (auto & pattern : *pkg_specs) {
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
-        goal->add_rpm_reason_change(option->get_value(), reason, std::nullopt);
+        goal->add_rpm_reason_change(option->get_value(), reason);
     }
 }
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -118,7 +118,7 @@ void UpgradeCommand::run() {
         advisory_bz->get_value(),
         advisory_cve->get_value());
     if (advisories.has_value()) {
-        settings.advisory_filter = advisories;
+        settings.set_advisory_filter(std::move(advisories.value()));
     }
 
     if (pkg_specs.empty()) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -651,12 +651,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         cmd_line += argv[i];
     }
 
-    auto result = transaction.run(
-        std::make_unique<RpmTransCB>(),
-        cmd_line,
-        std::nullopt,
-        comment == nullptr ? std::nullopt : std::make_optional<std::string>(comment));
-
+    auto result = transaction.run(std::make_unique<RpmTransCB>(), cmd_line, comment ? comment : "");
     if (result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         std::cout << "Transaction failed: " << libdnf::base::Transaction::transaction_result_to_string(result)
                   << std::endl;

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -124,17 +124,17 @@ sdbus::MethodReply Goal::get_transaction_problems(sdbus::MethodCall & call) {
             goal_resolve_log_item["goal_job_settings"] = goal_job_settings;
         }
         if (log.get_spec()) {
-            goal_resolve_log_item["spec"] = log.get_spec().value();
+            goal_resolve_log_item["spec"] = *log.get_spec();
         }
-        if (log.get_additional_data()) {
-            auto & data = log.get_additional_data();
+        if (log.get_additional_data().size() > 0) {
             // convert std::set<std::string> to std::vector<std::string>
-            goal_resolve_log_item["additional_data"] = std::vector<std::string>{data->begin(), data->end()};
+            goal_resolve_log_item["additional_data"] =
+                std::vector<std::string>{log.get_additional_data().begin(), log.get_additional_data().end()};
         }
         if (log.get_solver_problems()) {
             using DbusRule = sdbus::Struct<uint32_t, std::vector<std::string>>;
             std::vector<std::vector<DbusRule>> dbus_problems;
-            for (const auto & problem : log.get_solver_problems().value().get_problems()) {
+            for (const auto & problem : log.get_solver_problems()->get_problems()) {
                 std::vector<DbusRule> dbus_problem;
                 for (const auto & rule : problem) {
                     dbus_problem.emplace_back(DbusRule{static_cast<uint32_t>(rule.first), rule.second});

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -187,14 +187,12 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
 
     download_packages(session, *transaction);
 
-    std::optional<std::string> comment{};
+    std::string comment;
     if (options.find("comment") != options.end()) {
         comment = key_value_map_get<std::string>(options, "comment");
     }
 
-    auto rpm_result =
-        transaction->run(std::make_unique<DbusTransactionCB>(session), "dnf5daemon-server", std::nullopt, comment);
-
+    auto rpm_result = transaction->run(std::make_unique<DbusTransactionCB>(session), "dnf5daemon-server", comment);
     if (rpm_result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         throw sdbus::Error(
             dnfdaemon::ERROR_TRANSACTION,

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -29,8 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/rpm/package.hpp"
 
-#include <optional>
-
 
 namespace libdnf::advisory {
 
@@ -75,14 +73,15 @@ public:
     /// @param pattern      Pattern to match with reference id.
     /// @param cmp_type     What comparator to use with pattern, allows: EQ, IEXACT, GLOB, IGLOB, CONTAINS, ICONTAINS.
     /// @param type         Possible reference types are: "bugzilla", "cve", "vendor". If none is specified it matches all.
+    void filter_reference(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     void filter_reference(
-        const std::string & pattern,
-        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
-        const std::optional<std::string> type = {});
+        const std::string & pattern, const std::string & type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     void filter_reference(
-        const std::vector<std::string> & pattern,
-        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
-        const std::optional<std::string> type = {});
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_reference(
+        const std::vector<std::string> & patterns,
+        const std::string & type,
+        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter Advisories by severity.
     ///

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -282,7 +282,7 @@ public:
     void add_rpm_reason_change(
         const std::string & spec,
         const libdnf::transaction::TransactionItemReason reason,
-        const std::optional<std::string> & group_id,
+        const std::string & group_id = {},
         const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
 
     /// Add group install request to the goal. The `spec` will be resolved to groups in the resolve() call.

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -143,10 +143,16 @@ public:
 
     /// Optionally assign AdvisoryQuery that is used to filter goal target packages (used for upgrade and install)
     void set_advisory_filter(const libdnf::advisory::AdvisoryQuery & filter) { advisory_filter = filter; };
+    const libdnf::advisory::AdvisoryQuery * get_advisory_filter() const {
+        return advisory_filter ? &advisory_filter.value() : nullptr;
+    }
 
     // Which types of group packages are going to be installed with the group.
     // If not set, default is taken from ConfigMain.group_package_types
     void set_group_package_types(const libdnf::comps::PackageType type) { group_package_types = type; }
+    const libdnf::comps::PackageType * get_group_package_types() const {
+        return group_package_types ? &group_package_types.value() : nullptr;
+    }
 
     /// Set whether hints should be reported
     bool report_hint{true};

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -141,25 +141,25 @@ public:
     /// Return used value for clean_requirements_on_remove
     GoalUsedSetting get_used_clean_requirements_on_remove() const { return used_clean_requirements_on_remove; };
 
-    /// Set whether hints should be reported
-    bool report_hint{true};
-    /// Set strict, AUTO means that it is handled according the the default behavior
-    GoalSetting strict{GoalSetting::AUTO};
-    /// Set best, AUTO means that it is handled according the the default behavior
-    GoalSetting best{GoalSetting::AUTO};
-    /// Set clean_requirements_on_remove, AUTO means that it is handled according the the default behavior
-    GoalSetting clean_requirements_on_remove{GoalSetting::AUTO};
-    /// Define which installed packagies should be modified acording to repoid from which they were installed
-    std::vector<std::string> from_repo_ids;
-    /// Reduce candidates for the operation according repository ids
-    std::vector<std::string> to_repo_ids;
-
     /// Optionally assign AdvisoryQuery that is used to filter goal target packages (used for upgrade and install)
-    std::optional<libdnf::advisory::AdvisoryQuery> advisory_filter;
+    void set_advisory_filter(const libdnf::advisory::AdvisoryQuery & filter) { advisory_filter = filter; };
 
     // Which types of group packages are going to be installed with the group.
     // If not set, default is taken from ConfigMain.group_package_types
-    std::optional<libdnf::comps::PackageType> group_package_types{std::nullopt};
+    void set_group_package_types(const libdnf::comps::PackageType type) { group_package_types = type; }
+
+    /// Set whether hints should be reported
+    bool report_hint{true};
+    /// Set strict, AUTO means that it is handled according to the default behavior
+    GoalSetting strict{GoalSetting::AUTO};
+    /// Set best, AUTO means that it is handled according to the default behavior
+    GoalSetting best{GoalSetting::AUTO};
+    /// Set clean_requirements_on_remove, AUTO means that it is handled according to the default behavior
+    GoalSetting clean_requirements_on_remove{GoalSetting::AUTO};
+    /// Define which installed packages should be modified according to repoid from which they were installed
+    std::vector<std::string> from_repo_ids;
+    /// Reduce candidates for the operation according repository ids
+    std::vector<std::string> to_repo_ids;
 
 private:
     friend class Goal;
@@ -210,6 +210,8 @@ private:
     GoalUsedSetting used_best{GoalUsedSetting::UNUSED};
     GoalUsedSetting used_clean_requirements_on_remove{GoalUsedSetting::UNUSED};
     std::optional<libdnf::comps::PackageType> used_group_package_types{std::nullopt};
+    std::optional<libdnf::advisory::AdvisoryQuery> advisory_filter{std::nullopt};
+    std::optional<libdnf::comps::PackageType> group_package_types{std::nullopt};
 };
 
 

--- a/include/libdnf/base/log_event.hpp
+++ b/include/libdnf/base/log_event.hpp
@@ -41,10 +41,10 @@ public:
     LogEvent(
         libdnf::GoalAction action,
         libdnf::GoalProblem problem,
+        const std::set<std::string> & additional_data,
         const libdnf::GoalJobSettings & settings,
         const SpecType spec_type,
-        const std::string & spec,
-        const std::set<std::string> & additional_data);
+        const std::string & spec);
     LogEvent(libdnf::GoalProblem problem, const SolverProblems & solver_problems);
     ~LogEvent() = default;
 
@@ -52,39 +52,38 @@ public:
     libdnf::GoalAction get_action() const { return action; };
     /// @return GoalProblem that specify the type of report
     libdnf::GoalProblem get_problem() const { return problem; };
-    /// @return GoalJobSetting if it is relevant for the particular GoalProblem
-    const std::optional<libdnf::GoalJobSettings> & get_job_settings() const { return job_settings; };
-    /// @return SPEC if it is relevant for the particular GoalProblem
-    const std::optional<std::string> & get_spec() const { return spec; };
     /// @return Additional information (internal), that are required for formatted string
-    const std::optional<std::set<std::string>> & get_additional_data() const { return additional_data; };
+    const std::set<std::string> get_additional_data() const { return additional_data; };
+    /// @return GoalJobSetting if it is relevant for the particular GoalProblem
+    const libdnf::GoalJobSettings * get_job_settings() const { return job_settings ? &job_settings.value() : nullptr; };
+    /// @return SPEC if it is relevant for the particular GoalProblem
+    const std::string * get_spec() const { return spec ? &spec.value() : nullptr; };
     /// @return SolverProblems if they are relevant for the particular GoalProblem
-    const std::optional<SolverProblems> & get_solver_problems() const { return solver_problems; };
+    const SolverProblems * get_solver_problems() const { return solver_problems ? &solver_problems.value() : nullptr; };
 
+    /// Convert an element from resolve log to string;
+    std::string to_string() const {
+        return to_string(action, problem, additional_data, job_settings, spec_type, spec, solver_problems);
+    };
+
+private:
     /// Convert an element from resolve log to string;
     static std::string to_string(
         libdnf::GoalAction action,
         libdnf::GoalProblem problem,
+        const std::set<std::string> & additional_data,
         const std::optional<libdnf::GoalJobSettings> & settings,
         const std::optional<SpecType> & spec_type,
         const std::optional<std::string> & spec,
-        const std::optional<std::set<std::string>> & additional_data,
         const std::optional<SolverProblems> & solver_problems);
-
-    /// Convert an element from resolve log to string;
-    std::string to_string() const {
-        return to_string(action, problem, job_settings, spec_type, spec, additional_data, solver_problems);
-    };
-
-private:
-    friend class Goal;
 
     libdnf::GoalAction action;
     libdnf::GoalProblem problem;
+
+    std::set<std::string> additional_data;
     std::optional<libdnf::GoalJobSettings> job_settings;
     std::optional<SpecType> spec_type;
     std::optional<std::string> spec;
-    std::optional<std::set<std::string>> additional_data;
     std::optional<SolverProblems> solver_problems;
 };
 

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/goal_elements.hpp"
 #include "libdnf/base/log_event.hpp"
 #include "libdnf/base/solver_problems.hpp"
+#include "libdnf/common/proc.hpp"
 #include "libdnf/rpm/transaction_callbacks.hpp"
 
 #include <optional>
@@ -81,6 +82,19 @@ public:
     std::vector<libdnf::base::TransactionGroup> & get_transaction_groups() const;
 
     /// Prepare, check and run the transaction. All the transaction metadata
+    /// (`description` and `comment`) are stored in the history database.
+    ///
+    /// @param callbacks Callbacks to be called during rpm transaction.
+    /// @param description Description of the transaction (the console command for CLI,
+    //                     verbose description for API usage)
+    /// @param comment Any comment to store in the history database along with the transaction.
+    /// @return An enum describing the result of running the transaction.
+    TransactionRunResult run(
+        std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
+        const std::string & description,
+        const std::string & comment = {});
+
+    /// Prepare, check and run the transaction. All the transaction metadata
     /// (`description`, `user_id` and `comment`) are stored in the history database.
     ///
     /// @param callbacks Callbacks to be called during rpm transaction.
@@ -92,8 +106,8 @@ public:
     TransactionRunResult run(
         std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
         const std::string & description,
-        const std::optional<uint32_t> user_id,
-        const std::optional<std::string> comment);
+        const uint32_t user_id,
+        const std::string & comment = {});
 
     /// Return string representation of the TransactionRunResult enum
     static std::string transaction_result_to_string(const TransactionRunResult result);

--- a/include/libdnf/base/transaction_package.hpp
+++ b/include/libdnf/base/transaction_package.hpp
@@ -69,7 +69,9 @@ public:
 
     /// The REASON_CHANGE action requires group id in case the reason is changed to GROUP
     /// @return id of group the package belongs to
-    const std::optional<std::string> & get_reason_change_group_id() const noexcept { return reason_change_group_id; }
+    const std::string * get_reason_change_group_id() const noexcept {
+        return reason_change_group_id ? &reason_change_group_id.value() : nullptr;
+    }
 
 private:
     friend class Transaction::Impl;

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -177,12 +177,17 @@ void AdvisoryQuery::filter_type(const std::vector<std::string> & types, sack::Qu
     filter_dataiterator_internal(*get_rpm_pool(base), SOLVABLE_PATCHCATEGORY, *p_impl, cmp_type, types);
 }
 
-void AdvisoryQuery::filter_reference(
-    const std::string & pattern, sack::QueryCmp cmp_type, const std::optional<std::string> type) {
+void AdvisoryQuery::filter_reference(const std::string & pattern, sack::QueryCmp cmp_type) {
+    filter_reference_by_type_and_id(get_rpm_pool(base), *p_impl, cmp_type, {pattern}, std::nullopt);
+}
+void AdvisoryQuery::filter_reference(const std::string & pattern, const std::string & type, sack::QueryCmp cmp_type) {
     filter_reference_by_type_and_id(get_rpm_pool(base), *p_impl, cmp_type, {pattern}, type);
 }
+void AdvisoryQuery::filter_reference(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    filter_reference_by_type_and_id(get_rpm_pool(base), *p_impl, cmp_type, patterns, std::nullopt);
+}
 void AdvisoryQuery::filter_reference(
-    const std::vector<std::string> & patterns, sack::QueryCmp cmp_type, const std::optional<std::string> type) {
+    const std::vector<std::string> & patterns, const std::string & type, sack::QueryCmp cmp_type) {
     filter_reference_by_type_and_id(get_rpm_pool(base), *p_impl, cmp_type, patterns, type);
 }
 

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -284,10 +284,10 @@ void Goal::add_rpm_distro_sync(const rpm::PackageSet & package_set, const GoalJo
 void Goal::add_rpm_reason_change(
     const std::string & spec,
     const libdnf::transaction::TransactionItemReason reason,
-    const std::optional<std::string> & group_id,
+    const std::string & group_id,
     const libdnf::GoalJobSettings & settings) {
     libdnf_assert(
-        reason != libdnf::transaction::TransactionItemReason::GROUP || group_id != std::nullopt,
+        reason != libdnf::transaction::TransactionItemReason::GROUP || !group_id.empty(),
         "group_id is required for setting reason \"GROUP\"");
     p_impl->rpm_reason_change_specs.push_back(std::make_tuple(reason, spec, group_id, settings));
 }

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -178,7 +178,7 @@ void Transaction::Impl::add_resolve_log(
     const std::string & spec,
     const std::set<std::string> & additional_data,
     bool strict) {
-    resolve_logs.emplace_back(LogEvent(action, problem, settings, spec_type, spec, additional_data));
+    resolve_logs.emplace_back(LogEvent(action, problem, additional_data, settings, spec_type, spec));
     // TODO(jmracek) Use a logger properly
     auto & logger = *base->get_logger();
     if (strict) {

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -597,7 +597,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
                 system_state.remove_package_nevra_state(pkg.get_nevra());
             } else if (tspkg.get_action() == TransactionPackage::Action::REASON_CHANGE) {
                 if (tspkg_reason == transaction::TransactionItemReason::GROUP) {
-                    auto group_id = tspkg.get_reason_change_group_id().value();
+                    auto group_id = *tspkg.get_reason_change_group_id();
                     auto state = system_state.get_group_state(group_id);
                     state.packages.emplace_back(pkg.get_name());
                     system_state.set_group_state(group_id, state);

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -76,7 +76,7 @@ public:
         std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
         const std::string & description,
         const std::optional<uint32_t> user_id,
-        const std::optional<std::string> comment);
+        const std::string & comment);
 
 private:
     friend Transaction;

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -115,22 +115,22 @@ void AdvisoryAdvisoryQueryTest::test_filter_packages() {
 void AdvisoryAdvisoryQueryTest::test_filter_cve() {
     // Tests filter_reference method with cve
     AdvisoryQuery adv_query(base);
-    adv_query.filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
+    adv_query.filter_reference("3333", "cve");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
     adv_query = AdvisoryQuery(base);
-    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "cve");
+    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, "cve");
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
     adv_query = AdvisoryQuery(base);
-    adv_query.filter_reference(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ, "cve");
+    adv_query.filter_reference(std::vector<std::string>{"1111", "4444"}, "cve");
     expected = {get_advisory("DNF-2019-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
     adv_query = AdvisoryQuery(base);
-    adv_query.filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
+    adv_query.filter_reference("*", "cve", libdnf::sack::QueryCmp::GLOB);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
@@ -138,17 +138,17 @@ void AdvisoryAdvisoryQueryTest::test_filter_cve() {
 void AdvisoryAdvisoryQueryTest::test_filter_bugzilla() {
     // Tests filter_reference method with bugzilla
     AdvisoryQuery adv_query(base);
-    adv_query.filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
+    adv_query.filter_reference("2222", "bugzilla");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
     adv_query = AdvisoryQuery(base);
-    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "bugzilla");
+    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, "bugzilla");
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
     adv_query = AdvisoryQuery(base);
-    adv_query.filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
+    adv_query.filter_reference("*", "bugzilla", libdnf::sack::QueryCmp::GLOB);
     expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -317,7 +317,7 @@ void BaseGoalTest::test_upgrade_not_downgrade_from_cmdline() {
     auto & first_event = *log.begin();
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalAction::UPGRADE, first_event.get_action());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalProblem::ALREADY_INSTALLED, first_event.get_problem());
-    CPPUNIT_ASSERT_EQUAL(std::string("one.noarch"), *first_event.get_additional_data()->begin());
+    CPPUNIT_ASSERT_EQUAL(std::string("one.noarch"), *first_event.get_additional_data().begin());
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_best());

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -111,8 +111,8 @@ void RpmTransactionTest::test_transaction() {
     CPPUNIT_ASSERT_EQUAL(0, dl_callbacks_ptr->mirror_failure_cnt);
 
     // TODO(lukash) test transaction callbacks
-    libdnf::base::Transaction::TransactionRunResult res = transaction.run(
-        std::make_unique<libdnf::rpm::TransactionCallbacks>(), "install package one", std::nullopt, std::nullopt);
+    libdnf::base::Transaction::TransactionRunResult res =
+        transaction.run(std::make_unique<libdnf::rpm::TransactionCallbacks>(), "install package one");
 
     CPPUNIT_ASSERT_EQUAL(libdnf::base::Transaction::TransactionRunResult::SUCCESS, res);
     // TODO(lukash) assert the packages were installed

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -70,4 +70,4 @@ print("Running the transaction:")
 transaction_callbacks = TransactionCallbacks()
 transaction_callbacks_ptr = libdnf5.rpm.TransactionCallbacksUniquePtr(transaction_callbacks)
 
-transaction.run(transaction_callbacks_ptr, "install package one", None, None)
+transaction.run(transaction_callbacks_ptr, "install package one")

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -81,4 +81,4 @@ class TransactionCallbacks : public libdnf::rpm::TransactionCallbacks {
 // transaction. The third argument is user_id, omitted here for simplicity. The
 // fourth argument can be an arbitrary user comment.
 std::cout << std::endl << "Running the transaction:" << std::endl;
-transaction.run(std::make_unique<TransactionCallbacks>(), "install package one", std::nullopt, std::nullopt);
+transaction.run(std::make_unique<TransactionCallbacks>(), "install package one");


### PR DESCRIPTION
SWIG bindings don't support the `std::optional` type wrappers, so this PR aims to drop all these references away from the public API.

Closes #186.