### PR TITLE
Remove showdupesfromrepos config option

### DIFF
--- a/dnf5/commands/list/list.hpp
+++ b/dnf5/commands/list/list.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5/context.hpp>
 #include <libdnf-cli/output/package_list_sections.hpp>
-#include <libdnf/conf/option_bool.hpp>
+#include <libdnf-cli/session.hpp>
 #include <libdnf/rpm/package_set.hpp>
 
 #include <memory>
@@ -60,6 +60,9 @@ private:
     std::unique_ptr<libdnf::cli::session::BoolOption> recent{nullptr};
     std::unique_ptr<libdnf::cli::session::BoolOption> upgrades{nullptr};
     std::unique_ptr<libdnf::cli::session::BoolOption> autoremove{nullptr};
+
+    // show all NEVRAs, not only the latest one
+    std::unique_ptr<libdnf::cli::session::BoolOption> show_duplicates{nullptr};
 };
 
 

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -44,6 +44,9 @@ void SearchCommand::set_argument_parser() {
 
     all = std::make_unique<SearchAllOption>(*this);
     patterns = std::make_unique<SearchPatternsArguments>(*this, get_context());
+
+    auto show_duplicates = std::make_unique<libdnf::cli::session::BoolOption>(
+        *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
 }
 
 void SearchCommand::configure() {
@@ -54,7 +57,7 @@ void SearchCommand::configure() {
 
 void SearchCommand::run() {
     auto & base = get_context().base;
-    SearchProcessor processor(base, patterns->get_value(), all->get_value());
+    SearchProcessor processor(base, patterns->get_value(), all->get_value(), show_duplicates->get_value());
     libdnf::cli::output::print_search_results(processor.get_results());
 }
 

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -24,7 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
+#include <libdnf-cli/session.hpp>
 
 #include <memory>
 #include <vector>
@@ -43,6 +43,7 @@ public:
 private:
     std::unique_ptr<SearchAllOption> all{nullptr};
     std::unique_ptr<SearchPatternsArguments> patterns{nullptr};
+    std::unique_ptr<libdnf::cli::session::BoolOption> show_duplicates{nullptr};
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/search/search_processor.cpp
+++ b/dnf5/commands/search/search_processor.cpp
@@ -75,12 +75,13 @@ static auto get_cmp_from_pattern(const std::string & pattern) {
     }
 }
 
-SearchProcessor::SearchProcessor(libdnf::Base & base, std::vector<std::string> patterns, bool search_all)
+SearchProcessor::SearchProcessor(
+    libdnf::Base & base, std::vector<std::string> patterns, bool search_all, bool show_duplicates)
     : base(base),
       patterns(patterns),
       search_all(search_all),
       full_package_query(base),
-      showdupes(base.get_config().get_showdupesfromrepos_option().get_value()) {
+      showdupes(show_duplicates) {
     if (!showdupes) {
         full_package_query.filter_latest_evr();
     }

--- a/dnf5/commands/search/search_processor.hpp
+++ b/dnf5/commands/search/search_processor.hpp
@@ -35,7 +35,8 @@ namespace dnf5 {
 class SearchProcessor {
 public:
     /// Prepare the processor based on the parameters given by the user.
-    explicit SearchProcessor(libdnf::Base & base, std::vector<std::string> patterns, bool search_all);
+    explicit SearchProcessor(
+        libdnf::Base & base, std::vector<std::string> patterns, bool search_all, bool show_duplicates);
 
     /// Results computation method.
     libdnf::cli::output::SearchResults get_results();

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -122,8 +122,6 @@ public:
     const OptionBool & get_gpgkey_dns_verification_option() const;
     OptionBool & get_obsoletes_option();
     const OptionBool & get_obsoletes_option() const;
-    OptionBool & get_showdupesfromrepos_option();
-    const OptionBool & get_showdupesfromrepos_option() const;
     OptionBool & get_exit_on_lock_option();
     const OptionBool & get_exit_on_lock_option() const;
     OptionBool & get_allow_vendor_change_option();

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -209,7 +209,6 @@ class ConfigMain::Impl {
     OptionBool localpkg_gpgcheck{false};
     OptionBool gpgkey_dns_verification{false};
     OptionBool obsoletes{true};
-    OptionBool showdupesfromrepos{false};
     OptionBool exit_on_lock{false};
     OptionBool allow_vendor_change{true};
     OptionSeconds metadata_timer_sync{60 * 60 * 3};  // 3 hours
@@ -410,7 +409,6 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("localpkg_gpgcheck", localpkg_gpgcheck);
     owner.opt_binds().add("gpgkey_dns_verification", gpgkey_dns_verification);
     owner.opt_binds().add("obsoletes", obsoletes);
-    owner.opt_binds().add("showdupesfromrepos", showdupesfromrepos);
     owner.opt_binds().add("exit_on_lock", exit_on_lock);
     owner.opt_binds().add("allow_vendor_change", allow_vendor_change);
     owner.opt_binds().add("metadata_timer_sync", metadata_timer_sync);
@@ -829,13 +827,6 @@ OptionBool & ConfigMain::get_obsoletes_option() {
 }
 const OptionBool & ConfigMain::get_obsoletes_option() const {
     return p_impl->obsoletes;
-}
-
-OptionBool & ConfigMain::get_showdupesfromrepos_option() {
-    return p_impl->showdupesfromrepos;
-}
-const OptionBool & ConfigMain::get_showdupesfromrepos_option() const {
-    return p_impl->showdupesfromrepos;
 }
 
 OptionBool & ConfigMain::get_exit_on_lock_option() {


### PR DESCRIPTION
- the option is not documented even for dnf4
- the name is kind of cryptic

For commands that use it (list, info, search), the functionality is replaced by --showduplicates command line option.