### PR TITLE
Add a new method whether base was correctly initialized

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -85,7 +85,11 @@ public:
     /// The method is supposed to be called after configuration is updated, application plugins applied
     /// their pre configuration modification in configuration, but before repositories are loaded or any Package
     /// or Advisory query created.
+    /// Calling the method for the second time result in throwing an exception
     void setup();
+
+    /// Returns true when setup() (mandatory method in many workflows) was alredy called
+    bool is_initialized();
 
     // TODO(jmracek) Remove from public API due to unstability of the code
     transaction::TransactionHistoryWeakPtr get_transaction_history() { return transaction_history.get_weak_ptr(); }

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -192,4 +192,8 @@ void Base::setup() {
     p_impl->plugins.post_base_setup();
 }
 
+bool Base::is_initialized() {
+    return p_impl->pool.get() != nullptr;
+}
+
 }  // namespace libdnf


### PR DESCRIPTION
The methods is required in some applications with not exactly transparent work-flows.

Resolves: https://github.com/rpm-software-management/dnf5/issues/310