### PR TITLE
swig: Include dependent repo module for rpm

### DIFF
--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -14,6 +14,7 @@
 
 %import "common.i"
 %import "conf.i"
+%import "repo.i"
 %import "transaction.i"
 
 %exception {


### PR DESCRIPTION
RPM transaction API exposes `Repo` object, so it needs to be wrapped before that.