### PR TITLE
swig: Fix comps iterator wrappers

### DIFF
--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -30,16 +30,26 @@
 
 #define CV __perl_CV
 
-%template(SackQueryGroup) libdnf::sack::Query<libdnf::comps::Group>;
-%template(SackQueryEnvironment) libdnf::sack::Query<libdnf::comps::Environment>;
-
 %include "libdnf/comps/group/package.hpp"
 %include "libdnf/comps/group/group.hpp"
+%template(SetConstIteratorGroup) libdnf::SetConstIterator<libdnf::comps::Group>;
+%template(SetGroup) libdnf::Set<libdnf::comps::Group>;
+%template(SackQueryGroup) libdnf::sack::Query<libdnf::comps::Group>;
 %include "libdnf/comps/group/query.hpp"
+%template(SackGroup) libdnf::sack::Sack<libdnf::comps::Group>;
 %include "libdnf/comps/group/sack.hpp"
-%include "libdnf/comps/environment/environment.hpp"
-%include "libdnf/comps/environment/query.hpp"
-%include "libdnf/comps/environment/sack.hpp"
-%include "libdnf/comps/comps.hpp"
+%template(GroupSackWeakPtr) libdnf::WeakPtr<libdnf::comps::GroupSack, false>;
+add_iterator(SetGroup)
 
+%include "libdnf/comps/environment/environment.hpp"
+%template(SetConstIteratorEnvironment) libdnf::SetConstIterator<libdnf::comps::Environment>;
+%template(SetEnvironment) libdnf::Set<libdnf::comps::Environment>;
+%template(SackQueryEnvironment) libdnf::sack::Query<libdnf::comps::Environment>;
+%include "libdnf/comps/environment/query.hpp"
+%template(SackEnvironment) libdnf::sack::Sack<libdnf::comps::Environment>;
+%include "libdnf/comps/environment/sack.hpp"
+%template(EnvironmentSackWeakPtr) libdnf::WeakPtr<libdnf::comps::EnvironmentSack, false>;
+add_iterator(SetEnvironment)
+
+%include "libdnf/comps/comps.hpp"
 %template(CompsWeakPtr) libdnf::WeakPtr<libdnf::comps::Comps, false>;

--- a/test/python3/libdnf5/comps/test_comps_iterators.py
+++ b/test/python3/libdnf5/comps/test_comps_iterators.py
@@ -1,0 +1,31 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import libdnf5
+
+import base_test_case
+
+
+class TestCompsIterators(base_test_case.BaseTestCase):
+    def test_group_query_iterable(self):
+        query = libdnf5.comps.GroupQuery(self.base)
+        _ = [grp.get_groupid() for grp in query]
+        
+    def test_environment_query_iterable(self):
+        query = libdnf5.comps.EnvironmentQuery(self.base)
+        _ = [env.get_environmentid() for env in query]


### PR DESCRIPTION
`EnvironmentQuery` and `GroupQuery` iterators and related wrappers fixed.

Closes #296.