### PR TITLE
man: Add info about download command destination

### DIFF
--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -32,7 +32,7 @@ Description
 ===========
 
 The ``download`` command in ``DNF5`` is used for downloading binary and source packages
-defined in ``package-spec`` arguments.
+defined in ``package-spec`` arguments to the current working directory.
 
 
 Options


### PR DESCRIPTION
Just small fix in man pages following up the comment from DNF5 Fedora Test Days.