### PR TITLE
Install spec implementation

### DIFF
--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -38,13 +38,10 @@ public:
     void set_parent_command() override;
     void set_argument_parser() override;
     void configure() override;
-    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
-    std::vector<std::string> pkg_file_paths;
-    std::vector<libdnf::rpm::Package> cmdline_packages;
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 };

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -39,15 +39,17 @@ void InstallCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_description("Install software");
 
-    auto keys =
-        parser.add_new_positional_arg("keys_to_match", ArgumentParser::PositionalArg::UNLIMITED, nullptr, nullptr);
-    keys->set_description("List of keys to match");
+    auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
+    keys->set_description("List of package specs to install");
     keys->set_parse_hook_func(
         [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
-            parse_add_specs(argc, argv, pkg_specs, pkg_file_paths);
+            for (int i = 0; i < argc; ++i) {
+                pkg_specs.emplace_back(argv[i]);
+            }
             return true;
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, false, true, true, false); });
+    cmd.register_positional_arg(keys);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
 
@@ -59,8 +61,6 @@ void InstallCommand::set_argument_parser() {
     advisory_severity = std::make_unique<AdvisorySeverityOption>(*this);
     advisory_bz = std::make_unique<BzOption>(*this);
     advisory_cve = std::make_unique<CveOption>(*this);
-
-    cmd.register_positional_arg(keys);
 }
 
 void InstallCommand::configure() {
@@ -76,10 +76,6 @@ void InstallCommand::configure() {
     }
 
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-}
-
-void InstallCommand::load_additional_packages() {
-    cmdline_packages = get_context().add_cmdline_packages(pkg_file_paths);
 }
 
 void InstallCommand::run() {
@@ -100,11 +96,8 @@ void InstallCommand::run() {
     if (advisories.has_value()) {
         settings.advisory_filter = advisories;
     }
-    for (const auto & pkg : cmdline_packages) {
-        goal->add_rpm_install(pkg, settings);
-    }
     for (const auto & spec : pkg_specs) {
-        goal->add_rpm_install(spec, settings);
+        goal->add_install(spec, settings);
     }
 }
 

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -37,13 +37,10 @@ public:
     void set_parent_command() override;
     void set_argument_parser() override;
     void configure() override;
-    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
-    std::vector<std::string> pkg_file_paths;
-    std::vector<libdnf::rpm::Package> cmdline_packages;
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -36,13 +36,10 @@ public:
     void set_parent_command() override;
     void set_argument_parser() override;
     void configure() override;
-    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
-    std::vector<std::string> pkg_file_paths;
-    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
 

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -50,7 +50,6 @@ private:
     libdnf::OptionBool * info_option{nullptr};
     libdnf::OptionBool * nevra_option{nullptr};
     std::vector<std::string> pkg_specs;
-    std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
 
     libdnf::OptionStringList * whatdepends_option{nullptr};

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -36,14 +36,11 @@ public:
     void set_parent_command() override;
     void set_argument_parser() override;
     void configure() override;
-    void load_additional_packages() override;
     void run() override;
 
 private:
     std::string remove_pkg_spec;
-    std::vector<std::string> install_pkg_specs;
-    std::vector<std::string> install_pkg_file_paths;
-    std::vector<libdnf::rpm::Package> cmdline_packages;
+    std::string install_pkg_spec;
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 };

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -37,14 +37,11 @@ public:
     void set_parent_command() override;
     void set_argument_parser() override;
     void configure() override;
-    void load_additional_packages() override;
     void run() override;
 
 protected:
     libdnf::OptionBool * minimal{nullptr};
     std::vector<std::string> pkg_specs;
-    std::vector<std::string> pkg_file_paths;
-    std::vector<libdnf::rpm::Package> cmdline_packages;
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -44,7 +44,7 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
     }
     progress_bar->set_ticks(static_cast<int64_t>(downloaded));
     if (is_time_to_print()) {
-        multi_progress_bar->print();
+        print();
     }
     return 0;
 }
@@ -68,7 +68,7 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
-    multi_progress_bar->print();
+    print();
     return 0;
 }
 
@@ -76,12 +76,15 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
     auto * progress_bar = reinterpret_cast<libdnf::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     std::string message = std::string(msg) + " - " + url;
     progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, message);
-    multi_progress_bar->print();
+    print();
     return 0;
 }
 
 void DownloadCallbacks::reset_progress_bar() {
     multi_progress_bar.reset();
+    if (printed) {
+        std::cout << std::endl;
+    }
 }
 
 bool DownloadCallbacks::is_time_to_print() {
@@ -94,6 +97,11 @@ bool DownloadCallbacks::is_time_to_print() {
         return true;
     }
     return false;
+}
+
+void DownloadCallbacks::print() {
+    multi_progress_bar->print();
+    printed = true;
 }
 
 }  // namespace dnf5

--- a/dnf5/download_callbacks.hpp
+++ b/dnf5/download_callbacks.hpp
@@ -41,9 +41,11 @@ public:
 
 private:
     bool is_time_to_print();
+    void print();
 
     std::unique_ptr<libdnf::cli::progressbar::MultiProgressBar> multi_progress_bar;
     std::chrono::time_point<std::chrono::steady_clock> prev_print_time{std::chrono::steady_clock::now()};
+    bool printed{false};
 };
 
 }  // namespace dnf5

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -59,14 +59,6 @@ public:
     /// Sets callbacks for repositories and loads them, updating metadata if necessary.
     void load_repos(bool load_system);
 
-    /// Downloads the given URLs to specified destination local paths.
-    void download_urls(
-        std::vector<std::pair<std::string, std::filesystem::path>> url_to_dest_path, bool fail_fast, bool resume);
-
-    /// Adds packages from path-defined files to the command line repository.
-    /// Returns the added Package objects.
-    std::vector<libdnf::rpm::Package> add_cmdline_packages(const std::vector<std::string> & packages_paths);
-
     libdnf::Base base;
     std::vector<std::pair<std::string, std::string>> setopts;
     std::vector<std::string> enable_plugins_patterns;
@@ -164,14 +156,6 @@ void download_packages(const std::vector<libdnf::rpm::Package> & packages, const
 void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir);
 
 void run_transaction(libdnf::rpm::Transaction & transaction);
-
-/// Parses the items in the `specs` array and adds the individual items to the appropriate vector.
-/// Duplicate items are ignored.
-void parse_add_specs(
-    int specs_count,
-    const char * const specs[],
-    std::vector<std::string> & pkg_specs,
-    std::vector<std::string> & filepaths);
 
 /// Returns the names of matching packages and paths of matching package file names and directories.
 /// If `nevra_for_same_name` is true, it returns a full nevra for packages with the same name.

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -40,6 +40,39 @@ public:
     // TODO(jmracek) Not yet implemented
     void add_module_enable(const std::string & spec);
 
+    /// High level API for an artifact installation. A spec can be either a package
+    /// specification matched against NEVRA, provides, and file provides, or it can
+    /// be a path to local rpm file, or URL of rpm to be installed.
+    /// By using `@` prefix you can also specify a group, environmental group,
+    /// or a module to be installed.
+    /// @param spec  A string with installation spec
+    /// @param settings  A structure to override default goal settings.
+    void add_install(const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+
+    /// High level API for an artifact upgrade. See `add_install()` for details.
+    /// @param spec      A string with upgrade spec
+    /// @param settings  A structure to override default goal settings.
+    /// @param minimal   Whether to do smallest possible upgrade
+    void add_upgrade(
+        const std::string & spec,
+        const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings(),
+        bool minimal = false);
+
+    /// High level API for an artifact downgrade. See `add_install()` for details.
+    /// @param spec      A string with upgrade spec
+    /// @param settings  A structure to override default goal settings.
+    void add_downgrade(const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+
+    /// High level API for an artifact reinstall. See `add_install()` for details.
+    /// @param spec      A string with reinstall spec
+    /// @param settings  A structure to override default goal settings.
+    void add_reinstall(const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+
+    /// High level API for an artifact removal. See `add_install()` for details.
+    /// @param spec      A string with reinstall spec
+    /// @param settings  A structure to override default goal settings.
+    void add_remove(const std::string & spec, const libdnf::GoalJobSettings & settings = libdnf::GoalJobSettings());
+
     /// Add install request to the goal. The `spec` will be resolved to packages in the resolve() call. The operation will not
     /// result in a reinstall if the requested package is already installed. By default uses
     /// `clean_requirements_on_remove` set to `false`, which can be overridden in `settings`.

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -82,7 +82,8 @@ enum class GoalProblem : uint32_t {
     NOT_AVAILABLE = (1 << 11),
     ALREADY_INSTALLED = (1 << 12),
     SOLVER_PROBLEM_STRICT_RESOLVEMENT = (1 << 13),
-    WRITE_DEBUG = (1 << 14)
+    WRITE_DEBUG = (1 << 14),
+    UNSUPPORTED_ACTION = (1 << 15)
 };
 
 /// Types of Goal actions
@@ -103,6 +104,9 @@ enum class GoalAction {
     RESOLVE,
     REASON_CHANGE
 };
+
+/// Convert GoalAction enum to user-readable string
+std::string goal_action_to_string(GoalAction action);
 
 /// Settings for GoalJobSettings
 enum class GoalSetting { AUTO, SET_TRUE, SET_FALSE };

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -86,11 +86,6 @@ public:
     /// @return The system repository.
     libdnf::repo::RepoWeakPtr get_system_repo();
 
-    /// If not created yet, creates the cmdline repository and returns it.
-    /// @return The cmdline repository.
-    // TODO(lukash) this was private originally, but don't we want it on the public API?
-    libdnf::repo::RepoWeakPtr get_cmdline_repo();
-
     /// Add given paths to comdline repository.
     /// @param paths Vector of paths to rpm files to be inserted to cmdline repo. Can contain paths to local files or URLs of remote rpm files. Specifications that are neither file paths, nor URLs are ignored.
     /// @return Map path->rpm::Package which maps input path to newly created Package object in cmdline repo
@@ -142,6 +137,10 @@ private:
     friend class rpm::PackageSack;
 
     WeakPtrGuard<RepoSack, false> sack_guard;
+
+    /// If not created yet, creates the cmdline repository and returns it.
+    /// @return The cmdline repository.
+    libdnf::repo::RepoWeakPtr get_cmdline_repo();
 
     void internalize_repos();
 

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -91,6 +91,11 @@ public:
     // TODO(lukash) this was private originally, but don't we want it on the public API?
     libdnf::repo::RepoWeakPtr get_cmdline_repo();
 
+    /// Add given paths to comdline repository.
+    /// @param paths Vector of paths to rpm files to be inserted to cmdline repo. Can contain paths to local files or URLs of remote rpm files. Specifications that are neither file paths, nor URLs are ignored.
+    /// @return Map path->rpm::Package which maps input path to newly created Package object in cmdline repo
+    std::map<std::string, libdnf::rpm::Package> add_cmdline_packages(const std::vector<std::string> & paths);
+
     /// @return `true` if the system repository has been initialized (via `get_system_repo()`).
     bool has_system_repo() const noexcept { return system_repo; }
 

--- a/libdnf/base/goal_elements.cpp
+++ b/libdnf/base/goal_elements.cpp
@@ -131,4 +131,40 @@ libdnf::comps::PackageType GoalJobSettings::resolve_group_package_types(const li
     return *used_group_package_types;
 }
 
+std::string goal_action_to_string(GoalAction action) {
+    switch (action) {
+        case GoalAction::INSTALL:
+            return "Install";
+        case GoalAction::INSTALL_VIA_PROVIDE:
+            return "Install via provide";
+        case GoalAction::INSTALL_BY_GROUP:
+            return "Install by group";
+        case GoalAction::UPGRADE:
+            return "Upgrade";
+        case GoalAction::UPGRADE_ALL:
+            return "Upgrade all";
+        case GoalAction::UPGRADE_MINIMAL:
+            return "Upgrade minimal";
+        case GoalAction::UPGRADE_ALL_MINIMAL:
+            return "Upgrade all minimal";
+        case GoalAction::DOWNGRADE:
+            return "Downgrade";
+        case GoalAction::REINSTALL:
+            return "Reinstall";
+        case GoalAction::INSTALL_OR_REINSTALL:
+            return "Install or reinstall";
+        case GoalAction::REMOVE:
+            return "Remove";
+        case GoalAction::DISTRO_SYNC:
+            return "Distrosync";
+        case GoalAction::DISTRO_SYNC_ALL:
+            return "Distrosync all";
+        case GoalAction::REASON_CHANGE:
+            return "Reason Change";
+        case GoalAction::RESOLVE:
+            return "Resolve";
+    }
+    return "";
+}
+
 }  // namespace libdnf

--- a/libdnf/base/log_event.cpp
+++ b/libdnf/base/log_event.cpp
@@ -153,6 +153,9 @@ std::string LogEvent::to_string(
             return ret.append(solver_problems->to_string());
         case GoalProblem::WRITE_DEBUG:
             return ret.append(utils::sformat(_("Debug data written to \"{}\""), *additional_data->begin()));
+        case GoalProblem::UNSUPPORTED_ACTION:
+            return ret.append(utils::sformat(
+                _("{} action for argument \"{}\" is not supported."), goal_action_to_string(action), *spec));
     }
     return ret;
 }

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -201,7 +201,8 @@ libdnf::rpm::Package BaseTestCase::add_system_pkg(
 
 
 libdnf::rpm::Package BaseTestCase::add_cmdline_pkg(const std::string & relative_path) {
-    return repo_sack->get_cmdline_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + relative_path, false);
+    std::string path = PROJECT_BINARY_DIR "/test/data/" + relative_path;
+    return repo_sack->add_cmdline_packages({path}).at(path);
 }
 
 

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -61,10 +61,10 @@ void RpmPackageQueryTest::test_filter_latest_evr() {
     add_repo_solv("solv-repo1");
     add_repo_solv("solv-24pkgs");
 
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
+    const std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
     // also add 2 time the same package
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
+    add_cmdline_pkg(rpm_path);
+    add_cmdline_pkg(rpm_path);
 
     {
         PackageQuery query(base);
@@ -119,10 +119,10 @@ void RpmPackageQueryTest::test_filter_earliest_evr() {
     add_repo_solv("solv-repo1");
     add_repo_solv("solv-24pkgs");
 
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
+    std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
     // also add 2 time the same package
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
+    add_cmdline_pkg(rpm_path);
+    add_cmdline_pkg(rpm_path);
 
     {
         PackageQuery query(base);
@@ -296,9 +296,9 @@ void RpmPackageQueryTest::test_filter_name_packgset() {
 void RpmPackageQueryTest::test_filter_nevra_packgset() {
     add_repo_solv("solv-repo1");
 
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    repo_sack->get_system_repo()->add_rpm_package(rpm_path, false);
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
+    std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
+    repo_sack->get_system_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
+    add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);
     query1.filter_name({"cmdline"});
@@ -337,9 +337,9 @@ void RpmPackageQueryTest::test_filter_name_arch() {
 void RpmPackageQueryTest::test_filter_name_arch2() {
     add_repo_solv("solv-repo1");
 
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    repo_sack->get_system_repo()->add_rpm_package(rpm_path, false);
-    repo_sack->get_cmdline_repo()->add_rpm_package(rpm_path, false);
+    std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
+    repo_sack->get_system_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
+    add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);
     query1.filter_name({"cmdline"});


### PR DESCRIPTION
New high level API for installing any artifact using the same simple call goal.add_install(spec).

The spec here can be
- a repository package specification matched against NEVRA, provides, and file provides, e.g. "wget", "vim-*"
- a local rpm file (/the/location/package.rpm)
- a URL of remote rpm package
- by using '@' prefix also a group can be specified - @rpm-development-tools
- TODO: once installation of environmental groups and modules is  implemented, also these artifact will be able to be installed