### PR TITLE
[dnf5] Fix help in case argument parser detect error

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -90,7 +90,8 @@ void DownloadCommand::configure() {
         context.set_load_system_repo(true);
     } else if (!resolve_option->get_value() && alldeps_option->get_value()) {
         throw libdnf::cli::ArgumentParserMissingDependentArgumentError(
-            M_("Option alldeps should be used with resolve"));
+            //TODO(jrohel): Add support for requiring an argument by another argument in ArgumentParser?
+            M_("Option \"--alldeps\" should be used with \"--resolve\""));
     } else {
         context.set_load_system_repo(false);
     }


### PR DESCRIPTION
- if the user wants help (--help/-h argument is present) -> print help and only help without errors and the application ends with the return code libdnf::cli::ExitCode::SUCCESS.
- if user doesn't want help (--help/-h argument is not present) and argument parser detects missing/bad argument -> print an error message with a note about '--help' and application exits with return code libdnf::cli::ExitCode::ARGPARSER_ERROR

Solves: https://github.com/rpm-software-management/dnf5/issues/317

Requires modification of CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1247