### PR TITLE
solv_repo: Fix creating solver cache for comps (RhBug:2173929)

### DIFF
--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -398,7 +398,11 @@ void SolvRepo::load_repo_ext(RepodataType type, const RepoDownloader & downloade
     }
 
     if (config.get_build_cache_option().get_value()) {
-        write_ext(repo->nrepodata - 1, type);
+        if (type == RepodataType::COMPS) {
+            write_ext(comps_repo->nrepodata - 1, type);
+        } else {
+            write_ext(repo->nrepodata - 1, type);
+        }
     }
 }
 


### PR DESCRIPTION
There was a bug when creating a cache solver file for `comps` repos, an incorrect repo id was passed to `libsolv`. It was not always reproducible as it depends on the set of metadata being loaded.

Closes #341.