### PR TITLE
Fix installed groups loading to libsolv - take 2

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -118,6 +118,7 @@ private:
     friend class libdnf::rpm::Package;
     friend class libdnf::advisory::AdvisoryQuery;
     friend class libdnf::module::ModuleSack;
+    friend class libdnf::repo::RepoSack;
     friend class libdnf::repo::SolvRepo;
 
     /// Loads the default configuration. To load distribution-specific configuration.

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -127,10 +127,17 @@ public:
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
     libdnf::BaseWeakPtr get_base() const;
-    //
+
     /// For each enabled repository enable corresponding source repository.
     /// @since 5.0
     void enable_source_repos();
+
+    /// Re-create missing xml definitions for installed groups. Since we do not have
+    /// the state of the group in time of installation, current definition from
+    /// available repositories is going to be used.
+    /// In case the repo does not exist in repositories, only the minimal solvables
+    /// are created from info in system state.
+    void fix_group_missing_xml();
 
 private:
     friend class libdnf::Base;

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -429,6 +429,7 @@ void Repo::make_solv_repo() {
         // TODO(lukash) move the below to SolvRepo? Requires sharing Type
         if (type == Type::SYSTEM) {
             pool_set_installed(*get_rpm_pool(base), solv_repo->repo);
+            pool_set_installed(*get_comps_pool(base), solv_repo->comps_repo);
         }
 
         solv_repo->set_priority(-get_priority());

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -98,6 +98,12 @@ public:
 
     std::vector<std::string> & get_groups_missing_xml() { return groups_missing_xml; };
 
+    /// Create a group solvable based on what's available in system state. Used in
+    /// case we are not able to load metadata from xml file.
+    /// @param groupid  Id of the group
+    /// @param state    group state from the system state
+    void create_group_solvable(const std::string & groupid, const libdnf::system::GroupState & state);
+
     /// Read comps group solvable from its xml file.
     /// @param path  Path to xml file.
     /// @return      True if the group was successfully read.

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -129,8 +129,6 @@ private:
     /// Ranges of solvables for different types of data, used for writing libsolv cache files
     int main_solvables_start{0};
     int main_solvables_end{0};
-    int comps_solvables_start{0};
-    int comps_solvables_end{0};
     int updateinfo_solvables_start{0};
     int updateinfo_solvables_end{0};
 

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -98,6 +98,11 @@ public:
 
     std::vector<std::string> & get_groups_missing_xml() { return groups_missing_xml; };
 
+    /// Read comps group solvable from its xml file.
+    /// @param path  Path to xml file.
+    /// @return      True if the group was successfully read.
+    bool read_group_solvable_from_xml(const std::string & path);
+
 private:
     bool load_solv_cache(solv::Pool & pool, const char * type, int flags);
 

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -96,6 +96,8 @@ public:
 
     void set_needs_internalizing() { needs_internalizing = true; };
 
+    std::vector<std::string> & get_groups_missing_xml() { return groups_missing_xml; };
+
 private:
     bool load_solv_cache(solv::Pool & pool, const char * type, int flags);
 
@@ -123,6 +125,9 @@ private:
 
     bool can_use_solvfile_cache(solv::Pool & pool, utils::fs::File & solvfile_cache);
     void userdata_fill(SolvUserdata * userdata);
+
+    /// List of system repo groups without valid file with xml definition
+    std::vector<std::string> groups_missing_xml;
 
 public:
     ::Repo * repo{nullptr};  // libsolv pool retains ownership


### PR DESCRIPTION
This is alternative solution to https://github.com/rpm-software-management/dnf5/pull/406
Advantage of this PR is that there is no change in system state, therefore no duplicated information.
Installed group xml is now taken from available repositories, with a fall-back to generating minimal solvable from system state information in case the group is not available in repos.

Fixes: https://github.com/rpm-software-management/dnf5/issues/420