### PR TITLE
nevra: Fix cmp_* comparators

### DIFF
--- a/include/libdnf/rpm/nevra.hpp
+++ b/include/libdnf/rpm/nevra.hpp
@@ -182,7 +182,26 @@ inline void copy_nevra_attributes(const F & from, T & to) {
 
 
 /// Compare alpha and numeric segments of two versions.
+/// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
 int rpmvercmp(const char * lhs, const char * rhs);
+
+
+/// Compare evr part of two objects
+/// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
+template <typename L, typename R>
+int evrcmp(const L & lhs, const R & rhs) {
+    int r = rpmvercmp(lhs.get_epoch().c_str(), rhs.get_epoch().c_str());
+    if (r != 0) {
+        return r;
+    }
+
+    r = rpmvercmp(lhs.get_version().c_str(), rhs.get_version().c_str());
+    if (r != 0) {
+        return r;
+    }
+
+    return rpmvercmp(lhs.get_release().c_str(), rhs.get_release().c_str());
+}
 
 
 /// Compare two objects by their Name, Epoch:Version-Release and Arch.
@@ -197,8 +216,8 @@ bool cmp_nevra(const T & lhs, const T & rhs) {
         return false;
     }
 
-    // names and equal, compare by evr using rpm's rpmvercmp()
-    r = rpmvercmp(lhs.get_evr().c_str(), rhs.get_evr().c_str());
+    // names are equal, compare by evr
+    r = evrcmp(lhs, rhs);
     if (r < 0) {
         return true;
     } else if (r > 0) {
@@ -234,11 +253,12 @@ bool cmp_naevr(const T & lhs, const T & rhs) {
         return false;
     }
 
-    // names and arches are equal, compare by evr using rpm's rpmvercmp()
-    r = rpmvercmp(lhs.get_evr().c_str(), rhs.get_evr().c_str());
+    // names and arches are equal, compare by evr
+    r = evrcmp(lhs, rhs);
     if (r < 0) {
         return true;
     }
+
     return false;
 };
 

--- a/test/libdnf/rpm/test_nevra.cpp
+++ b/test/libdnf/rpm/test_nevra.cpp
@@ -215,12 +215,63 @@ public:
 }  // namespace
 
 
+void NevraTest::test_evrcmp() {
+    TestPackage foo_0_1_1_noarch("foo-1-1.noarch");
+    TestPackage foo_1_1_1_noarch("foo-1:1-1.noarch");
+    TestPackage foo_0_2_1_noarch("foo-2-1.noarch");
+    TestPackage foo_0_1_2_noarch("foo-1-2.noarch");
+    TestPackage foo_0_1_4_noarch("foo-1-4.noarch");
+    TestPackage foo_0_1_1_1_noarch("foo-1.1-1.noarch");
+
+    // order by epoch
+    std::vector<TestPackage> actual = {foo_1_1_1_noarch, foo_0_2_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_2_1_noarch, foo_1_1_1_noarch}), actual);
+
+    // order by epoch - already ordered
+    actual = {foo_0_2_1_noarch, foo_1_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_2_1_noarch, foo_1_1_1_noarch}), actual);
+
+    // order by version
+    actual = {foo_0_2_1_noarch, foo_0_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_2_1_noarch}), actual);
+
+    // order by version - already ordered
+    actual = {foo_0_1_1_noarch, foo_0_2_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_2_1_noarch}), actual);
+
+    // order by release
+    actual = {foo_0_1_2_noarch, foo_0_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_1_2_noarch}), actual);
+
+    // order by release - already ordered
+    actual = {foo_0_1_1_noarch, foo_0_1_2_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_1_2_noarch}), actual);
+
+    // order by version (with minor version > release)
+    actual = {foo_0_1_1_1_noarch, foo_0_1_4_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
+
+    // order by version (with minor version > release) - already sorted
+    actual = {foo_0_1_4_noarch, foo_0_1_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
+}
+
 void NevraTest::test_cmp_nevra() {
     TestPackage foo_0_1_1_noarch("foo-1-1.noarch");
     TestPackage foo_1_1_1_noarch("foo-1:1-1.noarch");
     TestPackage foo_0_2_1_noarch("foo-2-1.noarch");
     TestPackage foo_0_1_2_noarch("foo-1-2.noarch");
     TestPackage foo_0_1_1_x86_64("foo-1-1.x86_64");
+    TestPackage foo_0_1_4_noarch("foo-1-4.noarch");
+    TestPackage foo_0_1_1_1_noarch("foo-1.1-1.noarch");
     TestPackage bar_0_1_1_noarch("bar-1-1.noarch");
 
     // order by name
@@ -272,6 +323,16 @@ void NevraTest::test_cmp_nevra() {
     actual = {foo_0_1_1_noarch, foo_0_1_1_x86_64};
     std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
     CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_1_1_x86_64}), actual);
+
+    // order by version (with minor version > release)
+    actual = {foo_0_1_1_1_noarch, foo_0_1_4_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
+
+    // order by version (with minor version > release) - already sorted
+    actual = {foo_0_1_4_noarch, foo_0_1_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_nevra<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
 }
 
 
@@ -281,6 +342,8 @@ void NevraTest::test_cmp_naevr() {
     TestPackage foo_0_2_1_noarch("foo-2-1.noarch");
     TestPackage foo_0_1_2_noarch("foo-1-2.noarch");
     TestPackage foo_0_1_0_x86_64("foo-1-0.x86_64");
+    TestPackage foo_0_1_4_noarch("foo-1-4.noarch");
+    TestPackage foo_0_1_1_1_noarch("foo-1.1-1.noarch");
     TestPackage bar_0_1_1_noarch("bar-1-1.noarch");
 
     // order by name
@@ -332,4 +395,14 @@ void NevraTest::test_cmp_naevr() {
     actual = {foo_0_1_1_noarch, foo_0_1_0_x86_64};
     std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_naevr<TestPackage>);
     CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_1_noarch, foo_0_1_0_x86_64}), actual);
+
+    // order by version (with minor version > release)
+    actual = {foo_0_1_1_1_noarch, foo_0_1_4_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_naevr<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
+
+    // order by version (with minor version > release) - already sorted
+    actual = {foo_0_1_4_noarch, foo_0_1_1_1_noarch};
+    std::sort(actual.begin(), actual.end(), libdnf::rpm::cmp_naevr<TestPackage>);
+    CPPUNIT_ASSERT_EQUAL(std::vector<TestPackage>({foo_0_1_4_noarch, foo_0_1_1_1_noarch}), actual);
 }

--- a/test/libdnf/rpm/test_nevra.hpp
+++ b/test/libdnf/rpm/test_nevra.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 class NevraTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(NevraTest);
     CPPUNIT_TEST(test_nevra);
+    CPPUNIT_TEST(test_evrcmp);
     CPPUNIT_TEST(test_cmp_nevra);
     CPPUNIT_TEST(test_cmp_naevr);
     CPPUNIT_TEST_SUITE_END();
@@ -37,6 +38,7 @@ public:
     void tearDown() override;
 
     void test_nevra();
+    void test_evrcmp();
     void test_cmp_nevra();
     void test_cmp_naevr();
 };


### PR DESCRIPTION
Current implementation used rpmvercmp() on the whole EVR. But unfortunatelly rpmvercmp does not do any NEVRA parsing, it just compares two strings, which led to incorrect results.

For example these packages are in the current code ordered wrong:

firefox-0:100.0-2.fc36.x86_64
firefox-0:109.0.1-1.fc36.x86_64

the reason is that rmpvercmp() correctly returns that '0:100.0-2.fc36' version string is higher than '0:109.0.1-1.fc36'. But what is true for strings is not true for EVR. We need to compare each part (epoch, version, and release) separately.
For this a new evrcmp() function is introduced.