### PR TITLE
Rework download callbacks

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -343,7 +343,7 @@ std::chrono::time_point<std::chrono::steady_clock> DownloadCB::prev_print_time =
 void Context::download_urls(
     std::vector<std::pair<std::string, std::filesystem::path>> url_to_dest_path, bool fail_fast, bool resume) {
     libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
-    libdnf::repo::FileDownloader downloader(base.get_config());
+    libdnf::repo::FileDownloader downloader(base);
 
     for (auto & [url, dest_path] : url_to_dest_path) {
         if (!libdnf::utils::url::is_url(url)) {

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -1,0 +1,99 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "download_callbacks.hpp"
+
+namespace dnf5 {
+
+void * DownloadCallbacks::add_new_download(
+    [[maybe_unused]] void * user_data, const char * description, double total_to_download) {
+    if (!multi_progress_bar) {
+        multi_progress_bar = std::make_unique<libdnf::cli::progressbar::MultiProgressBar>();
+    }
+    auto progress_bar = std::make_unique<libdnf::cli::progressbar::DownloadProgressBar>(
+        total_to_download > 0 ? total_to_download : -1, description);
+    auto * ppb = progress_bar.get();
+    multi_progress_bar->add_bar(std::move(progress_bar));
+    return ppb;
+}
+
+int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, double downloaded) {
+    auto * progress_bar = reinterpret_cast<libdnf::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto total = static_cast<int64_t>(total_to_download);
+    if (total > 0) {
+        progress_bar->set_total_ticks(total);
+    }
+    if (progress_bar->get_state() == libdnf::cli::progressbar::ProgressBarState::READY) {
+        progress_bar->start();
+    }
+    progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    if (is_time_to_print()) {
+        multi_progress_bar->print();
+    }
+    return 0;
+}
+
+int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
+    auto * progress_bar = reinterpret_cast<libdnf::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    switch (status) {
+        case TransferStatus::SUCCESSFUL:
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
+            break;
+        case TransferStatus::ALREADYEXISTS:
+            // skipping the download -> downloading 0 bytes
+            progress_bar->set_ticks(0);
+            progress_bar->set_total_ticks(0);
+            progress_bar->add_message(libdnf::cli::progressbar::MessageType::SUCCESS, msg);
+            progress_bar->start();
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
+            break;
+        case TransferStatus::ERROR:
+            progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, msg);
+            progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
+            break;
+    }
+    multi_progress_bar->print();
+    return 0;
+}
+
+int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url) {
+    auto * progress_bar = reinterpret_cast<libdnf::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    std::string message = std::string(msg) + " - " + url;
+    progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->print();
+    return 0;
+}
+
+void DownloadCallbacks::reset_progress_bar() {
+    multi_progress_bar.reset();
+}
+
+bool DownloadCallbacks::is_time_to_print() {
+    auto now = std::chrono::steady_clock::now();
+    auto delta = now - prev_print_time;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
+    if (ms > 100) {
+        // 100ms equals to 10 FPS and that seems to be smooth enough
+        prev_print_time = now;
+        return true;
+    }
+    return false;
+}
+
+}  // namespace dnf5

--- a/dnf5/download_callbacks.hpp
+++ b/dnf5/download_callbacks.hpp
@@ -1,0 +1,51 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_DOWNLOAD_CALLBACKS_HPP
+#define DNF5_DOWNLOAD_CALLBACKS_HPP
+
+#include <libdnf-cli/progressbar/multi_progress_bar.hpp>
+#include <libdnf/repo/download_callbacks.hpp>
+
+#include <chrono>
+
+namespace dnf5 {
+
+class DownloadCallbacks : public libdnf::repo::DownloadCallbacks {
+public:
+    void * add_new_download(void * user_data, const char * description, double total_to_download) override;
+
+    int progress(void * user_cb_data, double total_to_download, double downloaded) override;
+
+    int end(void * user_cb_data, TransferStatus status, const char * msg) override;
+
+    int mirror_failure(void * user_cb_data, const char * msg, const char * url) override;
+
+    void reset_progress_bar();
+
+private:
+    bool is_time_to_print();
+
+    std::unique_ptr<libdnf::cli::progressbar::MultiProgressBar> multi_progress_bar;
+    std::chrono::time_point<std::chrono::steady_clock> prev_print_time{std::chrono::steady_clock::now()};
+};
+
+}  // namespace dnf5
+
+#endif

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -39,6 +39,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/swap/swap.hpp"
 #include "commands/upgrade/upgrade.hpp"
 #include "dnf5/context.hpp"
+#include "download_callbacks.hpp"
 #include "plugins.hpp"
 #include "utils.hpp"
 
@@ -603,6 +604,10 @@ int main(int argc, char * argv[]) try {
         return 0;
     }
 
+    auto download_callbacks_uptr = std::make_unique<dnf5::DownloadCallbacks>();
+    auto * download_callbacks = download_callbacks_uptr.get();
+    base.set_download_callbacks(std::move(download_callbacks_uptr));
+
     // Parse command line arguments
     {
         try {
@@ -689,6 +694,8 @@ int main(int argc, char * argv[]) try {
             context.set_transaction(goal->resolve());
 
             command->goal_resolved();
+
+            download_callbacks->reset_progress_bar();
 
             if (!libdnf::cli::output::print_transaction_table(*context.get_transaction())) {
                 return static_cast<int>(libdnf::cli::ExitCode::SUCCESS);

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <dnf5daemon-server/dbus.hpp>
 #include <dnf5daemon-server/transaction.hpp>
 #include <libdnf-cli/tty.hpp>
+#include <libdnf/repo/download_callbacks.hpp>
 #include <libdnf/repo/package_downloader.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
@@ -189,12 +190,12 @@ void PackageDownloadCB::end(sdbus::Signal & signal) {
         std::string msg;
         signal >> msg;
         using namespace libdnf::repo;
-        auto status = static_cast<DownloadCallbacks::TransferStatus>(status_i);
+        auto status = static_cast<libdnf::repo::DownloadCallbacks::TransferStatus>(status_i);
         switch (status) {
-            case DownloadCallbacks::TransferStatus::SUCCESSFUL:
+            case libdnf::repo::DownloadCallbacks::TransferStatus::SUCCESSFUL:
                 progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
-            case DownloadCallbacks::TransferStatus::ALREADYEXISTS:
+            case libdnf::repo::DownloadCallbacks::TransferStatus::ALREADYEXISTS:
                 // skipping the download -> downloading 0 bytes
                 progress_bar->set_ticks(0);
                 progress_bar->set_total_ticks(0);
@@ -202,7 +203,7 @@ void PackageDownloadCB::end(sdbus::Signal & signal) {
                 progress_bar->start();
                 progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
-            case DownloadCallbacks::TransferStatus::ERROR:
+            case libdnf::repo::DownloadCallbacks::TransferStatus::ERROR:
                 progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, msg);
                 progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
                 break;

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -96,6 +96,8 @@ Session::Session(
         s->dbus_register();
     }
     dbus_object->finishRegistration();
+
+    base->set_download_callbacks(std::make_unique<DownloadCallbacks>());
 }
 
 Session::~Session() {

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/logger/log_router.hpp"
 #include "libdnf/module/module_sack.hpp"
 #include "libdnf/plugin/iplugin.hpp"
+#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/repo/repo_sack.hpp"
 #include "libdnf/rpm/package_sack.hpp"
 #include "libdnf/transaction/transaction_history.hpp"
@@ -52,6 +53,11 @@ public:
     Base(std::vector<std::unique_ptr<Logger>> && loggers = {});
 
     ~Base();
+
+    void set_download_callbacks(std::unique_ptr<repo::DownloadCallbacks> && download_callbacks) {
+        this->download_callbacks = std::move(download_callbacks);
+    }
+    repo::DownloadCallbacks * get_download_callbacks() { return download_callbacks.get(); }
 
     /// Sets the pointer to the locked instance "Base" to "this" instance. Blocks if the pointer is already set.
     /// Pointer to a locked "Base" instance can be obtained using "get_locked_base()".
@@ -137,6 +143,7 @@ private:
     std::map<std::string, std::string> variables;
     transaction::TransactionHistory transaction_history;
     Vars vars;
+    std::unique_ptr<repo::DownloadCallbacks> download_callbacks;
 
     WeakPtrGuard<LogRouter, false> log_router_gurad;
     WeakPtrGuard<Vars, false> vars_gurad;

--- a/include/libdnf/repo/download_callbacks.hpp
+++ b/include/libdnf/repo/download_callbacks.hpp
@@ -20,6 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_REPO_DOWNLOAD_CALLBACKS_HPP
 #define LIBDNF_REPO_DOWNLOAD_CALLBACKS_HPP
 
+namespace libdnf {
+
+class Base;
+
+}
+
 namespace libdnf::repo {
 
 /// Base class for download callbacks.
@@ -31,23 +37,34 @@ public:
 
     virtual ~DownloadCallbacks() = default;
 
-    /// End of download callback.
-    /// @param status The transfer status.
-    /// @param msg The error message in case of error.
-    /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
-    virtual int end(TransferStatus status, const char * msg);
+    /// Notify the client that a new download has been created.
+    /// @param user_data User data entered together with url/package to download.
+    /// @param description The message describing new download (url/packagename).
+    /// @param total_to_download Total number of bytes to download.
+    /// @return Associated user data for new download.
+    virtual void * add_new_download(void * user_data, const char * description, double total_to_download);
 
     /// Download progress callback.
+    /// @param user_cb_data Associated user data obtained from new_download.
     /// @param total_to_download Total number of bytes to download.
     /// @param downloaded Number of bytes downloaded.
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
-    virtual int progress(double total_to_download, double downloaded);
+    virtual int progress(void * user_cb_data, double total_to_download, double downloaded);
+
+    /// End of download callback.
+    /// @param user_cb_data Associated user data obtained from new_download.
+    /// @param status The transfer status.
+    /// @param msg The error message in case of error.
+    /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
+    virtual int end(void * user_cb_data, TransferStatus status, const char * msg);
+
 
     /// Mirror failure callback.
+    /// @param user_cb_data Associated user data obtained from new_download.
     /// @param msg Error message.
     /// @param url Failed mirror URL.
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
-    virtual int mirror_failure(const char * msg, const char * url);
+    virtual int mirror_failure(void * user_cb_data, const char * msg, const char * url);
 };
 
 }  // namespace libdnf::repo

--- a/include/libdnf/repo/file_downloader.hpp
+++ b/include/libdnf/repo/file_downloader.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_REPO_FILE_DOWNLOADER_HPP
 #define LIBDNF_REPO_FILE_DOWNLOADER_HPP
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/conf/config_main.hpp"
 #include "libdnf/repo/download_callbacks.hpp"
@@ -38,7 +39,8 @@ class FileDownloadError : public Error {
 
 class FileDownloader {
 public:
-    explicit FileDownloader(ConfigMain & config);
+    explicit FileDownloader(const libdnf::BaseWeakPtr & base);
+    explicit FileDownloader(libdnf::Base & base);
     ~FileDownloader();
 
     /// Adds a file (URL) to download.

--- a/include/libdnf/repo/file_downloader.hpp
+++ b/include/libdnf/repo/file_downloader.hpp
@@ -23,7 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/conf/config_main.hpp"
-#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/repo/repo_weak.hpp"
 
 #include <memory>
@@ -47,19 +46,16 @@ public:
     /// @param repo The repository whose settings are to be used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
-    /// @param callbacks (optional) A pointer to an instance of the `FileDownloadCallbacks` class.
     void add(
         libdnf::repo::RepoWeakPtr & repo,
         const std::string & url,
         const std::string & destination,
-        std::unique_ptr<DownloadCallbacks> && callbacks = {});
+        void * user_data = nullptr);
 
     /// Adds a file (URL) to download. The settings from ConfigMain passed in the FileDownloader constructor are used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
-    /// @param callbacks (optional) A pointer to an instance of the `FileDownloadCallbacks` class.
-    void add(
-        const std::string & url, const std::string & destination, std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const std::string & url, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added files (URLs).
     /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_REPO_PACKAGE_DOWNLOADER_HPP
 
 #include "libdnf/conf/config_main.hpp"
-#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/rpm/package.hpp"
 
 #include <memory>
@@ -42,17 +41,12 @@ public:
 
     /// Adds a package to download to the standard location of repo cachedir/packages.
     /// @param package The package to download.
-    /// @param callbacks (optional) A pointer to an instance of the `PackageDownloadCallbacks` class.
-    void add(const libdnf::rpm::Package & package, std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const libdnf::rpm::Package & package, void * user_data = nullptr);
 
     /// Adds a package to download to a specific destination directory.
     /// @param package The package to download.
     /// @param destination The directory to which to download the package.
-    /// @param callbacks (optional) A pointer to an instance of the `PackageDownloadCallbacks` class.
-    void add(
-        const libdnf::rpm::Package & package,
-        const std::string & destination,
-        std::unique_ptr<DownloadCallbacks> && callbacks = {});
+    void add(const libdnf::rpm::Package & package, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added packages.
     /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -463,6 +463,10 @@ public:
     // TODO(dmach): throw an exception when getting a reason for an available package (it should work only for installed)
     libdnf::transaction::TransactionItemReason get_reason() const;
 
+    /// @return The `Base` object to which this object belongs.
+    /// @since 5.0.5
+    libdnf::BaseWeakPtr get_base() const;
+
 protected:
     // @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_new(DnfSack *sack, Id id)
     Package(const BaseWeakPtr & base, PackageId id);

--- a/libdnf/repo/download_callbacks.cpp
+++ b/libdnf/repo/download_callbacks.cpp
@@ -21,13 +21,27 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::repo {
 
-int DownloadCallbacks::end([[maybe_unused]] TransferStatus status, [[maybe_unused]] const char * msg) {
+void * DownloadCallbacks::add_new_download(
+    [[maybe_unused]] void * user_data,
+    [[maybe_unused]] const char * description,
+    [[maybe_unused]] double total_to_download) {
+    return nullptr;
+}
+
+int DownloadCallbacks::end(
+    [[maybe_unused]] void * user_cb_data, [[maybe_unused]] TransferStatus status, [[maybe_unused]] const char * msg) {
     return 0;
 }
-int DownloadCallbacks::progress([[maybe_unused]] double total_to_download, [[maybe_unused]] double downloaded) {
+
+int DownloadCallbacks::progress(
+    [[maybe_unused]] void * user_cb_data,
+    [[maybe_unused]] double total_to_download,
+    [[maybe_unused]] double downloaded) {
     return 0;
 }
-int DownloadCallbacks::mirror_failure([[maybe_unused]] const char * msg, [[maybe_unused]] const char * url) {
+
+int DownloadCallbacks::mirror_failure(
+    [[maybe_unused]] void * user_cb_data, [[maybe_unused]] const char * msg, [[maybe_unused]] const char * url) {
     return 0;
 }
 

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -22,7 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_downloader.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
 
+#include "libdnf/base/base.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/repo/download_callbacks.hpp"
 #include "libdnf/repo/repo.hpp"
 
 #include <librepo/librepo.h>
@@ -42,45 +44,49 @@ struct default_delete<LrPackageTarget> {
 
 namespace libdnf::repo {
 
-static int end_callback(void * data, LrTransferStatus status, const char * msg) {
-    if (!data) {
-        return 0;
-    }
-
-    auto cb_status = static_cast<DownloadCallbacks::TransferStatus>(status);
-    return static_cast<DownloadCallbacks *>(data)->end(cb_status, msg);
-}
-
-static int progress_callback(void * data, double total_to_download, double downloaded) {
-    if (!data) {
-        return 0;
-    }
-
-    return static_cast<DownloadCallbacks *>(data)->progress(total_to_download, downloaded);
-}
-
-static int mirror_failure_callback(void * data, const char * msg, const char * url) {
-    if (!data) {
-        return 0;
-    }
-
-    return static_cast<DownloadCallbacks *>(data)->mirror_failure(msg, url);
-}
-
 class PackageTarget {
 public:
-    PackageTarget(
-        const libdnf::rpm::Package & package,
-        const std::string & destination,
-        std::unique_ptr<DownloadCallbacks> && callbacks)
+    PackageTarget(const libdnf::rpm::Package & package, const std::string & destination, void * user_data)
         : package(package),
           destination(destination),
-          callbacks(std::move(callbacks)) {}
+          user_data(user_data) {}
 
     libdnf::rpm::Package package;
     std::string destination;
-    std::unique_ptr<DownloadCallbacks> callbacks;
+    void * user_data;
+    void * user_cb_data{nullptr};
 };
+
+static int end_callback(void * data, LrTransferStatus status, const char * msg) {
+    libdnf_assert(data != nullptr, "data in callback must be set");
+
+    auto * package_target = static_cast<PackageTarget *>(data);
+    auto cb_status = static_cast<DownloadCallbacks::TransferStatus>(status);
+    if (auto * download_callbacks = package_target->package.get_base()->get_download_callbacks()) {
+        return download_callbacks->end(package_target->user_cb_data, cb_status, msg);
+    }
+    return 0;
+}
+
+static int progress_callback(void * data, double total_to_download, double downloaded) {
+    libdnf_assert(data != nullptr, "data in callback must be set");
+
+    auto * package_target = static_cast<PackageTarget *>(data);
+    if (auto * download_callbacks = package_target->package.get_base()->get_download_callbacks()) {
+        return download_callbacks->progress(package_target->user_cb_data, total_to_download, downloaded);
+    }
+    return 0;
+}
+
+static int mirror_failure_callback(void * data, const char * msg, const char * url) {
+    libdnf_assert(data != nullptr, "data in callback must be set");
+
+    auto * package_target = static_cast<PackageTarget *>(data);
+    if (auto * download_callbacks = package_target->package.get_base()->get_download_callbacks()) {
+        return download_callbacks->mirror_failure(package_target->user_cb_data, msg, url);
+    }
+    return 0;
+}
 
 
 class PackageDownloader::Impl {
@@ -93,52 +99,60 @@ PackageDownloader::PackageDownloader() : p_impl(std::make_unique<Impl>()) {}
 PackageDownloader::~PackageDownloader() = default;
 
 
-void PackageDownloader::add(const libdnf::rpm::Package & package, std::unique_ptr<DownloadCallbacks> && callbacks) {
-    add(package, std::filesystem::path(package.get_repo()->get_cachedir()) / "packages", std::move(callbacks));
+void PackageDownloader::add(const libdnf::rpm::Package & package, void * user_data) {
+    add(package, std::filesystem::path(package.get_repo()->get_cachedir()) / "packages", user_data);
 }
 
 
-void PackageDownloader::add(
-    const libdnf::rpm::Package & package,
-    const std::string & destination,
-    std::unique_ptr<DownloadCallbacks> && callbacks) {
-    p_impl->targets.emplace_back(package, destination, std::move(callbacks));
+void PackageDownloader::add(const libdnf::rpm::Package & package, const std::string & destination, void * user_data) {
+    p_impl->targets.emplace_back(package, destination, user_data);
 }
 
 
 void PackageDownloader::download(bool fail_fast, bool resume) try {
     GError * err{nullptr};
-    GSList * list{nullptr};
+
     std::vector<std::unique_ptr<LrPackageTarget>> lr_targets;
+    lr_targets.reserve(p_impl->targets.size());
+    for (auto & pkg_target : p_impl->targets) {
+        std::filesystem::create_directory(pkg_target.destination);
 
-    for (auto it = p_impl->targets.rbegin(); it != p_impl->targets.rend(); ++it) {
-        std::filesystem::create_directory(it->destination);
+        if (auto * download_callbacks = pkg_target.package.get_base()->get_download_callbacks()) {
+            pkg_target.user_cb_data = download_callbacks->add_new_download(
+                pkg_target.user_data,
+                pkg_target.package.get_full_nevra().c_str(),
+                static_cast<double>(pkg_target.package.get_package_size()));
+        }
 
-        auto lr_target = lr_packagetarget_new_v3(
-            it->package.get_repo()->downloader->get_cached_handle().get(),
-            it->package.get_location().c_str(),
-            it->destination.c_str(),
-            static_cast<LrChecksumType>(it->package.get_checksum().get_type()),
-            it->package.get_checksum().get_checksum().c_str(),
-            static_cast<int64_t>(it->package.get_package_size()),
-            it->package.get_baseurl().empty() ? nullptr : it->package.get_baseurl().c_str(),
+        auto * lr_target = lr_packagetarget_new_v3(
+            pkg_target.package.get_repo()->downloader->get_cached_handle().get(),
+            pkg_target.package.get_location().c_str(),
+            pkg_target.destination.c_str(),
+            static_cast<LrChecksumType>(pkg_target.package.get_checksum().get_type()),
+            pkg_target.package.get_checksum().get_checksum().c_str(),
+            static_cast<int64_t>(pkg_target.package.get_package_size()),
+            pkg_target.package.get_baseurl().empty() ? nullptr : pkg_target.package.get_baseurl().c_str(),
             resume,
             progress_callback,
-            it->callbacks.get(),
+            &pkg_target,
             end_callback,
             mirror_failure_callback,
             0,
             0,
             &err);
 
-        if (lr_target == nullptr) {
+        if (!lr_target) {
             throw LibrepoError(std::unique_ptr<GError>(err));
         }
 
         lr_targets.emplace_back(lr_target);
-        list = g_slist_prepend(list, lr_target);
     }
 
+    // Adding items to the end of GSList is slow. We go from the back and add items to the beginning.
+    GSList * list{nullptr};
+    for (auto it = lr_targets.rbegin(); it != lr_targets.rend(); ++it) {
+        list = g_slist_prepend(list, it->get());
+    }
     std::unique_ptr<GSList, decltype(&g_slist_free)> list_holder(list, &g_slist_free);
 
     LrPackageDownloadFlag flags = static_cast<LrPackageDownloadFlag>(0);

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -385,4 +385,8 @@ Package::Package(const BaseWeakPtr & base, unsigned long long rpmdbid) : base(ba
     throw RuntimeError(M_("Package with rpmdbid was not found"));
 }
 
+BaseWeakPtr Package::get_base() const {
+    return base;
+}
+
 }  // namespace libdnf::rpm

--- a/libdnf/rpm/rpm_signature.cpp
+++ b/libdnf/rpm/rpm_signature.cpp
@@ -207,7 +207,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
         } else {
             // download the remote key
             downloaded_key = std::make_unique<libdnf::utils::fs::TempFile>("rpmkey");
-            libdnf::repo::FileDownloader downloader(base->get_config());
+            libdnf::repo::FileDownloader downloader(base);
             downloader.add(key_url, downloaded_key->get_path());
             downloader.download(true, true);
             key_path = downloaded_key->get_path();

--- a/test/libdnf/repo/test_package_downloader.cpp
+++ b/test/libdnf/repo/test_package_downloader.cpp
@@ -31,19 +31,25 @@ CPPUNIT_TEST_SUITE_REGISTRATION(PackageDownloaderTest);
 
 class DownloadCallbacks : public libdnf::repo::DownloadCallbacks {
 public:
-    int end(TransferStatus status, const char * msg) override {
+    int end([[maybe_unused]] void * user_cb_data, TransferStatus status, const char * msg) override {
         ++end_cnt;
         end_status = status;
         end_msg = libdnf::utils::string::c_to_str(msg);
         return 0;
     }
 
-    int progress([[maybe_unused]] double total_to_download, [[maybe_unused]] double downloaded) override {
+    int progress(
+        [[maybe_unused]] void * user_cb_data,
+        [[maybe_unused]] double total_to_download,
+        [[maybe_unused]] double downloaded) override {
         ++progress_cnt;
         return 0;
     }
 
-    int mirror_failure([[maybe_unused]] const char * msg, [[maybe_unused]] const char * url) override {
+    int mirror_failure(
+        [[maybe_unused]] void * user_cb_data,
+        [[maybe_unused]] const char * msg,
+        [[maybe_unused]] const char * url) override {
         ++mirror_failure_cnt;
         return 0;
     }
@@ -69,7 +75,9 @@ void PackageDownloaderTest::test_package_downloader() {
 
     auto cbs_unique_ptr = std::make_unique<DownloadCallbacks>();
     auto cbs = cbs_unique_ptr.get();
-    downloader.add(*query.begin(), std::move(cbs_unique_ptr));
+    base.set_download_callbacks(std::move(cbs_unique_ptr));
+
+    downloader.add(*query.begin());
 
     downloader.download(true, true);
 

--- a/test/python3/libdnf5/repo/test_package_downloader.py
+++ b/test/python3/libdnf5/repo/test_package_downloader.py
@@ -43,24 +43,24 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
             progress_cnt = 0
             mirror_failure_cnt = 0
 
-            def end(self, status, msg):
+            def end(self, user_cb_data, status, msg):
                 self.end_cnt += 1
                 self.end_status = status
                 self.end_msg = msg
                 return 0
 
-            def progress(self, total_to_download, downloaded):
+            def progress(self, user_cb_data, total_to_download, downloaded):
                 self.progress_cnt += 1
                 return 0
 
-            def mirror_failure(self, msg, url):
+            def mirror_failure(self, user_cb_data, msg, url):
                 self.mirror_failure_cnt += 1
                 return 0
 
         cbs = PackageDownloadCallbacks()
-        # TODO(lukash) try to wrap the creation of the unique_ptr so that cbs
-        # can be passed directly to downloader.add
-        downloader.add(query.begin().value(), libdnf5.repo.DownloadCallbacksUniquePtr(cbs))
+        self.base.set_download_callbacks(libdnf5.repo.DownloadCallbacksUniquePtr(cbs))
+
+        downloader.add(query.begin().value())
 
         downloader.download(True, True)
 

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -25,19 +25,21 @@ for tspkg in transaction.get_transaction_packages():
 # We only override one of the callbacks here, see
 # `libdnf.repo.DownloadCallbacks` documentation for a complete list.
 class PackageDownloadCallbacks(libdnf5.repo.DownloadCallbacks):
-    def mirror_failure(self, msg, url=""):
+    def mirror_failure(self, user_cb_data, msg, url=""):
         print("Mirror failure: ", msg)
+        return 0
 
 # Create a package downloader.
 downloader = libdnf5.repo.PackageDownloader()
+
 downloader_callbacks = PackageDownloadCallbacks()
-downloader_callbacks_ptr = libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks)
+base.set_download_callbacks(libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks))
 
 # Add the inbound packages (packages that are being installed on the system)
 # to the downloader.
 for tspkg in transaction.get_transaction_packages():
     if libdnf5.base.transaction.transaction_item_action_is_inbound(tspkg.get_action()):
-        downloader.add(tspkg.get_package(), downloader_callbacks_ptr)
+        downloader.add(tspkg.get_package())
 
 # Download the packages.
 #

--- a/test/ruby/libdnf5/repo/test_package_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_package_downloader.rb
@@ -39,19 +39,19 @@ class TestPackageDownloader < BaseTestCase
             @mirror_failure_cnt = 0
         end
 
-        def end(status, msg)
+        def end(user_data, status, msg)
             @end_cnt += 1
             @end_status = status
             @end_msg = msg
             return 0
         end
 
-        def progress(total_to_download, downloaded)
+        def progress(user_data, total_to_download, downloaded)
             @progress_cnt += 1
             return 0
         end
 
-        def mirror_failure(msg, url)
+        def mirror_failure(user_data, msg, url)
             @mirror_failure_cnt += 1
             return 0
         end
@@ -69,7 +69,9 @@ class TestPackageDownloader < BaseTestCase
         downloader = Repo::PackageDownloader.new()
 
         cbs = PackageDownloadCallbacks.new()
-        downloader.add(query.begin().value, Repo::DownloadCallbacksUniquePtr.new(cbs))
+        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(cbs))
+
+        downloader.add(query.begin().value)
 
         downloader.download(true, true)
 


### PR DESCRIPTION
Before the change, a unique instance of the `DownloadCallbacks` class was passed for each downloaded object - in the `downloader.add` call. Which was a problem when implicitly adding the necessary downloadable objects in the library (unavailable instance of `DownloadCallbacks`).

Only one instance of `DownloadCallbacks` is now used, which is passed to an instance of the `Base` class. Now we don't need to have an instance of `DownloadCallbacks` available when `downloader.add` is called.

Requires https://github.com/rpm-software-management/ci-dnf-stack/pull/1209