### PR TITLE
[dnf5] Add "up" and "update" aliases for "upgrade" command

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -117,6 +117,20 @@ descr = "Alias for 'repo list'"
 group_id = 'commands-compatibility-aliases'
 complete = true
 
+['up']
+type = 'command'
+attached_command = 'upgrade'
+descr = "Alias for 'upgrade'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
+['update']
+type = 'command'
+attached_command = 'upgrade'
+descr = "Alias for 'upgrade'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
 ['updateinfo']
 type = 'command'
 attached_command = 'advisory'


### PR DESCRIPTION
"update" is a deprecated alias for the "upgrade". But we will keep it for compatibility.  https://github.com/rpm-software-management/dnf5/issues/156