### PR TITLE
SWIG: Add advisory bindings

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 
 # list of all modules that will be included in libdnf bindings
-list(APPEND SWIG_LIBDNF5_MODULES base common comps conf logger repo rpm transaction plugin)
+list(APPEND SWIG_LIBDNF5_MODULES advisory base common comps conf logger repo rpm transaction plugin)
 
 
 # list of all modules that will be included in libdnf-cli bindings

--- a/bindings/libdnf5/advisory.i
+++ b/bindings/libdnf5/advisory.i
@@ -1,0 +1,47 @@
+#if defined(SWIGPYTHON)
+%module(package="libdnf5") advisory
+#elif defined(SWIGPERL)
+%module "libdnf5::advisory"
+#elif defined(SWIGRUBY)
+%module "libdnf5/advisory"
+#endif
+
+%include <exception.i>
+%include <std_vector.i>
+
+%include <shared.i>
+
+%import "common.i"
+
+// TODO(jkolarik): advisory modules skipped for now
+
+%{
+    #include "libdnf/advisory/advisory.hpp"
+    #include "libdnf/advisory/advisory_package.hpp"
+    #include "libdnf/advisory/advisory_set.hpp"
+    #include "libdnf/advisory/advisory_set_iterator.hpp"
+    #include "libdnf/advisory/advisory_collection.hpp"
+    #include "libdnf/advisory/advisory_query.hpp"
+    #include "libdnf/advisory/advisory_reference.hpp"
+%}
+
+#define CV __perl_CV
+
+%include "libdnf/advisory/advisory.hpp"
+%include "libdnf/advisory/advisory_package.hpp"
+%include "libdnf/advisory/advisory_set.hpp"
+
+%rename(next) libdnf::advisory::AdvisorySetIterator::operator++();
+%rename(value) libdnf::advisory::AdvisorySetIterator::operator*();
+%include "libdnf/advisory/advisory_set_iterator.hpp"
+
+%ignore libdnf::advisory::AdvisoryCollection::get_modules();
+%include "libdnf/advisory/advisory_collection.hpp"
+%include "libdnf/advisory/advisory_query.hpp"
+%include "libdnf/advisory/advisory_reference.hpp"
+
+%template(VectorAdvisoryCollection) std::vector<libdnf::advisory::AdvisoryCollection>;
+%template(VectorAdvisoryPackage) std::vector<libdnf::advisory::AdvisoryPackage>;
+%template(VectorAdvisoryReference) std::vector<libdnf::advisory::AdvisoryReference>;
+
+add_iterator(AdvisorySet)

--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -12,6 +12,7 @@
 
 %include <shared.i>
 
+%import "advisory.i"
 %import "common.i"
 %import "comps.i"
 %import "conf.i"

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -26,8 +26,6 @@
 }
 
 %{
-    #include "libdnf/advisory/advisory_module.hpp"
-    #include "libdnf/advisory/advisory_query.hpp"
     #include "libdnf/rpm/checksum.hpp"
     #include "libdnf/rpm/nevra.hpp"
     #include "libdnf/rpm/package.hpp"

--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -20,13 +20,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_ADVISORY_ADVISORY_HPP
 #define LIBDNF_ADVISORY_ADVISORY_HPP
 
-#include <libdnf/rpm/package_sack.hpp>
+#include "libdnf/base/base_weak.hpp"
 
+#include <string>
 #include <vector>
 
 
 namespace libdnf::advisory {
 
+class AdvisoryCollection;
 class AdvisoryReference;
 
 struct AdvisoryId {
@@ -127,10 +129,10 @@ public:
 protected:
     /// Construct the Advisory object
     ///
-    /// @param sack   WeakPtr to libdnf::rpm::PackageSack instance which holds the data.
+    /// @param base   WeakPtr to libdnf::base::Base instance which this object belongs to.
     /// @param id     AdvisoryId into libsolv pool.
     /// @return New Advisory instance.
-    Advisory(const libdnf::BaseWeakPtr & base, AdvisoryId id);
+    Advisory(const BaseWeakPtr & base, AdvisoryId id);
 
 private:
     friend class AdvisoryCollection;
@@ -139,7 +141,7 @@ private:
     friend class AdvisorySetIterator;
     friend class AdvisorySet;
 
-    libdnf::BaseWeakPtr base;
+    BaseWeakPtr base;
 
     AdvisoryId id;
 };

--- a/include/libdnf/advisory/advisory_collection.hpp
+++ b/include/libdnf/advisory/advisory_collection.hpp
@@ -63,12 +63,12 @@ public:
 
 private:
     friend Advisory;
-    friend AdvisoryQuery;
-    friend AdvisorySet;
-    friend AdvisoryPackage;
     friend AdvisoryModule;
+    friend AdvisoryPackage;
+    friend AdvisorySet;
+    friend class AdvisoryQuery;
 
-    AdvisoryCollection(const libdnf::BaseWeakPtr & base, AdvisoryId advisory, int index);
+    AdvisoryCollection(const BaseWeakPtr & base, AdvisoryId advisory, int index);
 
     //TODO(amatej): Hide into an Impl?
     /// Get all AdvisoryPackages stored in this AdvisoryCollection
@@ -87,7 +87,7 @@ private:
     ///                         them when collecting AdvisoryModules from multiple collections.
     void get_modules(std::vector<AdvisoryModule> & output);
 
-    libdnf::BaseWeakPtr base;
+    BaseWeakPtr base;
 
     AdvisoryId advisory;
 

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -20,7 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
 #define LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
 
-#include "libdnf/advisory/advisory.hpp"
+#include "advisory.hpp"
+
 #include "libdnf/common/impl_ptr.hpp"
 
 #include <vector>

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -20,14 +20,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
 #define LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
 
-#include "libdnf/advisory/advisory.hpp"
-#include "libdnf/advisory/advisory_collection.hpp"
-#include "libdnf/advisory/advisory_package.hpp"
-#include "libdnf/advisory/advisory_reference.hpp"
-#include "libdnf/advisory/advisory_set.hpp"
+#include "advisory.hpp"
+#include "advisory_collection.hpp"
+#include "advisory_package.hpp"
+#include "advisory_reference.hpp"
+#include "advisory_set.hpp"
+
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/rpm/package.hpp"
+#include "libdnf/rpm/package_set.hpp"
 
 
 namespace libdnf::advisory {
@@ -39,12 +41,12 @@ public:
     /// Create a new AdvisoryQuery instance.
     ///
     /// @param base     A weak pointer to Base
-    explicit AdvisoryQuery(const BaseWeakPtr & base);
+    explicit AdvisoryQuery(const libdnf::BaseWeakPtr & base);
 
     /// Create a new AdvisoryQuery instance.
     ///
     /// @param base     Reference to Base
-    explicit AdvisoryQuery(Base & base);
+    explicit AdvisoryQuery(libdnf::Base & base);
 
     AdvisoryQuery(const AdvisoryQuery & src) = default;
     AdvisoryQuery & operator=(const AdvisoryQuery & src) = default;

--- a/include/libdnf/advisory/advisory_reference.hpp
+++ b/include/libdnf/advisory/advisory_reference.hpp
@@ -66,9 +66,9 @@ private:
     /// @param advisory AdvisoryId into libsolv pool.
     /// @param index    Index of this reference in its advisory.
     /// @return New AdvisoryReference instance.
-    AdvisoryReference(const libdnf::BaseWeakPtr & base, AdvisoryId advisory, int index);
+    AdvisoryReference(const BaseWeakPtr & base, AdvisoryId advisory, int index);
 
-    libdnf::BaseWeakPtr base;
+    BaseWeakPtr base;
     AdvisoryId advisory;
 
     /// We cannot store IDs of reference data (id, type, title, url) because they

--- a/include/libdnf/advisory/advisory_set.hpp
+++ b/include/libdnf/advisory/advisory_set.hpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_ADVISORY_ADVISORY_SET_HPP
 #define LIBDNF_ADVISORY_ADVISORY_SET_HPP
 
-
+#include "advisory_package.hpp"
 #include "advisory_set_iterator.hpp"
 
 #include "libdnf/common/exception.hpp"
@@ -35,12 +35,6 @@ namespace libdnf::solv {
 class SolvMap;
 
 }  // namespace libdnf::solv
-
-namespace libdnf::rpm {
-
-class PackageQuery;
-
-}  // namespace libdnf::rpm
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -26,8 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/pool.hpp"
 #include "solv/solv_map.hpp"
 
-#include "libdnf/advisory/advisory_set.hpp"
-#include "libdnf/rpm/package_set.hpp"
 #include "libdnf/utils/patterns.hpp"
 
 #include <solv/evr.h>

--- a/test/python3/libdnf5/advisory/test_advisory.py
+++ b/test/python3/libdnf5/advisory/test_advisory.py
@@ -1,0 +1,32 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import libdnf5
+
+import base_test_case
+
+
+class TestAdvisory(base_test_case.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.add_repo_repomd("repomd-repo1")
+
+    def test_get_name(self):
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        query.filter_type("security")
+        pkg = next(iter(query))
+        self.assertEqual(pkg.get_name(), "DNF-2019-1")

--- a/test/python3/libdnf5/tutorial/transaction/transaction.py
+++ b/test/python3/libdnf5/tutorial/transaction/transaction.py
@@ -29,9 +29,6 @@ class PackageDownloadCallbacks(libdnf5.repo.DownloadCallbacks):
         print("Mirror failure: ", msg)
         return 0
 
-# Create a package downloader.
-downloader = libdnf5.repo.PackageDownloader()
-
 downloader_callbacks = PackageDownloadCallbacks()
 base.set_download_callbacks(libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks))
 


### PR DESCRIPTION
Generate bindings for `Advisory` objects.

This is needed for example for Ansible module, to apply security filters in `GoalJobSettings`.