### PR TITLE
Prefer transaction.download() over directly using PackageDownloader

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -270,26 +270,8 @@ void download_packages(const std::vector<libdnf::rpm::Package> & packages, const
     }
 
     std::cout << "Downloading Packages:" << std::endl;
-    try {
-        downloader.download(true, true);
-    } catch (const std::runtime_error & ex) {
-        std::cout << "Exception: " << ex.what() << std::endl;
-    }
+    downloader.download(true, true);
     std::cout << std::endl;
-}
-
-void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir) {
-    std::vector<libdnf::rpm::Package> downloads;
-    for (auto & tspkg : transaction.get_transaction_packages()) {
-        if (transaction_item_action_is_inbound(tspkg.get_action()) &&
-            tspkg.get_package().get_repo()->get_type() != libdnf::repo::Repo::Type::COMMANDLINE) {
-            downloads.push_back(tspkg.get_package());
-        }
-    }
-
-    if (!downloads.empty()) {
-        download_packages(downloads, dest_dir);
-    }
 }
 
 namespace {
@@ -634,7 +616,7 @@ bool Context::check_gpg_signatures(const libdnf::base::Transaction & transaction
 
 
 void Context::download_and_run(libdnf::base::Transaction & transaction) {
-    download_packages(transaction, nullptr);
+    transaction.download();
 
     std::cout << std::endl << "Verifying PGP signatures" << std::endl;
     if (!check_gpg_signatures(transaction)) {

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -29,9 +29,6 @@ class PackageDownloadCallbacks(libdnf5.repo.DownloadCallbacks):
         print("Mirror failure: ", msg)
         return 0
 
-# Create a package downloader.
-downloader = libdnf5.repo.PackageDownloader()
-
 downloader_callbacks = PackageDownloadCallbacks()
 base.set_download_callbacks(libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks))
 


### PR DESCRIPTION
Use the new [transaction.download()](https://github.com/rpm-software-management/dnf5/pull/294) in a couple places instead of using PackageDownloader directly. 

Not sure whether it's worth it to use it [here](https://github.com/rpm-software-management/dnf5/blob/adfdfb0535b62b96a8a4015dedbae663483f2ba9/dnf5daemon-server/services/goal/goal.cpp#L157) since download callbacks need to be set up.