### PR TITLE
PackageQuery: filter_nevra to accept more comparators

### DIFF
--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -182,11 +182,18 @@ public:
     /// @since 5.0
     void filter_nevra(const libdnf::rpm::Nevra & nevra, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    /// Filter packages by their `name-[epoch:]version-release.arch` attributes of the packages in the `package_set`.
+    /// Filter packages by their `name-[epoch:]version-release.arch` attributes of
+    /// the packages in the `package_set`.
+    /// Only packages whose name.arch is present in the `package_set` are taken into
+    /// account. Their epoch:version-release are then compared according to the
+    /// value of `cmp_type` with those in `package_set`.
+    /// Only the matching packages are kept in the query. In case `NOT` is used in
+    /// `cmp_type`, the matching packages are removed from the query.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
-    ///                         Supported values: `EQ`, `NEQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`,
+    ///                         and their combinations with `NOT`.
     /// @since 5.0
     void filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -317,6 +317,65 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query2));
 }
 
+void RpmPackageQueryTest::test_filter_nevra_packgset_cmp() {
+    add_repo_solv("solv-repo1");
+
+    // prepare query to compare packages with
+    PackageQuery patterns(base);
+    patterns.filter_nevra({"pkg-libs-1:1.2-4.x86_64"});
+    std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Pattern preparation failed", expected, to_vector(patterns));
+
+    {
+        // comparator EQ
+        PackageQuery query(base);
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::EQ);
+        std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("EQ comparator failed", expected, to_vector(query));
+    }
+
+    {
+        // comparator NEQ
+        PackageQuery query(base);
+        query.filter_name({"pkg-libs"});
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::NEQ);
+        std::vector<Package> expected = {get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("NEQ comparator failed", expected, to_vector(query));
+    }
+
+    {
+        // comparator LT
+        PackageQuery query(base);
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::LT);
+        std::vector<Package> expected = {get_pkg("pkg-libs-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("LT comparator failed", expected, to_vector(query));
+    }
+
+    {
+        // comparator LTE
+        PackageQuery query(base);
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::LTE);
+        std::vector<Package> expected = {get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("LTE comparator failed", expected, to_vector(query));
+    }
+
+    {
+        // comparator GT
+        PackageQuery query(base);
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::GT);
+        std::vector<Package> expected = {get_pkg("pkg-libs-1:1.3-4.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("GT comparator failed", expected, to_vector(query));
+    }
+
+    {
+        // comparator GTE
+        PackageQuery query(base);
+        query.filter_nevra(patterns, libdnf::sack::QueryCmp::GTE);
+        std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("GTE comparator failed", expected, to_vector(query));
+    }
+}
+
 void RpmPackageQueryTest::test_filter_name_arch() {
     add_repo_solv("solv-repo1");
 

--- a/test/libdnf/rpm/test_package_query.hpp
+++ b/test/libdnf/rpm/test_package_query.hpp
@@ -37,6 +37,7 @@ class RpmPackageQueryTest : public BaseTestCase {
     CPPUNIT_TEST(test_filter_name);
     CPPUNIT_TEST(test_filter_name_packgset);
     CPPUNIT_TEST(test_filter_nevra_packgset);
+    CPPUNIT_TEST(test_filter_nevra_packgset_cmp);
     CPPUNIT_TEST(test_filter_name_arch);
     CPPUNIT_TEST(test_filter_name_arch2);
     CPPUNIT_TEST(test_filter_nevra);
@@ -69,6 +70,7 @@ public:
     void test_filter_name();
     void test_filter_name_packgset();
     void test_filter_nevra_packgset();
+    void test_filter_nevra_packgset_cmp();
     void test_filter_name_arch();
     void test_filter_name_arch2();
     void test_filter_nevra();


### PR DESCRIPTION
Current implementation of filter_nevra(PackageSet) accepts only EQ and NEQ comparators.
This change enhances this filter to accept also GT, GTE, LT, and LTE comparators.