### PR TITLE
Add merge group to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 ---
 name: DNF 5 CI
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   package-build:


### PR DESCRIPTION
~~This pr is currently opened against not-the-main branch to test the merge-queue feature which has to be enabled in GH settings.~~
Open against master now.
By enabling the feature, all the checks will run once more before the pr gets automatically merged by GitHub.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue