### PR TITLE
[dnf5] Implement new argument "--show-new-leaves"

### DIFF
--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -114,6 +114,11 @@ public:
 
     bool get_dump_variables() const { return dump_variables; }
 
+    /// Set to true to show newly installed leaf packages and packages that became leaves after a transaction.
+    void set_show_new_leaves(bool show_new_leaves) { this->show_new_leaves = show_new_leaves; }
+
+    bool get_show_new_leaves() const { return show_new_leaves; }
+
     Plugins & get_plugins() { return *plugins; }
 
     libdnf5::Goal * get_goal(bool new_if_not_exist = true);
@@ -145,6 +150,7 @@ private:
     bool dump_main_config{false};
     std::vector<std::string> dump_repo_config_id_list;
     bool dump_variables{false};
+    bool show_new_leaves{false};
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -253,6 +253,9 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--setvar=VAR_NAME=VALUE``
     | Override a ``DNF5`` variable value, like ``arch``, ``releasever``, etc.
 
+``--show-new-leaves``
+    | Show newly installed leaf packages and packages that became leaves after a transaction.
+
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 


### PR DESCRIPTION
Shows newly installed leaf packages and packages that became leaves after a transaction.

I intend that the implementation of the `--show-new-leaves` argument in DNF5 will replace the functionality of the "show-leaves" plugin that is in the old DNF.

Unlike the plugin in the old DNF, this code calculates the new state (the list of new leaf packages) before the transaction is executed. The user will see the list even before confirming the transaction.