### PR TITLE
GoalPrivate: Copy ctor to set user_installed_packages

### DIFF
--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -209,6 +209,9 @@ inline GoalPrivate::GoalPrivate(const GoalPrivate & src)
     if (src.protected_packages) {
         protected_packages.reset(new libdnf::solv::SolvMap(*src.protected_packages));
     }
+    if (src.user_installed_packages) {
+        user_installed_packages.reset(new libdnf::solv::IdQueue(*src.user_installed_packages));
+    }
 }
 
 inline GoalPrivate::~GoalPrivate() {


### PR DESCRIPTION
The copy of the solved GoalPrivate is used to detect skipped jobs or usage of non-best candidate in the solution.
Without user_installed_packages set the results of the copy resolving are invalid.