### PR TITLE
modules: Rename ModuleState enum to ModuleStatus

### DIFF
--- a/include/libdnf/module/module_sack.hpp
+++ b/include/libdnf/module/module_sack.hpp
@@ -45,7 +45,7 @@ namespace libdnf::module {
 // ENABLED - a module that has an enabled stream.
 // DISABLED - a module that is disabled.
 // AVAILABLE - otherwise.
-enum class ModuleState { AVAILABLE, ENABLED, DISABLED };
+enum class ModuleStatus { AVAILABLE, ENABLED, DISABLED };
 
 
 /// Container with data and methods related to modules
@@ -62,7 +62,7 @@ public:
         CANNOT_RESOLVE_MODULES,
         CANNOT_RESOLVE_MODULE_SPEC,
         CANNOT_ENABLE_MULTIPLE_STREAMS,
-        CANNOT_MODIFY_MULTIPLE_TIMES_MODULE_STATE,
+        CANNOT_MODIFY_MULTIPLE_TIMES_MODULE_STATUS,
         /// Problem with latest modules during resolvement of module dependencies
         ERROR_IN_LATEST
     };
@@ -127,17 +127,17 @@ private:
 };
 
 
-class InvalidModuleState : public libdnf::Error {
+class InvalidModuleStatus : public libdnf::Error {
 public:
-    InvalidModuleState(const std::string & state);
+    InvalidModuleStatus(const std::string & status);
 
     const char * get_domain_name() const noexcept override { return "libdnf::module"; }
-    const char * get_name() const noexcept override { return "InvalidModuleState"; }
+    const char * get_name() const noexcept override { return "InvalidModuleStatus"; }
 };
 
 
-std::string module_state_to_string(ModuleState state);
-ModuleState module_state_from_string(const std::string & state);
+std::string module_status_to_string(ModuleStatus status);
+ModuleStatus module_status_from_string(const std::string & status);
 
 
 }  // namespace libdnf::module

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -138,7 +138,7 @@ struct from<libdnf::system::ModuleState> {
         libdnf::system::ModuleState module_state;
 
         module_state.enabled_stream = toml::find<std::string>(v, "enabled_stream");
-        module_state.state = libdnf::module::module_state_from_string(toml::find<std::string>(v, "state"));
+        module_state.status = libdnf::module::module_status_from_string(toml::find<std::string>(v, "state"));
         module_state.installed_profiles = toml::find<std::vector<std::string>>(v, "installed_profiles");
 
         return module_state;
@@ -152,7 +152,7 @@ struct into<libdnf::system::ModuleState> {
         toml::value res;
 
         res["enabled_stream"] = module_state.enabled_stream;
-        res["state"] = libdnf::module::module_state_to_string(module_state.state);
+        res["state"] = libdnf::module::module_status_to_string(module_state.status);
         res["installed_profiles"] = module_state.installed_profiles;
 
         return res;

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -57,12 +57,10 @@ public:
     std::vector<std::string> groups;
 };
 
-// TODO(lukash) same class name as module::ModuleState
-// probably better to name differently, although right now this class isn't on the interface and could be "hidden"
 class ModuleState {
 public:
     std::string enabled_stream;
-    module::ModuleState state{module::ModuleState::AVAILABLE};
+    module::ModuleStatus status{module::ModuleStatus::AVAILABLE};
     std::vector<std::string> installed_profiles{};
 };
 

--- a/libdnf/utils/dnf4convert/dnf4convert.cpp
+++ b/libdnf/utils/dnf4convert/dnf4convert.cpp
@@ -165,12 +165,12 @@ std::map<std::string, libdnf::system::ModuleState> Dnf4Convert::read_module_stat
             libdnf::system::ModuleState state;
             state.enabled_stream = module_config.stream.get_value();
             state.installed_profiles = module_config.profiles.get_value();
-            state.state = libdnf::module::ModuleState::AVAILABLE;
+            state.status = libdnf::module::ModuleStatus::AVAILABLE;
             auto status_value = module_config.state.get_value();
             if (status_value == "enabled") {
-                state.state = libdnf::module::ModuleState::ENABLED;
+                state.status = libdnf::module::ModuleStatus::ENABLED;
             } else if (status_value == "disabled") {
-                state.state = libdnf::module::ModuleState::DISABLED;
+                state.status = libdnf::module::ModuleStatus::DISABLED;
             }
             module_states.emplace(name, state);
         }

--- a/test/libdnf/system/test_state.cpp
+++ b/test/libdnf/system/test_state.cpp
@@ -122,11 +122,11 @@ void StateTest::test_state_read() {
 
     libdnf::system::ModuleState module_state_1{
         .enabled_stream = "stream-1",
-        .state = libdnf::module::ModuleState::ENABLED,
+        .status = libdnf::module::ModuleStatus::ENABLED,
         .installed_profiles = {"zigg", "zagg"}};
     CPPUNIT_ASSERT_EQUAL(module_state_1, state.get_module_state("module-1"));
     libdnf::system::ModuleState module_state_2{
-        .enabled_stream = "stream-2", .state = libdnf::module::ModuleState::DISABLED};
+        .enabled_stream = "stream-2", .status = libdnf::module::ModuleStatus::DISABLED};
     CPPUNIT_ASSERT_EQUAL(module_state_2, state.get_module_state("module-2"));
     CPPUNIT_ASSERT_EQUAL(std::string("foo"), state.get_rpmdb_cookie());
 }
@@ -150,9 +150,10 @@ void StateTest::test_state_write() {
     state.set_module_state(
         "module-1",
         {.enabled_stream = "stream-1",
-         .state = libdnf::module::ModuleState::ENABLED,
+         .status = libdnf::module::ModuleStatus::ENABLED,
          .installed_profiles = {"zigg", "zagg"}});
-    state.set_module_state("module-2", {.enabled_stream = "stream-2", .state = libdnf::module::ModuleState::DISABLED});
+    state.set_module_state(
+        "module-2", {.enabled_stream = "stream-2", .status = libdnf::module::ModuleStatus::DISABLED});
 
     state.set_rpmdb_cookie("foo");
 

--- a/test/shared/utils.hpp
+++ b/test/shared/utils.hpp
@@ -260,7 +260,7 @@ struct assertion_traits<libdnf::system::GroupState> {
 template <>
 struct assertion_traits<libdnf::system::ModuleState> {
     inline static bool equal(const libdnf::system::ModuleState & left, const libdnf::system::ModuleState & right) {
-        return left.enabled_stream == right.enabled_stream && left.state == right.state &&
+        return left.enabled_stream == right.enabled_stream && left.status == right.status &&
                left.installed_profiles == right.installed_profiles;
     }
 
@@ -268,7 +268,7 @@ struct assertion_traits<libdnf::system::ModuleState> {
         return fmt::format(
             "ModuleState: enabled_stream: {}, state: {}, installed_profiles: {}",
             module_state.enabled_stream,
-            libdnf::module::module_state_to_string(module_state.state),
+            libdnf::module::module_status_to_string(module_state.status),
             assertion_traits<std::vector<std::string>>::toString(module_state.installed_profiles));
     }
 };


### PR DESCRIPTION
The reason is that the name was the same as the ModuleState class in libdnf::state and it was confusing especially when both were used next to each other.