### PR TITLE
goal: Better handling of obsoleted pkg installation

### DIFF
--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -58,6 +58,13 @@ public:
     explicit PackageQuery(
         const libdnf::BaseWeakPtr & base, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES, bool empty = false);
     explicit PackageQuery(libdnf::Base & base, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES, bool empty = false);
+
+    /// Construct a new PackageQuery based on given PackageSet. This is a shortcut to creating
+    /// an empty PackageQuery and then updating it with the content of pkgset.
+    /// @param pkgset  A packageset that the new query will contain
+    /// @param flags   Which excludes the query respects
+    explicit PackageQuery(const PackageSet & pkgset, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES);
+
     PackageQuery(const PackageQuery & src);
     PackageQuery(PackageQuery && src) noexcept;
     ~PackageQuery();

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -267,6 +267,11 @@ PackageQuery::PackageQuery(const BaseWeakPtr & base, ExcludeFlags flags, bool em
 PackageQuery::PackageQuery(libdnf::Base & base, ExcludeFlags flags, bool empty)
     : PackageQuery(base.get_weak_ptr(), flags, empty) {}
 
+PackageQuery::PackageQuery(const PackageSet & pkgset, ExcludeFlags flags)
+    : PackageQuery(pkgset.get_base(), flags, true) {
+    update(pkgset);
+}
+
 PackageQuery::PackageQuery(const PackageQuery & src) : PackageSet(src), p_pq_impl(new PQImpl(*src.p_pq_impl)) {}
 
 PackageQuery::PackageQuery(PackageQuery && src) noexcept = default;


### PR DESCRIPTION
In situation where a package exists in multiple versions and some older version is being obsoleted, any of obsoleters was considered a valid solution.

The result could be really misleading. For example let's have this package set:

systemd-udev-1.0

systemd-udev-2.0
Obsoletes: systemd-udev < 2

systemd-boot-unsigned-2.0
Obsoletes: systemd-udev < 2

In this case `dnf install systemd-udev` may lead to installation of systemd-boot-unsigned which is probably not what the user expected. The reason is the split in the upgrade-path created by obsolete and both branches - systemd-udev-2.0 and systemd-boot-unsigned-2.0 are considered valid.

With this patch install command takes into account only obsoleters of the best version of the package so the `dnf install systemd-udev` results in correct installation of systemd-udev-2.0 package.

Resolves: https://github.com/rpm-software-management/dnf5/issues/339
Requires tests adjustment: https://github.com/rpm-software-management/ci-dnf-stack/pull/1236