### PR TITLE
Fix installed groups loading to libsolv pool

### DIFF
--- a/include/libdnf/comps/group/package.hpp
+++ b/include/libdnf/comps/group/package.hpp
@@ -66,6 +66,7 @@ inline constexpr bool any(PackageType flags) {
     return static_cast<std::underlying_type<PackageType>::type>(flags) != 0;
 }
 
+std::string package_type_to_string(const PackageType & type);
 PackageType package_type_from_string(const std::string & type);
 PackageType package_type_from_string(const std::vector<std::string> types);
 
@@ -102,19 +103,7 @@ public:
 
     /// @return std::string that corresponds to the PackageType.
     /// @since 5.0
-    std::string get_type_string() const {
-        switch (type) {
-            case PackageType::MANDATORY:
-                return "mandatory";
-            case PackageType::DEFAULT:
-                return "default";
-            case PackageType::OPTIONAL:
-                return "optional";
-            case PackageType::CONDITIONAL:
-                return "conditional";
-        }
-        return "";
-    }
+    std::string get_type_string() const { return package_type_to_string(type); }
 
     /// @return The condition (name of package) under which the package gets installed.
     /// @since 5.0

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -676,9 +676,15 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
             if (transaction_item_action_is_inbound(tsgroup.get_action())) {
                 libdnf::system::GroupState state;
                 state.userinstalled = tsgroup.get_reason() == transaction::TransactionItemReason::USER;
+                state.name = group.get_name();
                 // Remember packages installed by this group
                 for (const auto & pkg : group.get_packages()) {
                     auto pkg_name = pkg.get_name();
+                    libdnf::system::GroupPackage grp_pkg;
+                    grp_pkg.type = pkg.get_type();
+                    grp_pkg.name = pkg_name;
+                    grp_pkg.condition = pkg.get_condition();
+                    state.all_packages.push_back(std::move(grp_pkg));
                     if (inbound_packages_reason_group.find(pkg_name) != inbound_packages_reason_group.end()) {
                         // inbound package with reason GROUP from this transaction
                         state.packages.emplace_back(pkg_name);

--- a/libdnf/comps/group/package.cpp
+++ b/libdnf/comps/group/package.cpp
@@ -51,4 +51,18 @@ PackageType package_type_from_string(const std::vector<std::string> types) {
     return retval;
 }
 
+std::string package_type_to_string(const PackageType & type) {
+    switch (type) {
+        case PackageType::MANDATORY:
+            return "mandatory";
+        case PackageType::DEFAULT:
+            return "default";
+        case PackageType::OPTIONAL:
+            return "optional";
+        case PackageType::CONDITIONAL:
+            return "conditional";
+    }
+    return "";
+}
+
 }  // namespace libdnf::comps

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -424,6 +424,7 @@ void Repo::make_solv_repo() {
         // TODO(lukash) move the below to SolvRepo? Requires sharing Type
         if (type == Type::SYSTEM) {
             pool_set_installed(*get_rpm_pool(base), solv_repo->repo);
+            pool_set_installed(*get_comps_pool(base), solv_repo->comps_repo);
         }
 
         solv_repo->set_priority(-get_priority());

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -108,6 +108,12 @@ private:
     std::string solv_file_name(const char * type = nullptr);
     std::filesystem::path solv_file_path(const char * type = nullptr);
 
+    /// Create a group solvable based on what's available in system state. Used in
+    /// case we are not able to load metadata from xml file.
+    /// @param groupid  Id of the group
+    /// @param state    group state from the system state
+    void create_group_solvable(const std::string & groupid, const libdnf::system::GroupState & state);
+
     libdnf::BaseWeakPtr base;
     const ConfigRepo & config;
 

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -79,6 +79,30 @@ struct into<libdnf::system::NevraState> {
 
 
 template <>
+struct from<libdnf::system::GroupPackage> {
+    static libdnf::system::GroupPackage from_toml(const value & v) {
+        auto gp = toml::get<std::tuple<std::string, std::string, std::string>>(v);
+
+        libdnf::system::GroupPackage group_package;
+        group_package.name = std::get<0>(gp);
+        group_package.type = libdnf::comps::package_type_from_string(std::get<1>(gp));
+        group_package.condition = std::get<2>(gp);
+
+        return group_package;
+    }
+};
+
+
+template <>
+struct into<libdnf::system::GroupPackage> {
+    static toml::value into_toml(const libdnf::system::GroupPackage & group_package) {
+        return toml::array{
+            group_package.name, libdnf::comps::package_type_to_string(group_package.type), group_package.condition};
+    }
+};
+
+
+template <>
 struct from<libdnf::system::GroupState> {
     static libdnf::system::GroupState from_toml(const value & v) {
         libdnf::system::GroupState group_state;
@@ -86,6 +110,12 @@ struct from<libdnf::system::GroupState> {
         group_state.userinstalled = toml::find<bool>(v, "userinstalled");
         if (v.contains("packages")) {
             group_state.packages = toml::find<std::vector<std::string>>(v, "packages");
+        }
+        if (v.contains("name")) {
+            group_state.name = toml::find<std::string>(v, "name");
+        }
+        if (v.contains("all_packages")) {
+            group_state.all_packages = toml::find<std::vector<libdnf::system::GroupPackage>>(v, "all_packages");
         }
 
         return group_state;
@@ -100,6 +130,8 @@ struct into<libdnf::system::GroupState> {
 
         res["userinstalled"] = group_state.userinstalled;
         res["packages"] = group_state.packages;
+        res["name"] = group_state.name;
+        res["all_packages"] = group_state.all_packages;
 
         return res;
     }

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_SYSTEM_STATE_HPP
 
 #include "libdnf/common/exception.hpp"
+#include "libdnf/comps/group/package.hpp"
 #include "libdnf/module/module_sack.hpp"
 #include "libdnf/rpm/nevra.hpp"
 #include "libdnf/rpm/package.hpp"
@@ -46,10 +47,29 @@ public:
     std::string from_repo;
 };
 
+class GroupPackage {
+public:
+    std::string name;
+    libdnf::comps::PackageType type;
+    std::string condition;
+};
+
 class GroupState {
 public:
     bool userinstalled{false};
+    // List of packages that were installed along with the group
     std::vector<std::string> packages;
+
+    // name and all_packages attributes are kind of duplicit (information they
+    // contain is also part of the xml definition of the group also stored in the
+    // system state directory. But there are use cases where such xml is not
+    // available - e.g. in case the group state was re-created based on the
+    // history database.
+
+    // group name
+    std::string name;
+    // All packages as defined in the group in time it was installed.
+    std::vector<GroupPackage> all_packages;
 };
 
 class EnvironmentState {

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -244,16 +244,36 @@ struct assertion_traits<libdnf::system::NevraState> {
 };
 
 template <>
+struct assertion_traits<libdnf::system::GroupPackage> {
+    inline static bool equal(const libdnf::system::GroupPackage & left, const libdnf::system::GroupPackage & right) {
+        return left.name == right.name && left.type == right.type && left.condition == right.condition;
+    }
+
+    inline static std::string toString(const libdnf::system::GroupPackage & group_package) {
+        return fmt::format(
+            "GroupPackage: name: {}, type: {}, condition: {}",
+            group_package.name,
+            libdnf::comps::package_type_to_string(group_package.type),
+            group_package.condition);
+    }
+};
+
+template <>
 struct assertion_traits<libdnf::system::GroupState> {
     inline static bool equal(const libdnf::system::GroupState & left, const libdnf::system::GroupState & right) {
-        return left.userinstalled == right.userinstalled && left.packages == right.packages;
+        return left.userinstalled == right.userinstalled && left.packages == right.packages &&
+               left.name == right.name &&
+               assertion_traits<std::vector<libdnf::system::GroupPackage>>::equal(
+                   left.all_packages, right.all_packages);
     }
 
     inline static std::string toString(const libdnf::system::GroupState & group_state) {
         return fmt::format(
-            "GroupState: userinstalled: {}, packages: {}",
+            "GroupState: userinstalled: {}, name: {}, packages: {}, all_packages: {}",
             group_state.userinstalled,
-            assertion_traits<std::vector<std::string>>::toString(group_state.packages));
+            group_state.name,
+            assertion_traits<std::vector<std::string>>::toString(group_state.packages),
+            assertion_traits<std::vector<libdnf::system::GroupPackage>>::toString(group_state.all_packages));
     }
 };
 


### PR DESCRIPTION
Comps metadata are loaded to libsolv pool from comps.xml files.
In case these files are not available (typically for installed groups that were converted from dnf4 history database) they are not present, even though such groups are present in system state groups.toml file.
This patch

1. extends information about installed groups stored in system state to contain also group name and list of all group packages with their types. This information is present in dnf4 history db.
2. In case libdnf5 is not able to load system repo groups from stored xml files, create libsolv solvables for installed groups directly from system state using this info.

This way `dnf5 group list --installed` works as expected and it's possible to implement `dnf5 group upgrade` command.

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1244