### PR TITLE
Set a minimal sqlite version

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -63,6 +63,7 @@ Obsoletes:      microdnf < 4
 %global libmodulemd_version 2.5.0
 %global librepo_version 1.15.0
 %global libsolv_version 0.7.21
+%global sqlite_version 3.35.0
 %global swig_version 4
 %global zchunk_version 0.9.11
 
@@ -81,7 +82,7 @@ BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
 BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
-BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
 BuildRequires:  toml11-static
 
 %if %{with clang}
@@ -236,6 +237,7 @@ License:        LGPL-2.1-or-later
 #Requires:       libmodulemd{?_isa} >= {libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
+Requires:       sqlite-libs{%?_isa} >= %{sqlite_version}
 
 %description -n libdnf5
 Package management library.

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -90,7 +90,7 @@ target_include_directories(libdnf PRIVATE ${LIBREPO_INCLUDE_DIRS})
 target_link_libraries(libdnf ${LIBREPO_LDFLAGS})
 
 # SQLite3
-pkg_check_modules(SQLite3 REQUIRED sqlite3)
+pkg_check_modules(SQLite3 REQUIRED sqlite3>=3.35.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${SQLite3_MODULE_NAME}")
 target_link_libraries(libdnf ${SQLite3_LIBRARIES})
 


### PR DESCRIPTION
Installing a package on a system with sqlite-3.34.1 failed with:

    Running transaction
    SQL statement compilation failed: "
	INSERT INTO
	    "pkg_name" (
		"name"
	    )
	VALUES
	    (?)
	ON CONFLICT DO NOTHING
	RETURNING "id"
    ": (1) - SQL logic error

The cause is that libdnf5 uses "RETURNING" clause in sqlite queries. A support for this clause was added in sqlite-3.35.0. (Figured out experimentally and by reading sqlite sources. Sqlite news file only mentions "adds a number of new language features".)

This patch constrains the minial sqlite version to 3.35.0.