### PR TITLE
system state: Add package_types to the GroupState

### DIFF
--- a/include/libdnf/base/transaction_group.hpp
+++ b/include/libdnf/base/transaction_group.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/goal_elements.hpp"
 #include "libdnf/base/transaction.hpp"
 #include "libdnf/comps/group/group.hpp"
+#include "libdnf/comps/group/package.hpp"
 #include "libdnf/rpm/package.hpp"
 #include "libdnf/transaction/transaction_item_action.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
@@ -39,6 +40,7 @@ public:
     using Reason = transaction::TransactionItemReason;
     using State = transaction::TransactionItemState;
     using Action = transaction::TransactionItemAction;
+    using PackageType = libdnf::comps::PackageType;
 
     /// @return the underlying group.
     libdnf::comps::Group get_group() const { return group; }
@@ -58,13 +60,17 @@ public:
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
     Reason get_reason() const noexcept { return reason; }
 
+    /// @return package types requested to be installed with the group.
+    PackageType get_package_types() const noexcept { return package_types; }
+
 private:
     friend class Transaction::Impl;
 
-    TransactionGroup(const libdnf::comps::Group & grp, Action action, Reason reason)
+    TransactionGroup(const libdnf::comps::Group & grp, Action action, Reason reason, const PackageType types)
         : group(grp),
           action(action),
-          reason(reason) {}
+          reason(reason),
+          package_types(types) {}
 
     void set_state(State value) noexcept { state = value; }
 
@@ -72,6 +78,7 @@ private:
     Action action;
     Reason reason;
     State state{State::STARTED};
+    PackageType package_types;
 };
 
 }  // namespace libdnf::base

--- a/include/libdnf/comps/group/package.hpp
+++ b/include/libdnf/comps/group/package.hpp
@@ -28,19 +28,20 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::comps {
 
-class InvalidPackageType : public libdnf::Error {
-public:
-    InvalidPackageType(const std::string & action);
-
-    const char * get_domain_name() const noexcept override { return "libdnf::comps"; }
-    const char * get_name() const noexcept override { return "InvalidPackageType"; }
-};
-
 enum class PackageType : int {
     CONDITIONAL = 1 << 0,  // a weak dependency
     DEFAULT = 1 << 1,      // installed by default, but can be unchecked in the UI
     MANDATORY = 1 << 2,    // installed
     OPTIONAL = 1 << 3      // not installed by default, but can be checked in the UI
+};
+
+class InvalidPackageType : public libdnf::Error {
+public:
+    InvalidPackageType(const std::string & type);
+    InvalidPackageType(const PackageType type);
+
+    const char * get_domain_name() const noexcept override { return "libdnf::comps"; }
+    const char * get_name() const noexcept override { return "InvalidPackageType"; }
 };
 
 inline PackageType operator|(PackageType a, PackageType b) {
@@ -68,6 +69,8 @@ inline constexpr bool any(PackageType flags) {
 
 PackageType package_type_from_string(const std::string & type);
 PackageType package_type_from_string(const std::vector<std::string> types);
+std::string package_type_to_string(const PackageType type);
+std::vector<std::string> package_types_to_strings(const PackageType types);
 
 
 // TODO(dmach): isn't it more a package dependency rather than a package?

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -1426,7 +1426,7 @@ void Goal::Impl::add_group_install_to_goal(
                 }
             }
         }
-        rpm_goal.add_group(group, transaction::TransactionItemAction::INSTALL, reason);
+        rpm_goal.add_group(group, transaction::TransactionItemAction::INSTALL, reason, allowed_package_types);
     }
 }
 
@@ -1477,7 +1477,7 @@ void Goal::Impl::add_group_remove_to_goal(
 
                 remove_candidates.add(pkg);
             }
-            rpm_goal.add_group(group, transaction::TransactionItemAction::REMOVE, reason);
+            rpm_goal.add_group(group, transaction::TransactionItemAction::REMOVE, reason, {});
         }
     }
     if (remove_candidates.empty()) {

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -356,8 +356,8 @@ void Transaction::Impl::set_transaction(rpm::solv::GoalPrivate & solved_goal, Go
     }
 
     // Add groups to the transaction
-    for (auto & [group, action, reason] : solved_goal.list_groups()) {
-        TransactionGroup tsgrp(group, action, reason);
+    for (auto & [group, action, reason, package_types] : solved_goal.list_groups()) {
+        TransactionGroup tsgrp(group, action, reason, package_types);
         groups.emplace_back(std::move(tsgrp));
     }
 
@@ -680,6 +680,7 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
             if (transaction_item_action_is_inbound(tsgroup.get_action())) {
                 libdnf::system::GroupState state;
                 state.userinstalled = tsgroup.get_reason() == transaction::TransactionItemReason::USER;
+                state.package_types = tsgroup.get_package_types();
                 // Remember packages installed by this group
                 for (const auto & pkg : group.get_packages()) {
                     auto pkg_name = pkg.get_name();

--- a/libdnf/comps/group/package.cpp
+++ b/libdnf/comps/group/package.cpp
@@ -30,6 +30,9 @@ namespace libdnf::comps {
 InvalidPackageType::InvalidPackageType(const std::string & type)
     : libdnf::Error(M_("Invalid package type: {}"), type) {}
 
+InvalidPackageType::InvalidPackageType(const PackageType type)
+    : libdnf::Error(M_("Invalid package type: {}"), static_cast<int>(type)) {}
+
 PackageType package_type_from_string(const std::string & type) {
     if (type == "mandatory") {
         return PackageType::MANDATORY;
@@ -49,6 +52,31 @@ PackageType package_type_from_string(const std::vector<std::string> types) {
         retval |= package_type_from_string(type);
     }
     return retval;
+}
+
+std::string package_type_to_string(const PackageType type) {
+    switch (type) {
+        case PackageType::MANDATORY:
+            return "mandatory";
+        case PackageType::DEFAULT:
+            return "default";
+        case PackageType::CONDITIONAL:
+            return "conditional";
+        case PackageType::OPTIONAL:
+            return "optional";
+    }
+    throw InvalidPackageType(type);
+}
+
+std::vector<std::string> package_types_to_strings(const PackageType types) {
+    std::vector<std::string> result_types;
+    for (const auto available_type : std::vector<PackageType>{
+             PackageType::MANDATORY, PackageType::DEFAULT, PackageType::CONDITIONAL, PackageType::OPTIONAL}) {
+        if (any(types & available_type)) {
+            result_types.push_back(package_type_to_string(available_type));
+        }
+    }
+    return result_types;
 }
 
 }  // namespace libdnf::comps

--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -72,10 +72,12 @@ public:
     /// Remember group action in the transaction
     /// @param action Action to be commited - INSTALL, REMOVE, UPGRADE
     /// @param reason Reason for the group action - USER, DEPENDENCY
+    /// @param package_types Types of group packages requested to be installed along with the group. Used only for INSTALL action
     void add_group(
         const libdnf::comps::Group & group,
         transaction::TransactionItemAction action,
-        transaction::TransactionItemReason reason);
+        transaction::TransactionItemReason reason,
+        libdnf::comps::PackageType package_types);
 
     libdnf::GoalProblem resolve();
 
@@ -86,8 +88,11 @@ public:
     libdnf::solv::IdQueue list_removes();
     libdnf::solv::IdQueue list_obsoleted();
 
-    std::vector<
-        std::tuple<libdnf::comps::Group, transaction::TransactionItemAction, transaction::TransactionItemReason>>
+    std::vector<std::tuple<
+        libdnf::comps::Group,
+        transaction::TransactionItemAction,
+        transaction::TransactionItemReason,
+        libdnf::comps::PackageType>>
     list_groups() {
         return groups;
     };
@@ -183,8 +188,11 @@ private:
     bool run_in_strict_mode{false};
     bool clean_deps_present{false};
 
-    std::vector<
-        std::tuple<libdnf::comps::Group, transaction::TransactionItemAction, transaction::TransactionItemReason>>
+    std::vector<std::tuple<
+        libdnf::comps::Group,
+        transaction::TransactionItemAction,
+        transaction::TransactionItemReason,
+        libdnf::comps::PackageType>>
         groups;
 
     // Reason change requirements
@@ -310,8 +318,9 @@ inline void GoalPrivate::add_distro_sync(libdnf::solv::IdQueue & queue, bool ski
 inline void GoalPrivate::add_group(
     const libdnf::comps::Group & group,
     transaction::TransactionItemAction action,
-    transaction::TransactionItemReason reason) {
-    groups.emplace_back(group, action, reason);
+    transaction::TransactionItemReason reason,
+    libdnf::comps::PackageType package_types) {
+    groups.emplace_back(group, action, reason, package_types);
 }
 
 inline void GoalPrivate::add_reason_change(

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/fs/file.hpp"
 #include "utils/string.hpp"
 
+#include <libdnf/comps/group/package.hpp>
 #include <toml.hpp>
 
 
@@ -79,11 +80,29 @@ struct into<libdnf::system::NevraState> {
 
 
 template <>
+struct from<libdnf::comps::PackageType> {
+    static libdnf::comps::PackageType from_toml(const value & v) {
+        return libdnf::comps::package_type_from_string(toml::get<std::vector<std::string>>(v));
+    }
+};
+
+
+template <>
+struct into<libdnf::comps::PackageType> {
+    static toml::value into_toml(const libdnf::comps::PackageType & package_types) {
+        return libdnf::comps::package_types_to_strings(package_types);
+    }
+};
+
+template <>
 struct from<libdnf::system::GroupState> {
     static libdnf::system::GroupState from_toml(const value & v) {
         libdnf::system::GroupState group_state;
 
         group_state.userinstalled = toml::find<bool>(v, "userinstalled");
+        if (v.contains("package_types")) {
+            group_state.package_types = toml::find<libdnf::comps::PackageType>(v, "package_types");
+        }
         if (v.contains("packages")) {
             group_state.packages = toml::find<std::vector<std::string>>(v, "packages");
         }
@@ -99,6 +118,7 @@ struct into<libdnf::system::GroupState> {
         toml::value res;
 
         res["userinstalled"] = group_state.userinstalled;
+        res["package_types"] = group_state.package_types;
         res["packages"] = group_state.packages;
 
         return res;

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_SYSTEM_STATE_HPP
 
 #include "libdnf/common/exception.hpp"
+#include "libdnf/comps/group/package.hpp"
 #include "libdnf/module/module_sack.hpp"
 #include "libdnf/rpm/nevra.hpp"
 #include "libdnf/rpm/package.hpp"
@@ -50,6 +51,8 @@ class GroupState {
 public:
     bool userinstalled{false};
     std::vector<std::string> packages;
+    /// List of allowed group package types installed with the group. Group upgrade needs to respect it.
+    libdnf::comps::PackageType package_types;
 };
 
 class EnvironmentState {

--- a/test/libdnf/system/test_state.hpp
+++ b/test/libdnf/system/test_state.hpp
@@ -26,6 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "system/state.hpp"
 #include "utils/fs/temp.hpp"
 
+#include "libdnf/comps/group/package.hpp"
+
 #include <cppunit/extensions/HelperMacros.h>
 
 #include <memory>

--- a/test/shared/utils.hpp
+++ b/test/shared/utils.hpp
@@ -246,14 +246,17 @@ struct assertion_traits<libdnf::system::NevraState> {
 template <>
 struct assertion_traits<libdnf::system::GroupState> {
     inline static bool equal(const libdnf::system::GroupState & left, const libdnf::system::GroupState & right) {
-        return left.userinstalled == right.userinstalled && left.packages == right.packages;
+        return left.userinstalled == right.userinstalled && left.packages == right.packages &&
+               static_cast<int>(left.package_types) == static_cast<int>(right.package_types);
     }
 
     inline static std::string toString(const libdnf::system::GroupState & group_state) {
         return fmt::format(
-            "GroupState: userinstalled: {}, packages: {}",
+            "GroupState: userinstalled: {}, packages: {}, package_types: {}",
             group_state.userinstalled,
-            assertion_traits<std::vector<std::string>>::toString(group_state.packages));
+            assertion_traits<std::vector<std::string>>::toString(group_state.packages),
+            assertion_traits<std::vector<std::string>>::toString(
+                libdnf::comps::package_types_to_strings(group_state.package_types)));
     }
 };
 


### PR DESCRIPTION
To correctly implement `dnf5 group upgrade` command we need to now which types of packages were installed along with the group.
E.g. in case the group was installed without `optional` packages, upgrade also should not install new optional packages and vice versa - if the group was installed with optionals, then any new optional package gets also installed.