### PR TITLE
Strict config option deprecation

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/exception.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <rpm/rpmbuild.h>
 
@@ -78,6 +79,8 @@ void BuildDepCommand::set_argument_parser() {
             return true;
         });
     cmd.register_named_arg(defs);
+
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
 }
 
 void BuildDepCommand::configure() {

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -58,13 +58,6 @@ void BuildDepCommand::set_argument_parser() {
     });
     cmd.register_positional_arg(specs);
 
-    auto skip_unavailable = parser.add_new_named_arg("skip-unavailable");
-    skip_unavailable->set_long_name("skip-unavailable");
-    skip_unavailable->set_description("Skip build dependencies not available in repositories");
-    skip_unavailable->set_const_value("true");
-    skip_unavailable->link_value(&skip_unavailable_option);
-    cmd.register_named_arg(skip_unavailable);
-
     auto defs = parser.add_new_named_arg("rpm_macros");
     defs->set_short_name('D');
     defs->set_long_name("define");
@@ -277,10 +270,12 @@ void BuildDepCommand::run() {
 }
 
 void BuildDepCommand::goal_resolved() {
-    auto & transaction = *get_context().get_transaction();
+    auto & ctx = get_context();
+    auto & transaction = *ctx.get_transaction();
     auto transaction_problems = transaction.get_problems();
     if (transaction_problems != libdnf::GoalProblem::NO_PROBLEM) {
-        if (transaction_problems != libdnf::GoalProblem::NOT_FOUND || !skip_unavailable_option.get_value()) {
+        auto skip_unavailable = ctx.base.get_config().skip_unavailable().get_value();
+        if (transaction_problems != libdnf::GoalProblem::NOT_FOUND || !skip_unavailable) {
             throw GoalResolveError(transaction);
         }
     }

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -52,7 +52,6 @@ private:
     std::vector<std::string> pkg_specs{};
     std::vector<std::string> spec_file_paths{};
     std::vector<std::string> srpm_file_paths{};
-    libdnf::OptionBool skip_unavailable_option{false};
     std::vector<std::pair<std::string, std::string>> rpm_macros{};
 };
 

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "distro-sync.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/option_string.hpp>
 
 namespace dnf5 {
@@ -49,6 +50,8 @@ void DistroSyncCommand::set_argument_parser() {
     cmd.register_positional_arg(patterns_arg);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
 }
 
 void DistroSyncCommand::configure() {

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
 #define DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
 
-#include "../shared_options.hpp"
-
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "downgrade.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 using namespace libdnf::cli;
@@ -50,6 +52,8 @@ void DowngradeCommand::set_argument_parser() {
     cmd.register_positional_arg(keys);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
 }
 
 void DowngradeCommand::configure() {

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 #define DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 
-#include "../shared_options.hpp"
-
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 
 #include <memory>
 #include <vector>

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group_install.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/group/group.hpp>
 #include <libdnf/comps/group/query.hpp>
@@ -36,6 +37,9 @@ void GroupInstallCommand::set_argument_parser() {
 
     with_optional = std::make_unique<GroupWithOptionalOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
+
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
 }
 
 void GroupInstallCommand::configure() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "install.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/const.hpp>
 
 namespace dnf5 {
@@ -61,6 +62,9 @@ void InstallCommand::set_argument_parser() {
     advisory_severity = std::make_unique<AdvisorySeverityOption>(*this);
     advisory_bz = std::make_unique<BzOption>(*this);
     advisory_cve = std::make_unique<CveOption>(*this);
+
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
 }
 
 void InstallCommand::configure() {

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -21,9 +21,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_INSTALL_INSTALL_HPP
 
 #include "../advisory_shared.hpp"
-#include "../shared_options.hpp"
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 #include <libdnf/rpm/package.hpp>
 
 #include <memory>

--- a/dnf5/commands/mark/mark.cpp
+++ b/dnf5/commands/mark/mark.cpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "mark.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 using namespace libdnf::cli;
@@ -34,6 +36,7 @@ void MarkCommand::set_parent_command() {
 
 void MarkCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Change the reason of an installed package");
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
 }
 
 void MarkCommand::register_subcommands() {

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "reinstall.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 using namespace libdnf::cli;
@@ -48,6 +50,9 @@ void ReinstallCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, true, true); });
     cmd.register_positional_arg(keys);
+
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
 }
 
 void ReinstallCommand::configure() {

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -20,9 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_SWAP_SWAP_HPP
 #define DNF5_COMMANDS_SWAP_SWAP_HPP
 
-#include "../shared_options.hpp"
-
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 
 #include <vector>
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "upgrade.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/const.hpp>
 
 namespace dnf5 {
@@ -63,6 +64,7 @@ void UpgradeCommand::set_argument_parser() {
     cmd.register_positional_arg(keys);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -21,9 +21,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 
 #include "../advisory_shared.hpp"
-#include "../shared_options.hpp"
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -33,6 +33,7 @@ public:
               command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
 };
 
+
 }  // namespace dnf5
 
 #endif  // DNF5_COMMANDS_SHARED_OPTIONS_HPP

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/bgettext/bgettext-lib.h"
 
+#include <dnf5/context.hpp>
 #include <libdnf-cli/session.hpp>
 
 namespace dnf5 {
@@ -31,6 +32,30 @@ public:
     explicit AllowErasingOption(libdnf::cli::session::Command & command)
         : BoolOption(
               command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
+};
+
+class SkipBrokenOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit SkipBrokenOption(dnf5::Command & command)
+        : BoolOption(
+              command,
+              "skip-broken",
+              '\0',
+              _("Allow resolving of depsolve problems by skipping packages"),
+              false,
+              &command.get_context().base.get_config().skip_broken()) {}
+};
+
+class SkipUnavailableOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit SkipUnavailableOption(dnf5::Command & command)
+        : BoolOption(
+              command,
+              "skip-unavailable",
+              '\0',
+              _("Allow skipping unavailable packages"),
+              false,
+              &command.get_context().base.get_config().skip_unavailable()) {}
 };
 
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -264,20 +264,6 @@ void RootCommand::set_argument_parser() {
         global_options_group->register_argument(exclude);
     }
 
-    auto skip_broken = parser.add_new_named_arg("skip-broken");
-    skip_broken->set_long_name("skip-broken");
-    skip_broken->set_description("resolve depsolve problems by skipping packages");
-    skip_broken->set_const_value("true");
-    skip_broken->link_value(&config.skip_broken());
-    global_options_group->register_argument(skip_broken);
-
-    auto skip_unavailable = parser.add_new_named_arg("skip-unavailable");
-    skip_unavailable->set_long_name("skip-unavailable");
-    skip_unavailable->set_description("allow skipping unavailable packages");
-    skip_unavailable->set_const_value("true");
-    skip_unavailable->link_value(&config.skip_unavailable());
-    global_options_group->register_argument(skip_unavailable);
-
     auto enable_repo_ids = parser.add_new_named_arg("enable-repo");
     enable_repo_ids->set_long_name("enable-repo");
     enable_repo_ids->set_has_value(true);

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -271,6 +271,13 @@ void RootCommand::set_argument_parser() {
     skip_broken->link_value(&config.skip_broken());
     global_options_group->register_argument(skip_broken);
 
+    auto skip_unavailable = parser.add_new_named_arg("skip-unavailable");
+    skip_unavailable->set_long_name("skip-unavailable");
+    skip_unavailable->set_description("allow skipping unavailable packages");
+    skip_unavailable->set_const_value("true");
+    skip_unavailable->link_value(&config.skip_unavailable());
+    global_options_group->register_argument(skip_unavailable);
+
     auto enable_repo_ids = parser.add_new_named_arg("enable-repo");
     enable_repo_ids->set_long_name("enable-repo");
     enable_repo_ids->set_has_value(true);

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -267,8 +267,8 @@ void RootCommand::set_argument_parser() {
     auto skip_broken = parser.add_new_named_arg("skip-broken");
     skip_broken->set_long_name("skip-broken");
     skip_broken->set_description("resolve depsolve problems by skipping packages");
-    skip_broken->set_const_value("false");
-    skip_broken->link_value(&config.strict());
+    skip_broken->set_const_value("true");
+    skip_broken->link_value(&config.skip_broken());
     global_options_group->register_argument(skip_broken);
 
     auto enable_repo_ids = parser.add_new_named_arg("enable-repo");

--- a/dnf5daemon-client/commands/install/install.hpp
+++ b/dnf5daemon-client/commands/install/install.hpp
@@ -35,7 +35,8 @@ public:
     void run() override;
 
 private:
-    libdnf::OptionBool strict_option{false};
+    libdnf::OptionBool skip_broken_option{false};
+    libdnf::OptionBool skip_unavailable_option{false};
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -95,8 +95,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
             - repo_ids: list of strings
                 Identifiers of the repos from which the packages could be installed.
-            - strict: boolean, default true
-                Indicates whether existing but non-installable packages should be skipped (false) or cause transaction resolving fail (true).
+            - skip_broken: boolean, default false
+                Whether solver can skip packages with broken dependencies to resolve transaction
+            - skip_unavailable: boolean, default false
+                Whether nonexisting packages can be skipped.
 
         Unknown options are ignored.
     -->

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -324,19 +324,27 @@ sdbus::MethodReply Rpm::install(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMap options;
     call >> options;
 
-    libdnf::GoalSetting strict;
-    if (options.find("strict") != options.end()) {
-        strict =
-            key_value_map_get<bool>(options, "strict") ? libdnf::GoalSetting::SET_TRUE : libdnf::GoalSetting::SET_FALSE;
+    libdnf::GoalSetting skip_broken;
+    if (options.find("skip_broken") != options.end()) {
+        skip_broken = key_value_map_get<bool>(options, "skip_broken") ? libdnf::GoalSetting::SET_TRUE
+                                                                      : libdnf::GoalSetting::SET_FALSE;
     } else {
-        strict = libdnf::GoalSetting::AUTO;
+        skip_broken = libdnf::GoalSetting::AUTO;
+    }
+    libdnf::GoalSetting skip_unavailable;
+    if (options.find("skip_unavailable") != options.end()) {
+        skip_unavailable = key_value_map_get<bool>(options, "skip_unavailable") ? libdnf::GoalSetting::SET_TRUE
+                                                                                : libdnf::GoalSetting::SET_FALSE;
+    } else {
+        skip_unavailable = libdnf::GoalSetting::AUTO;
     }
     std::vector<std::string> repo_ids = key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
     // fill the goal
     auto & goal = session.get_goal();
     libdnf::GoalJobSettings setting;
-    setting.strict = strict;
+    setting.skip_broken = skip_broken;
+    setting.skip_unavailable = skip_unavailable;
     setting.to_repo_ids = repo_ids;
     for (const auto & spec : specs) {
         goal.add_rpm_install(spec, setting);

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -166,7 +166,8 @@ public:
         const std::string & long_name,
         char short_name,
         const std::string & desc,
-        bool default_value);
+        bool default_value,
+        libdnf::OptionBool * linked_option = nullptr);
 
     /// @return Parsed value.
     /// @since 5.0

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -134,8 +134,10 @@ public:
 
 struct GoalJobSettings : public ResolveSpecSettings {
 public:
-    /// Return used value for strict
-    GoalUsedSetting get_used_strict() const { return used_strict; };
+    /// Return used value for skip_broken
+    GoalUsedSetting get_used_skip_broken() const { return used_skip_broken; };
+    /// Return used value for skip_unavailable
+    GoalUsedSetting get_used_skip_unavailable() const { return used_skip_unavailable; };
     /// Return used value for best
     GoalUsedSetting get_used_best() const { return used_best; };
     /// Return used value for clean_requirements_on_remove
@@ -156,8 +158,10 @@ public:
 
     /// Set whether hints should be reported
     bool report_hint{true};
-    /// Set strict, AUTO means that it is handled according to the default behavior
-    GoalSetting strict{GoalSetting::AUTO};
+    /// Set skip_broken, AUTO means that it is handled according to the default behavior
+    GoalSetting skip_broken{GoalSetting::AUTO};
+    /// Set skip_unavailable, AUTO means that it is handled according to the default behavior
+    GoalSetting skip_unavailable{GoalSetting::AUTO};
     /// Set best, AUTO means that it is handled according to the default behavior
     GoalSetting best{GoalSetting::AUTO};
     /// Set clean_requirements_on_remove, AUTO means that it is handled according to the default behavior
@@ -173,19 +177,28 @@ private:
     // TODO(lukash) fix the documentation of the methods below, "resolve FOO and store
     // the result" doesn't really describe what is actually going on
 
-    /// Resolve strict value and store the result as the value used.
+    /// Resolve skip_broken value and store the result as the value used.
     ///
     /// @param cfg_main Main config used to resolve GoalSetting::auto
     /// @return Resolved value.
     /// @exception libdnf::AssertionError When a different value already stored or when invalid value
     /// @since 1.0
-    bool resolve_strict(const libdnf::ConfigMain & cfg_main);
-    /// Resolve strict value and store the result as the value used. When GoalSetting::auto it returns false
+    bool resolve_skip_broken(const libdnf::ConfigMain & cfg_main);
+    /// Resolve skip_broken value and store the result as the value used. When GoalSetting::auto it returns false
     ///
     /// @return Resolved value.
     /// @exception libdnf::AssertionError When a different value already stored
     /// @since 1.0
-    bool resolve_strict();
+    bool resolve_skip_broken();
+
+    /// Resolve skip_unavailable value and store the result as the value used.
+    ///
+    /// @param cfg_main Main config used to resolve GoalSetting::auto
+    /// @return Resolved value.
+    /// @exception libdnf::AssertionError When a different value already stored or when invalid value
+    /// @since 1.0
+    bool resolve_skip_unavailable(const libdnf::ConfigMain & cfg_main);
+
     /// Resolve best value and store the result as the value used.
     ///
     /// @param cfg_main Main config used to resolve GoalSetting::auto
@@ -212,7 +225,8 @@ private:
     /// @exception libdnf::AssertionError When a different value already stored or when invalid value
     libdnf::comps::PackageType resolve_group_package_types(const libdnf::ConfigMain & cfg_main);
 
-    GoalUsedSetting used_strict{GoalUsedSetting::UNUSED};
+    GoalUsedSetting used_skip_broken{GoalUsedSetting::UNUSED};
+    GoalUsedSetting used_skip_unavailable{GoalUsedSetting::UNUSED};
     GoalUsedSetting used_best{GoalUsedSetting::UNUSED};
     GoalUsedSetting used_clean_requirements_on_remove{GoalUsedSetting::UNUSED};
     std::optional<libdnf::comps::PackageType> used_group_package_types{std::nullopt};

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -172,10 +172,15 @@ public:
     const OptionStringList & history_record_packages() const;
     OptionString & rpmverbosity();
     const OptionString & rpmverbosity() const;
-    OptionBool & strict();  // :api
+    /// Option `strict` is deprecated. Please use skip_broken and skip_unavailable
+    OptionBool & strict();
     const OptionBool & strict() const;
-    OptionBool & skip_broken();  // :yum-compatibility
+    /// Solver is allowed to skip transaction packages with broken dependencies
+    OptionBool & skip_broken();
     const OptionBool & skip_broken() const;
+    /// Solver is allowed to skip packages that are not available in repositories
+    OptionBool & skip_unavailable();
+    const OptionBool & skip_unavailable() const;
     OptionBool & autocheck_running_kernel();  // :yum-compatibility
     const OptionBool & autocheck_running_kernel() const;
     OptionBool & clean_requirements_on_remove();

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -98,10 +98,9 @@ BoolOption::BoolOption(
     const std::string & long_name,
     char short_name,
     const std::string & desc,
-    bool default_value) {
+    bool default_value,
+    libdnf::OptionBool * linked_option) {
     auto & parser = command.get_session().get_argument_parser();
-    conf =
-        dynamic_cast<libdnf::OptionBool *>(parser.add_init_value(std::make_unique<libdnf::OptionBool>(default_value)));
     arg = parser.add_new_named_arg(long_name);
 
     if (!long_name.empty()) {
@@ -114,6 +113,12 @@ BoolOption::BoolOption(
 
     arg->set_description(desc);
     arg->set_const_value(default_value ? "false" : "true");
+    if (linked_option) {
+        conf = linked_option;
+    } else {
+        conf = dynamic_cast<libdnf::OptionBool *>(
+            parser.add_init_value(std::make_unique<libdnf::OptionBool>(default_value)));
+    }
     arg->link_value(conf);
 
     command.get_argument_parser_command()->register_named_arg(arg);

--- a/libdnf/base/goal_elements.cpp
+++ b/libdnf/base/goal_elements.cpp
@@ -24,12 +24,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-bool GoalJobSettings::resolve_strict(const libdnf::ConfigMain & cfg_main) {
+bool GoalJobSettings::resolve_skip_broken(const libdnf::ConfigMain & cfg_main) {
     auto resolved = GoalUsedSetting::UNUSED;
-    switch (strict) {
+    switch (skip_broken) {
         case GoalSetting::AUTO: {
-            bool strict = cfg_main.strict().get_value();
-            resolved = strict ? GoalUsedSetting::USED_TRUE : GoalUsedSetting::USED_FALSE;
+            bool skip_broken = cfg_main.skip_broken().get_value();
+            resolved = skip_broken ? GoalUsedSetting::USED_TRUE : GoalUsedSetting::USED_FALSE;
         } break;
         case GoalSetting::SET_TRUE:
             resolved = GoalUsedSetting::USED_TRUE;
@@ -40,23 +40,47 @@ bool GoalJobSettings::resolve_strict(const libdnf::ConfigMain & cfg_main) {
     }
 
     libdnf_assert(
-        used_strict == GoalUsedSetting::UNUSED || resolved == used_strict,
-        "\"strict\" is already set to a different value");
+        used_skip_broken == GoalUsedSetting::UNUSED || resolved == used_skip_broken,
+        "\"skip_broken\" is already set to a different value");
 
-    used_strict = resolved;
+    used_skip_broken = resolved;
     return resolved == GoalUsedSetting::USED_TRUE;
 }
 
-bool GoalJobSettings::resolve_strict() {
-    bool strict_bool = strict == GoalSetting::SET_TRUE;
-    auto resolved = strict_bool ? GoalUsedSetting::USED_TRUE : GoalUsedSetting::USED_FALSE;
+bool GoalJobSettings::resolve_skip_unavailable(const libdnf::ConfigMain & cfg_main) {
+    auto resolved = GoalUsedSetting::UNUSED;
+    switch (skip_unavailable) {
+        case GoalSetting::AUTO: {
+            bool skip_unavailable = cfg_main.skip_unavailable().get_value();
+            resolved = skip_unavailable ? GoalUsedSetting::USED_TRUE : GoalUsedSetting::USED_FALSE;
+        } break;
+        case GoalSetting::SET_TRUE:
+            resolved = GoalUsedSetting::USED_TRUE;
+            break;
+        case GoalSetting::SET_FALSE:
+            resolved = GoalUsedSetting::USED_FALSE;
+            break;
+    }
 
     libdnf_assert(
-        used_strict == GoalUsedSetting::UNUSED || resolved == used_strict, "Used value for 'used_strict' already set");
+        used_skip_unavailable == GoalUsedSetting::UNUSED || resolved == used_skip_unavailable,
+        "\"skip_unavailable\" is already set to a different value");
 
-    used_strict = resolved;
+    used_skip_unavailable = resolved;
+    return resolved == GoalUsedSetting::USED_TRUE;
+}
 
-    return strict_bool;
+bool GoalJobSettings::resolve_skip_broken() {
+    bool skip_broken_bool = skip_broken == GoalSetting::SET_TRUE;
+    auto resolved = skip_broken_bool ? GoalUsedSetting::USED_TRUE : GoalUsedSetting::USED_FALSE;
+
+    libdnf_assert(
+        used_skip_broken == GoalUsedSetting::UNUSED || resolved == used_skip_broken,
+        "Used value for 'used_skip_broken' already set");
+
+    used_skip_broken = resolved;
+
+    return skip_broken_bool;
 }
 
 bool GoalJobSettings::resolve_best(const libdnf::ConfigMain & cfg_main) {

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -59,7 +59,10 @@ public:
         rpm::PackageQuery installed_query);
 
     GoalProblem report_not_found(
-        GoalAction action, const std::string & pkg_spec, const GoalJobSettings & settings, bool strict);
+        GoalAction action,
+        const std::string & pkg_spec,
+        const GoalJobSettings & settings,
+        libdnf::Logger::Level log_level);
     void add_resolve_log(
         GoalAction action,
         GoalProblem problem,
@@ -67,7 +70,7 @@ public:
         const LogEvent::SpecType spec_type,
         const std::string & spec,
         const std::set<std::string> & additional_data,
-        bool strict);
+        libdnf::Logger::Level log_level);
     void add_resolve_log(
         GoalProblem problem,
         std::vector<std::vector<std::pair<libdnf::ProblemRules, std::vector<std::string>>>> problems);

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -434,7 +434,21 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("history_record", history_record);
     owner.opt_binds().add("history_record_packages", history_record_packages);
     owner.opt_binds().add("rpmverbosity", rpmverbosity);
-    owner.opt_binds().add("strict", strict);
+
+    // If strict value has been explicitly set, use it's negated value as a default
+    // for skip_broken and skip_unavailable
+    owner.opt_binds().add(
+        "strict",
+        strict,
+        [&](Option::Priority priority, const std::string & value) {
+            bool val = strict.from_string(value);
+            strict.set(priority, val);
+            skip_broken.set(Option::Priority::DEFAULT, !val);
+            skip_unavailable.set(Option::Priority::DEFAULT, !val);
+        },
+        nullptr,
+        false);
+
     owner.opt_binds().add("skip_broken", skip_broken);
     owner.opt_binds().add("skip_unavailable", skip_unavailable);
     owner.opt_binds().add("autocheck_running_kernel", autocheck_running_kernel);

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -251,8 +251,9 @@ class ConfigMain::Impl {
     OptionBool history_record{true};
     OptionStringList history_record_packages{std::vector<std::string>{"dnf", "rpm"}};
     OptionString rpmverbosity{"info"};
-    OptionBool strict{true};                    // :api
-    OptionBool skip_broken{false};              // :yum-compatibility
+    OptionBool strict{true};  // deprecated
+    OptionBool skip_broken{false};
+    OptionBool skip_unavailable{false};
     OptionBool autocheck_running_kernel{true};  // :yum-compatibility
     OptionBool clean_requirements_on_remove{true};
 
@@ -435,6 +436,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("rpmverbosity", rpmverbosity);
     owner.opt_binds().add("strict", strict);
     owner.opt_binds().add("skip_broken", skip_broken);
+    owner.opt_binds().add("skip_unavailable", skip_unavailable);
     owner.opt_binds().add("autocheck_running_kernel", autocheck_running_kernel);
     owner.opt_binds().add("clean_requirements_on_remove", clean_requirements_on_remove);
     owner.opt_binds().add("history_list_view", history_list_view);
@@ -1000,6 +1002,13 @@ OptionBool & ConfigMain::skip_broken() {
 }
 const OptionBool & ConfigMain::skip_broken() const {
     return p_impl->skip_broken;
+}
+
+OptionBool & ConfigMain::skip_unavailable() {
+    return p_impl->skip_unavailable;
+}
+const OptionBool & ConfigMain::skip_unavailable() const {
+    return p_impl->skip_unavailable;
 }
 
 OptionBool & ConfigMain::autocheck_running_kernel() {

--- a/libdnf/module/module_goal_private.cpp
+++ b/libdnf/module/module_goal_private.cpp
@@ -35,9 +35,9 @@ extern "C" {
 namespace libdnf::module {
 
 
-void ModuleGoalPrivate::add_provide_install(Id reldepid, bool strict, bool best) {
+void ModuleGoalPrivate::add_provide_install(Id reldepid, bool skip_broken, bool best) {
     staging.push_back(
-        SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES | SOLVER_SETARCH | SOLVER_SETEVR | (strict ? 0 : SOLVER_WEAK) |
+        SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES | SOLVER_SETARCH | SOLVER_SETEVR | (skip_broken ? SOLVER_WEAK : 0) |
             (best ? SOLVER_FORCEBEST : 0),
         reldepid);
 }

--- a/libdnf/module/module_goal_private.hpp
+++ b/libdnf/module/module_goal_private.hpp
@@ -46,10 +46,10 @@ public:
     /// Adds an install operation for given provide.
     ///
     /// @param reldepid Id of the reldep to install.
-    /// @param strict Whether it's strictly or only weakly required.
+    /// @param skip_broken Whether solver can skip reldep with unmet dependencies
     /// @param best Whether the latest version is required or not.
     /// @since 5.0
-    void add_provide_install(Id reldepid, bool strict, bool best);
+    void add_provide_install(Id reldepid, bool skip_broken, bool best);
 
     /// Resolve all operations.
     ///

--- a/libdnf/module/module_sack.cpp
+++ b/libdnf/module/module_sack.cpp
@@ -435,14 +435,14 @@ std::pair<std::vector<std::vector<std::string>>, ModuleSack::ModuleErrorType> Mo
             state = ModuleState::AVAILABLE;
         }
 
-        goal_strict.add_provide_install(reldep_id, 1, 1);
-        goal_weak.add_provide_install(reldep_id, 0, 0);
+        goal_strict.add_provide_install(reldep_id, 0, 1);
+        goal_weak.add_provide_install(reldep_id, 1, 0);
         if (state == ModuleState::ENABLED) {
-            goal_best.add_provide_install(reldep_id, 1, 1);
-            goal.add_provide_install(reldep_id, 1, 0);
-        } else {
             goal_best.add_provide_install(reldep_id, 0, 1);
             goal.add_provide_install(reldep_id, 0, 0);
+        } else {
+            goal_best.add_provide_install(reldep_id, 1, 1);
+            goal.add_provide_install(reldep_id, 1, 0);
         }
     }
 

--- a/test/dnf5daemon-server/test_install.py
+++ b/test/dnf5daemon-server/test_install.py
@@ -55,9 +55,9 @@ class InstallTest(support.InstallrootCase):
 
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))
 
-    def test_install_strict(self):
-        '''with strict=True attempt to install nonexistent package returns error'''
-        self.iface_rpm.install(['no_one'], dbus.Dictionary({'strict': True}, signature='sv'))
+    def test_install_no_skip_unavailable(self):
+        '''with skip_unavailable=False attempt to install nonexistent package returns error'''
+        self.iface_rpm.install(['no_one'], dbus.Dictionary({'skip_unavailable': False}, signature='sv'))
         resolved, result = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 
         self.assertEqual(result, 2)
@@ -71,12 +71,12 @@ class InstallTest(support.InstallrootCase):
         self.assertEqual(errors, dbus.Array([
             dbus.String('No match for argument: no_one')], signature=dbus.Signature('s')))
 
-    def test_install_nostrict(self):
+    def test_install_skip_unavailable(self):
         '''
-        with strict=True attempt to install nonexistent package returns empty
+        with skip_unavailable=True attempt to install nonexistent package returns empty
         transaction
         '''
-        self.iface_rpm.install(['no_one'], dbus.Dictionary({'strict': False}, signature='sv'))
+        self.iface_rpm.install(['no_one'], dbus.Dictionary({'skip_unavailable': True}, signature='sv'))
 
         resolved, result = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -55,7 +55,7 @@ void BaseGoalTest::test_install_not_available() {
     add_repo_repomd("repomd-repo1");
 
     libdnf::Goal goal(base);
-    base.get_config().strict().set(false);
+    base.get_config().skip_unavailable().set(true);
     base.get_config().best().set(true);
     base.get_config().clean_requirements_on_remove().set(true);
     goal.add_rpm_install("not_available");
@@ -72,7 +72,8 @@ void BaseGoalTest::test_install_not_available() {
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_FALSE, fist_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_TRUE, fist_event.get_job_settings()->get_used_best());
-    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_FALSE, fist_event.get_job_settings()->get_used_strict());
+    CPPUNIT_ASSERT_EQUAL(
+        libdnf::GoalUsedSetting::USED_TRUE, fist_event.get_job_settings()->get_used_skip_unavailable());
 }
 
 void BaseGoalTest::test_install_from_cmdline() {
@@ -221,7 +222,7 @@ void BaseGoalTest::test_remove_not_installed() {
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_TRUE, first_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_best());
-    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_strict());
+    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_skip_unavailable());
 }
 
 void BaseGoalTest::test_install_installed_pkg() {
@@ -321,7 +322,7 @@ void BaseGoalTest::test_upgrade_not_downgrade_from_cmdline() {
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_best());
-    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_strict());
+    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_skip_unavailable());
 }
 
 void BaseGoalTest::test_upgrade_not_available() {
@@ -346,7 +347,7 @@ void BaseGoalTest::test_upgrade_not_available() {
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_TRUE, first_event.get_job_settings()->get_used_best());
-    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_strict());
+    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_skip_unavailable());
 }
 
 void BaseGoalTest::test_upgrade_all() {


### PR DESCRIPTION
The PR introduces new config options

- `skip_broken` - for solver to enable resolving problems by skipping problematic packages
- `skip_unavailable` - to not fail when requested package is not available

Deprecated `strict` option (if explicitely set) is used as a default value for these new options.

Also all occurrences of `strict` usage in the codebase are replaced by `skip_broken` / `skip_unavailable`.

Fixes https://github.com/rpm-software-management/dnf5/issues/269