### PR TITLE
Load config and reposdir from installroot

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -410,6 +410,13 @@ void RootCommand::set_argument_parser() {
     installroot->link_value(&config.get_installroot_option());
     global_options_group->register_argument(installroot);
 
+    auto use_host_environment = parser.add_new_named_arg("use-host-environment");
+    use_host_environment->set_long_name("use-host-environment");
+    use_host_environment->set_description("use configuration, reposdir, and vars from the host system rather than the installroot");
+    use_host_environment->set_const_value("true");
+    use_host_environment->link_value(&config.use_host_environment());
+    global_options_group->register_argument(use_host_environment);
+
     auto releasever = parser.add_new_named_arg("releasever");
     releasever->set_long_name("releasever");
     releasever->set_has_value(true);

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -30,21 +30,21 @@ relative to where all packages will be installed. Think of it like doing
 ``chroot <root> dnf``, except using ``--installroot`` allows ``DNF5`` to work 
 before the chroot is created.
 
-`cachedir`, `log` files, `releasever`, and `gpgkey` are taken from or stored in 
-the installroot. Gpgkeys are imported into the installroot from a path relative 
-to the host which can be specified in the repository section of configuration files.
+`cachedir`, `log` files, `releasever`, and `gpgkey` are taken from or stored in
+the installroot. GPG keys are imported into the installroot from a path
+relative to the host which can be specified in the repository section of
+configuration files.
 
-`configuration` file and `reposdir` are searched inside the installroot first. 
-If they are not present, they are taken from the host system. 
+`configuration` file, `reposdir`, and `vars` are taken from inside the
+installroot, unless the command-line argument ``--use-host-environment`` is
+passed, in which case the configuration and environment from the host system
+will be used.
 
-Note: When a path is specified within a command line argument (``--config=CONFIG_FILE_PATH`` 
-in case of `configuration` file and ``--setopt=reposdir=REPO_DIR_PATH`` for `reposdir`), then 
-this path is always relative to the host with no exceptions.
-
-`vars` are taken from the host system or installroot according to `reposdir`. When `reposdir` 
-path is specified within a command line argument, vars are taken from the installroot. 
-When `varsdir` paths are specified within the command line argument (``--setopt=varsdir=<reposdir>``) 
-then those path are always relative to the host with no exceptions.
+Note: When a path is specified within a command line argument
+(``--config=CONFIG_FILE_PATH`` in case of `configuration` file,
+``--setopt=reposdir=/path/to/repodir`` for `reposdir` or
+``--setopt=varsdir=/paths/to/varsdir`` for `vars`), then this path is always
+relative to the host with no exceptions.
 
 `pluginpath` and `pluginconfpath` are relative to the host. 
 

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -36,7 +36,7 @@ relative to the host which can be specified in the repository section of
 configuration files.
 
 `configuration` file, `reposdir`, and `vars` are taken from inside the
-installroot, unless the command-line argument ``--use-host-environment`` is
+installroot, unless the command-line argument ``--use-host-config`` is
 passed, in which case the configuration and environment from the host system
 will be used.
 

--- a/include/libdnf/common/sack/sack.hpp
+++ b/include/libdnf/common/sack/sack.hpp
@@ -34,6 +34,8 @@ class Sack {
 public:
     using DataItemWeakPtr = WeakPtr<T, false>;
 
+    std::size_t size() const noexcept { return data.size(); }
+
     // EXCLUDES
 
     const Set<DataItemWeakPtr> & get_excludes() const noexcept { return excludes; }

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -94,6 +94,8 @@ public:
     const OptionStringList & get_group_package_types_option() const;
     OptionStringSet & get_optional_metadata_types_option();
     const OptionStringSet & get_optional_metadata_types_option() const;
+    OptionBool & get_use_host_environment_option();
+    const OptionBool & get_use_host_environment_option() const;
 
     //  NOTE: If you set this to 2, then because it keeps the current
     // kernel it means if you ever install an "old" kernel it'll get rid

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -94,8 +94,8 @@ public:
     const OptionStringList & get_group_package_types_option() const;
     OptionStringSet & get_optional_metadata_types_option();
     const OptionStringSet & get_optional_metadata_types_option() const;
-    OptionBool & get_use_host_environment_option();
-    const OptionBool & get_use_host_environment_option() const;
+    OptionBool & get_use_host_config_option();
+    const OptionBool & get_use_host_config_option() const;
 
     //  NOTE: If you set this to 2, then because it keeps the current
     // kernel it means if you ever install an "old" kernel it'll get rid

--- a/include/libdnf/conf/option.hpp
+++ b/include/libdnf/conf/option.hpp
@@ -69,6 +69,7 @@ public:
         MAINCONFIG = 20,
         AUTOMATICCONFIG = 30,
         REPOCONFIG = 40,
+        INSTALLROOT = 45,
         PLUGINDEFAULT = 50,
         PLUGINCONFIG = 60,
         DROPINCONFIG = 65,

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -92,8 +92,7 @@ void Base::load_config_from_file(const std::string & path) {
 void Base::load_config_from_file() {
     std::filesystem::path conf_path{config.get_config_file_path_option().get_value()};
     const auto & conf_path_priority = config.get_config_file_path_option().get_priority();
-    if (!config.get_use_host_environment_option().get_value() &&
-        conf_path_priority < Option::Priority::COMMANDLINE) {
+    if (!config.get_use_host_config_option().get_value() && conf_path_priority < Option::Priority::COMMANDLINE) {
         conf_path = config.get_installroot_option().get_value() / conf_path.relative_path();
     }
     try {
@@ -132,8 +131,8 @@ void Base::load_config_from_dir(const std::string & dir_path) {
 
 void Base::load_config_from_dir() {
     std::filesystem::path conf_dir{libdnf::CONF_DIRECTORY};
-    if (!config.use_host_environment().get_value()) {
-        conf_dir = config.installroot().get_value() / conf_dir.relative_path();
+    if (!config.get_use_host_config_option().get_value()) {
+        conf_dir = config.get_installroot_option().get_value() / conf_dir.relative_path();
     }
 
     load_config_from_dir(conf_dir);
@@ -158,21 +157,21 @@ void Base::setup() {
 
     // Resolve installroot configuration
     std::string vars_installroot{"/"};
-    if (!config.use_host_environment().get_value()) {
+    if (!config.get_use_host_config_option().get_value()) {
         // Prepend installroot to each reposdir and varsdir
-        const std::filesystem::path installroot{config.installroot().get_value()};
+        const std::filesystem::path installroot{config.get_installroot_option().get_value()};
 
         std::vector<std::string> installroot_reposdirs;
-        for (const auto & reposdir : config.reposdir().get_value()) {
+        for (const auto & reposdir : config.get_reposdir_option().get_value()) {
             std::filesystem::path reposdir_path{reposdir};
             installroot_reposdirs.push_back((installroot / reposdir_path.relative_path()).string());
         }
-        config.reposdir().set(Option::Priority::INSTALLROOT, installroot_reposdirs);
+        config.get_reposdir_option().set(Option::Priority::INSTALLROOT, installroot_reposdirs);
 
         // Unless varsdir paths are specified on the command line, load vars
         // from the installroot
-        if (config.varsdir().get_priority() < Option::Priority::COMMANDLINE) {
-            vars_installroot = config.installroot().get_value();
+        if (config.get_varsdir_option().get_priority() < Option::Priority::COMMANDLINE) {
+            vars_installroot = config.get_installroot_option().get_value();
         }
     }
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -164,7 +164,7 @@ class ConfigMain::Impl {
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
     OptionNumber<std::int32_t> errorlevel{3, 0, 10};
     OptionPath installroot{"/", false, true};
-    OptionBool use_host_environment{false};
+    OptionBool use_host_config{false};
     OptionPath config_file_path{CONF_FILENAME};
     OptionBool plugins{true};
     OptionPath pluginpath{DEFAULT_LIBDNF5_PLUGINS_LIB_DIR};
@@ -349,7 +349,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("debuglevel", debuglevel);
     owner.opt_binds().add("errorlevel", errorlevel);
     owner.opt_binds().add("installroot", installroot);
-    owner.opt_binds().add("use_host_environment", use_host_environment);
+    owner.opt_binds().add("use_host_config", use_host_config);
     owner.opt_binds().add("config_file_path", config_file_path);
     owner.opt_binds().add("plugins", plugins);
     owner.opt_binds().add("pluginpath", pluginpath);
@@ -590,11 +590,11 @@ const OptionPath & ConfigMain::get_installroot_option() const {
     return p_impl->installroot;
 }
 
-OptionBool & ConfigMain::get_use_host_environment_option() {
-    return p_impl->use_host_environment;
+OptionBool & ConfigMain::get_use_host_config_option() {
+    return p_impl->use_host_config;
 }
-const OptionBool & ConfigMain::get_use_host_environment_option() const {
-    return p_impl->use_host_environment;
+const OptionBool & ConfigMain::get_use_host_config_option() const {
+    return p_impl->use_host_config;
 }
 
 OptionPath & ConfigMain::get_config_file_path_option() {

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -164,6 +164,7 @@ class ConfigMain::Impl {
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
     OptionNumber<std::int32_t> errorlevel{3, 0, 10};
     OptionPath installroot{"/", false, true};
+    OptionBool use_host_environment{false};
     OptionPath config_file_path{CONF_FILENAME};
     OptionBool plugins{true};
     OptionPath pluginpath{DEFAULT_LIBDNF5_PLUGINS_LIB_DIR};
@@ -348,6 +349,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("debuglevel", debuglevel);
     owner.opt_binds().add("errorlevel", errorlevel);
     owner.opt_binds().add("installroot", installroot);
+    owner.opt_binds().add("use_host_environment", use_host_environment);
     owner.opt_binds().add("config_file_path", config_file_path);
     owner.opt_binds().add("plugins", plugins);
     owner.opt_binds().add("pluginpath", pluginpath);
@@ -586,6 +588,13 @@ OptionPath & ConfigMain::get_installroot_option() {
 }
 const OptionPath & ConfigMain::get_installroot_option() const {
     return p_impl->installroot;
+}
+
+OptionBool & ConfigMain::get_use_host_environment_option() {
+    return p_impl->use_host_environment;
+}
+const OptionBool & ConfigMain::get_use_host_environment_option() const {
+    return p_impl->use_host_environment;
 }
 
 OptionPath & ConfigMain::get_config_file_path_option() {

--- a/libdnf/conf/vars.cpp
+++ b/libdnf/conf/vars.cpp
@@ -236,8 +236,9 @@ void Vars::set(const std::string & name, const std::string & value, Priority pri
 void Vars::load(const std::string & installroot, const std::vector<std::string> & directories) {
     load_from_env();
 
+    const std::filesystem::path installroot_path{installroot};
     for (const auto & dir : directories) {
-        load_from_dir(std::filesystem::path(installroot) / dir);
+        load_from_dir(installroot_path / std::filesystem::path(dir).relative_path());
     }
 
     detect_vars(installroot);


### PR DESCRIPTION
Loads dnf.conf and reposdir from the installroot, unless --use_root_config is passed. Resolves https://github.com/rpm-software-management/dnf5/issues/257 and https://github.com/rpm-software-management/dnf5/issues/248.

This behavior is different from the current behavior of DNF4. When given an installroot, DNF4 will look for a config file and reposdir in the installroot, but if they are not present it will fall back to the default config file and/or reposdir. In this PR we only consider the config file and reposdir in the installroot, regardless of whether the files are there.

When `--use_root_config` is passed, the setting of installroot will not affect the config file path or reposdir.

The reposdir taken from the installroot is given priority greater than that specified in dnf.conf, but less priority than a reposdir specified by a plugin, so that a plugin could still override the setting.

The config file path can still be overridden with the command-line argument `--config`. Perhaps a similar `--reposdir` argument would be useful too?

The documentation still needs to be updated to reflect the changed behavior and the new `--use_root_config` flag.



