### PR TITLE
Add `transaction.test()`

### DIFF
--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -81,6 +81,14 @@ public:
     /// @return the transaction groups.
     std::vector<libdnf::base::TransactionGroup> & get_transaction_groups() const;
 
+    /// Check the transaction by running it with RPMTRANS_FLAG_TEST. The import
+    /// of any necessary public keys will be requested, and transaction checks
+    /// will be performed, but no changes to the installed package set will be
+    /// made. These checks are performed automatically by run(); it is
+    /// redundant to call test() before calling run().
+    /// @return An enum describing the result of the transaction
+    TransactionRunResult test();
+
     /// Prepare, check and run the transaction. All the transaction metadata
     /// (`description` and `comment`) are stored in the history database.
     ///

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -72,6 +72,8 @@ public:
         GoalProblem problem,
         std::vector<std::vector<std::pair<libdnf::ProblemRules, std::vector<std::string>>>> problems);
 
+    TransactionRunResult test();
+
     TransactionRunResult run(
         std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
         const std::string & description,
@@ -97,6 +99,13 @@ private:
 
     // history db transaction id
     int64_t history_db_id = 0;
+
+    TransactionRunResult _run(
+        std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
+        const std::string & description,
+        const std::optional<uint32_t> user_id,
+        const std::string & comment,
+        const bool test_only);
 };
 
 


### PR DESCRIPTION
Allows dry running a transaction using `RPMTRANS_FLAG_TEST` by calling `transaction.verify()`, regardless of what tsflags are set on the base config. So you could run:

```
    libdnf::Goal goal(base);
    auto transaction = goal.resolve();
    auto result = transaction.verify()
    // check result of verification, possibly change the transaction

    transaction.run(...)
```

without creating a whole new `base` with the RPMTRANS_FLAG_TEST flag set.

Example use case: https://bugzilla.redhat.com/show_bug.cgi?id=2109660