### PR TITLE
Ignore inaccessible config file unless its path was specified as --config=...

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -93,6 +93,9 @@
 %include "libdnf/conf/option_binds.hpp"
 
 %ignore libdnf::ConfigParserError;
+%ignore libdnf::InaccessibleConfigError;
+%ignore libdnf::MissingConfigError;
+%ignore libdnf::InvalidConfigError;
 %ignore ConfigParserSectionNotFoundError;
 %ignore ConfigParserOptionNotFoundError;
 %include "libdnf/conf/config_parser.hpp"

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_BASE_BASE_HPP
 
 #include "libdnf/base/base_weak.hpp"
+#include "libdnf/common/exception.hpp"
 #include "libdnf/common/impl_ptr.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/comps/comps.hpp"

--- a/include/libdnf/conf/config_parser.hpp
+++ b/include/libdnf/conf/config_parser.hpp
@@ -34,6 +34,30 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+/// Error accessing config file other than ENOENT; e.g. we don't have read permission
+class InaccessibleConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "InaccessibleConfigError"; }
+};
+
+/// Configuration file is missing
+class MissingConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "MissingConfigError"; }
+};
+
+/// Configuration file is invalid
+class InvalidConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "InvalidConfigError"; }
+};
+
 class ConfigParserError : public Error {
 public:
     using Error::Error;

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -77,27 +77,29 @@ void Base::load_defaults() {
         ConfigParser parser;
         parser.read(file_path);
         config.load_from_parser(parser, "main", vars, *get_logger(), Option::Priority::DEFAULT);
-    } catch (const std::filesystem::filesystem_error & ex) {
-        if (ex.code().value() == ENOENT) {
-            log_router.debug("Configuration file \"{}\" not found", file_path);
-        } else {
-            std::throw_with_nested(RuntimeError(M_("Unable to load configuration file \"{}\""), file_path));
-        }
-    } catch (const libdnf::Error & ex) {
-        std::throw_with_nested(RuntimeError(M_("Error in configuration file \"{}\""), file_path));
+    } catch (const libdnf::MissingConfigError & ex) {
+        log_router.debug("Configuration file \"{}\" not found", file_path);
     }
 }
 
-void Base::load_config_from_file(const std::string & path) try {
+void Base::load_config_from_file(const std::string & path) {
     ConfigParser parser;
     parser.read(path);
     config.load_from_parser(parser, "main", vars, *get_logger());
-} catch (const Error & e) {
-    std::throw_with_nested(RuntimeError(M_("Unable to load configuration file \"{}\""), path));
 }
 
-void Base::load_config_from_file() {
+void Base::load_config_from_file() try {
     load_config_from_file(config.config_file_path().get_value());
+} catch (const MissingConfigError & e) {
+    // Ignore the missing config file unless the user specified it via --config=...
+    if (config.config_file_path().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+        throw;
+    }
+} catch (const InaccessibleConfigError & e) {
+    // Ignore the inaccessible config file unless the user specified it via --config=...
+    if (config.config_file_path().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+        throw;
+    }
 }
 
 void Base::load_config_from_dir(const std::string & dir_path) {

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -352,7 +352,20 @@ void RepoSack::create_repos_from_file(const std::string & path) {
 }
 
 void RepoSack::create_repos_from_config_file() {
-    create_repos_from_file(std::filesystem::path(base->get_config().config_file_path().get_value()));
+    const auto & path = base->get_config().config_file_path().get_value();
+    try {
+        create_repos_from_file(std::filesystem::path(path));
+    } catch (const libdnf::MissingConfigError & e) {
+        // Ignore the missing config file unless user specified it via --config=...
+        if (base->get_config().config_file_path().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+            throw;
+        }
+    } catch (const libdnf::InaccessibleConfigError & e) {
+        // Ignore the inaccessible config file unless user specified it via --config=...
+        if (base->get_config().config_file_path().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+            throw;
+        }
+    }
 }
 
 void RepoSack::create_repos_from_dir(const std::string & dir_path) {


### PR DESCRIPTION
Ignore a missing or otherwise inaccessible `/etc/dnf/dnf.conf` instead of throwing an error.

If the user specifies the path to the config file on the command line, like `dnf --config=/path/to/dnf.conf`, then an error will still be thrown and displayed.

Similarly, if the config file is accessible but malformed/invalid, an error will still be thrown.

Resolves https://github.com/rpm-software-management/dnf5/issues/305
