### PR TITLE
logger: Add support for logging in API scripts

### DIFF
--- a/bindings/libdnf5/logger.i
+++ b/bindings/libdnf5/logger.i
@@ -20,6 +20,7 @@ typedef int32_t pid_t;
     #include "libdnf/common/weak_ptr.hpp"
     #include "libdnf/logger/log_router.hpp"
     #include "libdnf/logger/memory_buffer_logger.hpp"
+    #include "libdnf/logger/factory.hpp"
 %}
 
 #define CV __perl_CV
@@ -45,3 +46,4 @@ wrap_unique_ptr(MemoryBufferLoggerUniquePtr, libdnf::MemoryBufferLogger);
 
 %include "libdnf/logger/log_router.hpp"
 %include "libdnf/logger/memory_buffer_logger.hpp"
+%include "libdnf/logger/factory.hpp"

--- a/bindings/libdnf5/logger.i
+++ b/bindings/libdnf5/logger.i
@@ -19,6 +19,7 @@ typedef int32_t pid_t;
 %{
     #include "libdnf/common/weak_ptr.hpp"
     #include "libdnf/logger/log_router.hpp"
+    #include "libdnf/logger/global_logger.hpp"
     #include "libdnf/logger/memory_buffer_logger.hpp"
     #include "libdnf/logger/factory.hpp"
 %}
@@ -45,5 +46,6 @@ wrap_unique_ptr(MemoryBufferLoggerUniquePtr, libdnf::MemoryBufferLogger);
 }
 
 %include "libdnf/logger/log_router.hpp"
+%include "libdnf/logger/global_logger.hpp"
 %include "libdnf/logger/memory_buffer_logger.hpp"
 %include "libdnf/logger/factory.hpp"

--- a/include/libdnf/logger/factory.hpp
+++ b/include/libdnf/logger/factory.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_LOGGER_FACTORY_HPP
+#define LIBDNF_LOGGER_FACTORY_HPP
+
+#include "logger.hpp"
+
+#include "libdnf/base/base.hpp"
+
+
+namespace libdnf {
+
+// File logger destination filename.
+constexpr const char * FILE_LOGGER_FILENAME = "dnf5.log";
+
+/// @brief Helper method for creating a file logger.
+/// @param base Reference to Base for loading the configured logger path.
+/// @return Instance of a new file logger.
+std::unique_ptr<libdnf::Logger> create_file_logger(libdnf::Base & base);
+
+}  // namespace libdnf
+
+#endif

--- a/libdnf/logger/factory.cpp
+++ b/libdnf/logger/factory.cpp
@@ -1,0 +1,51 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/logger/factory.hpp"
+
+#include "libdnf/logger/stream_logger.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+
+namespace libdnf {
+
+using namespace std::filesystem;
+
+std::unique_ptr<libdnf::Logger> create_file_logger(Base & base) {
+    auto & config = base.get_config();
+    auto & installroot = config.get_installroot_option().get_value();
+    auto & logdir = config.get_logdir_option().get_value();
+    auto logdir_full_path = path(installroot) / path(logdir).relative_path();
+
+    create_directories(logdir_full_path);
+    auto log_file = logdir_full_path / FILE_LOGGER_FILENAME;
+    auto log_stream = std::make_unique<std::ofstream>(log_file, std::ios::app);
+    if (!log_stream->is_open()) {
+        throw std::runtime_error(fmt::format("Cannot open log file: {}: {}", log_file.c_str(), strerror(errno)));
+    }
+
+    // Throw exceptions if there is an error while writing to the log stream
+    log_stream->exceptions(std::ios::badbit | std::ios::failbit);
+
+    return std::make_unique<libdnf::StreamLogger>(std::move(log_stream));
+}
+
+}  // namespace libdnf

--- a/test/libdnf/logger/test_file_logger.cpp
+++ b/test/libdnf/logger/test_file_logger.cpp
@@ -1,0 +1,63 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_file_logger.hpp"
+
+#include "libdnf/logger/factory.hpp"
+
+
+using namespace std::filesystem;
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FileLoggerTest);
+
+
+void FileLoggerTest::setUp() {
+    BaseTestCase::setUp();
+
+    auto & config = base.get_config();
+    auto & installroot = config.get_installroot_option().get_value();
+    auto & temp_logdir = "/var/log/FileLoggerTestLogDir";
+    config.get_logdir_option().set(temp_logdir);
+
+    full_log_path = path(installroot) / path(temp_logdir).relative_path() / libdnf::FILE_LOGGER_FILENAME;
+}
+
+
+void FileLoggerTest::tearDown() {
+    BaseTestCase::tearDown();
+    remove_all(full_log_path.parent_path());
+}
+
+
+void FileLoggerTest::test_file_logger_create() {
+    CPPUNIT_ASSERT(!exists(full_log_path));
+    auto file_logger = libdnf::create_file_logger(base);
+    CPPUNIT_ASSERT(exists(full_log_path));
+}
+
+
+void FileLoggerTest::test_file_logger_add() {
+    auto log_router = base.get_logger();
+    auto loggers_count_before = log_router->get_loggers_count();
+    auto file_logger = libdnf::create_file_logger(base);
+    log_router->add_logger(std::move(file_logger));
+    CPPUNIT_ASSERT_EQUAL(loggers_count_before + 1, log_router->get_loggers_count());
+}

--- a/test/libdnf/logger/test_file_logger.hpp
+++ b/test/libdnf/logger/test_file_logger.hpp
@@ -1,0 +1,46 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF_TEST_FILE_LOGGER_HPP
+#define LIBDNF_TEST_FILE_LOGGER_HPP
+
+#include "base_test_case.hpp"
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class FileLoggerTest : public BaseTestCase {
+    CPPUNIT_TEST_SUITE(FileLoggerTest);
+    CPPUNIT_TEST(test_file_logger_create);
+    CPPUNIT_TEST(test_file_logger_add);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+    void test_file_logger_create();
+    void test_file_logger_add();
+
+private:
+    std::filesystem::path full_log_path;
+};
+
+#endif

--- a/test/python3/libdnf5/logger/test_file_logger.py
+++ b/test/python3/libdnf5/logger/test_file_logger.py
@@ -45,3 +45,16 @@ class TestFileLogger(base_test_case.BaseTestCase):
         logger = libdnf5.logger.create_file_logger(self.base)
         log_router.add_logger(logger)
         self.assertEqual(loggers_count_before + 1, log_router.get_loggers_count())
+
+    def test_with_global_logger(self):
+        log_router = self.base.get_logger()
+        global_logger = libdnf5.logger.GlobalLogger()
+        global_logger.set(log_router.get(), libdnf5.logger.Logger.Level_DEBUG)
+        logger = libdnf5.logger.create_file_logger(self.base)
+        log_router.add_logger(logger)
+
+        # Run an action including librepo logging
+        self.add_repo_repomd("repomd-repo1")
+
+        with open(self.full_log_path) as logfile:
+            self.assertTrue('[librepo]' in logfile.read())

--- a/test/python3/libdnf5/logger/test_file_logger.py
+++ b/test/python3/libdnf5/logger/test_file_logger.py
@@ -1,0 +1,47 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import libdnf5
+
+import base_test_case
+
+import os
+import shutil
+
+
+class TestFileLogger(base_test_case.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        config = self.base.get_config()
+        config.logdir = "FileLoggerTestLogDir"
+        self.full_log_path = os.path.join(config.installroot, config.logdir, libdnf5.logger.FILE_LOGGER_FILENAME)
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(os.path.dirname(self.full_log_path), ignore_errors=True)
+
+    def test_file_logger_create(self):
+        self.assertFalse(os.path.exists(self.full_log_path))
+        _ = libdnf5.logger.create_file_logger(self.base)
+        self.assertTrue(os.path.exists(self.full_log_path))
+
+    def test_file_logger_add(self):
+        log_router = self.base.get_logger()
+        loggers_count_before = log_router.get_loggers_count()
+        logger = libdnf5.logger.create_file_logger(self.base)
+        log_router.add_logger(logger)
+        self.assertEqual(loggers_count_before + 1, log_router.get_loggers_count())


### PR DESCRIPTION
Create helper method for easily creating a file logger based on configured file path. The logic was separated from the `main` to its own file in order to be usable for API users.

Also added bindings for `GlobalLogger` class to setup libraries logging in API scripts.