### PR TITLE
Handle std::filesystem::directory_iterator errors

### DIFF
--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -120,10 +120,15 @@ void Plugins::load_plugins(const std::string & dir_path) {
     auto logger = context->base.get_logger();
 
     std::vector<std::filesystem::path> lib_paths;
-    for (const auto & p : std::filesystem::directory_iterator(dir_path)) {
+    std::error_code ec;
+    for (const auto & p : std::filesystem::directory_iterator(dir_path, ec)) {
         if ((p.is_regular_file() || p.is_symlink()) && p.path().extension() == ".so") {
             lib_paths.emplace_back(p.path());
         }
+    }
+    if (ec) {
+        logger->warning("Cannot read dnf5 plugins directory \"{}\": {}", dir_path, ec.message());
+        return;
     }
     std::sort(lib_paths.begin(), lib_paths.end());
 

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -243,10 +243,15 @@ void PythonPluginLoader::load_plugins_from_dir(const fs::path & dir_path) {
         throw std::runtime_error("PythonPluginLoader::load_from_dir() dir_path cannot be empty");
 
     std::vector<fs::path> lib_names;
-    for (auto & p : std::filesystem::directory_iterator(dir_path)) {
+    std::error_code ec;
+    for (auto & p : std::filesystem::directory_iterator(dir_path, ec)) {
         if ((p.is_regular_file() || p.is_symlink()) && p.path().extension() == ".py") {
             lib_names.emplace_back(p.path());
         }
+    }
+    if (ec) {
+        logger.warning("PythonPluginLoader: Cannot read plugins directory \"{}\": {}", dir_path.string(), ec.message());
+        return;
     }
     std::sort(lib_names.begin(), lib_names.end());
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -102,11 +102,16 @@ void Base::load_config_from_file() {
 
 void Base::load_config_from_dir(const std::string & dir_path) {
     std::vector<std::filesystem::path> paths;
-    for (auto & dentry : std::filesystem::directory_iterator(dir_path)) {
+    std::error_code ec;
+    for (auto & dentry : std::filesystem::directory_iterator(dir_path, ec)) {
         auto & path = dentry.path();
         if (path.extension() == ".conf") {
             paths.push_back(path);
         }
+    }
+    if (ec) {
+        log_router.warning("Cannot read configuration from directory \"{}\": {}", dir_path, ec.message());
+        return;
     }
     std::sort(paths.begin(), paths.end());
     for (auto & path : paths) {

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -367,7 +367,12 @@ void RepoSack::create_repos_from_config_file() {
 }
 
 void RepoSack::create_repos_from_dir(const std::string & dir_path) {
-    std::filesystem::directory_iterator di(dir_path);
+    std::error_code ec;
+    std::filesystem::directory_iterator di(dir_path, ec);
+    if (ec) {
+        base->get_logger()->warning("Cannot read repositories from directory \"{}\": {}", dir_path, ec.message());
+        return;
+    }
     std::vector<std::filesystem::path> paths;
     for (auto & dentry : di) {
         auto & path = dentry.path();

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -418,7 +418,8 @@ void GoalPrivate::write_debugdata(const std::filesystem::path & abs_dest_dir) {
     libdnf_assert_goal_resolved();
 
     // Removes old debug data, if it exists.
-    for (const auto & dir_entry : std::filesystem::directory_iterator(abs_dest_dir)) {
+    std::error_code ec;
+    for (const auto & dir_entry : std::filesystem::directory_iterator(abs_dest_dir, ec)) {
         std::filesystem::remove(dir_entry);
     }
 


### PR DESCRIPTION
Setting *dir config options to non-existing or non-accessible directory leads to unnecessary crash.
In case of reposdir also a warning is written to the log.

Resolves: https://github.com/rpm-software-management/dnf5/issues/249