### PR TITLE
search: Fix typo from the previous commit

### DIFF
--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -45,7 +45,7 @@ void SearchCommand::set_argument_parser() {
     all = std::make_unique<SearchAllOption>(*this);
     patterns = std::make_unique<SearchPatternsArguments>(*this, get_context());
 
-    auto show_duplicates = std::make_unique<libdnf::cli::session::BoolOption>(
+    show_duplicates = std::make_unique<libdnf::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
 }
 


### PR DESCRIPTION
Fix search command to work after previous changes related to `show_duplicates` option.