### PR TITLE
swig: Add bindings for LogEvent

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -37,6 +37,8 @@
 %{
     #include "libdnf/logger/memory_buffer_logger.hpp"
     #include "libdnf/base/base.hpp"
+    #include "libdnf/base/solver_problems.hpp"
+    #include "libdnf/base/log_event.hpp"
     #include "libdnf/base/transaction.hpp"
     #include "libdnf/base/transaction_package.hpp"
     #include "libdnf/base/goal.hpp"
@@ -49,8 +51,15 @@
 %template(VarsWeakPtr) libdnf::WeakPtr<libdnf::Vars, false>;
 
 %include "libdnf/base/base.hpp"
+
+%include "libdnf/base/solver_problems.hpp"
+%include "libdnf/base/log_event.hpp"
+
 %ignore libdnf::base::TransactionError;
 %include "libdnf/base/transaction.hpp"
+
+%template(VectorLogEvent) std::vector<libdnf::base::LogEvent>;
+
 %include "libdnf/base/transaction_package.hpp"
 
 %template(VectorBaseTransactionPackage) std::vector<libdnf::base::TransactionPackage>;

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -6,6 +6,7 @@
 %module "libdnf5/common"
 #endif
 
+%include <cstring.i>
 %include <exception.i>
 %include <stdint.i>
 %include <std_map.i>
@@ -17,6 +18,14 @@
 %include <std_vector.i>
 
 %include <shared.i>
+
+%typemap(out) std::string * {
+    if ($1 == nullptr) {
+        $result = SWIG_FromCharPtrAndSize("", 0);
+    } else {
+        $result = SWIG_FromCharPtrAndSize($1->c_str(), $1->size());
+    }
+}
 
 %{
     #include "libdnf/common/weak_ptr.hpp"

--- a/test/python3/libdnf5/base/test_goal.py
+++ b/test/python3/libdnf5/base/test_goal.py
@@ -69,3 +69,18 @@ class TestGoal(unittest.TestCase):
 
         self.assertRaises(RuntimeError, goal.add_rpm_reason_change, '@fake-group-spec',
                           libdnf5.base.transaction.TransactionItemReason_GROUP, '')
+
+    def test_log_events_wrapper(self):
+        # Try accessing transaction.get_resolve_logs()
+        base = libdnf5.base.Base()
+        base.setup()
+
+        goal = libdnf5.base.Goal(base)
+        goal.add_install('unknown_spec')
+
+        transaction = goal.resolve()
+        logs = transaction.get_resolve_logs()
+        self.assertTrue(logs)
+        first_log = next(iter(logs))
+        self.assertEqual(libdnf5.base.GoalProblem_NOT_FOUND,
+                         first_log.get_problem())

--- a/test/python3/libdnf5/base/test_goal.py
+++ b/test/python3/libdnf5/base/test_goal.py
@@ -72,11 +72,13 @@ class TestGoal(unittest.TestCase):
 
     def test_log_events_wrapper(self):
         # Try accessing transaction.get_resolve_logs()
+        spec = 'unknown_spec'
+
         base = libdnf5.base.Base()
         base.setup()
 
         goal = libdnf5.base.Goal(base)
-        goal.add_install('unknown_spec')
+        goal.add_install(spec)
 
         transaction = goal.resolve()
         logs = transaction.get_resolve_logs()
@@ -84,3 +86,4 @@ class TestGoal(unittest.TestCase):
         first_log = next(iter(logs))
         self.assertEqual(libdnf5.base.GoalProblem_NOT_FOUND,
                          first_log.get_problem())
+        self.assertEqual(spec, first_log.get_spec())


### PR DESCRIPTION
Allow API users to access wrappers for `libdnf::base::LogEvent` class and `get_resolve_logs()` method on the `libdnf::base::Transaction`.

Python API unit tests for the wrappers are included.