### PR TITLE
Disable parallel running of some unit tests

### DIFF
--- a/test/dnf5daemon-server/CMakeLists.txt
+++ b/test/dnf5daemon-server/CMakeLists.txt
@@ -10,6 +10,8 @@ add_test(
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
+set_property(TEST test_dnf5daemon_server PROPERTY RUN_SERIAL TRUE)
+
 set_property(TEST test_dnf5daemon_server PROPERTY ENVIRONMENT
     "${ASAN_OPTIONS}"
     "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"

--- a/test/libdnf/CMakeLists.txt
+++ b/test/libdnf/CMakeLists.txt
@@ -29,3 +29,4 @@ endif()
 
 
 add_test(NAME test_libdnf COMMAND run_tests)
+set_tests_properties(test_libdnf PROPERTIES RUN_SERIAL TRUE)

--- a/test/perl5/CMakeLists.txt
+++ b/test/perl5/CMakeLists.txt
@@ -24,6 +24,8 @@ macro(add_perl_test)
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 
+    set_property(TEST "${target}" PROPERTY RUN_SERIAL TRUE)
+
     set_property(TEST ${target} PROPERTY ENVIRONMENT
         "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
         "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"

--- a/test/python3/libdnf5/CMakeLists.txt
+++ b/test/python3/libdnf5/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_test(NAME test_python3_libdnf COMMAND ${Python3_EXECUTABLE} -m unittest WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set_property(TEST test_python3_libdnf PROPERTY RUN_SERIAL TRUE)
+
 set_property(TEST test_python3_libdnf PROPERTY ENVIRONMENT
     "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
     "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"

--- a/test/ruby/CMakeLists.txt
+++ b/test/ruby/CMakeLists.txt
@@ -14,6 +14,8 @@ macro(add_ruby_test)
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 
+    set_property(TEST "${target}" PROPERTY RUN_SERIAL TRUE)
+
     # TODO the ODR violation seems like a problem with the Ruby bindings that
     # should be fixed
     set(ASAN_OPTIONS "${ASAN_OPTIONS},detect_odr_violation=0")

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -12,3 +12,4 @@ target_link_libraries(run_tests_tutorial stdc++ libdnf libdnf-cli cppunit)
 
 
 add_test(NAME test_tutorial COMMAND run_tests_tutorial)
+set_tests_properties(test_tutorial PROPERTIES RUN_SERIAL TRUE)


### PR DESCRIPTION
It's because of librpm. Testing CLI utilities can run in parallel.

Fixes an issue that often appeared in unit tests in the COPR build when using the multi-threaded version of the `RepoSack::update_and_load_repos`:
```
TRACE [rpm] entering chroot /tmp/libdnf5_unittest.wkCbFF/installroot/
ERROR [rpm] Unable to change root directory: Operation not permitted
```