### PR TITLE
Implement dnf5 provides

### DIFF
--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -17,18 +17,18 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "libdnf-cli/output/provides.hpp"
+#include "libdnf5-cli/output/provides.hpp"
 
 #include "provides.hpp"
 
-#include <libdnf/conf/const.hpp>
-#include <libdnf/rpm/package_query.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 #include <iostream>
 
 namespace dnf5 {
 
-using namespace libdnf::cli;
+using namespace libdnf5::cli;
 
 void ProvidesCommand::set_parent_command() {
     auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
@@ -61,37 +61,37 @@ void ProvidesCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.base.get_config().get_optional_metadata_types_option().add_item(
-        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
+        libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
 void ProvidesCommand::run() {
     auto & ctx = get_context();
 
-    libdnf::rpm::PackageSet result_pset(ctx.base);
-    libdnf::rpm::PackageQuery full_package_query(ctx.base);
+    libdnf5::rpm::PackageSet result_pset(ctx.base);
+    libdnf5::rpm::PackageQuery full_package_query(ctx.base);
     auto provides_query = full_package_query;
-    provides_query.filter_provides(pkg_specs, libdnf::sack::QueryCmp::GLOB);
+    provides_query.filter_provides(pkg_specs, libdnf5::sack::QueryCmp::GLOB);
     if (!provides_query.empty()) {
         full_package_query = provides_query;
     } else {
         // If provides query doesn't match anything try matching files
-        full_package_query.filter_file(pkg_specs, libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_file(pkg_specs, libdnf5::sack::QueryCmp::GLOB);
     }
 
     if (pkg_specs.empty()) {
         result_pset |= full_package_query;
     } else {
-        const libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false};
+        const libdnf5::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false};
         for (const auto & spec : pkg_specs) {
-            libdnf::rpm::PackageQuery package_query(full_package_query);
+            libdnf5::rpm::PackageQuery package_query(full_package_query);
             package_query.resolve_pkg_spec(spec, settings, true);
             result_pset |= package_query;
         }
     }
 
     for (auto package : result_pset) {
-        libdnf::cli::output::print_provides_table(package);
+        libdnf5::cli::output::print_provides_table(package);
     }
 }
 

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -1,0 +1,94 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "provides.hpp"
+
+#include <libdnf/rpm/package_query.hpp>
+
+#include <iostream>
+
+namespace dnf5 {
+
+using namespace libdnf::cli;
+
+void ProvidesCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("query_commands").register_argument(arg_parser_this_cmd);
+}
+
+void ProvidesCommand::set_argument_parser() {
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_description("Find what package provides the given argument");
+
+    auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
+    keys->set_description("List of package specs to query");
+    keys->set_parse_hook_func(
+        [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
+            for (int i = 0; i < argc; ++i) {
+                pkg_specs.emplace_back(argv[i]);
+            }
+            return true;
+        });
+    keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, false, true, true, false); });
+    cmd.register_positional_arg(keys);
+}
+
+void ProvidesCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+}
+
+void ProvidesCommand::run() {
+    auto & ctx = get_context();
+
+    libdnf::rpm::PackageSet result_pset(ctx.base);
+    libdnf::rpm::PackageQuery full_package_query(ctx.base);
+    auto provides_query = full_package_query;
+    provides_query.filter_provides(pkg_specs, libdnf::sack::QueryCmp::GLOB);
+    if (!provides_query.empty()) {
+        full_package_query = provides_query;
+    } else {
+        // If provides query doesn't match anything try matching files
+        full_package_query.filter_file(pkg_specs, libdnf::sack::QueryCmp::GLOB);
+    }
+
+    if (pkg_specs.empty()) {
+        result_pset |= full_package_query;
+    } else {
+        const libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false};
+        for (const auto & spec : pkg_specs) {
+            libdnf::rpm::PackageQuery package_query(full_package_query);
+            package_query.resolve_pkg_spec(spec, settings, true);
+            result_pset |= package_query;
+        }
+    }
+
+    for (auto package : result_pset) {
+        std::cout << package.get_full_nevra() << '\n';
+    }
+}
+
+
+}  // namespace dnf5

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "provides.hpp"
 
+#include <libdnf/conf/const.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
 #include <iostream>
@@ -59,6 +60,7 @@ void ProvidesCommand::set_argument_parser() {
 void ProvidesCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
+    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "libdnf-cli/output/provides.hpp"
+
 #include "provides.hpp"
 
 #include <libdnf/rpm/package_query.hpp>
@@ -86,7 +88,7 @@ void ProvidesCommand::run() {
     }
 
     for (auto package : result_pset) {
-        std::cout << package.get_full_nevra() << '\n';
+        libdnf::cli::output::print_provides_table(package);
     }
 }
 

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -60,7 +60,8 @@ void ProvidesCommand::set_argument_parser() {
 void ProvidesCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/commands/provides/provides.hpp
+++ b/dnf5/commands/provides/provides.hpp
@@ -1,0 +1,42 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef DNF5_COMMANDS_PROVIDES_PROVIDES_HPP
+#define DNF5_COMMANDS_PROVIDES_PROVIDES_HPP
+
+#include <dnf5/context.hpp>
+
+namespace dnf5 {
+
+class ProvidesCommand : public Command {
+public:
+    explicit ProvidesCommand(Context & context) : Command(context, "provides") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+
+private:
+    std::vector<std::string> pkg_specs;
+};
+
+}  // namespace dnf5
+
+#endif  // DNF5_COMMANDS_PROVIDES_PROVIDES_HPP

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -35,6 +35,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/makecache/makecache.hpp"
 #include "commands/mark/mark.hpp"
 #include "commands/module/module.hpp"
+#include "commands/provides/provides.hpp"
 #include "commands/reinstall/reinstall.hpp"
 #include "commands/remove/remove.hpp"
 #include "commands/repo/repo.hpp"
@@ -555,6 +556,7 @@ static void add_commands(Context & context) {
     context.add_and_initialize_command(std::make_unique<ListCommand>(context));
     context.add_and_initialize_command(std::make_unique<InfoCommand>(context));
     context.add_and_initialize_command(std::make_unique<CheckUpgradeCommand>(context));
+    context.add_and_initialize_command(std::make_unique<ProvidesCommand>(context));
 
     context.add_and_initialize_command(std::make_unique<GroupCommand>(context));
     context.add_and_initialize_command(std::make_unique<EnvironmentCommand>(context));

--- a/include/libdnf5-cli/output/provides.hpp
+++ b/include/libdnf5-cli/output/provides.hpp
@@ -1,0 +1,63 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF_CLI_OUTPUT_PROVIDES_HPP
+#define LIBDNF_CLI_OUTPUT_PROVIDES_HPP
+
+#include <libsmartcols/libsmartcols.h>
+
+namespace libdnf::cli::output {
+
+
+static void add_line_into_provides_table(struct libscols_table * table, const char * key, const char * value) {
+    struct libscols_line * ln = scols_table_new_line(table, nullptr);
+    scols_line_set_data(ln, 0, key);
+    scols_line_set_data(ln, 1, value);
+}
+
+template <class Package>
+static struct libscols_table * create_provides_table(Package & package) {
+    struct libscols_table * table = scols_new_table();
+    scols_table_enable_noheadings(table, 1);
+    scols_table_set_column_separator(table, " : ");
+    scols_table_new_column(table, "key", 5, 0);
+    struct libscols_column * cl = scols_table_new_column(table, "value", 10, SCOLS_FL_WRAP);
+    scols_column_set_safechars(cl, "\n");
+    scols_column_set_wrapfunc(cl, scols_wrapnl_chunksize, scols_wrapnl_nextchunk, nullptr);
+
+    add_line_into_provides_table(table, package.get_name().c_str(), package.get_summary().c_str());
+    add_line_into_provides_table(table, "Repo", package.get_repo_id().c_str());
+    add_line_into_provides_table(table, "Matched from", "");
+    add_line_into_provides_table(table, "Provide", "");
+    add_line_into_provides_table(table, "Filename", "");
+
+    return table;
+}
+
+template <class Package>
+static void print_provides_table(Package & package) {
+    auto table = create_provides_table(package);
+    scols_print_table(table);
+    scols_unref_table(table);
+}
+
+}  // namespace libdnf::cli::output
+
+#endif  // LIBDNF_CLI_OUTPUT_PROVIDES_HPP

--- a/include/libdnf5-cli/output/provides.hpp
+++ b/include/libdnf5-cli/output/provides.hpp
@@ -18,12 +18,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#ifndef LIBDNF_CLI_OUTPUT_PROVIDES_HPP
-#define LIBDNF_CLI_OUTPUT_PROVIDES_HPP
+#ifndef LIBDNF5_CLI_OUTPUT_PROVIDES_HPP
+#define LIBDNF5_CLI_OUTPUT_PROVIDES_HPP
 
 #include <libsmartcols/libsmartcols.h>
 
-namespace libdnf::cli::output {
+namespace libdnf5::cli::output {
 
 
 static void add_line_into_provides_table(struct libscols_table * table, const char * key, const char * value) {
@@ -58,6 +58,6 @@ static void print_provides_table(Package & package) {
     scols_unref_table(table);
 }
 
-}  // namespace libdnf::cli::output
+}  // namespace libdnf5::cli::output
 
-#endif  // LIBDNF_CLI_OUTPUT_PROVIDES_HPP
+#endif  // LIBDNF5_CLI_OUTPUT_PROVIDES_HPP


### PR DESCRIPTION
- [x] boilerplate code from `dnf5 repoquery --whatprovides`
- [ ] match files by filename
- [ ] highlight output
- [x] format output using smartcols


current output
```
$ ./dnf5/dnf5 provides dnf rpm
Updating and loading repositories:
Repositories loaded.
dnf          : Package manager
Repo         : @System
Matched from : 
Provide      : 
Filename     : 
rpm          : The RPM package management system
Repo         : @System
Matched from : 
Provide      : 
Filename     : 
dnf          : Package manager
Repo         : fedora
Matched from : 
Provide      : 
Filename     : 
rpm          : The RPM package management system
Repo         : fedora
Matched from : 
Provide      : 
Filename     : 

```