### PR TITLE
RepoSack: remember the repo file path

### DIFF
--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -341,6 +341,7 @@ void RepoSack::create_repos_from_file(const std::string & path) {
         logger.debug("Creating repo \"{}\" from config file \"{}\" section \"{}\"", repo_id, path, section);
 
         auto repo = create_repo(repo_id);
+        repo->set_repo_file_path(path);
         auto & repo_cfg = repo->get_config();
         repo_cfg.load_from_parser(parser, section, *base->get_vars(), *base->get_logger());
 


### PR DESCRIPTION
The *.repo file name will be needed to implement the 'dnf5 copr' logic in the future.