### PR TITLE
PackageQuery::filter_unneeded() and wrapper for libsolv Solver class

### DIFF
--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -611,7 +611,7 @@ public:
     /// @param timestamp Only packages built after this will pass
     void filter_recent(const time_t timestamp);
 
-    /// Keep in the query only user-installed packages.
+    /// Keep in the query only installed packages that are user-installed.
     void filter_userinstalled();
 
     /// Filter unneeded packages. Unneeded packages are those which are installed as

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -611,6 +611,9 @@ public:
     /// @param timestamp Only packages built after this will pass
     void filter_recent(const time_t timestamp);
 
+    /// Keep in the query only user-installed packages.
+    void filter_userinstalled();
+
     /// Filter unneeded packages. Unneeded packages are those which are installed as
     /// dependencies and are not required by any user-installed package any more.
     void filter_unneeded();

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -611,6 +611,10 @@ public:
     /// @param timestamp Only packages built after this will pass
     void filter_recent(const time_t timestamp);
 
+    /// Filter unneeded packages. Unneeded packages are those which are installed as
+    /// dependencies and are not required by any user-installed package any more.
+    void filter_unneeded();
+
     // TODO(jmracek) return std::pair<bool, std::unique_ptr<libdnf::rpm::Nevra>>
     // @replaces libdnf/sack/query.hpp:method:std::pair<bool, std::unique_ptr<Nevra>> filterSubject(const char * subject, HyForm * forms, bool icase, bool with_nevra, bool with_provides, bool with_filenames);
     std::pair<bool, libdnf::rpm::Nevra> resolve_pkg_spec(

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../module/module_sack_impl.hpp"
 #include "repo_cache_private.hpp"
 #include "rpm/package_sack_impl.hpp"
+#include "solv/solver.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
 #include "utils/string.hpp"
 #include "utils/url.hpp"
@@ -320,20 +321,8 @@ void RepoSack::update_and_load_enabled_repos(bool load_system) {
 
 
 void RepoSack::dump_debugdata(const std::string & dir) {
-    Solver * solver = solver_create(*get_rpm_pool(base));
-
-    try {
-        std::filesystem::create_directory(dir);
-
-        int ret = testcase_write(solver, dir.c_str(), 0, NULL, NULL);
-        if (!ret) {
-            throw SystemError(errno, M_("Failed to write debug data to {}"), dir);
-        }
-    } catch (...) {
-        solver_free(solver);
-        throw;
-    }
-    solver_free(solver);
+    libdnf::solv::Solver solver{get_rpm_pool(base)};
+    solver.write_debugdata(dir, false);
 }
 
 

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -2456,6 +2456,17 @@ void PackageQuery::filter_recent(const time_t timestamp) {
     }
 }
 
+void PackageQuery::filter_userinstalled() {
+    filter_installed();
+    for (const auto & pkg : *this) {
+        auto reason = pkg.get_reason();
+        if (reason == libdnf::transaction::TransactionItemReason::WEAK_DEPENDENCY ||
+            reason == libdnf::transaction::TransactionItemReason::DEPENDENCY) {
+            p_impl->remove_unsafe(pkg.get_id().id);
+        }
+    }
+}
+
 void PackageQuery::filter_unneeded() {
     auto & pool = get_rpm_pool(p_impl->base);
 

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -2457,14 +2457,17 @@ void PackageQuery::filter_recent(const time_t timestamp) {
 }
 
 void PackageQuery::filter_userinstalled() {
+    auto & pool = get_rpm_pool(p_impl->base);
+    libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
     filter_installed();
     for (const auto & pkg : *this) {
         auto reason = pkg.get_reason();
-        if (reason == libdnf::transaction::TransactionItemReason::WEAK_DEPENDENCY ||
-            reason == libdnf::transaction::TransactionItemReason::DEPENDENCY) {
-            p_impl->remove_unsafe(pkg.get_id().id);
+        if (reason != libdnf::transaction::TransactionItemReason::WEAK_DEPENDENCY &&
+            reason != libdnf::transaction::TransactionItemReason::DEPENDENCY) {
+            filter_result.add_unsafe(pkg.get_id().id);
         }
     }
+    *p_impl &= filter_result;
 }
 
 void PackageQuery::filter_unneeded() {

--- a/libdnf/solv/solver.cpp
+++ b/libdnf/solv/solver.cpp
@@ -1,0 +1,152 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "solver.hpp"
+
+#include "utils/bgettext/bgettext-mark-domain.h"
+
+#include <filesystem>
+
+extern "C" {
+#include <solv/solver.h>
+#include <solv/testcase.h>
+}
+
+#define solver_initialized_assert() libdnf_assert(solver, "Solver is not initialized.")
+
+
+namespace libdnf::solv {
+
+Solver::Solver(Pool & pool) {
+    solver = ::solver_create(*pool);
+}
+
+Solver::~Solver() {
+    if (solver) {
+        ::solver_free(solver);
+    }
+}
+
+void Solver::init(::Pool * pool) {
+    if (solver) {
+        ::solver_free(solver);
+    }
+    solver = ::solver_create(pool);
+}
+
+void Solver::init(Pool & pool) {
+    init(*pool);
+}
+
+void Solver::reset() {
+    if (solver) {
+        ::solver_free(solver);
+        solver = nullptr;
+    }
+}
+
+void Solver::write_debugdata(std::filesystem::path debug_dir, bool with_transaction) {
+    solver_initialized_assert();
+    std::error_code ec;
+    std::filesystem::create_directories(debug_dir, ec);
+    for (const auto & dir_entry : std::filesystem::directory_iterator(debug_dir, ec)) {
+        std::filesystem::remove(dir_entry);
+    }
+    auto ret = ::testcase_write(
+        solver,
+        debug_dir.c_str(),
+        with_transaction ? TESTCASE_RESULT_TRANSACTION | TESTCASE_RESULT_PROBLEMS : 0,
+        NULL,
+        NULL);
+    if (ret == 0) {
+        const auto * libsolv_err_msg = ::pool_errstr(solver->pool);
+        throw RuntimeError(M_("Writing debugsolver data into \"{}\" failed: {}"), debug_dir.native(), libsolv_err_msg);
+    }
+}
+
+int Solver::solve(IdQueue & job) {
+    solver_initialized_assert();
+    return ::solver_solve(solver, &job.get_queue());
+}
+
+IdQueue Solver::get_unneeded() {
+    solver_initialized_assert();
+    IdQueue unneeded_queue;
+    ::pool_createwhatprovides(solver->pool);
+    ::solver_get_unneeded(solver, &unneeded_queue.get_queue(), 0);
+    return unneeded_queue;
+}
+
+int Solver::set_flag(int flag, int value) {
+    solver_initialized_assert();
+    return ::solver_set_flag(solver, flag, value);
+}
+
+int Solver::get_decisionlevel(Id p) {
+    solver_initialized_assert();
+    return ::solver_get_decisionlevel(solver, p);
+}
+
+::Transaction * Solver::create_transaction() {
+    solver_initialized_assert();
+    return ::solver_create_transaction(solver);
+}
+
+unsigned int Solver::problem_count() {
+    solver_initialized_assert();
+    return ::solver_problem_count(solver);
+}
+
+IdQueue Solver::findallproblemrules(Id problem) {
+    solver_initialized_assert();
+    IdQueue rules;
+    ::solver_findallproblemrules(solver, problem, &rules.get_queue());
+    return rules;
+}
+
+IdQueue Solver::allruleinfos(Id rid) {
+    solver_initialized_assert();
+    IdQueue infos;
+    ::solver_allruleinfos(solver, rid, &infos.get_queue());
+    return infos;
+}
+
+const char * Solver::problemruleinfo2str(SolverRuleinfo type, Id source, Id target, Id dep) {
+    solver_initialized_assert();
+    return ::solver_problemruleinfo2str(solver, type, source, target, dep);
+}
+
+int Solver::describe_decision(Id p, Id * infop) {
+    solver_initialized_assert();
+    return ::solver_describe_decision(solver, p, infop);
+}
+
+SolverRuleinfo Solver::ruleclass(Id rid) {
+    solver_initialized_assert();
+    return ::solver_ruleclass(solver, rid);
+}
+
+IdQueue Solver::get_cleandeps() {
+    solver_initialized_assert();
+    IdQueue deps;
+    ::solver_get_cleandeps(solver, &deps.get_queue());
+    return deps;
+}
+
+}  // namespace libdnf::solv

--- a/libdnf/solv/solver.hpp
+++ b/libdnf/solv/solver.hpp
@@ -1,0 +1,120 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_SOLV_SOLVER_HPP
+#define LIBDNF_SOLV_SOLVER_HPP
+
+#include "id_queue.hpp"
+#include "pool.hpp"
+
+#include <filesystem>
+
+extern "C" {
+#include <solv/solver.h>
+}
+
+
+namespace libdnf::solv {
+
+class Solver {
+public:
+    Solver(){};
+    explicit Solver(Pool & pool);
+
+    Solver(const Solver & solver) = delete;
+    Solver & operator=(const Solver & solver) = delete;
+
+    ~Solver();
+
+    ::Solver * operator*() { return &*solver; }
+    ::Solver * operator*() const { return &*solver; }
+
+    ::Solver * operator->() { return &*solver; }
+    ::Solver * operator->() const { return &*solver; }
+
+    /// initialize or reinitialize `solver` with given pool
+    void init(Pool & pool);
+
+    /// Used in ModuleGoalPrivate::resolve()
+    /// If ModuleSack::Impl moves from libsolv `Pool *` to `libdnf::solv::Pool`,
+    /// this method can be dropped.
+    void init(::Pool * pool);
+
+    /// drop current `solver` object
+    void reset();
+
+    /// returns true if `solver` exists
+    bool is_initialized() { return solver != nullptr; };
+
+    /// Write solver debug data to given directory
+    /// @param with_transaction Whether transaction data are dumped
+    void write_debugdata(std::filesystem::path debug_dir, bool with_transaction = true);
+
+    /// Wrap libsolv solver_solve() method
+    /// @param job Solver job
+    int solve(IdQueue & job);
+
+    /// Wrap libsolv solver_get_unneeded() method
+    IdQueue get_unneeded();
+
+    /// Wrap libsolv solver_set_flag() method
+    /// @param flag Flag about to be set
+    /// @param value New value
+    int set_flag(int flag, int value);
+
+    /// Wrap libsolv solver_get_decisionlevel() method
+    int get_decisionlevel(Id p);
+
+    /// Wrap libsolv solver_create_transaction() method
+    ::Transaction * create_transaction();
+
+    /// Wrap libsolv solver_problem_count() method
+    unsigned int problem_count();
+
+    /// Wrap libsolv solver_findallproblemrules() method
+    /// @param problem Rules responsible for this problem are returned
+    IdQueue findallproblemrules(Id problem);
+
+    /// Wrap libsolv solver_allruleinfos() method
+    /// @param rid Rule id
+    IdQueue allruleinfos(Id rid);
+
+    /// Wrap libsolv solver_get_cleandeps() method
+    IdQueue get_cleandeps();
+
+    /// Wrap libsolv problemruleinfo2str() method
+    const char * problemruleinfo2str(SolverRuleinfo type, Id source, Id target, Id dep);
+
+    /// Wrap libsolv solver_describe_decision() method
+    /// @param p Solvable
+    /// @param infop Reason why solvable is installed or erased
+    int describe_decision(Id p, Id * infop);
+
+    /// Wrap libsolv solver_ruleclass() method
+    /// @param rid Rule id
+    SolverRuleinfo ruleclass(Id rid);
+
+protected:
+    ::Solver * solver{nullptr};
+};
+
+
+}  // namespace libdnf::solv
+
+#endif  // LIBDNF_SOLV_SOLVER_HPP

--- a/libdnf/transaction/Swdb.cpp
+++ b/libdnf/transaction/Swdb.cpp
@@ -465,23 +465,6 @@ Swdb::createCompsGroupItem()
 }
 */
 
-/**
- * Filter unneeded packages from pool
- *
- * \return list of user installed package IDs
- */
-void Swdb::filterUserinstalled(libdnf::rpm::PackageSet & installed) const {
-    // TODO(dmach): if performance is an issue, rewrite this using the libsolv layer
-    for (auto it = installed.begin(); it != installed.end(); it++) {
-        auto pkg = *it;
-        auto reason = Package::resolveTransactionItemReason(get_connection(), pkg.get_name(), pkg.get_arch(), -1);
-        // if not dep or weak, than consider it user installed
-        if (reason == TransactionItemReason::DEPENDENCY || reason == TransactionItemReason::WEAK_DEPENDENCY) {
-            installed.remove(pkg);
-        }
-    }
-}
-
 std::vector<int64_t> Swdb::searchTransactionsByRPM(const std::vector<std::string> & patterns) {
     return Package::searchTransactions(get_connection(), patterns);
 }

--- a/libdnf/transaction/Swdb.hpp
+++ b/libdnf/transaction/Swdb.hpp
@@ -123,11 +123,6 @@ public:
     void setReleasever(std::string value);
     void add_console_output_line(int file_descriptor, const std::string & line);
 
-    /**
-    * @brief Remove packages from PackageSet that were installed as Dependency or WEAK_DEPENDENCY
-    */
-    void filterUserinstalled(libdnf::rpm::PackageSet & installed) const;
-
     libdnf::utils::SQLite3 & get_connection() const { return *conn; }
 
     Transaction * get_transaction_in_progress() { return transactionInProgress.get(); }


### PR DESCRIPTION
- introduces new filter_unneeded for package queries. This is important for implementation of  `autoremove` and `list --autoremove` commands
- also wraps libsolv `Solver` class into `libdnf::solv::Solver`. This enables safer memory management and sharing the debugdata writing code.