### PR TITLE
Move clang-format back to the latest Fedora

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,17 +6,8 @@ jobs:
   clang-format:
     name: Clang Format
     runs-on: ubuntu-latest
-    # TODO(mblaha) temporarily lock to Fedora 35 due to bugged
-    # clang-format (clang-tools-extra-0:14.0.0-1.fc36):
-    # https://github.com/llvm/llvm-project/issues/55260
-    # change back to ghcr.io/rpm-software-management/dnf-ci-host when fixed
-    container: registry.fedoraproject.org/fedora:35
+    container: ghcr.io/rpm-software-management/dnf-ci-host
     steps:
-      # TODO(mblaha) remove this step when dnf-ci-host image is used again
-      - name: Install clang-tools-extra and git
-        run: |
-          dnf install -y git clang-tools-extra
-
       - name: Check out sources
         uses: actions/checkout@v2
         with:

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -1390,7 +1390,9 @@ void PackageQuery::PQImpl::filter_provides(
             auto reldep_list_size = reldep_list.size();
             for (int index = 0; index < reldep_list_size; ++index) {
                 Id reldep_id = reldep_list.get_id(index).id;
-                FOR_PROVIDES(p, pp, reldep_id) { filter_result.add_unsafe(p); }
+                FOR_PROVIDES(p, pp, reldep_id) {
+                    filter_result.add_unsafe(p);
+                }
             }
             break;
         }


### PR DESCRIPTION
Blocked by https://github.com/rpm-software-management/ci-dnf-stack/pull/1223