### PR TITLE
Fix a typo in sqlite Requires in dnf5.spec

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -237,7 +237,7 @@ License:        LGPL-2.1-or-later
 #Requires:       libmodulemd{?_isa} >= {libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
-Requires:       sqlite-libs{%?_isa} >= %{sqlite_version}
+Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
 
 %description -n libdnf5
 Package management library.


### PR DESCRIPTION
Introduced with commit bcc12c612379bbba665768bc2e3e3c3c1f5e55f5 (Set a minimal sqlite version).