### PR TITLE
swig: Fix TransactionItemReason wrappers

### DIFF
--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -14,6 +14,7 @@
 
 %import "common.i"
 %import "repo.i"
+%import "transaction.i"
 
 %{
     #include "libdnf/comps/group/package.hpp"

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -14,6 +14,7 @@
 
 %import "common.i"
 %import "conf.i"
+%import "transaction.i"
 
 %exception {
     try {

--- a/test/python3/libdnf5/rpm/test_package_query.py
+++ b/test/python3/libdnf5/rpm/test_package_query.py
@@ -130,3 +130,10 @@ class TestPackageQuery(base_test_case.BaseTestCase):
         self.assertEqual(nevra.get_name(), "pkg")
         self.assertEqual(nevra.get_arch(), "x86_64")
         self.assertFalse(nevra.has_just_name())
+
+    def test_pkg_reason_value(self):
+        # Test wrapper for reason enum
+        query = libdnf5.rpm.PackageQuery(self.base)
+        query.filter_name(["pkg"])
+        package = next(iter(query))
+        self.assertEqual(package.get_reason(), libdnf5.transaction.TransactionItemReason_NONE)


### PR DESCRIPTION
Include transaction module prior to dependent modules, otherwise enum wrappers are not ready for these modules.

Resolves #216.