### PR TITLE
swig: Throw Python exception on undefined var

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -17,6 +17,8 @@
 %exception {
     try {
         $action
+    } catch (const std::out_of_range & e) {
+        SWIG_exception(SWIG_IndexError, e.what());
     } catch (const std::runtime_error & e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
     }

--- a/test/python3/libdnf5/conf/test_vars.py
+++ b/test/python3/libdnf5/conf/test_vars.py
@@ -1,0 +1,24 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import base_test_case
+
+
+class TestVars(base_test_case.BaseTestCase):
+    def test_getting_undefined_variable(self):
+        vars = self.base.get_vars()
+        self.assertRaises(IndexError, vars.get_value, "undefined")


### PR DESCRIPTION
Throw a Python exception instead of C++ one when undefined variable is being accessed.

Closes #292.