### PR TITLE
Set POOL_FLAG_WHATPROVIDESWITHDISABLED to libsolv pool

### DIFF
--- a/libdnf/module/module_sack_impl.hpp
+++ b/libdnf/module/module_sack_impl.hpp
@@ -38,7 +38,11 @@ class ModuleGoalPrivate;
 
 class ModuleSack::Impl {
 public:
-    Impl(const BaseWeakPtr & base) : base(base), module_metadata(base), pool(pool_create()) {}
+    /// Create libsolv pool and set POOL_FLAG_WHATPROVIDESWITHDISABLED to ensure excluded packages are not taken as
+    /// candidates for solver
+    Impl(const BaseWeakPtr & base) : base(base), module_metadata(base), pool(pool_create()) {
+        pool_set_flag(pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
+    }
     ~Impl() { pool_free(pool); }
 
     const std::vector<std::unique_ptr<ModuleItem>> & get_modules();

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -77,7 +77,12 @@ private:
 
 class Pool {
 public:
-    Pool() : considered(0) { pool = pool_create(); }
+    /// Create libsolv pool and set POOL_FLAG_WHATPROVIDESWITHDISABLED to ensure excluded packages are not taken as
+    /// candidates for solver
+    Pool() : considered(0) {
+        pool = pool_create();
+        pool_set_flag(pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
+    }
 
     Pool(const Pool & pool) = delete;
     Pool & operator=(const Pool & pool) = delete;


### PR DESCRIPTION
POOL_FLAG_WHATPROVIDESWITHDISABLED ensures that excluded packages are not taken as candidates for solver. This is specific behavior is unique for DNF, because we runs make provides ready on top of all packages including excluded packages.

Resolves: https://github.com/openSUSE/libsolv/issues/518