### PR TITLE
Introduce a new API assertion

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -21,6 +21,14 @@
 %import "rpm.i"
 %import "transaction.i"
 
+%exception {
+    try {
+        $action
+    } catch (const libdnf::UserAssertionError & e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+}
+
 %{
     #include "libdnf/logger/memory_buffer_logger.hpp"
     #include "libdnf/base/base.hpp"

--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -16,6 +16,14 @@
 %import "repo.i"
 %import "transaction.i"
 
+%exception {
+    try {
+        $action
+    } catch (const libdnf::UserAssertionError & e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+}
+
 %{
     #include "libdnf/comps/group/package.hpp"
     #include "libdnf/comps/group/group.hpp"

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -22,6 +22,8 @@
         $action
     } catch (const std::runtime_error & e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
+    } catch (const libdnf::UserAssertionError & e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
     }
 }
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -60,8 +60,9 @@ void Base::lock() {
 }
 
 void Base::unlock() {
-    libdnf_assert(locked_base, "Base::unlock() called on unlocked \"Base\" instance");
-    libdnf_assert(locked_base == this, "Called Base::unlock(). But the lock is not owned by this \"Base\" instance.");
+    libdnf_user_assert(locked_base, "Base::unlock() called on unlocked \"Base\" instance");
+    libdnf_user_assert(
+        locked_base == this, "Called Base::unlock(). But the lock is not owned by this \"Base\" instance.");
     locked_base = nullptr;
     locked_base_mutex.unlock();
 }
@@ -138,7 +139,7 @@ void Base::load_plugins() {
 
 void Base::setup() {
     auto & pool = p_impl->pool;
-    libdnf_assert(!pool, "Base was already initialized");
+    libdnf_user_assert(!pool, "Base was already initialized");
 
     load_plugins();
     p_impl->plugins.init();

--- a/libdnf/base/base_impl.hpp
+++ b/libdnf/base/base_impl.hpp
@@ -45,12 +45,12 @@ public:
     libdnf::advisory::AdvisorySackWeakPtr get_rpm_advisory_sack() { return rpm_advisory_sack.get_weak_ptr(); }
 
     solv::RpmPool & get_rpm_pool() {
-        libdnf_assert(pool, "Base instance was not fully initialized by Base::setup()");
+        libdnf_user_assert(pool, "Base instance was not fully initialized by Base::setup()");
         return *pool;
     }
 
     solv::CompsPool & get_comps_pool() {
-        libdnf_assert(comps_pool, "Base instance was not fully initialized by Base::setup()");
+        libdnf_user_assert(comps_pool, "Base instance was not fully initialized by Base::setup()");
         return *comps_pool;
     }
 

--- a/libdnf/common/exception.cpp
+++ b/libdnf/common/exception.cpp
@@ -52,6 +52,29 @@ const char * AssertionError::what() const noexcept {
     }
 }
 
+UserAssertionError::UserAssertionError(
+    const char * assertion, const SourceLocation & location, const std::string & message)
+    : logic_error(message),
+      condition(assertion),
+      location(location) {}
+
+
+const char * UserAssertionError::what() const noexcept {
+    try {
+        str_what = location.file_name + std::string(":") + std::to_string(location.source_line) + ": " +
+                   location.function_name;
+        if (condition) {
+            str_what += std::string(": API Assertion '") + condition + "' failed: ";
+        } else {
+            str_what += ": API Assertion failed: ";
+        }
+        str_what += logic_error::what();
+        return str_what.c_str();
+    } catch (...) {
+        return logic_error::what();
+    }
+}
+
 SystemError::SystemError(int error_code) : Error(M_("System error")), error_code(error_code), has_user_message(false) {}
 
 std::string SystemError::get_error_message() const {

--- a/test/libdnf/base/test_base.cpp
+++ b/test/libdnf/base/test_base.cpp
@@ -50,13 +50,38 @@ void BaseTest::test_weak_ptr() {
     CPPUNIT_ASSERT_THROW(vars2->get_value("test_variable"), libdnf::AssertionError);
 }
 
-void BaseTest::test_incorrect_workflow() {
+void BaseTest::test_missing_setup() {
     // Creates a new Base object
     auto base = get_preconfigured_base();
 
     // Base object is not fully initialized - not initialized by Base::setup()
-    CPPUNIT_ASSERT_THROW(libdnf::rpm::PackageQuery(*base.get()), libdnf::AssertionError);
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::PackageQuery(*base.get()), libdnf::UserAssertionError);
 
     base->setup();
     libdnf::rpm::PackageQuery(*base.get());
+}
+
+void BaseTest::test_repeated_setup() {
+    // Creates a new Base object
+    auto base = get_preconfigured_base();
+
+    // Initialize the Base
+    base->setup();
+
+    // Base was already initialized
+    CPPUNIT_ASSERT_THROW(base->setup(), libdnf::UserAssertionError);
+}
+
+void BaseTest::test_unlock_not_locked() {
+    // Creates a new Base object
+    auto base = get_preconfigured_base();
+
+    // Base::unlock() called on unlocked Base instance
+    CPPUNIT_ASSERT_THROW(base->unlock(), libdnf::UserAssertionError);
+
+    // Lock the Base first
+    base->lock();
+
+    // Unlocking should work now
+    base->unlock();
 }

--- a/test/libdnf/base/test_base.hpp
+++ b/test/libdnf/base/test_base.hpp
@@ -30,12 +30,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 class BaseTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(BaseTest);
     CPPUNIT_TEST(test_weak_ptr);
-    CPPUNIT_TEST(test_incorrect_workflow);
+    CPPUNIT_TEST(test_missing_setup);
+    CPPUNIT_TEST(test_repeated_setup);
+    CPPUNIT_TEST(test_unlock_not_locked);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void test_weak_ptr();
-    void test_incorrect_workflow();
+    void test_missing_setup();
+    void test_repeated_setup();
+    void test_unlock_not_locked();
 };
 
 

--- a/test/python3/libdnf5/base/test_base.py
+++ b/test/python3/libdnf5/base/test_base.py
@@ -53,3 +53,13 @@ class TestBase(unittest.TestCase):
         #    vars.get_value("test_variable")
         #with self.assertRaisesRegex(RuntimeError, 'Dereferencing an invalidated WeakPtr'):
         #    vars2.get_value("test_variable")
+
+    def test_missing_setup_goal_resolve(self):
+        # Create a new Base object
+        base = libdnf5.base.Base()
+
+        # Create a new empty Goal
+        goal = libdnf5.base.Goal(base)
+
+        # Try to resolve the goal without running base.setup()
+        self.assertRaises(RuntimeError, goal.resolve)

--- a/test/python3/libdnf5/comps/test_group.py
+++ b/test/python3/libdnf5/comps/test_group.py
@@ -28,3 +28,10 @@ class TestGroup(base_test_case.BaseTestCase):
         self.add_repo_repomd("repomd-comps-core")
         q_core = libdnf5.comps.GroupQuery(self.base)
         core = q_core.get()
+
+    def test_group_query_without_setup(self):
+        # Create a new Base object
+        base = libdnf5.base.Base()
+
+        # Try to create a group query without running base.setup()
+        self.assertRaises(RuntimeError, libdnf5.comps.GroupQuery, base)

--- a/test/python3/libdnf5/rpm/test_package_query.py
+++ b/test/python3/libdnf5/rpm/test_package_query.py
@@ -137,3 +137,10 @@ class TestPackageQuery(base_test_case.BaseTestCase):
         query.filter_name(["pkg"])
         package = next(iter(query))
         self.assertEqual(package.get_reason(), libdnf5.transaction.TransactionItemReason_NONE)
+
+    def test_pkg_query_without_setup(self):
+        # Create a new Base object
+        base = libdnf5.base.Base()
+
+        # Try to create a packge query without running base.setup()
+        self.assertRaises(RuntimeError, libdnf5.rpm.PackageQuery, base)


### PR DESCRIPTION
Introducing a new `UserAssertionError` to be thrown when clients are using our public API in a bad way.

This one is intended to be handled on the SWIG layer as opposed to the `AssertionError` which is supposed to terminate the process and collect coredump.

Closes #290.