### PR TITLE
swig: Fixes for transaction related bindings

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -63,10 +63,7 @@
 %include "libdnf/base/transaction.hpp"
 %include "libdnf/base/transaction_package.hpp"
 
-%ignore std::vector<libdnf::base::TransactionPackage>::vector(size_type);
-%ignore std::vector<libdnf::base::TransactionPackage>::vector(unsigned int);
-%ignore std::vector<libdnf::base::TransactionPackage>::resize;
-%template(VectorTransactionPackage) std::vector<libdnf::base::TransactionPackage>;
+%template(VectorBaseTransactionPackage) std::vector<libdnf::base::TransactionPackage>;
 
 %include "libdnf/base/goal.hpp"
 %include "libdnf/base/goal_elements.hpp"

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -43,6 +43,10 @@
     }
 }
 
+%ignore std::vector::vector(size_type);
+%ignore std::vector::vector(unsigned int);
+%ignore std::vector::resize;
+
 %template(VectorString) std::vector<std::string>;
 #if defined(SWIGPYTHON) || defined(SWIGRUBY)
 %template(SetString) std::set<std::string>;

--- a/bindings/libdnf5/transaction.i
+++ b/bindings/libdnf5/transaction.i
@@ -21,6 +21,7 @@
     #include "libdnf/transaction/transaction_item_state.hpp"
 
     // transaction items
+    #include "libdnf/transaction/transaction_item.hpp"
     #include "libdnf/transaction/comps_group.hpp"
     #include "libdnf/transaction/comps_environment.hpp"
     #include "libdnf/transaction/rpm_package.hpp"
@@ -39,6 +40,7 @@
 %include "libdnf/transaction/transaction_item_state.hpp"
 
 // transaction items
+%include "libdnf/transaction/transaction_item.hpp"
 %include "libdnf/transaction/comps_group.hpp"
 %include "libdnf/transaction/comps_environment.hpp"
 %include "libdnf/transaction/rpm_package.hpp"
@@ -48,3 +50,6 @@
 
 // transaction
 %include "libdnf/transaction/transaction.hpp"
+
+%template(VectorTransaction) std::vector<libdnf::transaction::Transaction>;
+%template(VectorTransactionPackage) std::vector<libdnf::transaction::Package>;

--- a/include/libdnf/repo/download_callbacks.hpp
+++ b/include/libdnf/repo/download_callbacks.hpp
@@ -45,14 +45,14 @@ public:
     virtual void * add_new_download(void * user_data, const char * description, double total_to_download);
 
     /// Download progress callback.
-    /// @param user_cb_data Associated user data obtained from new_download.
+    /// @param user_cb_data Associated user data obtained from add_new_download.
     /// @param total_to_download Total number of bytes to download.
     /// @param downloaded Number of bytes downloaded.
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
     virtual int progress(void * user_cb_data, double total_to_download, double downloaded);
 
     /// End of download callback.
-    /// @param user_cb_data Associated user data obtained from new_download.
+    /// @param user_cb_data Associated user data obtained from add_new_download.
     /// @param status The transfer status.
     /// @param msg The error message in case of error.
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
@@ -60,7 +60,7 @@ public:
 
 
     /// Mirror failure callback.
-    /// @param user_cb_data Associated user data obtained from new_download.
+    /// @param user_cb_data Associated user data obtained from add_new_download.
     /// @param msg Error message.
     /// @param url Failed mirror URL.
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.


### PR DESCRIPTION
Allow accessing methods from `TransactionItem` base class and iterating over transaction history items.