### PR TITLE
Small fixes in doc and formating

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language: Cpp
 BasedOnStyle: Google
-Standard: Cpp11
+Standard: c++20
 
 
 # Characters per line

--- a/doc/contributing/coding_style_cpp.rst
+++ b/doc/contributing/coding_style_cpp.rst
@@ -1,7 +1,7 @@
 C++ coding style
 ================
 
-* C++17
+* C++20
 * Indent by 4 spaces
 * Up to 120 characters per line
 * Comments start with two forward slashes: ``//``

--- a/doc/contributing/project_layout.rst
+++ b/doc/contributing/project_layout.rst
@@ -21,5 +21,6 @@ Project layout
     +-- libdnf-plugins          # libdnf C/C++ plugins
     +-- dnf5daemon-client       # command line client for dnf5daemon-server
     +-- dnf5daemon-server       # DBus package manager service
-    +-- dnf5                # dnf5 command line package manager
+    +-- dnf5                    # dnf5 command line package manager
+    +-- dnf5-plugins            # dnf5 plugins
     +-- test                    # tests; similar layout to the bindings


### PR DESCRIPTION
- Fix .clang-format: Replace Cpp11 with c++20
- [doc] Coding style: Use C++20
- [doc] project layout: Add dnf5-plugins directory