### PR TITLE
Correctly load repos from installroot config file

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -35,6 +35,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/package_sack.hpp"
 #include "libdnf/transaction/transaction_history.hpp"
 
+#include <functional>
 #include <map>
 
 
@@ -70,6 +71,9 @@ public:
 
     /// Returns a pointer to a locked "Base" instance or "nullptr" if no instance is locked.
     static Base * get_locked_base() noexcept;
+
+    /// Call a function that loads the config file, catching errors appropriately
+    void with_config_file_path(std::function<void(const std::string &)> func);
 
     /// Loads main configuration from file defined by the current configuration.
     void load_config_from_file();

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -92,7 +92,8 @@ void Base::load_config_from_file(const std::string & path) {
 void Base::load_config_from_file() {
     std::filesystem::path conf_path{config.get_config_file_path_option().get_value()};
     const auto & conf_path_priority = config.get_config_file_path_option().get_priority();
-    if (!config.get_use_host_config_option().get_value() && conf_path_priority < Option::Priority::COMMANDLINE) {
+    const auto & use_host_config = config.get_use_host_config_option().get_value();
+    if (!use_host_config && conf_path_priority < Option::Priority::COMMANDLINE) {
         conf_path = config.get_installroot_option().get_value() / conf_path.relative_path();
     }
     try {

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -352,26 +352,8 @@ void RepoSack::create_repos_from_file(const std::string & path) {
 }
 
 void RepoSack::create_repos_from_config_file() {
-    std::filesystem::path conf_path{base->get_config().get_config_file_path_option().get_value()};
-    const auto & conf_path_priority = base->get_config().get_config_file_path_option().get_priority();
-    const auto & use_host_config = base->get_config().get_use_host_config_option().get_value();
-    if (!use_host_config && conf_path_priority < Option::Priority::COMMANDLINE) {
-        const auto & installroot = base->get_config().get_installroot_option().get_value();
-        conf_path = installroot / conf_path.relative_path();
-    }
-    try {
-        create_repos_from_file(conf_path);
-    } catch (const libdnf::MissingConfigError & e) {
-        // Ignore the missing config file unless user specified it via --config=...
-        if (conf_path_priority >= libdnf::Option::Priority::COMMANDLINE) {
-            throw;
-        }
-    } catch (const libdnf::InaccessibleConfigError & e) {
-        // Ignore the inaccessible config file unless user specified it via --config=...
-        if (conf_path_priority >= libdnf::Option::Priority::COMMANDLINE) {
-            throw;
-        }
-    }
+    base->with_config_file_path(
+        std::function<void(const std::string &)>{[this](const std::string & path) { create_repos_from_file(path); }});
 }
 
 void RepoSack::create_repos_from_dir(const std::string & dir_path) {

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -352,17 +352,23 @@ void RepoSack::create_repos_from_file(const std::string & path) {
 }
 
 void RepoSack::create_repos_from_config_file() {
-    const auto & path = base->get_config().get_config_file_path_option().get_value();
+    std::filesystem::path conf_path{base->get_config().get_config_file_path_option().get_value()};
+    const auto & conf_path_priority = base->get_config().get_config_file_path_option().get_priority();
+    const auto & use_host_config = base->get_config().get_use_host_config_option().get_value();
+    if (!use_host_config && conf_path_priority < Option::Priority::COMMANDLINE) {
+        const auto & installroot = base->get_config().get_installroot_option().get_value();
+        conf_path = installroot / conf_path.relative_path();
+    }
     try {
-        create_repos_from_file(std::filesystem::path(path));
+        create_repos_from_file(conf_path);
     } catch (const libdnf::MissingConfigError & e) {
         // Ignore the missing config file unless user specified it via --config=...
-        if (base->get_config().get_config_file_path_option().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+        if (conf_path_priority >= libdnf::Option::Priority::COMMANDLINE) {
             throw;
         }
     } catch (const libdnf::InaccessibleConfigError & e) {
         // Ignore the inaccessible config file unless user specified it via --config=...
-        if (base->get_config().get_config_file_path_option().get_priority() >= libdnf::Option::Priority::COMMANDLINE) {
+        if (conf_path_priority >= libdnf::Option::Priority::COMMANDLINE) {
             throw;
         }
     }


### PR DESCRIPTION
Fixes a bungle in https://github.com/rpm-software-management/dnf5/pull/271; `create_repos_from_config_file` was not reading the config file from the installroot.

Resolves https://github.com/rpm-software-management/dnf5/issues/248