### PR TITLE
modules: Reject overlong nsvcap strings

### DIFF
--- a/common/utils/regex.hpp
+++ b/common/utils/regex.hpp
@@ -1,0 +1,28 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_UTILS_REGEX_HPP
+#define LIBDNF_UTILS_REGEX_HPP
+
+
+// Limit the string legth, because GCC std::regex_match() exhausts a stack on very long strings.
+#define MAX_STRING_LENGTH_FOR_REGEX_MATCH 2 << 10
+
+
+#endif  // LIBDNF_UTILS_REGEX_HPP

--- a/libdnf/module/nsvcap.cpp
+++ b/libdnf/module/nsvcap.cpp
@@ -25,6 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/module/nsvcap.hpp"
 
+#include "utils/regex.hpp"
+
 #include <array>
 #include <regex>
 #include <string>
@@ -93,6 +95,12 @@ const std::vector<Nsvcap::Form> & Nsvcap::get_default_module_spec_forms() {
 
 bool Nsvcap::parse(const std::string nsvcap_str, Nsvcap::Form form) {
     enum { NAME = 1, STREAM = 2, VERSION = 3, CONTEXT = 4, ARCH = 5, PROFILE = 6, _LAST_ };
+
+    if (nsvcap_str.length() > MAX_STRING_LENGTH_FOR_REGEX_MATCH) {
+        // GCC std::regex_match() exhausts a stack on very long strings.
+        return false;
+    }
+
     std::smatch matched_result;
     auto matched = std::regex_match(nsvcap_str, matched_result, NSVCAP_FORM_REGEX[static_cast<unsigned>(form) - 1]);
     if (!matched || matched_result[NAME].str().size() == 0) {

--- a/libdnf/solv/reldep_parser.cpp
+++ b/libdnf/solv/reldep_parser.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "reldep_parser.hpp"
 
+#include "utils/regex.hpp"
+
 #include <regex>
 #include <string>
 
@@ -26,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::solv {
 
 static const std::regex RELDEP_REGEX("^(\\S*)\\s*(\\S*)?\\s*(\\S*)$");
-#define MAX_RELDEP_LENGTH 2 << 10
 
 static bool set_cmp_type(libdnf::rpm::Reldep::CmpType * cmp_type, std::string cmp_type_string, long int length) {
     if (length == 2) {
@@ -64,7 +65,7 @@ static bool set_cmp_type(libdnf::rpm::Reldep::CmpType * cmp_type, std::string cm
 bool ReldepParser::parse(const std::string & reldep) {
     enum { NAME = 1, CMP_TYPE = 2, EVR = 3 };
     std::smatch match;
-    if (reldep.length() > MAX_RELDEP_LENGTH) {
+    if (reldep.length() > MAX_STRING_LENGTH_FOR_REGEX_MATCH) {
         // GCC std::regex_match() exhausts a stack on very long strings.
         return false;
     }

--- a/test/libdnf/module/test_module.cpp
+++ b/test/libdnf/module/test_module.cpp
@@ -426,6 +426,10 @@ void ModuleTest::test_nsvcap() {
 
     // Empty fields are not allowed
     CPPUNIT_ASSERT_EQUAL(false, nsvcap.parse("meson:master::06d0a27d", Nsvcap::Form::NSVC));
+
+    // Strings longer than 2 KB are not allowed
+    CPPUNIT_ASSERT_EQUAL(true, nsvcap.parse(std::string(2048, 'a'), Nsvcap::Form::N));
+    CPPUNIT_ASSERT_EQUAL(false, nsvcap.parse(std::string(2048 + 1, 'a'), Nsvcap::Form::N));
 }
 
 


### PR DESCRIPTION
There is a known bug in GCC std::regex_match() that exhausts a stack on very long strings.

This patch prevents this by rejecting strings longer than 2 KB. Another solution would be to move to a heap-based regular expression engine, like PCRE2.

<https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164>