### PR TITLE
transaction: Fix impl constructor

### DIFF
--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -42,6 +42,7 @@ public:
           libsolv_transaction(src.libsolv_transaction ? transaction_create_clone(src.libsolv_transaction) : nullptr),
           problems(src.problems),
           packages(src.packages),
+          groups(src.groups),
           resolve_logs(src.resolve_logs),
           transaction_problems(src.transaction_problems) {}
     ~Impl();


### PR DESCRIPTION
Fix missing `groups` object copy in constructor.

Closes #384.