### PR TITLE
SWIG: Add wrapper for package changelogs

### DIFF
--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -63,6 +63,8 @@
 %include "libdnf/rpm/reldep_list.hpp"
 %include "libdnf/rpm/package.hpp"
 
+%template(VectorChangelog) std::vector<libdnf::rpm::Changelog>;
+
 %rename(next) libdnf::rpm::PackageSetIterator::operator++();
 %rename(value) libdnf::rpm::PackageSetIterator::operator*();
 %include "libdnf/rpm/package_set_iterator.hpp"

--- a/test/data/repos-repomd/repomd-repo1/repodata/other.xml
+++ b/test/data/repos-repomd/repomd-repo1/repodata/other.xml
@@ -3,6 +3,8 @@
 
 <package pkgid="ec57b154a186fdc1f71976fc0fde97d51c744bc88d222828b4cfa42e3b1f855b" name="pkg" arch="x86_64">
   <version epoch="0" ver="1.2" rel="3"/>
+  <changelog author="Joe Black" date="1641027600">First change</changelog>
+  <changelog author="Jo White" date="1672563600">Second change</changelog>
 </package>
 
 <package pkgid="caa857c48130b4fdea3f7fa498da4324ae2ac00c8900d71c0eef0a90457636bd" name="pkg-libs" arch="x86_64">

--- a/test/data/repos-repomd/repomd-repo1/repodata/repomd.xml
+++ b/test/data/repos-repomd/repomd-repo1/repodata/repomd.xml
@@ -17,8 +17,8 @@
     <open-size>52911</open-size>
   </data>
   <data type="other">
-    <checksum type="sha256">6b1629e202cf424f893dda1ddec703165234c22f0ad5a1657dc77b357db2d189</checksum>
-    <open-checksum type="sha256">6b1629e202cf424f893dda1ddec703165234c22f0ad5a1657dc77b357db2d189</open-checksum>
+    <checksum type="sha256">10e89f037bb2fb624576f2b1268b123be3c5130e50cd6ccaa744ca0af17bf9a2</checksum>
+    <open-checksum type="sha256">10e89f037bb2fb624576f2b1268b123be3c5130e50cd6ccaa744ca0af17bf9a2</open-checksum>
     <location href="repodata/other.xml" />
     <timestamp>1597222003</timestamp>
     <size>13799</size>

--- a/test/python3/libdnf5/rpm/test_package_query.py
+++ b/test/python3/libdnf5/rpm/test_package_query.py
@@ -144,3 +144,15 @@ class TestPackageQuery(base_test_case.BaseTestCase):
 
         # Try to create a packge query without running base.setup()
         self.assertRaises(RuntimeError, libdnf5.rpm.PackageQuery, base)
+
+    def test_pkg_get_changelogs(self):
+        # Test wrapper for changelogs vector
+        query = libdnf5.rpm.PackageQuery(self.base)
+        query.filter_name(["pkg"])
+        package = next(iter(query))
+        logs = package.get_changelogs()
+        self.assertEqual(2, logs.size())
+        log = next(iter(logs))
+        self.assertEqual('First change', log.text)
+        self.assertEqual('Joe Black', log.author)
+        self.assertEqual(1641027600, log.timestamp)


### PR DESCRIPTION
Add bindings for `libdnf::rpm::Package::get_changelogs()` and provide related unit tests.

Closes #320.