### PR TITLE
reposack: No checksums for cmdline repo packages

### DIFF
--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -88,8 +88,10 @@ public:
 
     /// Add given paths to comdline repository.
     /// @param paths Vector of paths to rpm files to be inserted to cmdline repo. Can contain paths to local files or URLs of remote rpm files. Specifications that are neither file paths, nor URLs are ignored.
+    /// @param calculate_checksum Whether libsolv should calculate and store checksum of added packages. Setting to true significantly reduces performance.
     /// @return Map path->rpm::Package which maps input path to newly created Package object in cmdline repo
-    std::map<std::string, libdnf::rpm::Package> add_cmdline_packages(const std::vector<std::string> & paths);
+    std::map<std::string, libdnf::rpm::Package> add_cmdline_packages(
+        const std::vector<std::string> & paths, bool calculate_checksum = false);
 
     /// @return `true` if the system repository has been initialized (via `get_system_repo()`).
     bool has_system_repo() const noexcept { return system_repo; }

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -88,7 +88,8 @@ RepoWeakPtr RepoSack::get_cmdline_repo() {
 }
 
 
-std::map<std::string, libdnf::rpm::Package> RepoSack::add_cmdline_packages(const std::vector<std::string> & paths) {
+std::map<std::string, libdnf::rpm::Package> RepoSack::add_cmdline_packages(
+    const std::vector<std::string> & paths, bool calculate_checksum) {
     // find remote URLs and local file paths in the input
     std::vector<std::string> rpm_urls;
     std::vector<std::string> rpm_filepaths;
@@ -156,14 +157,14 @@ std::map<std::string, libdnf::rpm::Package> RepoSack::add_cmdline_packages(const
 
         // fill the command line repo with downloaded URLs
         for (const auto & [url, path] : url_to_path) {
-            path_to_package.emplace(url, cmdline_repo->add_rpm_package(path.string(), true));
+            path_to_package.emplace(url, cmdline_repo->add_rpm_package(path.string(), calculate_checksum));
         }
     }
 
     // fill the command line repo with local files
     for (const auto & path : rpm_filepaths) {
         if (!path_to_package.contains(path)) {
-            path_to_package.emplace(path, cmdline_repo->add_rpm_package(path, true));
+            path_to_package.emplace(path, cmdline_repo->add_rpm_package(path, calculate_checksum));
         }
     }
 


### PR DESCRIPTION
Calculating checksums of a package in libsolv is pretty expensive and we do not need this feature for cmdline repo packages.

Related: https://github.com/rpm-software-management/dnf5/issues/237