### PR TITLE
conf: Change OptionStringSet implementation to std::set

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -59,8 +59,8 @@
 %include "libdnf/conf/option_seconds.hpp"
 %include "libdnf/conf/option_string.hpp"
 %include "libdnf/conf/option_string_list.hpp"
+%template(OptionStringSet) libdnf::OptionStringContainer<std::set<std::string>>;
 %template(OptionStringList) libdnf::OptionStringContainer<std::vector<std::string>>;
-%template(OptionStringSet) libdnf::OptionStringContainer<std::unordered_set<std::string>>;
 
 %ignore libdnf::OptionPathNotFoundError;
 %include "libdnf/conf/option_path.hpp"

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -961,8 +961,7 @@ std::vector<std::string> match_specs(
         try {
             // create rpm repositories according configuration files
             base.get_repo_sack()->create_repos_from_system_configuration();
-            base.get_config().optional_metadata_types().set(
-                libdnf::Option::Priority::RUNTIME, std::unordered_set<std::string>{});
+            base.get_config().optional_metadata_types().set(libdnf::Option::Priority::RUNTIME, std::set<std::string>{});
 
             ctx.apply_repository_setopts();
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -961,7 +961,8 @@ std::vector<std::string> match_specs(
         try {
             // create rpm repositories according configuration files
             base.get_repo_sack()->create_repos_from_system_configuration();
-            base.get_config().optional_metadata_types().set(libdnf::Option::Priority::RUNTIME, std::set<std::string>{});
+            base.get_config().optional_metadata_types().set(
+                libdnf::Option::Priority::RUNTIME, libdnf::OptionStringSet::ValueType{});
 
             ctx.apply_repository_setopts();
 

--- a/include/libdnf/conf/const.hpp
+++ b/include/libdnf/conf/const.hpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_CONF_CONST_HPP
 #define LIBDNF_CONF_CONST_HPP
 
+#include <set>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 
@@ -58,7 +58,7 @@ constexpr const char * METADATA_TYPE_OTHER = "other";
 constexpr const char * METADATA_TYPE_PRESTO = "presto";
 constexpr const char * METADATA_TYPE_UPDATEINFO = "updateinfo";
 
-const std::unordered_set<std::string> OPTIONAL_METADATA_TYPES{
+const std::set<std::string> OPTIONAL_METADATA_TYPES{
     METADATA_TYPE_COMPS, METADATA_TYPE_FILELISTS, METADATA_TYPE_OTHER, METADATA_TYPE_PRESTO, METADATA_TYPE_UPDATEINFO};
 
 }  // namespace libdnf

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -24,7 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <optional>
 #include <regex>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 
@@ -156,7 +156,7 @@ inline const char * OptionStringContainer<T>::get_delimiters() const noexcept {
 }
 
 using OptionStringList = OptionStringContainer<std::vector<std::string>>;
-using OptionStringSet = OptionStringContainer<std::unordered_set<std::string>>;
+using OptionStringSet = OptionStringContainer<std::set<std::string>>;
 
 }  // namespace libdnf
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -187,7 +187,7 @@ class ConfigMain::Impl {
     OptionStringList installonlypkgs{INSTALLONLYPKGS};
     OptionStringList group_package_types{GROUP_PACKAGE_TYPES};
     OptionStringSet optional_metadata_types{
-        std::set<std::string>{libdnf::METADATA_TYPE_COMPS, libdnf::METADATA_TYPE_UPDATEINFO}};
+        OptionStringSet::ValueType{libdnf::METADATA_TYPE_COMPS, libdnf::METADATA_TYPE_UPDATEINFO}};
     OptionNumber<std::uint32_t> installonly_limit{3, 0, [](const std::string & value) -> std::uint32_t {
                                                       if (value == "<off>") {
                                                           return 0;

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -187,7 +187,7 @@ class ConfigMain::Impl {
     OptionStringList installonlypkgs{INSTALLONLYPKGS};
     OptionStringList group_package_types{GROUP_PACKAGE_TYPES};
     OptionStringSet optional_metadata_types{
-        std::unordered_set<std::string>{libdnf::METADATA_TYPE_COMPS, libdnf::METADATA_TYPE_UPDATEINFO}};
+        std::set<std::string>{libdnf::METADATA_TYPE_COMPS, libdnf::METADATA_TYPE_UPDATEINFO}};
     OptionNumber<std::uint32_t> installonly_limit{3, 0, [](const std::string & value) -> std::uint32_t {
                                                       if (value == "<off>") {
                                                           return 0;

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -235,6 +235,6 @@ std::string OptionStringContainer<T>::to_string(const ValueType & value) const {
 }
 
 template class OptionStringContainer<std::vector<std::string>>;
-template class OptionStringContainer<std::unordered_set<std::string>>;
+template class OptionStringContainer<std::set<std::string>>;
 
 }  // namespace libdnf

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -744,7 +744,7 @@ void RepoDownloader::add_countme_flag(LibrepoHandle & handle) {
 
 
 // TODO(jkolarik): currently all metadata are loaded for system repo, maybe we want it configurable?
-std::unordered_set<std::string> RepoDownloader::get_optional_metadata() const {
+std::set<std::string> RepoDownloader::get_optional_metadata() const {
     if (repo_type == Repo::Type::SYSTEM) {
         return libdnf::OPTIONAL_METADATA_TYPES;
     } else {

--- a/libdnf/repo/repo_downloader.hpp
+++ b/libdnf/repo/repo_downloader.hpp
@@ -92,7 +92,7 @@ private:
     std::string get_persistdir() const;
     void add_countme_flag(LibrepoHandle & handle);
 
-    std::unordered_set<std::string> get_optional_metadata() const;
+    std::set<std::string> get_optional_metadata() const;
 
     libdnf::BaseWeakPtr base;
     const ConfigRepo & config;

--- a/test/libdnf/conf/test_option.cpp
+++ b/test/libdnf/conf/test_option.cpp
@@ -495,38 +495,38 @@ void OptionTest::test_options_string_list_custom_delimiters() {
 }
 
 void OptionTest::test_options_string_set() {
-    const std::unordered_set<std::string> initial{"x", "y", "z"};
+    const std::set<std::string> initial{"x", "y", "z"};
     OptionStringSet option(initial);
     CPPUNIT_ASSERT(initial == option.get_value());
 
     option.set(Option::Priority::RUNTIME, "a, b, c");
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"a", "b", "c"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"a", "b", "c"}) == option.get_value());
 
     option.set(Option::Priority::RUNTIME, "a, b, a, a");
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"a", "b"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"a", "b"}) == option.get_value());
 }
 
 void OptionTest::test_options_list_add() {
     OptionStringSet option("1, 2, 3");
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"1", "2", "3"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3"}) == option.get_value());
 
-    std::unordered_set<std::string> another_set{"4", "5", "6"};
+    std::set<std::string> another_set{"4", "5", "6"};
     option.add(another_set);
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"1", "2", "3", "4", "5", "6"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3", "4", "5", "6"}) == option.get_value());
 
-    std::unordered_set<std::string> set_with_existing_values{"7", "5", "4"};
+    std::set<std::string> set_with_existing_values{"7", "5", "4"};
     option.add(set_with_existing_values);
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"1", "2", "3", "4", "5", "6", "7"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3", "4", "5", "6", "7"}) == option.get_value());
 }
 
 void OptionTest::test_options_list_add_item() {
-    const std::unordered_set<std::string> initial{"item1"};
+    const std::set<std::string> initial{"item1"};
     OptionStringSet option(initial);
     CPPUNIT_ASSERT(initial == option.get_value());
 
     option.add_item("item2");
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"item1", "item2"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"item1", "item2"}) == option.get_value());
 
     option.add_item("item1");
-    CPPUNIT_ASSERT((std::unordered_set<std::string>{"item1", "item2"}) == option.get_value());
+    CPPUNIT_ASSERT((std::set<std::string>{"item1", "item2"}) == option.get_value());
 }

--- a/test/libdnf/conf/test_option.cpp
+++ b/test/libdnf/conf/test_option.cpp
@@ -495,38 +495,38 @@ void OptionTest::test_options_string_list_custom_delimiters() {
 }
 
 void OptionTest::test_options_string_set() {
-    const std::set<std::string> initial{"x", "y", "z"};
+    const OptionStringSet::ValueType initial{"x", "y", "z"};
     OptionStringSet option(initial);
     CPPUNIT_ASSERT(initial == option.get_value());
 
     option.set(Option::Priority::RUNTIME, "a, b, c");
-    CPPUNIT_ASSERT((std::set<std::string>{"a", "b", "c"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"a", "b", "c"}) == option.get_value());
 
     option.set(Option::Priority::RUNTIME, "a, b, a, a");
-    CPPUNIT_ASSERT((std::set<std::string>{"a", "b"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"a", "b"}) == option.get_value());
 }
 
 void OptionTest::test_options_list_add() {
     OptionStringSet option("1, 2, 3");
-    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3"}) == option.get_value());
 
-    std::set<std::string> another_set{"4", "5", "6"};
+    OptionStringSet::ValueType another_set{"4", "5", "6"};
     option.add(another_set);
-    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3", "4", "5", "6"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3", "4", "5", "6"}) == option.get_value());
 
-    std::set<std::string> set_with_existing_values{"7", "5", "4"};
+    OptionStringSet::ValueType set_with_existing_values{"7", "5", "4"};
     option.add(set_with_existing_values);
-    CPPUNIT_ASSERT((std::set<std::string>{"1", "2", "3", "4", "5", "6", "7"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3", "4", "5", "6", "7"}) == option.get_value());
 }
 
 void OptionTest::test_options_list_add_item() {
-    const std::set<std::string> initial{"item1"};
+    const OptionStringSet::ValueType initial{"item1"};
     OptionStringSet option(initial);
     CPPUNIT_ASSERT(initial == option.get_value());
 
     option.add_item("item2");
-    CPPUNIT_ASSERT((std::set<std::string>{"item1", "item2"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"item1", "item2"}) == option.get_value());
 
     option.add_item("item1");
-    CPPUNIT_ASSERT((std::set<std::string>{"item1", "item2"}) == option.get_value());
+    CPPUNIT_ASSERT((OptionStringSet::ValueType{"item1", "item2"}) == option.get_value());
 }


### PR DESCRIPTION
Because `std::unordered_set` is not supported in some bindings yet (even in new SWIG 4.1), moving to `std::set`. We don't expect lot of stored values in these options, so there should be no performance regression.

Also added a commit with some small refactoring to reference defined `OptionStringSet::ValueType` where it makes sense to avoid possible changes in future when internal container implementation is changed.