### PR TITLE
Option "disable_multithreading", `repo::RepoSack` ctors and `repo::Repo::fetch_metadata` method private, fix/adjust unit tests

### DIFF
--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -46,6 +46,8 @@ public:
     const OptionNumber<std::int32_t> & debuglevel() const;
     OptionNumber<std::int32_t> & errorlevel();
     const OptionNumber<std::int32_t> & errorlevel() const;
+    OptionBool & disable_multithreading();
+    const OptionBool & disable_multithreading() const;
     OptionPath & installroot();
     const OptionPath & installroot() const;
     OptionPath & config_file_path();

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -131,11 +131,6 @@ public:
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.isLocal()
     bool is_local() const;
 
-    /// Downloads repository metadata from the origin or reads the local metadata cache if still valid.
-    /// @return true if fresh metadata were downloaded, false otherwise.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.load()
-    bool fetch_metadata();
-
     /// Reads metadata from local cache.
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.loadCache(bool throwExcept)
     void read_metadata_cache();
@@ -347,6 +342,11 @@ private:
     friend class FileDownloader;
     friend class PackageDownloader;
     friend class solv::Pool;
+
+    /// Downloads repository metadata from the origin or reads the local metadata cache if still valid.
+    /// @return true if fresh metadata were downloaded, false otherwise.
+    /// @replaces libdnf:repo/Repo.hpp:method:Repo.load()
+    bool fetch_metadata();
 
     void make_solv_repo();
 

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -37,9 +37,6 @@ using RepoSackWeakPtr = WeakPtr<RepoSack, false>;
 
 class RepoSack : public sack::Sack<Repo> {
 public:
-    explicit RepoSack(const libdnf::BaseWeakPtr & base) : base(base) {}
-    explicit RepoSack(libdnf::Base & base);
-
     /// Creates a new clear repository with default configuration.
     /// @param id The new repo id
     /// @return A weak pointer to the new repo
@@ -144,8 +141,12 @@ public:
     void enable_source_repos();
 
 private:
+    friend class libdnf::Base;
     friend class RepoQuery;
     friend class rpm::PackageSack;
+
+    explicit RepoSack(const libdnf::BaseWeakPtr & base) : base(base) {}
+    explicit RepoSack(libdnf::Base & base);
 
     WeakPtrGuard<RepoSack, false> sack_guard;
 

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -112,8 +112,12 @@ public:
     /// @param load_system Whether to load the system repository
     void update_and_load_enabled_repos(bool load_system);
 
-    /// Downloads (if necessary) repository metadata and loads them in parallel.
+    /// Downloads (if necessary) repository metadata and loads them.
     ///
+    /// It works in parallel unless multithreading is disabled with
+    /// the "disable_multithreading" configuration option.
+    ///
+    /// Multi-threaded version:
     /// Launches a thread that picks repos from a queue and loads them into
     /// memory (calling their `load()` method). Then iterates over `repos`,
     /// potentially downloads fresh metadata (by calling the
@@ -121,8 +125,13 @@ public:
     /// speeds up the process by loading repos into memory while others are being
     /// downloaded.
     ///
+    /// Single-threaded version:
+    /// Iterates over `repos`. Potentially downloads fresh metadata
+    /// (by calling the `download_metadata()` method) and then loads them into memory
+    /// (calling their `load()` method).
+    ///
     /// @param repos The repositories to update and load
-    void update_and_load_repos(libdnf::repo::RepoQuery & repos);
+    void update_and_load_repos(const libdnf::repo::RepoQuery & repos);
 
     RepoSackWeakPtr get_weak_ptr() { return RepoSackWeakPtr(this, &sack_guard); }
 
@@ -145,6 +154,9 @@ private:
     libdnf::repo::RepoWeakPtr get_cmdline_repo();
 
     void internalize_repos();
+
+    void update_and_load_repos_singlethreaded(const libdnf::repo::RepoQuery & repos);
+    void update_and_load_repos_multithreaded(const libdnf::repo::RepoQuery & repos);
 
     BaseWeakPtr base;
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -163,6 +163,7 @@ class ConfigMain::Impl {
 
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
     OptionNumber<std::int32_t> errorlevel{3, 0, 10};
+    OptionBool disable_multithreading{false};
     OptionPath installroot{"/", false, true};
     OptionPath config_file_path{CONF_FILENAME};
     OptionBool plugins{true};
@@ -347,6 +348,7 @@ class ConfigMain::Impl {
 ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("debuglevel", debuglevel);
     owner.opt_binds().add("errorlevel", errorlevel);
+    owner.opt_binds().add("disable_multithreading", disable_multithreading);
     owner.opt_binds().add("installroot", installroot);
     owner.opt_binds().add("config_file_path", config_file_path);
     owner.opt_binds().add("plugins", plugins);
@@ -579,6 +581,13 @@ OptionNumber<std::int32_t> & ConfigMain::errorlevel() {
 }
 const OptionNumber<std::int32_t> & ConfigMain::errorlevel() const {
     return p_impl->errorlevel;
+}
+
+OptionBool & ConfigMain::disable_multithreading() {
+    return p_impl->disable_multithreading;
+}
+const OptionBool & ConfigMain::disable_multithreading() const {
+    return p_impl->disable_multithreading;
 }
 
 OptionPath & ConfigMain::installroot() {

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -42,12 +42,12 @@ using fmt::format;
 
 libdnf::repo::RepoWeakPtr BaseTestCase::add_repo(const std::string & repoid, const std::string & repo_path, bool load) {
     auto repo = repo_sack->create_repo(repoid);
-
     repo->get_config().baseurl().set("file://" + repo_path);
 
     if (load) {
-        repo->fetch_metadata();
-        repo->load();
+        libdnf::repo::RepoQuery repos(base);
+        repos.filter_id(repoid);
+        repo_sack->update_and_load_repos(repos);
     }
 
     return repo;
@@ -220,6 +220,12 @@ libdnf::rpm::Package BaseTestCase::first_query_pkg(libdnf::rpm::PackageQuery & q
 
 void BaseTestCase::setUp() {
     TestCaseFixture::setUp();
+
+    // TODO(jrohel) If a thread is created (even empty), the unit test will fail during COPR build.
+    // Change the root directory is not permited. Really strange:
+    // 2023-02-14T12:11:06+0000 [6695] TRACE [rpm] entering chroot /tmp/libdnf5_unittest.wkCbFF/installroot/
+    // 2023-02-14T12:11:06+0000 [6695] ERROR [rpm] Unable to change root directory: Operation not permitted
+    base.get_config().disable_multithreading().set(true);
 
     // TODO we could use get_preconfigured_base() for this now, but that would
     // need changing the `base` member to a unique_ptr

--- a/test/libdnf/repo/test_repo_query.cpp
+++ b/test/libdnf/repo/test_repo_query.cpp
@@ -27,8 +27,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RepoQueryTest);
 
 void RepoQueryTest::test_query_basics() {
     auto repo_sack = base.get_repo_sack();
-    //libdnf::repo::RepoSack repo_sack(base);
-    //auto repo_sack_weak_ptr = repo_sack.get_weak_ptr();
 
     // Creates new repositories in the repo_sack
     auto repo1 = repo_sack->create_repo("repo1");

--- a/test/perl5/libdnf5/rpm/test_package_query.t
+++ b/test/perl5/libdnf5/rpm/test_package_query.t
@@ -29,6 +29,8 @@ use libdnf5::base;
 
 my $base = new libdnf5::base::Base();
 
+$base->get_config()->disable_multithreading()->set(1);
+
 # Sets path to cache directory.
 my $tmpdir = tempdir("libdnf5_perl5_unittest.XXXX", TMPDIR => 1, CLEANUP => 1);
 $base->get_config()->installroot()->set($libdnf5::conf::Option::Priority_RUNTIME, $tmpdir."/installroot");
@@ -40,7 +42,8 @@ $base->setup();
 my $repo_sack = $base->get_repo_sack();
 
 # Creates new repositories in the repo_sack
-my $repo = $repo_sack->create_repo("repomd-repo1");
+my $repoid = "repomd-repo1";
+my $repo = $repo_sack->create_repo($repoid);
 
 # Tunes repository configuration (baseurl is mandatory)
 my $project_source_dir = $ENV{"PROJECT_SOURCE_DIR"};
@@ -50,8 +53,9 @@ my $repo_cfg = $repo->get_config();
 $repo_cfg->baseurl()->set($libdnf5::conf::Option::Priority_RUNTIME, $baseurl);
 
 # fetch repo metadata and load it
-$repo->fetch_metadata();
-$repo->load();
+my $repos = new libdnf5::repo::RepoQuery($base);
+$repos->filter_id($repoid);
+$repo_sack->update_and_load_repos($repos);
 
 #test_size()
 {

--- a/test/perl5/libdnf5/rpm/test_package_query.t
+++ b/test/perl5/libdnf5/rpm/test_package_query.t
@@ -37,7 +37,7 @@ $base->get_config()->cachedir()->set($libdnf5::conf::Option::Priority_RUNTIME, $
 # Sets base internals according to configuration
 $base->setup();
 
-my $repo_sack = new libdnf5::repo::RepoSack($base);
+my $repo_sack = $base->get_repo_sack();
 
 # Creates new repositories in the repo_sack
 my $repo = $repo_sack->create_repo("repomd-repo1");

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -31,6 +31,9 @@ PROJECT_SOURCE_DIR = os.environ["PROJECT_SOURCE_DIR"]
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.base = libdnf5.base.Base()
+
+        self.base.get_config().disable_multithreading().set(True)
+
         self.temp_dir = tempfile.mkdtemp(prefix="libdnf5_python3_unittest.")
 
         self.base.get_config().installroot().set(os.path.join(self.temp_dir, "installroot"))
@@ -50,12 +53,12 @@ class BaseTestCase(unittest.TestCase):
         Add a repo from `repo_path`.
         """
         repo = self.repo_sack.create_repo(repoid)
-
         repo.get_config().baseurl().set("file://" + repo_path)
 
         if load:
-            repo.fetch_metadata()
-            repo.load()
+            repos = libdnf5.repo.RepoQuery(self.base)
+            repos.filter_id(repoid)
+            self.repo_sack.update_and_load_repos(repos)
 
         return repo
 

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -29,7 +29,8 @@ class TestRepo(base_test_case.BaseTestCase):
 
 
     def test_load_repo(self):
-        repo = self.add_repo_repomd("repomd-repo1", load=False)
+        repoid = "repomd-repo1"
+        repo = self.add_repo_repomd(repoid, load=False)
 
         class RepoCallbacks(libdnf5.repo.RepoCallbacks):
             start_cnt = 0
@@ -71,10 +72,12 @@ class TestRepo(base_test_case.BaseTestCase):
         # can be passed directly to repo.set_callbacks
         repo.set_callbacks(libdnf5.repo.RepoCallbacksUniquePtr(cbs))
 
-        repo.fetch_metadata()
+        repos = libdnf5.repo.RepoQuery(self.base)
+        repos.filter_id(repoid)
+        self.repo_sack.update_and_load_repos(repos)
 
         self.assertEqual(cbs.start_cnt, 1)
-        self.assertEqual(cbs.start_what, "repomd-repo1")
+        self.assertEqual(cbs.start_what, repoid)
 
         self.assertEqual(cbs.end_cnt, 1)
         self.assertEqual(cbs.end_error_message, None)
@@ -83,5 +86,3 @@ class TestRepo(base_test_case.BaseTestCase):
         self.assertEqual(cbs.fastest_mirror_cnt, 0)
         self.assertEqual(cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)
-
-        repo.load()

--- a/test/ruby/libdnf5/base_test_case.rb
+++ b/test/ruby/libdnf5/base_test_case.rb
@@ -31,6 +31,9 @@ PROJECT_SOURCE_DIR = ENV["PROJECT_SOURCE_DIR"]
 class BaseTestCase < Test::Unit::TestCase
     def setup()
         @base = Base::Base.new()
+
+        @base.get_config().disable_multithreading().set(true)
+
         @temp_dir = Dir.mktmpdir("libdnf5_ruby_unittest.")
 
         @base.get_config().installroot().set(File.join(@temp_dir, "installroot"))
@@ -50,12 +53,12 @@ class BaseTestCase < Test::Unit::TestCase
     # Add a repo from `repo_path`.
     def _add_repo(repoid, repo_path, load=true)
         repo = @repo_sack.create_repo(repoid)
-
         repo.get_config().baseurl().set("file://" + repo_path)
 
         if load
-          repo.fetch_metadata()
-          repo.load()
+          repos = Repo::RepoQuery.new(@base)
+          repos.filter_id(repoid)
+          @repo_sack.update_and_load_repos(repos)
         end
 
         return repo

--- a/test/ruby/libdnf5/repo/test_repo.rb
+++ b/test/ruby/libdnf5/repo/test_repo.rb
@@ -80,15 +80,18 @@ class TestRepo < BaseTestCase
     end
 
     def test_load_repo()
-        repo = add_repo_repomd("repomd-repo1", load=false)
+        repoid = "repomd-repo1"
+        repo = add_repo_repomd(repoid, load=false)
 
         cbs = RepoCallbacks.new()
         repo.set_callbacks(Repo::RepoCallbacksUniquePtr.new(cbs))
 
-        repo.fetch_metadata()
+        repos = Repo::RepoQuery.new(@base)
+        repos.filter_id(repoid)
+        @repo_sack.update_and_load_repos(repos)
 
         assert_equal(1, cbs.start_cnt)
-        assert_equal("repomd-repo1", cbs.start_what)
+        assert_equal(repoid, cbs.start_what)
 
         assert_equal(1, cbs.end_cnt)
         assert_equal(nil, cbs.end_error_message)
@@ -97,7 +100,5 @@ class TestRepo < BaseTestCase
         assert_equal(0, cbs.fastest_mirror_cnt)
         assert_equal(0, cbs.handle_mirror_failure_cnt)
         assert_equal(0, cbs.repokey_import_cnt)
-
-        repo.load()
     end
 end


### PR DESCRIPTION
- New configuration option "disable_multithreading".
- `RepoSack::update_and_load_repos`: Added single-threaded mode (used when multi-threaded mode is disabled
 by configuration option "disable_multithreading".
- Makes `repo::RepoSack` ctors and `repo::Repo::fetch_metadata` method private.
- Unit tests: Use `RepoSack::update_and_load_repos` method instead of `repo::Repo::fetch_metadata` and `repo::Repo::load` 
- Unit tests: Fix: Use "base.get_repo_sack" in all places
