### PR TITLE
Add detect_release to public API

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -42,6 +42,8 @@
 #define CV __perl_CV
 #define final
 
+wrap_unique_ptr(StringUniquePtr, std::string);
+
 %include "libdnf/version.hpp"
 
 %include "libdnf/conf/const.hpp"

--- a/include/libdnf/conf/vars.hpp
+++ b/include/libdnf/conf/vars.hpp
@@ -86,6 +86,8 @@ public:
     /// @param name Name of the variable
     const Variable & get(const std::string & name) const { return variables.at(name); }
 
+    static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
+
 private:
     friend class Base;
 

--- a/libdnf/conf/vars.cpp
+++ b/libdnf/conf/vars.cpp
@@ -129,9 +129,13 @@ static const char * detect_arch() {
     return value;
 }
 
-static std::optional<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path) {
+
+// ==================================================================
+
+
+std::unique_ptr<std::string> Vars::detect_release(const BaseWeakPtr & base, const std::string & install_root_path) {
     init_lib_rpm();
-    std::optional<std::string> release_ver;
+    std::unique_ptr<std::string> release_ver;
 
     libdnf::rpm::RpmLogGuard rpm_log_guard(base);
 
@@ -153,7 +157,7 @@ static std::optional<std::string> detect_release(const BaseWeakPtr & base, const
             }
             if (version) {
                 // Is the result of rpmdsEVR(ds) valid after rpmdsFree(ds)? Make a copy to be sure.
-                release_ver = version;
+                release_ver = std::make_unique<std::string>(version);
             }
             rpmdsFree(ds);
         }
@@ -166,7 +170,6 @@ static std::optional<std::string> detect_release(const BaseWeakPtr & base, const
     return release_ver;
 }
 
-// ==================================================================
 
 Vars::Vars(Base & base) : Vars(base.get_weak_ptr()) {}
 


### PR DESCRIPTION
There is a use case where they need to detect releasever before setting cachedir and calling base.setup()

Resolves: https://github.com/rpm-software-management/dnf5/issues/281