### PR TITLE
NullLogger::write: Fix type of time argument

### DIFF
--- a/include/libdnf/logger/null_logger.hpp
+++ b/include/libdnf/logger/null_logger.hpp
@@ -31,7 +31,11 @@ class NullLogger : public Logger {
 public:
     void log_line(Level /*level*/, const std::string & /*message*/) noexcept override {}
 
-    void write(time_t /*time*/, pid_t /*pid*/, Level /*level*/, const std::string & /*message*/) noexcept override {}
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & /*time*/,
+        pid_t /*pid*/,
+        Level /*level*/,
+        const std::string & /*message*/) noexcept override {}
 };
 
 }  // namespace libdnf


### PR DESCRIPTION
The type of the argument in the parent method was changed some time ago. But the NullLogger descendant was forgotten.
The bug is not detected until someone uses the header file with NullLogger.