### PR TITLE
rpm: Correctly order rpm transaction items

### DIFF
--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -163,6 +163,11 @@ void Transaction::fill(const base::Transaction & transaction) {
         }
     }
     libdnf_assert(implicit_ts_elements.empty(), "The rpm transaction contains more elements than requested");
+
+    // generate ordering for the rpm transaction
+    if (rpmtsOrder(ts)) {
+        throw TransactionError(M_("Failed to order the rpm transaction."));
+    };
 }
 
 int Transaction::run() {


### PR DESCRIPTION
Once the transaction is filled, it must be sorted correctly. Otherwise the transaction (especially the "pre" scriptlets) may end up with unsatisfied dependencies.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2164378