### PR TITLE
Add transaction.download()

### DIFF
--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -81,6 +81,13 @@ public:
     /// @return the transaction groups.
     std::vector<libdnf::base::TransactionGroup> & get_transaction_groups() const;
 
+    /// Download all inbound packages (packages that are being installed on the
+    /// system). Fails immediately on the first package download failure. Will
+    /// try to resume downloads of any partially-downloaded RPMs.
+    /// @param dest_dir Destination directory for downloaded RPMs. Default is
+    /// the standard location of repo cachedir/packages.
+    void download(const std::string & dest_dir = {});
+
     /// Check the transaction by running it with RPMTRANS_FLAG_TEST. The import
     /// of any necessary public keys will be requested, and transaction checks
     /// will be performed, but no changes to the installed package set will be

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -89,19 +89,11 @@ void RpmTransactionTest::test_transaction() {
         TransactionItemState::STARTED)};
     CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 
-    libdnf::repo::PackageDownloader downloader;
-
     auto dl_callbacks = std::make_unique<PackageDownloadCallbacks>();
     auto dl_callbacks_ptr = dl_callbacks.get();
     base.set_download_callbacks(std::move(dl_callbacks));
 
-    for (auto & tspkg : transaction.get_transaction_packages()) {
-        if (transaction_item_action_is_inbound(tspkg.get_action())) {
-            downloader.add(tspkg.get_package());
-        }
-    }
-
-    downloader.download(true, true);
+    transaction.download();
 
     CPPUNIT_ASSERT_EQUAL(1, dl_callbacks_ptr->end_cnt);
     CPPUNIT_ASSERT_EQUAL(PackageDownloadCallbacks::TransferStatus::SUCCESSFUL, dl_callbacks_ptr->end_status);

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -35,19 +35,8 @@ downloader = libdnf5.repo.PackageDownloader()
 downloader_callbacks = PackageDownloadCallbacks()
 base.set_download_callbacks(libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks))
 
-# Add the inbound packages (packages that are being installed on the system)
-# to the downloader.
-for tspkg in transaction.get_transaction_packages():
-    if libdnf5.base.transaction.transaction_item_action_is_inbound(tspkg.get_action()):
-        downloader.add(tspkg.get_package())
-
 # Download the packages.
-#
-# The first argument is `fail_fast`, meaning the download will fail right away
-# on a first package download failure. The second argument is `resume`, if
-# `true`, the downloader will try to resume downloads of any partially
-# downloaded RPMs.
-downloader.download(True, True)
+transaction.download()
 
 # A class for defining the RPM transaction callbacks.
 #

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -41,24 +41,8 @@ private:
 
 base.set_download_callbacks(std::make_unique<PackageDownloadCallbacks>());
 
-// Create a package downloader.
-libdnf::repo::PackageDownloader downloader;
-
-// Add the inbound packages (packages that are being installed on the system)
-// to the downloader.
-for (auto & tspkg : transaction.get_transaction_packages()) {
-    if (transaction_item_action_is_inbound(tspkg.get_action())) {
-        downloader.add(tspkg.get_package());
-    }
-}
-
 // Download the packages.
-//
-// The first argument is `fail_fast`, meaning the download will fail right away
-// on a first package download failure. The second argument is `resume`, if
-// `true`, the downloader will try to resume downloads of any partially
-// downloaded RPMs.
-downloader.download(true, true);
+transaction.download();
 
 // A class for defining the RPM transaction callbacks.
 //


### PR DESCRIPTION
`transaction.download()` downloads all inbound packages on the transaction, equivalent to the following:

```
libdnf::repo::PackageDownloader downloader;
for (auto & tspkg : transaction.get_transaction_packages()) {
    if (transaction_item_action_is_inbound(tspkg.get_action())) {
        downloader.add(tspkg.get_package());
    }
}
downloader.download(true, true);
```

Resolves https://github.com/rpm-software-management/dnf5/issues/277