### PR TITLE
modules: Add ModuleDB to store the runtime states of all modules

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -39,6 +39,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <map>
 
 
+namespace libdnf::module {
+
+class ModuleDB;
+
+}
+
+
 namespace libdnf {
 
 using LogRouterWeakPtr = WeakPtr<LogRouter, false>;
@@ -117,6 +124,7 @@ private:
     friend class libdnf::Goal;
     friend class libdnf::rpm::Package;
     friend class libdnf::advisory::AdvisoryQuery;
+    friend class libdnf::module::ModuleDB;
     friend class libdnf::module::ModuleSack;
     friend class libdnf::repo::RepoSack;
     friend class libdnf::repo::SolvRepo;

--- a/libdnf/module/module_db.cpp
+++ b/libdnf/module/module_db.cpp
@@ -1,0 +1,302 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "module/module_db.hpp"
+
+#include "base/base_impl.hpp"
+#include "utils/bgettext/bgettext-mark-domain.h"
+
+#include "libdnf/module/module_errors.hpp"
+#include "libdnf/module/module_query.hpp"
+
+#include <modulemd-2.0/modulemd.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace libdnf::module {
+
+
+void ModuleDB::initialize() {
+    if (initialized) {
+        return;
+    }
+
+    for (const auto & state : base->p_impl->get_system_state().get_module_states()) {
+        runtime_module_states.emplace(
+            state.first, RuntimeModuleState({.original = state.second, .changed = state.second}));
+    }
+
+    for (const auto & module_item : base->module_sack.get_modules()) {
+        auto module_name = module_item->get_name();
+        if (runtime_module_states.find(module_name) == runtime_module_states.end()) {
+            runtime_module_states.emplace(module_name, RuntimeModuleState());
+        }
+    }
+
+    initialized = true;
+}
+
+
+void ModuleDB::save() {
+    for (auto & item : runtime_module_states) {
+        base->p_impl->get_system_state().set_module_state(item.first, item.second.changed);
+    }
+}
+
+
+const ModuleDB::RuntimeModuleState & ModuleDB::get_runtime_module_state(const std::string & module_name) const {
+    if (auto it = runtime_module_states.find(module_name); it != runtime_module_states.end()) {
+        return it->second;
+    } else {
+        throw NoModuleError(M_("No such module: {}"), module_name);
+    }
+}
+
+
+ModuleDB::RuntimeModuleState & ModuleDB::get_runtime_module_state(const std::string & module_name) {
+    if (auto it = runtime_module_states.find(module_name); it != runtime_module_states.end()) {
+        return it->second;
+    } else {
+        throw NoModuleError(M_("No such module: {}"), module_name);
+    }
+}
+
+
+const ModuleStatus & ModuleDB::get_status(const std::string & module_name) const {
+    return get_runtime_module_state(module_name).changed.status;
+}
+
+
+const std::string & ModuleDB::get_enabled_stream(const std::string & module_name) const {
+    return get_runtime_module_state(module_name).changed.enabled_stream;
+}
+
+
+const std::vector<std::string> & ModuleDB::get_installed_profiles(const std::string & module_name) const {
+    return get_runtime_module_state(module_name).changed.installed_profiles;
+}
+
+
+std::vector<std::string> ModuleDB::get_all_changed_modules(const ModuleStatus new_status) const {
+    std::vector<std::string> result;
+
+    for (const auto & item : runtime_module_states) {
+        if (item.second.original.status != new_status && item.second.changed.status == new_status) {
+            result.emplace_back(item.first);
+        }
+    }
+
+    return result;
+}
+
+
+std::vector<std::string> ModuleDB::get_all_newly_disabled_modules() const {
+    return get_all_changed_modules(ModuleStatus::DISABLED);
+}
+
+
+std::vector<std::string> ModuleDB::get_all_newly_reset_modules() const {
+    return get_all_changed_modules(ModuleStatus::AVAILABLE);
+}
+
+
+std::map<std::string, std::string> ModuleDB::get_all_newly_enabled_streams() const {
+    std::map<std::string, std::string> result;
+
+    for (const auto & item : runtime_module_states) {
+        if (item.second.original.status != ModuleStatus::ENABLED &&
+            item.second.changed.status == ModuleStatus::ENABLED) {
+            result.emplace(item.first, item.second.changed.enabled_stream);
+        }
+    }
+
+    return result;
+}
+
+
+std::map<std::string, std::string> ModuleDB::get_all_newly_disabled_streams() const {
+    std::map<std::string, std::string> result;
+
+    for (const auto & item : runtime_module_states) {
+        if (item.second.original.status != ModuleStatus::DISABLED &&
+            item.second.changed.status == ModuleStatus::DISABLED) {
+            result.emplace(item.first, item.second.original.enabled_stream);
+        }
+    }
+
+    return result;
+}
+
+
+std::map<std::string, std::string> ModuleDB::get_all_newly_reset_streams() const {
+    std::map<std::string, std::string> result;
+
+    for (const auto & item : runtime_module_states) {
+        if (item.second.original.status != ModuleStatus::AVAILABLE &&
+            item.second.changed.status == ModuleStatus::AVAILABLE) {
+            result.emplace(item.first, item.second.original.enabled_stream);
+        }
+    }
+
+    return result;
+}
+
+
+std::map<std::string, std::pair<std::string, std::string>> ModuleDB::get_all_newly_switched_streams() const {
+    std::map<std::string, std::pair<std::string, std::string>> result;
+
+    for (const auto & item : runtime_module_states) {
+        // Do not report as switched streams that are not enabled
+        if (item.second.changed.status != ModuleStatus::ENABLED) {
+            continue;
+        }
+        // Do not report as switched streams that were not enabled before
+        if (item.second.original.status != ModuleStatus::ENABLED) {
+            continue;
+        }
+
+        const auto & old_value = item.second.original.enabled_stream;
+        const auto & new_value = item.second.changed.enabled_stream;
+
+        // Do not report as switched streams that were or are not enabled
+        if (old_value.empty() || new_value.empty()) {
+            continue;
+        }
+
+        if (old_value != new_value) {
+            result.emplace(item.first, std::make_pair(old_value, new_value));
+        }
+    }
+
+    return result;
+}
+
+
+std::map<std::string, std::vector<std::string>> ModuleDB::get_all_changed_profiles(bool installed) const {
+    std::map<std::string, std::vector<std::string>> result;
+
+    for (auto & item : runtime_module_states) {
+        auto old_profiles = item.second.original.installed_profiles;
+        auto new_profiles = item.second.changed.installed_profiles;
+
+        std::sort(old_profiles.begin(), old_profiles.end());
+        std::sort(new_profiles.begin(), new_profiles.end());
+        std::vector<std::string> profiles_diff;
+        if (installed) {
+            std::set_difference(
+                new_profiles.begin(),
+                new_profiles.end(),
+                old_profiles.begin(),
+                old_profiles.end(),
+                std::back_inserter(profiles_diff));
+        } else {
+            std::set_difference(
+                old_profiles.begin(),
+                old_profiles.end(),
+                new_profiles.begin(),
+                new_profiles.end(),
+                std::back_inserter(profiles_diff));
+        }
+
+        if (profiles_diff.size() > 0) {
+            result.emplace(item.first, std::move(profiles_diff));
+        }
+    }
+
+    return result;
+}
+
+
+std::map<std::string, std::vector<std::string>> ModuleDB::get_all_newly_installed_profiles() const {
+    return get_all_changed_profiles();
+}
+
+
+std::map<std::string, std::vector<std::string>> ModuleDB::get_all_newly_removed_profiles() const {
+    return get_all_changed_profiles(false);
+}
+
+
+bool ModuleDB::change_status(const std::string & module_name, ModuleStatus status) {
+    auto & runtime_module_state = get_runtime_module_state(module_name);
+
+    if (runtime_module_state.changed.status == status) {
+        return false;
+    }
+
+    runtime_module_state.changed.status = status;
+    return true;
+}
+
+
+bool ModuleDB::change_stream(const std::string & module_name, const std::string & stream, const bool count) {
+    auto & runtime_module_state = get_runtime_module_state(module_name);
+    const auto & updated_value = runtime_module_state.changed.enabled_stream;
+    if (updated_value == stream) {
+        return false;
+    }
+    if (count) {
+        runtime_module_state.stream_changes_num++;
+    }
+    const auto & original_value = runtime_module_state.original.enabled_stream;
+    if (original_value != updated_value && runtime_module_state.stream_changes_num > 1) {
+        throw EnableMultipleStreamsError(M_("Cannot enable multiple streams for module '{}'"), module_name);
+    }
+    runtime_module_state.changed.enabled_stream = stream;
+    return true;
+}
+
+
+bool ModuleDB::add_profile(const std::string & module_name, const std::string & profile) {
+    auto & profiles = get_runtime_module_state(module_name).changed.installed_profiles;
+
+    // Return false if the profile is already there.
+    if (std::find(std::begin(profiles), std::end(profiles), profile) != std::end(profiles)) {
+        return false;
+    }
+
+    profiles.push_back(profile);
+    return true;
+}
+
+
+bool ModuleDB::remove_profile(const std::string & module_name, const std::string & profile) {
+    auto & profiles = get_runtime_module_state(module_name).changed.installed_profiles;
+
+    for (auto it = profiles.begin(); it != profiles.end(); it++) {
+        if (*it == profile) {
+            profiles.erase(it);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+void ModuleDB::clear_profiles(const std::string & module_name) {
+    get_runtime_module_state(module_name).changed.installed_profiles.clear();
+}
+
+
+}  // namespace libdnf::module

--- a/libdnf/module/module_db.hpp
+++ b/libdnf/module/module_db.hpp
@@ -1,0 +1,110 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_MODULE_MODULE_DB_HPP
+#define LIBDNF_MODULE_MODULE_DB_HPP
+
+#include "system/state.hpp"
+
+#include "libdnf/base/base_weak.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace libdnf::module {
+
+
+// Stores states of all modules
+// @replaces libdnf:module/ModulePackageContainer.cpp:class:ModulePackageContainer::Impl::ModulePersistor
+class ModuleDB {
+public:
+    ModuleDB(const BaseWeakPtr & base) : base(base) {}
+
+    /// Load all module states from `system::State` and create states for available modules.
+    void initialize();
+    /// Update the `system::State` with all the changes.
+    void save();
+
+    /// Get module status for given module name.
+    const ModuleStatus & get_status(const std::string & module_name) const;
+    /// Get enabled streams for given module name.
+    const std::string & get_enabled_stream(const std::string & module_name) const;
+    /// Get installed profiles for given module name.
+    const std::vector<std::string> & get_installed_profiles(const std::string & module_name) const;
+
+    /// Get module names of all modules that were not originally disabled, but are disabled now.
+    std::vector<std::string> get_all_newly_disabled_modules() const;
+    /// Get module names of all modules that were not originally available, but are available now.
+    std::vector<std::string> get_all_newly_reset_modules() const;
+    /// Get map of module names and their enabled streams for all modules that were not originally enabled,
+    /// but are enabled now.
+    std::map<std::string, std::string> get_all_newly_enabled_streams() const;
+    /// Get map of module names and their originally enabled streams for all modules that were originally enabled,
+    /// but are disabled now.
+    std::map<std::string, std::string> get_all_newly_disabled_streams() const;
+    /// Get map of module names and their originally enabled streams for all modules that were originally enabled,
+    /// but are available now.
+    std::map<std::string, std::string> get_all_newly_reset_streams() const;
+    /// Get map of module names and their originally and newly enabled streams for all modules with switched streams.
+    std::map<std::string, std::pair<std::string, std::string>> get_all_newly_switched_streams() const;
+    /// Get map of module names and their newly installed profiles for all modules with added profiles.
+    std::map<std::string, std::vector<std::string>> get_all_newly_installed_profiles() const;
+    /// Get map of module names and their removed profiles for all modules with removed profiles.
+    std::map<std::string, std::vector<std::string>> get_all_newly_removed_profiles() const;
+
+    bool change_status(const std::string & module_name, ModuleStatus status);
+    bool change_stream(const std::string & module_name, const std::string & stream, const bool count = false);
+    bool add_profile(const std::string & module_name, const std::string & profile);
+    bool remove_profile(const std::string & module_name, const std::string & profile);
+    void clear_profiles(const std::string & module_name);
+
+private:
+    friend ModuleSack;
+
+    struct RuntimeModuleState {
+        system::ModuleState original;
+        system::ModuleState changed;
+        int stream_changes_num = 0;
+    };
+
+
+    /// Get the runtime module state for given module name.
+    const RuntimeModuleState & get_runtime_module_state(const std::string & module_name) const;
+    RuntimeModuleState & get_runtime_module_state(const std::string & module_name);
+
+    /// Get all module names for modules that newly have the given status.
+    std::vector<std::string> get_all_changed_modules(const ModuleStatus new_status) const;
+    /// Get all module names and changes in their profiles if there are any.
+    /// @param installed If `true`, get installed profiles, if `false`, get removed profiles.
+    std::map<std::string, std::vector<std::string>> get_all_changed_profiles(bool installed = true) const;
+
+    BaseWeakPtr base;
+
+    /// Map of module names and their runtime states.
+    std::map<std::string, struct RuntimeModuleState> runtime_module_states;
+
+    bool initialized = false;
+};
+
+
+}  // namespace libdnf::module
+
+
+#endif  // LIBDNF_MODULE_MODULE_DB_HPP

--- a/libdnf/module/module_sack_impl.hpp
+++ b/libdnf/module/module_sack_impl.hpp
@@ -20,9 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_MODULE_MODULE_SACK_IMPL_HPP
 #define LIBDNF_MODULE_MODULE_SACK_IMPL_HPP
 
+#include "base/base_impl.hpp"
+#include "module/module_db.hpp"
 #include "module/module_metadata.hpp"
 #include "solv/solv_map.hpp"
 
+#include "libdnf/base/base.hpp"
 #include "libdnf/module/module_sack.hpp"
 #include "libdnf/rpm/reldep_list.hpp"
 
@@ -46,7 +49,8 @@ public:
         : module_sack(&module_sack),
           base(base),
           module_metadata(base),
-          pool(pool_create()) {
+          pool(pool_create()),
+          module_db(new ModuleDB(base)) {
         pool_set_flag(pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
     }
     ~Impl() {
@@ -125,6 +129,8 @@ private:
     std::map<std::string, std::string> module_defaults;
     std::unique_ptr<libdnf::solv::SolvMap> excludes;
     std::map<Id, ModuleItem *> active_modules;
+
+    std::unique_ptr<ModuleDB> module_db;
 
     /// @brief Method for autodetection of the platform id.
     /// @return If platform id was detected, it returns a pair where the first item is the platform

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -399,6 +399,11 @@ std::vector<std::string> State::get_installed_groups() {
 }
 
 
+const std::map<std::string, ModuleState> & State::get_module_states() {
+    return module_states;
+}
+
+
 ModuleState State::get_module_state(const std::string & name) {
     auto it = module_states.find(name);
     if (it == module_states.end()) {

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -191,6 +191,10 @@ public:
     /// @since 5.0
     void remove_environment_state(const std::string & id);
 
+    /// @return All module states.
+    /// @since 5.0.8
+    const std::map<std::string, ModuleState> & get_module_states();
+
     /// @return The state of a module.
     /// @param name The module id to get the state for.
     /// @since 5.0.8

--- a/test/libdnf/module/test_module.hpp
+++ b/test/libdnf/module/test_module.hpp
@@ -36,6 +36,7 @@ class ModuleTest : public BaseTestCase {
     CPPUNIT_TEST(test_query_latest);
     CPPUNIT_TEST(test_nsvcap);
     CPPUNIT_TEST(test_query_spec);
+    CPPUNIT_TEST(test_module_db);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -46,6 +47,9 @@ public:
     void test_query_latest();
     void test_nsvcap();
     void test_query_spec();
+    void test_module_db();
+
+    std::unique_ptr<libdnf::utils::fs::TempDir> temp_dir;
 };
 
 #endif


### PR DESCRIPTION
Contains also the same commit as in https://github.com/rpm-software-management/dnf5/pull/387 , because it requires it.