### PR TITLE
Use repo::DownloadCallbacks for all downloads

### DIFF
--- a/dnf5/download_callbacks.hpp
+++ b/dnf5/download_callbacks.hpp
@@ -29,23 +29,30 @@ namespace dnf5 {
 
 class DownloadCallbacks : public libdnf::repo::DownloadCallbacks {
 public:
+    void set_number_widget_visible(bool value);
+
+    void set_show_total_bar_limit(std::size_t limit);
+
+    void reset_progress_bar();
+
+private:
     void * add_new_download(void * user_data, const char * description, double total_to_download) override;
 
     int progress(void * user_cb_data, double total_to_download, double downloaded) override;
 
     int end(void * user_cb_data, TransferStatus status, const char * msg) override;
 
-    int mirror_failure(void * user_cb_data, const char * msg, const char * url) override;
+    int mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) override;
 
-    void reset_progress_bar();
-
-private:
     bool is_time_to_print();
     void print();
 
     std::unique_ptr<libdnf::cli::progressbar::MultiProgressBar> multi_progress_bar;
     std::chrono::time_point<std::chrono::steady_clock> prev_print_time{std::chrono::steady_clock::now()};
     bool printed{false};
+
+    bool number_widget_visible{false};
+    std::size_t show_total_bar_limit{0};
 };
 
 }  // namespace dnf5

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -606,7 +606,10 @@ int main(int argc, char * argv[]) try {
 
     auto download_callbacks_uptr = std::make_unique<dnf5::DownloadCallbacks>();
     auto * download_callbacks = download_callbacks_uptr.get();
-    base.set_download_callbacks(std::move(download_callbacks_uptr));
+    download_callbacks->set_show_total_bar_limit(static_cast<std::size_t>(-1));
+    if (!context.get_quiet()) {
+        base.set_download_callbacks(std::move(download_callbacks_uptr));
+    }
 
     // Parse command line arguments
     {
@@ -691,6 +694,8 @@ int main(int argc, char * argv[]) try {
             command->goal_resolved();
 
             download_callbacks->reset_progress_bar();
+            download_callbacks->set_number_widget_visible(true);
+            download_callbacks->set_show_total_bar_limit(0);
 
             if (!libdnf::cli::output::print_transaction_table(*context.get_transaction())) {
                 return static_cast<int>(libdnf::cli::ExitCode::SUCCESS);

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -97,7 +97,7 @@ Session::Session(
     }
     dbus_object->finishRegistration();
 
-    base->set_download_callbacks(std::make_unique<DownloadCallbacks>());
+    base->set_download_callbacks(std::make_unique<DownloadCallbacksProxy>());
 }
 
 Session::~Session() {
@@ -168,6 +168,7 @@ bool Session::read_all_repos() {
         enabled_repos.filter_enabled(true);
         enabled_repos.filter_type(libdnf::repo::Repo::Type::AVAILABLE);
         for (auto & repo : enabled_repos) {
+            repo->set_user_data(this);
             repo->set_callbacks(std::make_unique<DbusRepoCB>(*this));
         }
 

--- a/include/libdnf-cli/progressbar/download_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/download_progress_bar.hpp
@@ -47,7 +47,7 @@ public:
     // TODO(dmach): add print() method
 
     bool get_number_widget_visible() const noexcept { return number_widget.get_visible(); }
-    void set_number_widget_visible(bool value) { number_widget.set_visible(value); };
+    void set_number_widget_visible(bool value) noexcept { number_widget.set_visible(value); }
 
 protected:
     void to_stream(std::ostream & stream) override;

--- a/include/libdnf-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/multi_progress_bar.hpp
@@ -45,12 +45,20 @@ public:
     }
     friend std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar);
 
+    /// Sets the minimum number of registered progress bars to show the total bar.
+    void set_total_bar_visible_limit(std::size_t value) noexcept { total_bar_visible_limit = value; }
+
+    /// Sets the visibility of number widget in the total bar.
+    void set_total_bar_number_widget_visible(bool value) noexcept { total.set_number_widget_visible(value); }
+
 private:
+    std::size_t total_bar_visible_limit{0};
     std::vector<std::unique_ptr<ProgressBar>> bars_all;
     std::vector<ProgressBar *> bars_todo;
     std::vector<ProgressBar *> bars_done;
     DownloadProgressBar total;
-    std::size_t printed_lines = 0;
+    bool line_printed{false};
+    std::size_t num_of_lines_to_clear{0};
 };
 
 

--- a/include/libdnf-cli/progressbar/widgets/widget.hpp
+++ b/include/libdnf-cli/progressbar/widgets/widget.hpp
@@ -34,7 +34,7 @@ class ProgressBar;
 class Widget {
 public:
     bool get_visible() const noexcept { return visible; }
-    void set_visible(bool value) { visible = value; };
+    void set_visible(bool value) noexcept { visible = value; };
 
     ProgressBar * get_bar() const noexcept { return bar; }
     void set_bar(ProgressBar * value) { bar = value; }

--- a/include/libdnf/repo/download_callbacks.hpp
+++ b/include/libdnf/repo/download_callbacks.hpp
@@ -32,9 +32,44 @@ namespace libdnf::repo {
 /// To implement a callback, inherit from this class and override the virtual methods.
 class DownloadCallbacks {
 public:
+    enum class FastestMirrorStage {
+        /// Fastest mirror detection started. ptr is `nullptr`.
+        INIT,
+
+        // TODO(lukash) what does CACHELOADING mean?
+        /// `ptr` is a (`char *`) pointer to a string with path to the cache file.
+        /// Do not modify or free the string.
+        CACHELOADING,
+
+        /// If cache was loaded successfully, `ptr` is `nullptr`, otherwise it
+        /// is a (`char *`) string containing the error message. Do not modify
+        /// or free the string.
+        CACHELOADINGSTATUS,
+
+        /// Detection (pinging) in progress. If all data was loaded from cache,
+        /// this stage is skiped. `ptr` is a pointer to `long`, the number of
+        /// mirrors which will be tested.
+        DETECTION,
+
+        /// Detection is done, sorting mirrors, updating cache, etc. `ptr` is
+        /// `nullptr`.
+        FINISHING,
+
+        /// The last invocation of the fastest mirror callback. If detection
+        /// was successful, `ptr` is `nullptr`. Otherwise it is a (`char *`) /
+        /// string containing the error message. Do not modify or free the
+        /// string.
+        STATUS,
+    };
+
     /// Transfer status codes.
     enum class TransferStatus { SUCCESSFUL, ALREADYEXISTS, ERROR };
 
+    DownloadCallbacks() = default;
+    DownloadCallbacks(const DownloadCallbacks &) = delete;
+    DownloadCallbacks(DownloadCallbacks &&) = delete;
+    DownloadCallbacks & operator=(const DownloadCallbacks &) = delete;
+    DownloadCallbacks & operator=(DownloadCallbacks &&) = delete;
     virtual ~DownloadCallbacks() = default;
 
     /// Notify the client that a new download has been created.
@@ -58,13 +93,21 @@ public:
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
     virtual int end(void * user_cb_data, TransferStatus status, const char * msg);
 
-
     /// Mirror failure callback.
     /// @param user_cb_data Associated user data obtained from add_new_download.
     /// @param msg Error message.
     /// @param url Failed mirror URL.
+    /// @param metadata the type of metadata that is being downloaded TODO(lukash) should this point to LoadFlags in some way?
     /// @return TODO(lukash) uses the LrCbReturnCode enum from librepo, we should translate that.
-    virtual int mirror_failure(void * user_cb_data, const char * msg, const char * url);
+    virtual int mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata);
+
+    // TODO(lukash) needs more specifics about how the detection works
+    /// Callback for fastest mirror detection.
+    /// @param user_cb_data Associated user data obtained from new_download.
+    /// @param stage the stage of the fastest mirror detection, refer to `FastestMirrorStage`
+    /// @param ptr pointer to additional data depending on the stage, refer to `FastestMirrorStage`
+    // TODO(lukash) the varying data type for ptr will not work with bindings, we need unambiguous API
+    virtual void fastest_mirror(void * user_cb_data, FastestMirrorStage stage, const char * ptr);
 };
 
 }  // namespace libdnf::repo

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -100,6 +100,14 @@ public:
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.setCallbacks(std::unique_ptr<RepoCallbacks> && callbacks)
     void set_callbacks(std::unique_ptr<libdnf::repo::RepoCallbacks> && callbacks);
 
+    /// @brief Sets the associated user data. These are used in callbacks.
+    /// @param user_data  Pointer to user data
+    void set_user_data(void * user_data) noexcept;
+
+    /// @brief Gets the associated user data.
+    /// @return Pointer to user data
+    void * get_user_data() const noexcept;
+
     /// Verify repo object configuration
     /// Will throw exception if Repo has no mirror or baseurl set or if Repo type is unsupported.
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.verify()

--- a/include/libdnf/repo/repo_callbacks.hpp
+++ b/include/libdnf/repo/repo_callbacks.hpp
@@ -25,70 +25,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::repo {
 
-/// Base class for repository metadata download callbacks.
+/// Base class for repository callbacks.
 /// To implement callbacks, inherit from this class and override virtual methods.
 class RepoCallbacks {
 public:
-    enum class FastestMirrorStage {
-        /// Fastest mirror detection started. ptr is `nullptr`.
-        INIT,
-
-        // TODO(lukash) what does CACHELOADING mean?
-        /// `ptr` is a (`char *`) pointer to a string with path to the cache file.
-        /// Do not modify or free the string.
-        CACHELOADING,
-
-        /// If cache was loaded successfully, `ptr` is `nullptr`, otherwise it
-        /// is a (`char *`) string containing the error message. Do not modify
-        /// or free the string.
-        CACHELOADINGSTATUS,
-
-        /// Detection (pinging) in progress. If all data was loaded from cache,
-        /// this stage is skiped. `ptr` is a pointer to `long`, the number of
-        /// mirrors which will be tested.
-        DETECTION,
-
-        /// Detection is done, sorting mirrors, updating cache, etc. `ptr` is
-        /// `nullptr`.
-        FINISHING,
-
-        /// The last invocation of the fastest mirror callback. If detection
-        /// was successful, `ptr` is `nullptr`. Otherwise it is a (`char *`) /
-        /// string containing the error message. Do not modify or free the
-        /// string.
-        STATUS,
-    };
+    RepoCallbacks() = default;
+    RepoCallbacks(const RepoCallbacks &) = delete;
+    RepoCallbacks(RepoCallbacks &&) = delete;
+    RepoCallbacks & operator=(const RepoCallbacks &) = delete;
+    RepoCallbacks & operator=(RepoCallbacks &&) = delete;
+    virtual ~RepoCallbacks() = default;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-
-    /// Start of download callback.
-    /// @param what The name (if set) or the id of the repository
-    virtual void start(const char * what) {}
-
-    /// End of download callback.
-    /// @param error_message `nullptr` on success, otherwise the error message
-    virtual void end(const char * error_message) {}
-
-    /// Download progress callback.
-    /// @param total_to_download total amount of bytes to download
-    /// @param downloaded bytes downloaded
-    /// @return TODO(lukash) this uses librepo's LrCbReturnCode, we should have our own enum
-    virtual int progress(double total_to_download, double downloaded) { return 0; }
-
-    // TODO(lukash) needs more specifics about how the detection works
-    /// Callback for fastest mirror detection.
-    /// @param stage the stage of the fastest mirror detection, refer to `FastestMirrorStage`
-    /// @param ptr pointer to additional data depending on the stage, refer to `FastestMirrorStage`
-    // TODO(lukash) the varying data type for ptr will not work with bindings, we need unambiguous API
-    virtual void fastest_mirror(FastestMirrorStage stage, const char * ptr) {}
-
-    /// Mirror failure callback. Called when downloading from a mirror failed.
-    /// @param msg the error message
-    /// @param url the mirror url
-    /// @param metadata the type of metadata that is being downloaded TODO(lukash) should this point to LoadFlags in some way?
-    /// @return TODO(lukash) this uses librepo's LrCbReturnCode, we should have our own enum
-    virtual int handle_mirror_failure(const char * msg, const char * url, const char * metadata) { return 0; }
 
     /// GPG key import callback. Allows to confirm or deny the import.
     /// @param id the key id
@@ -106,10 +55,7 @@ public:
         return true;
     }
 #pragma GCC diagnostic pop
-
-    virtual ~RepoCallbacks() = default;
 };
-
 
 }  // namespace libdnf::repo
 

--- a/libdnf/repo/download_callbacks.cpp
+++ b/libdnf/repo/download_callbacks.cpp
@@ -41,8 +41,16 @@ int DownloadCallbacks::progress(
 }
 
 int DownloadCallbacks::mirror_failure(
-    [[maybe_unused]] void * user_cb_data, [[maybe_unused]] const char * msg, [[maybe_unused]] const char * url) {
+    [[maybe_unused]] void * user_cb_data,
+    [[maybe_unused]] const char * msg,
+    [[maybe_unused]] const char * url,
+    [[maybe_unused]] const char * metadata) {
     return 0;
 }
+
+void DownloadCallbacks::fastest_mirror(
+    [[maybe_unused]] void * user_cb_data,
+    [[maybe_unused]] FastestMirrorStage stage,
+    [[maybe_unused]] const char * ptr) {}
 
 }  // namespace libdnf::repo

--- a/libdnf/repo/file_downloader.cpp
+++ b/libdnf/repo/file_downloader.cpp
@@ -95,7 +95,7 @@ static int mirror_failure_callback(void * data, const char * msg, const char * u
 
     auto * file_target = static_cast<FileTarget *>(data);
     if (auto * download_callbacks = file_target->base->get_download_callbacks()) {
-        return download_callbacks->mirror_failure(file_target->user_cb_data, msg, url);
+        return download_callbacks->mirror_failure(file_target->user_cb_data, msg, url, nullptr);
     }
     return 0;
 }

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -83,7 +83,7 @@ static int mirror_failure_callback(void * data, const char * msg, const char * u
 
     auto * package_target = static_cast<PackageTarget *>(data);
     if (auto * download_callbacks = package_target->package.get_base()->get_download_callbacks()) {
-        return download_callbacks->mirror_failure(package_target->user_cb_data, msg, url);
+        return download_callbacks->mirror_failure(package_target->user_cb_data, msg, url, nullptr);
     }
     return 0;
 }

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -113,6 +113,14 @@ void Repo::set_callbacks(std::unique_ptr<RepoCallbacks> && callbacks) {
     downloader->set_callbacks(std::move(callbacks));
 }
 
+void Repo::set_user_data(void * user_data) noexcept {
+    downloader->set_user_data(user_data);
+}
+
+void * Repo::get_user_data() const noexcept {
+    return downloader->get_user_data();
+}
+
 std::string::size_type Repo::verify_id(const std::string & repo_id) {
     return repo_id.find_first_not_of(REPOID_CHARS);
 }

--- a/libdnf/repo/repo_downloader.hpp
+++ b/libdnf/repo/repo_downloader.hpp
@@ -69,6 +69,8 @@ public:
     LibrepoHandle & get_cached_handle();
 
     void set_callbacks(std::unique_ptr<libdnf::repo::RepoCallbacks> && callbacks) noexcept;
+    void set_user_data(void * user_data) noexcept;
+    void * get_user_data() const noexcept;
 
     const std::string & get_metadata_path(const std::string & metadata_type) const;
 
@@ -100,6 +102,15 @@ private:
     RepoPgp pgp;
 
     std::unique_ptr<RepoCallbacks> callbacks;
+    void * user_data{nullptr};
+    void * user_cb_data{nullptr};
+    double prev_total_to_download;
+    double prev_downloaded;
+    double sum_prev_downloaded;
+
+    static int progress_cb(void * data, double total_to_download, double downloaded);
+    static void fastest_mirror_cb(void * data, LrFastestMirrorStages stage, void * ptr);
+    static int mirror_failure_cb(void * data, const char * msg, const char * url, const char * metadata);
 
     // download input
     bool preserve_remote_time = false;

--- a/test/libdnf/repo/test_package_downloader.cpp
+++ b/test/libdnf/repo/test_package_downloader.cpp
@@ -49,7 +49,8 @@ public:
     int mirror_failure(
         [[maybe_unused]] void * user_cb_data,
         [[maybe_unused]] const char * msg,
-        [[maybe_unused]] const char * url) override {
+        [[maybe_unused]] const char * url,
+        [[maybe_unused]] const char * metadata) override {
         ++mirror_failure_cnt;
         return 0;
     }

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -59,7 +59,8 @@ public:
     int mirror_failure(
         [[maybe_unused]] void * user_cb_data,
         [[maybe_unused]] const char * msg,
-        [[maybe_unused]] const char * url) override {
+        [[maybe_unused]] const char * url,
+        [[maybe_unused]] const char * metadata) override {
         ++mirror_failure_cnt;
         return 0;
     }

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -31,7 +31,7 @@ class TestRepo(base_test_case.BaseTestCase):
         repoid = "repomd-repo1"
         repo = self.add_repo_repomd(repoid, load=False)
 
-        class RepoCallbacks(libdnf5.repo.RepoCallbacks):
+        class DownloadCallbacks(libdnf5.repo.DownloadCallbacks):
             start_cnt = 0
             start_what = None
 
@@ -41,30 +41,38 @@ class TestRepo(base_test_case.BaseTestCase):
             progress_cnt = 0
             fastest_mirror_cnt = 0
             handle_mirror_failure_cnt = 0
-            repokey_import_cnt = 0
 
-            def start(self, what):
+            def add_new_download(self, user_data, descr, total):
                 self.start_cnt += 1
-                self.start_what = what
+                self.start_what = descr
+                return None
 
-            def end(self, error_message):
+            def end(self, user_cb_data, status, error_message):
                 self.end_cnt += 1
                 self.end_error_message = error_message
+                return 0
 
-            def progress(self, total_to_download, downloaded):
+            def progress(self, user_cb_data, total_to_download, downloaded):
                 self.progress_cnt += 1
                 return 0
 
-            def fastest_mirror(self, stage, ptr):
+            def fastest_mirror(self, user_cb_data, stage, ptr):
                 self.fastest_mirror_cnt += 1
 
-            def handle_mirror_failure(self, msg, url, metadata):
+            def handle_mirror_failure(self, user_cb_data, msg, url, metadata):
                 self.handle_mirror_failure_cnt += 1
                 return 0
+
+        class RepoCallbacks(libdnf5.repo.RepoCallbacks):
+            repokey_import_cnt = 0
 
             def repokey_import(self, id, user_id, fingerprint, url, timestamp):
                 self.repokey_import_cnt += 1
                 return True
+
+        dl_cbs = DownloadCallbacks()
+        self.base.set_download_callbacks(
+            libdnf5.repo.DownloadCallbacksUniquePtr(dl_cbs))
 
         cbs = RepoCallbacks()
         # TODO(lukash) try to wrap the creation of the unique_ptr so that cbs
@@ -75,13 +83,13 @@ class TestRepo(base_test_case.BaseTestCase):
         repos.filter_id(repoid)
         self.repo_sack.update_and_load_repos(repos)
 
-        self.assertEqual(cbs.start_cnt, 1)
-        self.assertEqual(cbs.start_what, repoid)
+        self.assertEqual(dl_cbs.start_cnt, 1)
+        self.assertEqual(dl_cbs.start_what, repoid)
 
-        self.assertEqual(cbs.end_cnt, 1)
-        self.assertEqual(cbs.end_error_message, None)
+        self.assertEqual(dl_cbs.end_cnt, 1)
+        self.assertEqual(dl_cbs.end_error_message, None)
 
-        self.assertGreaterEqual(cbs.progress_cnt, 1)
-        self.assertEqual(cbs.fastest_mirror_cnt, 0)
-        self.assertEqual(cbs.handle_mirror_failure_cnt, 0)
+        self.assertGreaterEqual(dl_cbs.progress_cnt, 1)
+        self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
+        self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -33,7 +33,10 @@ for (const auto & tspkg : transaction.get_transaction_packages()) {
 class PackageDownloadCallbacks : public libdnf::repo::DownloadCallbacks {
 private:
     int mirror_failure(
-        [[maybe_unused]] void * user_cb_data, const char * msg, [[maybe_unused]] const char * url) override {
+        [[maybe_unused]] void * user_cb_data,
+        const char * msg,
+        [[maybe_unused]] const char * url,
+        [[maybe_unused]] const char * metadata) override {
         std::cout << "Mirror failure: " << msg << std::endl;
         return 0;
     }


### PR DESCRIPTION
Previously, methods from repo::RepoCallbacks were used for repository metadata download.