### PR TITLE
Add explicit package version for libdnf5-cli

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -11,6 +11,7 @@ URL:            https://github.com/rpm-software-management/dnf5
 Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
 
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Requires:       dnf-data
 Recommends:     bash-completion
 


### PR DESCRIPTION
The change was suggested by rpminspect. See the description bellow.

Add the indicated explicit Requires to the spec file for the named subpackage. Subpackages depending on shared libraries in another subpackage must carry an explicit
'Requires: SUBPACKAGE_NAME = %{version}-%{release}' in the spec file. VERIFY Subpackage dnf5 on s390x carries
'Requires: libdnf-cli.so.1()(64bit)' which comes from subpackage libdnf5-cli but does not carry an explicit package version requirement. Please add 'Requires: libdnf5-cli = %{version}-%{release}' to the spec file to avoid the need to test interoperability between various combinations of old and new subpackages.