### PR TITLE
Implementation of autodetecting modular platform ID

### DIFF
--- a/include/libdnf/module/module_item.hpp
+++ b/include/libdnf/module/module_item.hpp
@@ -228,6 +228,9 @@ private:
     void create_dependencies() const;
     void create_solvable_and_dependencies();
 
+    static void create_platform_solvable(
+        const ModuleSackWeakPtr & module_sack, const std::string & name, const std::string & stream);
+
     // Corresponds to one yaml document
     _ModulemdModuleStream * md_stream;
 

--- a/include/libdnf/module/module_item.hpp
+++ b/include/libdnf/module/module_item.hpp
@@ -228,6 +228,10 @@ private:
     void create_dependencies() const;
     void create_solvable_and_dependencies();
 
+    /// @brief Create platform solvable. Intended to be used for autodetecting modular platform ID.
+    /// @param module_sack Reference to a modular sack where the target pool with solvables is located.
+    /// @param name Platform name.
+    /// @param stream Platform stream.
     static void create_platform_solvable(
         const ModuleSackWeakPtr & module_sack, const std::string & name, const std::string & stream);
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -269,7 +269,7 @@ class ConfigMain::Impl {
     OptionString comment{nullptr};
     OptionBool downloadonly{false};  // runtime only option
     OptionBool ignorearch{false};
-    OptionString module_platform_id{nullptr};
+    OptionString module_platform_id{nullptr, ".+:.+", false};
     OptionBool module_stream_switch{false};
     OptionBool module_obsoletes{false};
 

--- a/libdnf/module/module_item.cpp
+++ b/libdnf/module/module_item.cpp
@@ -329,6 +329,7 @@ std::string ModuleItem::get_yaml() const {
 }
 
 
+/// A common function to create a solvable based on passed parameters.
 static void create_solvable_worker(
     Pool * pool,
     Solvable * solvable,

--- a/libdnf/module/module_sack_impl.hpp
+++ b/libdnf/module/module_sack_impl.hpp
@@ -118,7 +118,9 @@ private:
     std::unique_ptr<libdnf::solv::SolvMap> excludes;
     std::map<Id, ModuleItem *> active_modules;
 
-    // Autodetection of platform id. Returns a pair with detected name and stream.
+    /// @brief Method for autodetection of the platform id.
+    /// @return If platform id was detected, it returns a pair where the first item is the platform
+    ///         module name and second is the platform stream. Otherwise std::nullopt is returned.
     std::optional<std::pair<std::string, std::string>> detect_platform_name_and_stream() const;
 };
 


### PR DESCRIPTION
Platform ID for modules is automatically detected based on the following values in given order sorted by priority:
1. Use `module_platform_id` configuration option value, if it is explicitly set up.
2. Parse `Provides` value from the latest available package in enabled repositories.
3. Parse `Provides` value from the latest installed package on the local system.
4. Parse `PLATFORM_ID` value from `os-release` files on the local system.

The logic is implemented based on the original [PR](https://github.com/rpm-software-management/libdnf/pull/712) from `libdnf` component.