### PR TITLE
Add methods for configuration options to simplify setting values during runtime

### DIFF
--- a/include/libdnf/conf/option.hpp
+++ b/include/libdnf/conf/option.hpp
@@ -93,6 +93,9 @@ public:
     /// @replaces libdnf:conf/Option.hpp:method:Option.set(Priority priority, const std::string & value)
     virtual void set(Priority priority, const std::string & value) = 0;
 
+    /// Parses input string and sets new value and runtime priority.
+    virtual void set(const std::string & value) = 0;
+
     /// Gets a string representation of the stored value.
     /// @replaces libdnf:conf/Option.hpp:method:Option.getValueString()
     virtual std::string get_value_string() const = 0;

--- a/include/libdnf/conf/option_bool.hpp
+++ b/include/libdnf/conf/option_bool.hpp
@@ -63,10 +63,16 @@ public:
     /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, bool value)
     void set(Priority priority, bool value);
 
+    /// Sets new value with the runtime priority.
+    void set(bool value);
+
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Gets the stored value.
     /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValue()

--- a/include/libdnf/conf/option_child.hpp
+++ b/include/libdnf/conf/option_child.hpp
@@ -49,10 +49,16 @@ public:
     /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, bool value)
     void set(Priority priority, const typename ParentOptionType::ValueType & value);
 
+    /// Sets new value and runtime priority.
+    void set(const typename ParentOptionType::ValueType & value);
+
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, std::string value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Gets the stored value. If no value is stored, value from the parent is returned.
     /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValue()
@@ -103,6 +109,9 @@ public:
     /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.set(Priority priority, std::string value)
     void set(Priority priority, const std::string & value) override;
 
+    /// Sets new value and runtime priority.
+    void set(const std::string & value) override;
+
     /// Gets the stored value. If no value is stored, value from the parent is returned.
     /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValue()
     const std::string & get_value() const;
@@ -150,8 +159,18 @@ inline void OptionChild<ParentOptionType, Enable>::set(
 }
 
 template <class ParentOptionType, class Enable>
+inline void OptionChild<ParentOptionType, Enable>::set(const typename ParentOptionType::ValueType & value) {
+    set(Priority::RUNTIME, value);
+}
+
+template <class ParentOptionType, class Enable>
 inline void OptionChild<ParentOptionType, Enable>::set(Priority priority, const std::string & value) {
     set(priority, parent->from_string(value));
+}
+
+template <class ParentOptionType, class Enable>
+inline void OptionChild<ParentOptionType, Enable>::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 template <class ParentOptionType, class Enable>
@@ -213,6 +232,14 @@ inline void OptionChild<
         set_priority(priority);
         this->value = val;
     }
+}
+
+template <class ParentOptionType>
+inline void OptionChild<
+    ParentOptionType,
+    typename std::enable_if<std::is_same<typename ParentOptionType::ValueType, std::string>::value>::type>::
+    set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 template <class ParentOptionType>

--- a/include/libdnf/conf/option_enum.hpp
+++ b/include/libdnf/conf/option_enum.hpp
@@ -51,10 +51,16 @@ public:
     /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, bool value)
     void set(Priority priority, ValueType value);
 
+    /// Sets new value and runtime priority.
+    void set(ValueType value);
+
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Gets the stored value.
     /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValue()
@@ -109,6 +115,9 @@ public:
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Gets the stored value.
     /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValue()

--- a/include/libdnf/conf/option_number.hpp
+++ b/include/libdnf/conf/option_number.hpp
@@ -69,10 +69,16 @@ public:
     /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, bool value)
     void set(Priority priority, ValueType value);
 
+    /// Sets new value and runtime priority.
+    void set(ValueType value);
+
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Gets the stored value.
     /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValue()

--- a/include/libdnf/conf/option_path.hpp
+++ b/include/libdnf/conf/option_path.hpp
@@ -70,6 +70,9 @@ public:
     /// @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
+
     /// Tests input value and throws exception if the value is not allowed.
     /// @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.test(const std::string & value)
     void test(const std::string & value) const;

--- a/include/libdnf/conf/option_seconds.hpp
+++ b/include/libdnf/conf/option_seconds.hpp
@@ -47,6 +47,9 @@ public:
     /// @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
+
     /// Parses input string and returns result.
     /// @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.fromString(const std::string & value)
     ValueType from_string(const std::string & value) const;

--- a/include/libdnf/conf/option_string.hpp
+++ b/include/libdnf/conf/option_string.hpp
@@ -46,6 +46,9 @@ public:
     /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
+    /// Sets new value and runtime priority.
+    void set(const std::string & value) override;
+
     /// Gets the stored value.
     /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValue()
     const std::string & get_value() const;

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -60,10 +60,16 @@ public:
     /// @replaces libdnf:conf/OptionStingList.hpp:method:OptionStringList.set(Priority priority, bool value)
     virtual void set(Priority priority, const ValueType & value);
 
+    /// Sets new value and runtime priority.
+    void set(const ValueType & value);
+
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
     /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
+
+    /// Parses input string and sets new value and runtime priority.
+    void set(const std::string & value) override;
 
     /// Adds items from an another container.
     /// New items are stored in the container value and the runtime priority is set as this is intended to use only through the API.

--- a/libdnf/conf/option_bool.cpp
+++ b/libdnf/conf/option_bool.cpp
@@ -93,8 +93,16 @@ void OptionBool::set(Priority priority, bool value) {
     }
 }
 
+void OptionBool::set(bool value) {
+    set(Priority::RUNTIME, value);
+}
+
 void OptionBool::set(Priority priority, const std::string & value) {
     set(priority, from_string(value));
+}
+
+void OptionBool::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 std::string OptionBool::to_string(bool value) const {

--- a/libdnf/conf/option_enum.cpp
+++ b/libdnf/conf/option_enum.cpp
@@ -104,8 +104,18 @@ void OptionEnum<T>::set(Priority priority, ValueType value) {
 }
 
 template <typename T>
+void OptionEnum<T>::set(ValueType value) {
+    set(Priority::RUNTIME, value);
+}
+
+template <typename T>
 void OptionEnum<T>::set(Priority priority, const std::string & value) {
     set(priority, from_string(value));
+}
+
+template <typename T>
+void OptionEnum<T>::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 template <typename T>
@@ -171,6 +181,10 @@ void OptionEnum<std::string>::set(Priority priority, const std::string & value) 
         this->value = val;
         set_priority(priority);
     }
+}
+
+void OptionEnum<std::string>::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 }  // namespace libdnf

--- a/libdnf/conf/option_number.cpp
+++ b/libdnf/conf/option_number.cpp
@@ -101,8 +101,18 @@ void OptionNumber<T>::set(Priority priority, ValueType value) {
 }
 
 template <typename T>
+void OptionNumber<T>::set(ValueType value) {
+    set(Priority::RUNTIME, value);
+}
+
+template <typename T>
 void OptionNumber<T>::set(Option::Priority priority, const std::string & value) {
     set(priority, from_string(value));
+}
+
+template <typename T>
+void OptionNumber<T>::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 template <typename T>

--- a/libdnf/conf/option_path.cpp
+++ b/libdnf/conf/option_path.cpp
@@ -99,4 +99,8 @@ void OptionPath::set(Priority priority, const std::string & value) {
     }
 }
 
+void OptionPath::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
+}
+
 }  // namespace libdnf

--- a/libdnf/conf/option_seconds.cpp
+++ b/libdnf/conf/option_seconds.cpp
@@ -86,4 +86,8 @@ void OptionSeconds::set(Priority priority, const std::string & value) {
     set(priority, from_string(value));
 }
 
+void OptionSeconds::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
+}
+
 }  // namespace libdnf

--- a/libdnf/conf/option_string.cpp
+++ b/libdnf/conf/option_string.cpp
@@ -86,6 +86,10 @@ void OptionString::set(Priority priority, const std::string & value) {
     }
 }
 
+void OptionString::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
+}
+
 const std::string & OptionString::get_value() const {
     if (get_priority() == Priority::EMPTY) {
         //TODO(jrohel): We don't know the option name at this time. Add a text name to the options

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -181,8 +181,18 @@ void OptionStringContainer<T>::set(Priority priority, const ValueType & value) {
 }
 
 template <typename T>
+void OptionStringContainer<T>::set(const ValueType & value) {
+    set(Priority::RUNTIME, value);
+}
+
+template <typename T>
 void OptionStringContainer<T>::set(Priority priority, const std::string & value) {
     set(priority, from_string(value));
+}
+
+template <typename T>
+void OptionStringContainer<T>::set(const std::string & value) {
+    set(Priority::RUNTIME, value);
 }
 
 template <typename T>

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -55,9 +55,9 @@ void BaseGoalTest::test_install_not_available() {
     add_repo_repomd("repomd-repo1");
 
     libdnf::Goal goal(base);
-    base.get_config().strict().set(libdnf::Option::Priority::RUNTIME, false);
-    base.get_config().best().set(libdnf::Option::Priority::RUNTIME, true);
-    base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
+    base.get_config().strict().set(false);
+    base.get_config().best().set(true);
+    base.get_config().clean_requirements_on_remove().set(true);
     goal.add_rpm_install("not_available");
     auto transaction = goal.resolve();
 
@@ -95,7 +95,7 @@ void BaseGoalTest::test_install_from_cmdline() {
 
 void BaseGoalTest::test_install_multilib_all() {
     add_repo_solv("solv-multilib");
-    base.get_config().multilib_policy().set(libdnf::Option::Priority::RUNTIME, "all");
+    base.get_config().multilib_policy().set("all");
 
     libdnf::Goal goal(base);
     goal.add_rpm_install("multilib");
@@ -204,7 +204,7 @@ void BaseGoalTest::test_remove() {
 }
 
 void BaseGoalTest::test_remove_not_installed() {
-    base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
+    base.get_config().clean_requirements_on_remove().set(true);
 
     libdnf::Goal goal(base);
     goal.add_rpm_remove("not_installed");
@@ -325,8 +325,8 @@ void BaseGoalTest::test_upgrade_not_downgrade_from_cmdline() {
 }
 
 void BaseGoalTest::test_upgrade_not_available() {
-    base.get_config().best().set(libdnf::Option::Priority::RUNTIME, true);
-    base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
+    base.get_config().best().set(true);
+    base.get_config().clean_requirements_on_remove().set(true);
 
     libdnf::rpm::PackageQuery query(base);
 

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -43,7 +43,7 @@ using libdnf::utils::sformat;
 libdnf::repo::RepoWeakPtr BaseTestCase::add_repo(const std::string & repoid, const std::string & repo_path, bool load) {
     auto repo = repo_sack->create_repo(repoid);
 
-    repo->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, "file://" + repo_path);
+    repo->get_config().baseurl().set("file://" + repo_path);
 
     if (load) {
         repo->fetch_metadata();
@@ -225,9 +225,9 @@ void BaseTestCase::setUp() {
     temp = std::make_unique<libdnf::utils::fs::TempDir>("libdnf5_unittest");
     std::filesystem::create_directory(temp->get_path() / "installroot");
 
-    base.get_config().installroot().set(libdnf::Option::Priority::RUNTIME, temp->get_path() / "installroot");
-    base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, temp->get_path() / "cache");
-    base.get_config().optional_metadata_types().set(libdnf::Option::Priority::RUNTIME, libdnf::OPTIONAL_METADATA_TYPES);
+    base.get_config().installroot().set(temp->get_path() / "installroot");
+    base.get_config().cachedir().set(temp->get_path() / "cache");
+    base.get_config().optional_metadata_types().set(libdnf::OPTIONAL_METADATA_TYPES);
 
     base.get_vars()->set("arch", "x86_64");
 

--- a/test/libdnf/conf/test_conf.cpp
+++ b/test/libdnf/conf/test_conf.cpp
@@ -49,8 +49,7 @@ void ConfTest::test_config_repo() {
     repo::ConfigRepo config_repo(config, "test-repo");
     ConfigParser parser;
     parser.read(PROJECT_SOURCE_DIR "/test/libdnf/conf/data/main.conf");
-    base->get_config().varsdir().set(
-        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base->get_config().varsdir().set(std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
     base->setup();
     config_repo.load_from_parser(parser, "repo-1", *base->get_vars(), logger);
 

--- a/test/libdnf/conf/test_option.cpp
+++ b/test/libdnf/conf/test_option.cpp
@@ -115,6 +115,7 @@ void OptionTest::test_options_bool() {
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, true), AssertionError);
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, false), AssertionError);
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, std::string("true")), AssertionError);
+    CPPUNIT_ASSERT_THROW(option.set(true), AssertionError);
 }
 
 

--- a/test/libdnf/conf/test_vars.cpp
+++ b/test/libdnf/conf/test_vars.cpp
@@ -31,8 +31,7 @@ void VarsTest::setUp() {
 }
 
 void VarsTest::test_vars() {
-    base->get_config().varsdir().set(
-        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base->get_config().varsdir().set(std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
     // Load all variables.
     base->setup();
 
@@ -42,12 +41,10 @@ void VarsTest::test_vars() {
 }
 
 void VarsTest::test_vars_multiple_dirs() {
-    base->get_config().varsdir().set(
-        libdnf::Option::Priority::RUNTIME,
-        std::vector<std::string>{
-            PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars",
-            PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars2",
-        });
+    base->get_config().varsdir().set(std::vector<std::string>{
+        PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars",
+        PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars2",
+    });
     // Load all variables.
     base->setup();
 
@@ -55,8 +52,7 @@ void VarsTest::test_vars_multiple_dirs() {
 }
 
 void VarsTest::test_vars_env() {
-    base->get_config().varsdir().set(
-        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base->get_config().varsdir().set(std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
     // Setting environment variables.
     // Environment variables have higher priority than variables from files.
     setenv("DNF0", "foo0", 1);

--- a/test/libdnf/repo/test_repo_query.cpp
+++ b/test/libdnf/repo/test_repo_query.cpp
@@ -41,10 +41,10 @@ void RepoQueryTest::test_query_basics() {
     repo2->disable();
     repo1_updates->disable();
     repo2_updates->enable();
-    repo1->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, "file:///path/to/repo1");
-    repo2->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo2");
-    repo1_updates->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo1_updates");
-    repo2_updates->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo2_updates");
+    repo1->get_config().baseurl().set("file:///path/to/repo1");
+    repo2->get_config().baseurl().set("https://host/path/to/repo2");
+    repo1_updates->get_config().baseurl().set("https://host/path/to/repo1_updates");
+    repo2_updates->get_config().baseurl().set("https://host/path/to/repo2_updates");
 
     // create a RepoQuery and test that it contains expected repos
     libdnf::repo::RepoQuery repo_query(base);

--- a/test/libdnf/test_case_fixture.cpp
+++ b/test/libdnf/test_case_fixture.cpp
@@ -83,8 +83,8 @@ std::unique_ptr<libdnf::Base> TestCaseFixture::get_preconfigured_base() {
     std::filesystem::create_directory(temp->get_path() / "installroot");
 
     std::unique_ptr<libdnf::Base> base(new libdnf::Base());
-    base->get_config().installroot().set(libdnf::Option::Priority::RUNTIME, temp->get_path() / "installroot");
-    base->get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, temp->get_path() / "cache");
+    base->get_config().installroot().set(temp->get_path() / "installroot");
+    base->get_config().cachedir().set(temp->get_path() / "cache");
 
     return base;
 }

--- a/test/libdnf/transaction/transaction_test_base.cpp
+++ b/test/libdnf/transaction/transaction_test_base.cpp
@@ -31,6 +31,6 @@ void TransactionTestBase::tearDown() {}
 
 std::unique_ptr<libdnf::Base> TransactionTestBase::new_base() {
     auto new_base = std::make_unique<libdnf::Base>();
-    new_base->get_config().transaction_history_dir().set(libdnf::Option::Priority::RUNTIME, temp_dir->get_path());
+    new_base->get_config().transaction_history_dir().set(temp_dir->get_path());
     return new_base;
 }

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -33,15 +33,9 @@ class BaseTestCase(unittest.TestCase):
         self.base = libdnf5.base.Base()
         self.temp_dir = tempfile.mkdtemp(prefix="libdnf5_python3_unittest.")
 
-        self.base.get_config().installroot().set(
-            libdnf5.conf.Option.Priority_RUNTIME,
-            os.path.join(self.temp_dir, "installroot"))
-        self.base.get_config().cachedir().set(
-            libdnf5.conf.Option.Priority_RUNTIME,
-            os.path.join(self.temp_dir, "cache"))
-        self.base.get_config().optional_metadata_types().set(
-            libdnf5.conf.Option.Priority_RUNTIME, 
-            libdnf5.conf.OPTIONAL_METADATA_TYPES)
+        self.base.get_config().installroot().set(os.path.join(self.temp_dir, "installroot"))
+        self.base.get_config().cachedir().set(os.path.join(self.temp_dir, "cache"))
+        self.base.get_config().optional_metadata_types().set(libdnf5.conf.OPTIONAL_METADATA_TYPES)
 
         self.base.setup()
 
@@ -57,7 +51,7 @@ class BaseTestCase(unittest.TestCase):
         """
         repo = self.repo_sack.create_repo(repoid)
 
-        repo.get_config().baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, "file://" + repo_path)
+        repo.get_config().baseurl().set("file://" + repo_path)
 
         if load:
             repo.fetch_metadata()

--- a/test/python3/libdnf5/repo/test_repo_query.py
+++ b/test/python3/libdnf5/repo/test_repo_query.py
@@ -27,19 +27,19 @@ class TestRepoQuery(base_test_case.BaseTestCase):
         # Creates new repositories in the repo_sack
         repo1 = self.repo_sack.create_repo("repo1")
         repo1.enable();
-        repo1.get_config().baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, "file:///path/to/repo1")
+        repo1.get_config().baseurl().set("file:///path/to/repo1")
 
         repo2 = self.repo_sack.create_repo("repo2")
         repo2.disable();
-        repo2.get_config().baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, "https://host/path/to/repo2")
+        repo2.get_config().baseurl().set("https://host/path/to/repo2")
 
         repo1_updates = self.repo_sack.create_repo("repo1_updates")
         repo1_updates.disable();
-        repo1_updates.get_config().baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, "https://host/path/to/repo1_updates")
+        repo1_updates.get_config().baseurl().set("https://host/path/to/repo1_updates")
 
         repo2_updates = self.repo_sack.create_repo("repo2_updates")
         repo2_updates.enable();
-        repo2_updates.get_config().baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, "https://host/path/to/repo2_updates")
+        repo2_updates.get_config().baseurl().set("https://host/path/to/repo2_updates")
 
         # create a RepoQuery and test that it contains expected repos
         repo_query = libdnf5.repo.RepoQuery(self.base)

--- a/test/python3/libdnf5/tutorial/repo/load_repo.py
+++ b/test/python3/libdnf5/tutorial/repo/load_repo.py
@@ -15,7 +15,7 @@ repo = repo_sack.create_repo("rpm-repo1")
 # * file:///absolute/path/url/
 # * https://example.com/url/
 base_config = repo.get_config()
-base_config.baseurl().set(libdnf5.conf.Option.Priority_RUNTIME, baseurl);
+base_config.baseurl().set(baseurl);
 
 # If out of date, downloads fresh metadata of all available repositories and
 # loads the repositories into memory.

--- a/test/python3/libdnf5/tutorial/session/create_base.py
+++ b/test/python3/libdnf5/tutorial/session/create_base.py
@@ -17,7 +17,7 @@ base.load_config_from_file()
 # it to a different location. The Base instance will then work with the
 # installroot directory tree as its root for the rest of its lifetime.
 base_config = base.get_config()
-base_config.installroot().set(libdnf5.conf.Option.Priority_RUNTIME, installroot)
+base_config.installroot().set(installroot)
 
 # Load vars and do other initialization (of libsolv pool, etc.) based on the
 # configuration.  Locks the installroot and varsdir configuration values so

--- a/test/ruby/libdnf5/base_test_case.rb
+++ b/test/ruby/libdnf5/base_test_case.rb
@@ -33,8 +33,8 @@ class BaseTestCase < Test::Unit::TestCase
         @base = Base::Base.new()
         @temp_dir = Dir.mktmpdir("libdnf5_ruby_unittest.")
 
-        @base.get_config().installroot().set(Conf::Option::Priority_RUNTIME, File.join(@temp_dir, "installroot"))
-        @base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, File.join(@temp_dir, "cache"))
+        @base.get_config().installroot().set(File.join(@temp_dir, "installroot"))
+        @base.get_config().cachedir().set(File.join(@temp_dir, "cache"))
 
         # Sets Base internals according to configuration
         @base.setup()
@@ -51,7 +51,7 @@ class BaseTestCase < Test::Unit::TestCase
     def _add_repo(repoid, repo_path, load=true)
         repo = @repo_sack.create_repo(repoid)
 
-        repo.get_config().baseurl().set(Conf::Option::Priority_RUNTIME, "file://" + repo_path)
+        repo.get_config().baseurl().set("file://" + repo_path)
 
         if load
           repo.fetch_metadata()

--- a/test/tutorial/repo/load_repo.cpp
+++ b/test/tutorial/repo/load_repo.cpp
@@ -14,7 +14,7 @@ auto repo = repo_sack->create_repo("my_new_repo_id");
 // * /absolute/path/
 // * file:///absolute/path/url/
 // * https://example.com/url/
-repo->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, baseurl);
+repo->get_config().baseurl().set(baseurl);
 
 // If out of date, downloads fresh metadata of all available repositories and
 // loads the repositories into memory.

--- a/test/tutorial/session/create_base.cpp
+++ b/test/tutorial/session/create_base.cpp
@@ -18,7 +18,7 @@ base.load_config_from_file();
 // Installroot is set to '/' when we're working with the system, but we can set
 // it to a different location. The Base instance will then work with the
 // installroot directory tree as its root for the rest of its lifetime.
-base.get_config().installroot().set(libdnf::Option::Priority::RUNTIME, installroot);
+base.get_config().installroot().set(installroot);
 
 // Load vars and do other initialization (of libsolv pool, etc.) based on the
 // configuration.  Locks the installroot and varsdir configuration values so

--- a/test/tutorial/test_tutorial.cpp
+++ b/test/tutorial/test_tutorial.cpp
@@ -48,7 +48,7 @@ void TutorialTest::test_create_base() {
 void TutorialTest::test_load_repo() {
     #include "session/create_base.cpp"
 
-    base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cachedir);
+    base.get_config().cachedir().set(cachedir);
 
     #include "repo/load_repo.cpp"
 }
@@ -57,7 +57,7 @@ void TutorialTest::test_load_repo() {
 void TutorialTest::test_load_system_repos() {
     #include "session/create_base.cpp"
 
-    base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cachedir);
+    base.get_config().cachedir().set(cachedir);
 
     #include "repo/load_system_repos.cpp"
 }
@@ -66,7 +66,7 @@ void TutorialTest::test_load_system_repos() {
 void TutorialTest::test_query() {
     #include "session/create_base.cpp"
 
-    base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cachedir);
+    base.get_config().cachedir().set(cachedir);
 
     #include "repo/load_repo.cpp"
     #include "query/query.cpp"
@@ -76,7 +76,7 @@ void TutorialTest::test_query() {
 void TutorialTest::test_transaction() {
     #include "session/create_base.cpp"
 
-    base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cachedir);
+    base.get_config().cachedir().set(cachedir);
 
     #include "repo/load_repo.cpp"
     #include "transaction/transaction.cpp"


### PR DESCRIPTION
Overloads for `set` methods were added in order to simplify usage of configuration option setters for API users.

Related issue: #66.