### PR TITLE
dnfdaemon: Fix download callbacks

### DIFF
--- a/dnf5daemon-client/callbacks.hpp
+++ b/dnf5daemon-client/callbacks.hpp
@@ -42,45 +42,31 @@ protected:
 };
 
 
-class RepoCB final : public DbusCallback {
+class DownloadCB final : public DbusCallback {
 public:
-    explicit RepoCB(Context & context);
-    virtual ~RepoCB() = default;
+    explicit DownloadCB(Context & context);
+    virtual ~DownloadCB() = default;
 
-    void start(sdbus::Signal & signal);
-    void end(sdbus::Signal & signal);
+    void add_new_download(sdbus::Signal & signal);
     void progress(sdbus::Signal & signal);
+    void end(sdbus::Signal & signal);
+    void mirror_failure(sdbus::Signal & signal);
     void key_import(sdbus::Signal & signal);
 
-private:
-    libdnf::cli::progressbar::DownloadProgressBar progress_bar{-1, ""};
-    std::size_t msg_lines{0};
-    void print_progress_bar();
-};
-
-
-class PackageDownloadCB final : public DbusCallback {
-public:
-    explicit PackageDownloadCB(Context & context);
-    virtual ~PackageDownloadCB() = default;
-
-    void start(sdbus::Signal & signal);
-    void end(sdbus::Signal & signal);
-    void progress(sdbus::Signal & signal);
-    void mirror_failure(sdbus::Signal & signal);
+    void reset_progress_bar();
+    void set_number_widget_visible(bool value);
+    void set_show_total_bar_limit(std::size_t limit);
 
 private:
-    libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
-    // map {package id: progressbar}
-    std::map<int, libdnf::cli::progressbar::DownloadProgressBar *> package_bars;
+    libdnf::cli::progressbar::DownloadProgressBar * find_progress_bar(const std::string & download_id);
+    void print();
 
-    libdnf::cli::progressbar::DownloadProgressBar * find_progress_bar(const int pkg_id) {
-        if (package_bars.find(pkg_id) != package_bars.end()) {
-            return package_bars.at(pkg_id);
-        } else {
-            return nullptr;
-        }
-    }
+    bool printed{false};
+    bool number_widget_visible{false};
+    std::size_t show_total_bar_limit{static_cast<std::size_t>(-1)};
+    std::unique_ptr<libdnf::cli::progressbar::MultiProgressBar> multi_progress_bar;
+    // map {download_id: progressbar}
+    std::unordered_map<std::string, libdnf::cli::progressbar::DownloadProgressBar *> progress_bars;
 };
 
 

--- a/dnf5daemon-client/commands/command.cpp
+++ b/dnf5daemon-client/commands/command.cpp
@@ -67,6 +67,12 @@ void TransactionCommand::run_transaction() {
         dbus_goal_wrapper.set_resolve_logs(std::move(problems));
     }
 
+    if (auto download_cb = ctx.get_download_cb()) {
+        download_cb->reset_progress_bar();
+        download_cb->set_number_widget_visible(true);
+        download_cb->set_show_total_bar_limit(0);
+    }
+
     // print the transaction to the user and ask for confirmation
     if (!libdnf::cli::output::print_transaction_table(dbus_goal_wrapper)) {
         return;

--- a/dnf5daemon-client/context.cpp
+++ b/dnf5daemon-client/context.cpp
@@ -61,8 +61,7 @@ void Context::init_session(sdbus::IConnection & connection) {
 
     session_proxy = sdbus::createProxy(connection, dnfdaemon::DBUS_NAME, session_object_path);
     // register progress bars callbacks
-    repocb = std::make_unique<RepoCB>(*this);
-    package_download_cb = std::make_unique<PackageDownloadCB>(*this);
+    download_cb = std::make_unique<DownloadCB>(*this);
     transaction_cb = std::make_unique<TransactionCB>(*this);
     session_proxy->finishRegistration();
 }

--- a/dnf5daemon-client/context.hpp
+++ b/dnf5daemon-client/context.hpp
@@ -67,11 +67,12 @@ public:
     libdnf::OptionString installroot{"/"};
     libdnf::OptionString releasever{""};
 
+    DownloadCB * get_download_cb() { return download_cb.get(); }
+
 private:
     sdbus::ObjectPath session_object_path;
     dnfdaemon::RepoStatus repositories_status;
-    std::unique_ptr<RepoCB> repocb;
-    std::unique_ptr<PackageDownloadCB> package_download_cb;
+    std::unique_ptr<DownloadCB> download_cb;
     std::unique_ptr<TransactionCB> transaction_cb;
 };
 

--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -59,15 +59,12 @@ const char * const INTERFACE_GROUP = "org.rpm.dnf.v0.comps.Group";
 const char * const INTERFACE_SESSION_MANAGER = "org.rpm.dnf.v0.SessionManager";
 
 // signals
-const char * const SIGNAL_REPO_LOAD_START = "repo_load_start";
-const char * const SIGNAL_REPO_LOAD_PROGRESS = "repo_load_progress";
-const char * const SIGNAL_REPO_LOAD_END = "repo_load_end";
-const char * const SIGNAL_REPO_KEY_IMPORT_REQUEST = "repo_key_import_request";
+const char * const SIGNAL_DOWNLOAD_ADD_NEW = "download_add_new";
+const char * const SIGNAL_DOWNLOAD_PROGRESS = "download_progress";
+const char * const SIGNAL_DOWNLOAD_END = "download_end";
+const char * const SIGNAL_DOWNLOAD_MIRROR_FAILURE = "download_mirror_failure";
 
-const char * const SIGNAL_PACKAGE_DOWNLOAD_START = "package_download_start";
-const char * const SIGNAL_PACKAGE_DOWNLOAD_PROGRESS = "package_download_progress";
-const char * const SIGNAL_PACKAGE_DOWNLOAD_END = "package_download_end";
-const char * const SIGNAL_PACKAGE_DOWNLOAD_MIRROR_FAILURE = "package_download_mirror_failure";
+const char * const SIGNAL_REPO_KEY_IMPORT_REQUEST = "repo_key_import_request";
 
 const char * const SIGNAL_TRANSACTION_TRANSACTION_START = "transaction_transaction_start";
 const char * const SIGNAL_TRANSACTION_TRANSACTION_PROGRESS = "transaction_transaction_progress";

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -1,0 +1,126 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<node>
+<!-- org.rpm.dnf.v0.Base:
+   @short_description: Interface to Base class
+-->
+<interface name="org.rpm.dnf.v0.Base">
+    <!--
+        read_all_repos:
+        @retval: `true` if repositories were successfuly loaded, `false` otherwise.
+
+        Explicitely ask for loading repositories metadata.
+    -->
+    <method name="read_all_repos">
+        <arg name="retval" type="b" direction="out"/>
+    </method>
+
+    <!--
+        download_add_new:
+        @session_object_path: object path of the dnf5daemon session
+        @download_id: unique id of downloaded object (repo or package)
+        @description: the description of the downloaded object
+        @total_to_download: total bytes to download
+
+        A new download has started.
+    -->
+    <signal name="download_add_new">
+        <arg name="session_object_path" type="o" />
+        <arg name="download_id" type="s" />
+        <arg name="description" type="s" />
+        <arg name="total_to_download" type="x" />
+    </signal>
+
+    <!--
+        download_progress:
+        @session_object_path: object path of the dnf5daemon session
+        @download_id: unique id of downloaded object (repo or package)
+        @total_to_download: total bytes to download
+        @downloaded: bytes already downloaded
+
+        Progress in downloading.
+    -->
+    <signal name="download_progress">
+        <arg name="session_object_path" type="o" />
+        <arg name="download_id" type="s" />
+        <arg name="total_to_download" type="x" />
+        <arg name="downloaded" type="x" />
+    </signal>
+
+    <!--
+        mirror_failure:
+        @session_object_path: object path of the dnf5daemon session
+        @download_id: unique id of downloaded object (repo or package)
+        @message: an error message
+        @url: URL being downloaded
+        @metadata: For repository metadata download contains metadata type
+
+        Mirror failure during the download.
+    -->
+    <signal name="mirror_failure">
+        <arg name="session_object_path" type="o" />
+        <arg name="download_id" type="s" />
+        <arg name="message" type="s" />
+        <arg name="url" type="s" />
+        <arg name="metadata" type="s" />
+    </signal>
+
+    <!--
+        download_end:
+        @session_object_path: object path of the dnf5daemon session
+        @download_id: unique id of downloaded object (repo or package)
+        @status: libdnf::repo::DownloadCallbacks::TransferStatus (0 - successful, 1 - already exists, 2 - error)
+        @error: error message in case of failed download
+
+        Downloading has ended.
+    -->
+    <signal name="repo_load_end">
+        <arg name="session_object_path" type="o" />
+        <arg name="download_id" type="s" />
+        <arg name="status" type="i" />
+        <arg name="message" type="s" />
+    </signal>
+
+    <!--
+        repo_key_import_request:
+        @session_object_path: object path of the dnf5daemon session
+        @key_id: PGP key id
+        @user_ids: User id
+        @key_fingerprint: Fingerprint of the PGP key
+        @key_url: URL of the PGP key
+        @timestamp: timestamp when the key was created
+
+        Request for repository key import confirmation.
+    -->
+    <signal name="repo_key_import_request">
+        <arg name="session_object_path" type="o" />
+        <arg name="key_id" type="s" />
+        <arg name="user_ids" type="as" />
+        <arg name="key_fingerprint" type="s" />
+        <arg name="key_url" type="s" />
+        <arg name="timestamp" type="x" />
+    </signal>
+
+</interface>
+
+</node>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
@@ -60,62 +60,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="confirmed" type="b" direction="in"/>
     </method>
 
-    <!--
-        repo_load_start:
-        @session_object_path: object path of the dnf5daemon session
-        @repository_name: the name of repository
-
-        Repository metadata loading has started.
-    -->
-    <signal name="repo_load_start">
-        <arg name="session_object_path" type="o" />
-        <arg name="repository_name" type="s" />
-    </signal>
-
-    <!--
-        repo_load_progress:
-        @session_object_path: object path of the dnf5daemon session
-        @downloaded: bytes already downloaded
-        @total: total bytes to download
-
-        Progress in repository metadata downloading.
-    -->
-    <signal name="repo_load_progress">
-        <arg name="session_object_path" type="o" />
-        <arg name="downloaded" type="t" />
-        <arg name="total" type="t" />
-    </signal>
-
-    <!--
-        repo_load_end:
-        @session_object_path: object path of the dnf5daemon session
-
-        Repository metadata loading has ended.
-    -->
-    <signal name="repo_load_end">
-        <arg name="session_object_path" type="o" />
-    </signal>
-
-    <!--
-        repo_key_import_request:
-        @session_object_path: object path of the dnf5daemon session
-        @key_id: GPG key id
-        @user_id: User id
-        @key_fingerprint: Fingerprint of the GPG key
-        @key_url: URL of the GPG key
-        @timestamp: timestamp when the key was created
-
-        Request for repository key import confirmation.
-    -->
-    <signal name="repo_key_import_request">
-        <arg name="session_object_path" type="o" />
-        <arg name="key_id" type="s" />
-        <arg name="user_id" type="s" />
-        <arg name="key_fingerprint" type="s" />
-        <arg name="key_url" type="s" />
-        <arg name="timestamp" type="x" />
-    </signal>
-
 </interface>
 
 </node>

--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -37,6 +37,11 @@ void Base::dbus_register() {
         dnfdaemon::INTERFACE_BASE, "read_all_repos", "", "b", [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Base::read_all_repos, call, session.session_locale);
         });
+    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST, "ossssx");
+    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_ADD_NEW, "os");
+    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_PROGRESS, "ott");
+    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_END, "o");
+    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_MIRROR_FAILURE, "o");
 }
 
 sdbus::MethodReply Base::read_all_repos(sdbus::MethodCall & call) {

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -211,19 +211,17 @@ void Repo::dbus_register() {
         dnfdaemon::INTERFACE_REPO, "confirm_key", "sb", "", [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Repo::confirm_key, call);
         });
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST, "ossssx");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_LOAD_START, "os");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_LOAD_PROGRESS, "ott");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_LOAD_END, "o");
 }
 
 sdbus::MethodReply Repo::confirm_key(sdbus::MethodCall & call) {
     std::string key_id;
     bool confirmed;
     call >> key_id >> confirmed;
-    if (!session.check_authorization(dnfdaemon::POLKIT_CONFIRM_KEY_IMPORT, call.getSender())) {
-        session.confirm_key(key_id, false);
-        throw std::runtime_error("Not authorized");
+    if (confirmed) {
+        if (!session.check_authorization(dnfdaemon::POLKIT_CONFIRM_KEY_IMPORT, call.getSender())) {
+            session.confirm_key(key_id, false);
+            throw std::runtime_error("Not authorized");
+        }
     }
     session.confirm_key(key_id, confirmed);
     return call.createReply();


### PR DESCRIPTION
This patch adapts dnfdaemon callbacks to unified repo::DownloadCallbacks introduced in commit d24cad69.
The new implementation is much simpler and resolves several segfaults in the dnf5daemon-server.

- specialized RepoCB and PackageDownloadCB are replaced with shared DownloadCB
- since repository and package downloads now share the same callbacks, signals are moved from REPO to BASE interface
- added new "download_add_new" signal for the new download callback "add_new_download"

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2184276