### PR TITLE
progressbar: Prevent length_error exception (RhBug:2184271)

### DIFF
--- a/libdnf-cli/progressbar/widgets/progress.cpp
+++ b/libdnf-cli/progressbar/widgets/progress.cpp
@@ -44,7 +44,7 @@ std::string ProgressWidget::to_string() const {
 
     os << get_delimiter_before();
     os << "[";
-    if (get_bar()->get_total_ticks() > 0) {
+    if (get_bar()->get_total_ticks() > 0 && get_bar()->get_ticks() > 0) {
         progress = static_cast<std::size_t>(rint(
             static_cast<double>(get_bar()->get_ticks()) / static_cast<double>(get_bar()->get_total_ticks()) *
             (static_cast<double>(width) - 2)));


### PR DESCRIPTION
In case the current ticks in the progress bar are not set (default to -1), the `std::string(progress, '=')` might result in throwing std::length_error exception:

terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_M_create
Aborted (core dumped)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2184271