### PR TITLE
dnf5: Transaction progress: Fix total number of actions, hide total transaction progress bar

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -190,6 +190,8 @@ public:
         }
     }
 
+    libdnf::cli::progressbar::MultiProgressBar * get_multi_progress_bar() { return &multi_progress_bar; }
+
     void install_progress(
         [[maybe_unused]] const libdnf::rpm::TransactionItem & item,
         uint64_t amount,
@@ -535,7 +537,23 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         cmd_line += argv[i];
     }
 
-    transaction.set_callbacks(std::make_unique<RpmTransCB>());
+    // Compute the total number of transaction actions (number of bars)
+    // Total number of actions = number of packages in the transaction +
+    //                           action of verifying package files if new package files are present in the transaction +
+    //                           action of preparing transaction
+    const auto & trans_packages = transaction.get_transaction_packages();
+    auto num_of_actions = trans_packages.size() + 1;
+    for (auto & trans_pkg : trans_packages) {
+        if (libdnf::transaction::transaction_item_action_is_inbound(trans_pkg.get_action())) {
+            ++num_of_actions;
+            break;
+        }
+    }
+
+    auto callbacks = std::make_unique<RpmTransCB>();
+    callbacks->get_multi_progress_bar()->set_total_num_of_bars(num_of_actions);
+    transaction.set_callbacks(std::move(callbacks));
+
     transaction.set_description(cmd_line);
 
     if (comment) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -176,6 +176,10 @@ namespace {
 
 class RpmTransCB : public libdnf::rpm::TransactionCallbacks {
 public:
+    RpmTransCB() {
+        multi_progress_bar.set_total_bar_visible_limit(libdnf::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
+    }
+
     ~RpmTransCB() {
         if (active_progress_bar &&
             active_progress_bar->get_state() != libdnf::cli::progressbar::ProgressBarState::ERROR) {
@@ -539,6 +543,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
     }
 
     auto result = transaction.run();
+    std::cout << std::endl;
     if (result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         std::cout << "Transaction failed: " << libdnf::base::Transaction::transaction_result_to_string(result)
                   << std::endl;

--- a/include/libdnf-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/multi_progress_bar.hpp
@@ -53,6 +53,14 @@ public:
     /// Sets the visibility of number widget in the total bar.
     void set_total_bar_number_widget_visible(bool value) noexcept { total.set_number_widget_visible(value); }
 
+    /// Allows to preset the value of the total number of progress bars.
+    /// If the value is lower than the current number of registered progress bars, it is automatically increased.
+    void set_total_num_of_bars(std::size_t value) noexcept;
+
+    /// Returns the total number of progress bars.
+    /// It can be greater than the current number of registered progress bars.
+    std::size_t get_total_num_of_bars() const noexcept;
+
 private:
     std::size_t total_bar_visible_limit{0};
     std::vector<std::unique_ptr<ProgressBar>> bars_all;

--- a/include/libdnf-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/multi_progress_bar.hpp
@@ -35,6 +35,8 @@ namespace libdnf::cli::progressbar {
 
 class MultiProgressBar {
 public:
+    static constexpr std::size_t NEVER_VISIBLE_LIMIT = static_cast<std::size_t>(-1);
+
     explicit MultiProgressBar();
     ~MultiProgressBar();
 

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -79,6 +79,9 @@ public:
     // TODO(jrohel): Return reference instead of copy?
     std::vector<libdnf::base::TransactionPackage> get_transaction_packages() const;
 
+    /// @return the number of transaction packages.
+    std::size_t get_transaction_packages_count() const;
+
     /// @return the transaction groups.
     std::vector<libdnf::base::TransactionGroup> & get_transaction_groups() const;
 

--- a/libdnf-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf-cli/progressbar/multi_progress_bar.cpp
@@ -60,12 +60,38 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
     }
 
     bars_all.push_back(std::move(bar));
-    total.set_total(static_cast<int>(bars_all.size()));
 
-    // update total (in [num/total]) in all bars
-    for (auto & i : bars_all) {
+    // update total (in [num/total]) in total progress bar
+    auto registered_bars_count = static_cast<int32_t>(bars_all.size());
+    if (total.get_total() < registered_bars_count) {
+        total.set_total(registered_bars_count);
+    }
+
+    // update total (in [num/total]) in all bars to do
+    for (auto & i : bars_todo) {
         i->set_total(total.get_total());
     }
+}
+
+
+void MultiProgressBar::set_total_num_of_bars(std::size_t value) noexcept {
+    if (value < bars_all.size()) {
+        value = bars_all.size();
+    }
+    auto num_of_bars = static_cast<int>(value);
+    if (num_of_bars != total.get_total()) {
+        total.set_total(num_of_bars);
+
+        // update total (in [num/total]) in all bars to do
+        for (auto & i : bars_todo) {
+            i->set_total(total.get_total());
+        }
+    }
+}
+
+
+std::size_t MultiProgressBar::get_total_num_of_bars() const noexcept {
+    return static_cast<std::size_t>(total.get_total());
 }
 
 

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -102,6 +102,10 @@ std::vector<TransactionPackage> Transaction::get_transaction_packages() const {
     return p_impl->packages;
 }
 
+std::size_t Transaction::get_transaction_packages_count() const {
+    return p_impl->packages.size();
+}
+
 std::vector<TransactionGroup> & Transaction::get_transaction_groups() const {
     return p_impl->groups;
 }


### PR DESCRIPTION
- dnf5: Hides total transaction progress bar - It was showing nonsensical information.
- dnf5: Fixes total number of actions (steps) in transaction progress - It shows [x/max], before fix [x/x+1].

Solves: https://bugzilla.redhat.com/show_bug.cgi?id=2180229