### PR TITLE
Fix repository specific excludes

### DIFF
--- a/libdnf/common/sack/match_int64.cpp
+++ b/libdnf/common/sack/match_int64.cpp
@@ -59,11 +59,10 @@ bool match_int64(int64_t value, QueryCmp cmp, int64_t pattern) {
 
 
 bool match_int64(int64_t value, QueryCmp cmp, const std::vector<int64_t> & patterns) {
-    bool result = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & pattern : patterns) {
-        if (match_int64(value, cmp, pattern)) {
-            result = true;
-            break;
+        if (match_int64(value, cmp, pattern) != result) {
+            return !result;
         }
     }
     return result;
@@ -71,11 +70,10 @@ bool match_int64(int64_t value, QueryCmp cmp, const std::vector<int64_t> & patte
 
 
 bool match_int64(const std::vector<int64_t> & values, QueryCmp cmp, int64_t pattern) {
-    bool result = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & value : values) {
-        if (match_int64(value, cmp, pattern)) {
-            result = true;
-            break;
+        if (match_int64(value, cmp, pattern) != result) {
+            return !result;
         }
     }
     return result;
@@ -83,18 +81,12 @@ bool match_int64(const std::vector<int64_t> & values, QueryCmp cmp, int64_t patt
 
 
 bool match_int64(const std::vector<int64_t> & values, QueryCmp cmp, const std::vector<int64_t> & patterns) {
-    bool result = false;
-    bool found = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & value : values) {
         for (auto & pattern : patterns) {
-            if (match_int64(value, cmp, pattern)) {
-                result = true;
-                found = true;
-                break;
+            if (match_int64(value, cmp, pattern) != result) {
+                return !result;
             }
-        }
-        if (found) {
-            break;
         }
     }
     return result;

--- a/libdnf/common/sack/match_string.cpp
+++ b/libdnf/common/sack/match_string.cpp
@@ -85,43 +85,41 @@ bool match_string(const std::string & value, QueryCmp cmp, const std::string & p
 }
 
 
+// cmp is positive: return true if the value matches at least one of patterns
+// cmp is negative: return true if value doesn't match any of patterns
 bool match_string(const std::string & value, QueryCmp cmp, const std::vector<std::string> & patterns) {
-    bool result = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & pattern : patterns) {
-        if (match_string(value, cmp, pattern)) {
-            result = true;
-            break;
+        if (match_string(value, cmp, pattern) != result) {
+            return !result;
         }
     }
     return result;
 }
 
 
+// cmp is positive: return true if at least one of the values matches the pattern
+// cmp is negative: return true if neither of the values matches the pattern
 bool match_string(const std::vector<std::string> & values, QueryCmp cmp, const std::string & pattern) {
-    bool result = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & value : values) {
-        if (match_string(value, cmp, pattern)) {
-            result = true;
-            break;
+        if (match_string(value, cmp, pattern) != result) {
+            return !result;
         }
     }
     return result;
 }
 
 
+// cmp is positive: return true if at least one of the values matches at least one of the patterns
+// cmp is negative: return true if none of the values matches none of the patterns
 bool match_string(const std::vector<std::string> & values, QueryCmp cmp, const std::vector<std::string> & patterns) {
-    bool result = false;
-    bool found = false;
+    bool result = (cmp & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     for (auto & value : values) {
         for (auto & pattern : patterns) {
-            if (match_string(value, cmp, pattern)) {
-                result = true;
-                found = true;
-                break;
+            if (match_string(value, cmp, pattern) != result) {
+                return !result;
             }
-        }
-        if (found) {
-            break;
         }
     }
     return result;

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -113,7 +113,9 @@ void PackageSack::Impl::load_config_excludes_includes(bool only_main) {
     if (!only_main) {
         libdnf::repo::RepoQuery rq(base);
         rq.filter_enabled(true);
-        rq.filter_id(disable_excludes, libdnf::sack::QueryCmp::NOT_GLOB);
+        if (!disable_excludes.empty()) {
+            rq.filter_id(disable_excludes, libdnf::sack::QueryCmp::NOT_GLOB);
+        }
         for (const auto & repo : rq) {
             if (!repo->get_config().includepkgs().get_value().empty()) {
                 repo->set_use_includes(true);


### PR DESCRIPTION
rq.filter_id(disable_excludes, libdnf::sack::QueryCmp::NOT_GLOB) in case of empty `disable_excludes` filters out all repositories.

Resolves https://github.com/rpm-software-management/dnf5/issues/233