### PR TITLE
Add capability to find binaries to resolve_spec

### DIFF
--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -125,6 +125,9 @@ public:
     /// Important for queries that resolve SPEC
     bool with_filenames{true};
     /// Important for queries that resolve SPEC
+    /// It will check whether SPEC is a binary -> /usr/(s)bin/<SPEC>
+    bool with_binaries{true};
+    /// Important for queries that resolve SPEC
     std::vector<libdnf::rpm::Nevra::Form> nevra_forms{};
 
     /// these flags are used only for group resolving

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -618,6 +618,9 @@ public:
     /// dependencies and are not required by any user-installed package any more.
     void filter_unneeded();
 
+    /// Resolve spec according to provided settings. It tests whether spec is NEVRA type, provide, file or binary.
+    /// It retuns only the first mach type. If spec has a mathes as NEVRA and provide type it only keeps matches with
+    /// the first tested type (NEVRA).
     // TODO(jmracek) return std::pair<bool, std::unique_ptr<libdnf::rpm::Nevra>>
     // @replaces libdnf/sack/query.hpp:method:std::pair<bool, std::unique_ptr<Nevra>> filterSubject(const char * subject, HyForm * forms, bool icase, bool with_nevra, bool with_provides, bool with_filenames);
     std::pair<bool, libdnf::rpm::Nevra> resolve_pkg_spec(


### PR DESCRIPTION
It will enhance UX when usel want to install package according to binary name without additional search steps.

It will allow to install open-ssh using `dnf5 install ssh`.

Resolves: https://github.com/rpm-software-management/dnf5/issues/338