### PR TITLE
Make distrosync as a targeted operation

### DIFF
--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -305,7 +305,7 @@ inline void GoalPrivate::add_distro_sync(libdnf::solv::IdQueue & queue, bool str
     Id what = get_rpm_pool().queuetowhatprovides(queue);
     staging.push_back(
         SOLVER_DISTUPGRADE | SOLVER_SOLVABLE_ONE_OF | SOLVER_SETARCH | SOLVER_SETEVR | (strict ? 0 : SOLVER_WEAK) |
-            (best ? SOLVER_FORCEBEST : 0) | (clean_deps ? SOLVER_CLEANDEPS : 0),
+            (best ? SOLVER_FORCEBEST : 0) | (clean_deps ? SOLVER_CLEANDEPS : 0) | SOLVER_TARGETED,
         what);
 }
 


### PR DESCRIPTION
DNF provides all candidates for transaction to libsolv, therefore we have to force libsolv to use only those candidates for the job solution => to make job TARGETED. If distrosync or upgrade job is not marked as TARGETED explicitly, libsolv mark as TARGETED job without installed package in the set of candidates.

The patch unify upgrade and distrosync flags in DNF5 => using SOLVER_TARGETED.

Resolves: https://github.com/rpm-software-management/dnf5/issues/222