### PR TITLE
transaction: Change API to run transaction without args

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -651,7 +651,14 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         cmd_line += argv[i];
     }
 
-    auto result = transaction.run(std::make_unique<RpmTransCB>(), cmd_line, comment ? comment : "");
+    transaction.set_callbacks(std::make_unique<RpmTransCB>());
+    transaction.set_description(cmd_line);
+
+    if (comment) {
+        transaction.set_comment(comment);
+    }
+
+    auto result = transaction.run();
     if (result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         std::cout << "Transaction failed: " << libdnf::base::Transaction::transaction_result_to_string(result)
                   << std::endl;
@@ -660,7 +667,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         }
     }
 
-    // TODO(mblaha): print a summary of successfull transaction
+    // TODO(mblaha): print a summary of successful transaction
 }
 
 libdnf::Goal * Context::get_goal(bool new_if_not_exist) {

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -192,7 +192,11 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
         comment = key_value_map_get<std::string>(options, "comment");
     }
 
-    auto rpm_result = transaction->run(std::make_unique<DbusTransactionCB>(session), "dnf5daemon-server", comment);
+    transaction->set_callbacks(std::make_unique<DbusTransactionCB>(session));
+    transaction->set_description("dnf5daemon-server");
+    transaction->set_comment(comment);
+
+    auto rpm_result = transaction->run();
     if (rpm_result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         throw sdbus::Error(
             dnfdaemon::ERROR_TRANSACTION,

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -63,7 +63,8 @@ public:
     Transaction(Transaction && transaction);
     ~Transaction();
 
-    /// Return basic overvie about result of resolving transaction. The get complete informaion use get_resolve_logs()
+    /// Return basic overview about result of resolving transaction.
+    /// To get complete information, use get_resolve_logs().
     libdnf::GoalProblem get_problems();
 
     /// Returns information about resolvement of Goal.
@@ -89,33 +90,32 @@ public:
     /// @return An enum describing the result of the transaction
     TransactionRunResult test();
 
-    /// Prepare, check and run the transaction. All the transaction metadata
-    /// (`description` and `comment`) are stored in the history database.
+    /// @brief Prepare, check and run the transaction.
     ///
-    /// @param callbacks Callbacks to be called during rpm transaction.
-    /// @param description Description of the transaction (the console command for CLI,
-    //                     verbose description for API usage)
-    /// @param comment Any comment to store in the history database along with the transaction.
+    /// All the transaction metadata that was set (`description`, `user_id` or `comment`)
+    /// is stored in the history database.
+    ///
+    /// To watch progress or trigger actions during specific transactions events,
+    /// setup the `callbacks` object.
+    ///
     /// @return An enum describing the result of running the transaction.
-    TransactionRunResult run(
-        std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
-        const std::string & description,
-        const std::string & comment = {});
+    TransactionRunResult run();
 
-    /// Prepare, check and run the transaction. All the transaction metadata
-    /// (`description`, `user_id` and `comment`) are stored in the history database.
-    ///
-    /// @param callbacks Callbacks to be called during rpm transaction.
-    /// @param description Description of the transaction (the console command for CLI,
-    //                     verbose description for API usage)
-    /// @param user_id UID of the user that started the transaction.
-    /// @param comment Any comment to store in the history database along with the transaction.
-    /// @return An enum describing the result of running the transaction.
-    TransactionRunResult run(
-        std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
-        const std::string & description,
-        const uint32_t user_id,
-        const std::string & comment = {});
+    /// @brief Setup callbacks to be called during rpm transaction.
+    /// @param callbacks Implemented callbacks object.
+    void set_callbacks(std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks);
+
+    /// @brief Setup a description of the transaction.
+    /// @param description Value could be the console command for CLI or verbose description for API usage.
+    void set_description(const std::string & description);
+
+    /// @brief Setup the id of the user that started the transaction. If not set, current login user UID is used.
+    /// @param user_id UID value.
+    void set_user_id(const uint32_t user_id);
+
+    /// @brief Setup a comment to store in the history database along with the transaction.
+    /// @param comment Any string value.
+    void set_comment(const std::string & comment);
 
     /// Return string representation of the TransactionRunResult enum
     static std::string transaction_result_to_string(const TransactionRunResult result);
@@ -132,6 +132,11 @@ private:
 
     class Impl;
     std::unique_ptr<Impl> p_impl;
+
+    std::unique_ptr<libdnf::rpm::TransactionCallbacks> callbacks;
+    std::optional<uint32_t> user_id;
+    std::string comment;
+    std::string description;
 };
 
 }  // namespace libdnf::base

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -226,23 +226,28 @@ Transaction::TransactionRunResult Transaction::test() {
     return p_impl->test();
 }
 
-Transaction::TransactionRunResult Transaction::run(
-    std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
-    const std::string & description,
-    const std::string & comment) {
-    return p_impl->run(std::move(callbacks), description, std::nullopt, comment);
-}
-
-Transaction::TransactionRunResult Transaction::run(
-    std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks,
-    const std::string & description,
-    const uint32_t user_id,
-    const std::string & comment) {
+Transaction::TransactionRunResult Transaction::run() {
     return p_impl->run(std::move(callbacks), description, user_id, comment);
 }
 
 std::vector<std::string> Transaction::get_transaction_problems() const noexcept {
     return p_impl->transaction_problems;
+}
+
+void Transaction::set_callbacks(std::unique_ptr<libdnf::rpm::TransactionCallbacks> && callbacks) {
+    this->callbacks = std::move(callbacks);
+}
+
+void Transaction::set_description(const std::string & description) {
+    this->description = description;
+}
+
+void Transaction::set_user_id(const uint32_t user_id) {
+    this->user_id = user_id;
+}
+
+void Transaction::set_comment(const std::string & comment) {
+    this->comment = comment;
 }
 
 void Transaction::Impl::set_transaction(rpm::solv::GoalPrivate & solved_goal, GoalProblem problems) {

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -111,8 +111,9 @@ void RpmTransactionTest::test_transaction() {
     CPPUNIT_ASSERT_EQUAL(0, dl_callbacks_ptr->mirror_failure_cnt);
 
     // TODO(lukash) test transaction callbacks
-    libdnf::base::Transaction::TransactionRunResult res =
-        transaction.run(std::make_unique<libdnf::rpm::TransactionCallbacks>(), "install package one");
+    transaction.set_callbacks(std::make_unique<libdnf::rpm::TransactionCallbacks>());
+    transaction.set_description("install package one");
+    auto res = transaction.run();
 
     CPPUNIT_ASSERT_EQUAL(libdnf::base::Transaction::TransactionRunResult::SUCCESS, res);
     // TODO(lukash) assert the packages were installed

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -58,16 +58,14 @@ class TransactionCallbacks(libdnf5.rpm.TransactionCallbacks):
     def install_start(self, item, total=0):
         print(libdnf5.base.transaction.transaction_item_action_to_string(item.get_action()), " ",
               item.get_package().get_nevra())
-# Run the transaction.
-#
-# The second through fourth arguments are transaction metadata that will be
-# stored in the history database.
-#
-# The second argument is expected to be a verbose description of the
-# transaction. The third argument is user_id, omitted here for simplicity. The
-# fourth argument can be an arbitrary user comment.
-print("Running the transaction:")
+
 transaction_callbacks = TransactionCallbacks()
 transaction_callbacks_ptr = libdnf5.rpm.TransactionCallbacksUniquePtr(transaction_callbacks)
+transaction.set_callbacks(transaction_callbacks_ptr)
 
-transaction.run(transaction_callbacks_ptr, "install package one")
+# Add transaction metadata to be stored in the history database.
+transaction.set_description("install package one")
+
+# Run the transaction.
+print("Running the transaction:")
+transaction.run()

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -72,13 +72,11 @@ class TransactionCallbacks : public libdnf::rpm::TransactionCallbacks {
     }
 };
 
+transaction.set_callbacks(std::make_unique<TransactionCallbacks>());
+
+// Add transaction metadata to be stored in the history database.
+transaction.set_description("install package one");
+
 // Run the transaction.
-//
-// The second through fourth arguments are transaction metadata that will be
-// stored in the history database.
-//
-// The second argument is expected to be a verbose description of the
-// transaction. The third argument is user_id, omitted here for simplicity. The
-// fourth argument can be an arbitrary user comment.
 std::cout << std::endl << "Running the transaction:" << std::endl;
-transaction.run(std::make_unique<TransactionCallbacks>(), "install package one");
+transaction.run();


### PR DESCRIPTION
All the `transaction.run()` arguments could be optional, therefore changing the API to pass the arguments with class setters.