### PR TITLE
dnfdaemon: Fix double loading of system repo

### DIFF
--- a/dnf5daemon-client/context.cpp
+++ b/dnf5daemon-client/context.cpp
@@ -77,27 +77,4 @@ void Context::on_repositories_ready(const bool & result) {
 }
 
 
-dnfdaemon::RepoStatus Context::wait_for_repos() {
-    if (repositories_status == dnfdaemon::RepoStatus::NOT_READY) {
-        auto callback = [this](const sdbus::Error * error, const bool & result) {
-            if (error == nullptr) {
-                // No error
-                this->on_repositories_ready(result);
-            } else {
-                // We got a D-Bus error...
-                this->on_repositories_ready(false);
-            }
-        };
-        repositories_status = dnfdaemon::RepoStatus::PENDING;
-        session_proxy->callMethodAsync("read_all_repos")
-            .onInterface(dnfdaemon::INTERFACE_BASE)
-            .withTimeout(static_cast<uint64_t>(-1))
-            .uponReplyInvoke(callback);
-    }
-    while (repositories_status == dnfdaemon::RepoStatus::PENDING) {
-        sleep(1);
-    }
-    return repositories_status;
-}
-
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/context.hpp
+++ b/dnf5daemon-client/context.hpp
@@ -47,9 +47,6 @@ public:
     void init_session(sdbus::IConnection & connection);
     sdbus::ObjectPath & get_session_object_path() { return session_object_path; };
 
-    // initialize repository metadata loading on server side and wait for results
-    dnfdaemon::RepoStatus wait_for_repos();
-
     // signal handlers
     void on_repositories_ready(const bool & result);
 


### PR DESCRIPTION
There are paths in dbus workflows that will cause system repo to be
loaded twice resulting in assertion error:
```
libdnf/./solv/pool.hpp:228: void libdnf::solv::Pool::swap_considered_map(libdnf::solv::SolvMap&): Assertion 'other_considered_map.allocated_size() == 0 || other_considered_map.allocated_size() >= get_nsolvables()' failed: The considered map is smaller than the number of solvables in the pool
```
Resolves: https://github.com/rpm-software-management/dnf5/issues/229