### PR TITLE
generate dist-info for Python bindings

### DIFF
--- a/bindings/python3/CMakeLists.txt
+++ b/bindings/python3/CMakeLists.txt
@@ -46,8 +46,17 @@ function(add_python3_module LIBRARY_NAME MODULE_NAME)
     swig_link_libraries(${TARGET_NAME} ${C_LIBRARY_NAME})
     swig_link_libraries(${TARGET_NAME} ${Python3_LIBRARIES})
 
+    # generate a dist-info for the library (redundantly created for multi-module packages, oh well...)
+    set(DISTINFO_PATH "${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_NAME}-${CMAKE_PROJECT_VERSION}.dist-info")
+    set(METADATA_FILE "${DISTINFO_PATH}/METADATA")
+    file(MAKE_DIRECTORY ${DISTINFO_PATH})
+    file(WRITE ${METADATA_FILE} "Metadata-Version: 2.1\n")
+    file(APPEND ${METADATA_FILE} "Name: ${LIBRARY_NAME}\n")
+    file(APPEND ${METADATA_FILE} "Version: ${CMAKE_PROJECT_VERSION}\n")
+
     install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION ${Python3_SITEARCH}/${LIBRARY_NAME})
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}.py DESTINATION ${Python3_SITEARCH}/${LIBRARY_NAME})
+    install(DIRECTORY ${DISTINFO_PATH} DESTINATION ${Python3_SITEARCH})
 endfunction()
 
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -376,6 +376,7 @@ Python 3 bindings for the libdnf library.
 
 %files -n python3-libdnf5
 %{python3_sitearch}/libdnf5
+%{python3_sitearch}/libdnf5-*.dist-info
 %license COPYING.md
 %license lgpl-2.1.txt
 %endif
@@ -395,6 +396,7 @@ Python 3 bindings for the libdnf5-cli library.
 
 %files -n python3-libdnf5-cli
 %{python3_sitearch}/libdnf5_cli
+%{python3_sitearch}/libdnf5_cli-*.dist-info
 %license COPYING.md
 %license lgpl-2.1.txt
 %endif


### PR DESCRIPTION
fixes #446 

* ensures that `libdnf5` and `libdnf5_cli` Python bindings include minimal distribution metadata (per https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata). This makes the presence of the binding and its version visible to standard Python tools like `pip`, and makes it easier for, eg, Ansible users to discover if the bindings are available to the current Python.

Note that `python3-rpm` and `python3-gpg` are already doing something similar (just using the older and largely deprecated `egg-info` metadata instead of `dist-info`).

After build/install with this change:
```
(dnf5) [root@690bb604ca02 build]# pip list
Package     Version
----------- -------
libdnf5     5.0.7
libdnf5_cli 5.0.7
pip         22.2.2
setuptools  62.6.0
```

I've also reserved `libdnf5` and `libdnf5_cli` on PyPI, just in case someone decides to try and include one of these in a requirements/freeze file- it would work properly with this change if the OS-packaged libs are present, but don't want to let a malicious party grab those projects and get people installing who-knows-what in the case where they're not installed. Regardless if they're ever used to publish working versions of these (would be nice, hint hint :wink:), I'm happy to hand the keys to those PyPI packages over to a maintainer if desired.