### PR TITLE
Add 4 aliases for dnf5 commands

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -82,6 +82,13 @@ header = "Compatibility Aliases:"
 #  { id_path = 'remove.unneeded' }
 # ]
 
+['dg']
+type = 'command'
+attached_command = 'downgrade'
+descr = "Alias for 'downgrade'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
 ['groupinfo']
 type = 'command'
 attached_command = 'group.info'
@@ -96,12 +103,26 @@ descr = "Alias for 'group list'"
 group_id = 'commands-compatibility-aliases'
 complete = true
 
+['in']
+type = 'command'
+attached_command = 'install'
+descr = "Alias for 'install'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
 ['ls']
 type = 'command'
 attached_command = 'list'
 descr = "Alias for 'list'"
 group_id = 'commands-compatibility-aliases'
 complete = true
+
+['rei']
+type = 'command'
+attached_command = 'reinstall'
+descr = "Alias for 'reinstall'"
+group_id = 'commands-compatibility-aliases'
+complete = false
 
 ['repoinfo']
 type = 'command'
@@ -116,6 +137,13 @@ attached_command = 'repo.list'
 descr = "Alias for 'repo list'"
 group_id = 'commands-compatibility-aliases'
 complete = true
+
+['rm']
+type = 'command'
+attached_command = 'remove'
+descr = "Alias for 'remove'"
+group_id = 'commands-compatibility-aliases'
+complete = false
 
 ['up']
 type = 'command'


### PR DESCRIPTION
It provides a compatibility with DNF.

Part of:
https://github.com/rpm-software-management/dnf5/issues/137
https://github.com/rpm-software-management/dnf5/issues/149
https://github.com/rpm-software-management/dnf5/issues/148
https://github.com/rpm-software-management/dnf5/issues/142