### PR TITLE
Hide swig/python detected a memory leak message

### DIFF
--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -245,3 +245,6 @@ del ClassName##__iter__
 %template(PreserveOrderMapStringPreserveOrderMapStringString) libdnf::PreserveOrderMap<std::string, libdnf::PreserveOrderMap<std::string, std::string>>;
 
 %exception;  // beware this resets all exception handlers if you import this file after defining any
+
+// Base weak ptr is used across the codebase
+%include "libdnf/base/base_weak.hpp"

--- a/bindings/python3/CMakeLists.txt
+++ b/bindings/python3/CMakeLists.txt
@@ -15,6 +15,22 @@ function(add_python3_module LIBRARY_NAME MODULE_NAME)
     set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
         -Wno-redundant-decls
     )
+    # Currenly the SWIG_PYTHON_SILENT_MEMLEAK controls only whether message:
+    # "swig/python detected a memory leak of type '%s', no destructor found." is printed, used here:
+    # https://github.com/swig/swig/blob/33f6a2d0b2c3d90b928f56ddfa599afe87903f76/Lib/python/pyrun.swg#L776
+    # We want to supress this message due to a bug in Python part of swig.
+    # The core of the issue is that Python Swig has a global list of types used in all swig modules. This is
+    # needed because the modules are interlinked eg. libdnf::Base is used in all of them. During finalization
+    # of the Python runtime unused modules are cleaned up before garbage collector runs and cleans global objects.
+    # This can result in a situation where for example libdnf5.advisory module is destoyed, removing its types
+    # from the global swig types list includeing libdnf5.base.Base, and only after that a global libdnf5.base.Base
+    # is garbage collected which is now missing type information -> no destructor can be called -> swig want's to
+    # print the message
+    # There is an issue reported on SWIG with the same root cause: https://github.com/swig/swig/issues/2037 it
+    # also contains more details.
+    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+        -DSWIG_PYTHON_SILENT_MEMLEAK
+    )
     set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS}
         -doxygen
     )


### PR DESCRIPTION
Since swig-4.1 (from f38) message warning about memory leak can be
printed when libdnf5 python api is used. It is reproducible with just:
```
import libdnf5.base

def asd():
    pass

base = libdnf5.base.Base()
```
But also happens in our ci-dnf-stack python API tests, therefore it is
blocking our switch to f38 as a base for CI: https://github.com/rpm-software-management/ci-dnf-stack/pull/1226

Currenly it happens due to a bug in SWIG therefore we wan't to silent
the message.
Unfortunately this might hide some real problems.