### PR TITLE
Implement keepcache functionality (RhBug:2176384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Next release
+
+- Implement keepcache functionality (RhBug:2176384)
+  - API changes:
+    - libdnf::repo::PackageDownloader default ctor dropped (now accepting the Base object)
+    - libdnf::base::Transaction not accepting dest_dir anymore (implicitly taken from configuration)
+  - A note for existing users:
+    - Regardless of the keepcache option, all downloaded packages have been cached up until now.
+    - Starting from now, downloaded packages will be kept only until the next successful transaction (keepcache=False by default).
+    - To remove all existing packages from the cache, use the `dnf5 clean packages` command.
+
 # 5.0.11
 
 - Add --contains-pkgs option to group info

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -23,9 +23,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/bgettext/bgettext-mark-domain.h"
 
 #include <libdnf/conf/option_string.hpp>
+#include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
+
+#include <iostream>
 
 
 namespace dnf5 {
@@ -146,7 +149,16 @@ void DownloadCommand::run() {
     }
 
     if (!download_pkgs.empty()) {
-        download_packages(download_pkgs, ctx.base.get_config().get_destdir_option().get_value().c_str());
+        libdnf::repo::PackageDownloader downloader(ctx.base);
+        auto destination = ctx.base.get_config().get_destdir_option().get_value().c_str();
+
+        for (auto & pkg : download_pkgs) {
+            downloader.add(pkg, destination);
+        }
+
+        std::cout << "Downloading Packages:" << std::endl;
+        downloader.download(true, true);
+        std::cout << std::endl;
     }
 }
 

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -152,6 +152,9 @@ void DownloadCommand::run() {
         libdnf::repo::PackageDownloader downloader(ctx.base);
         auto destination = ctx.base.get_config().get_destdir_option().get_value().c_str();
 
+        // for download command, we don't want to mark the packages for removal
+        downloader.force_keep_packages(true);
+
         for (auto & pkg : download_pkgs) {
             downloader.add(pkg, destination);
         }

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -150,13 +150,12 @@ void DownloadCommand::run() {
 
     if (!download_pkgs.empty()) {
         libdnf::repo::PackageDownloader downloader(ctx.base);
-        auto destination = ctx.base.get_config().get_destdir_option().get_value().c_str();
 
         // for download command, we don't want to mark the packages for removal
         downloader.force_keep_packages(true);
 
         for (auto & pkg : download_pkgs) {
-            downloader.add(pkg, destination);
+            downloader.add(pkg);
         }
 
         std::cout << "Downloading Packages:" << std::endl;

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -158,7 +158,7 @@ void Context::load_repos(bool load_system) {
 }
 
 void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir) {
-    libdnf::repo::PackageDownloader downloader;
+    libdnf::repo::PackageDownloader downloader(packages.front().get_base());
 
     for (auto & package : packages) {
         if (dest_dir != nullptr) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -34,8 +34,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/base/base.hpp>
 #include <libdnf/base/goal.hpp>
 #include <libdnf/conf/const.hpp>
-#include <libdnf/repo/file_downloader.hpp>
-#include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
 #include <libdnf/rpm/rpm_signature.hpp>
@@ -155,22 +153,6 @@ void Context::load_repos(bool load_system) {
         download_callbacks->reset_progress_bar();
     }
     print_info("Repositories loaded.");
-}
-
-void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir) {
-    libdnf::repo::PackageDownloader downloader(packages.front().get_base());
-
-    for (auto & package : packages) {
-        if (dest_dir != nullptr) {
-            downloader.add(package, dest_dir);
-        } else {
-            downloader.add(package);
-        }
-    }
-
-    std::cout << "Downloading Packages:" << std::endl;
-    downloader.download(true, true);
-    std::cout << std::endl;
 }
 
 namespace {

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -148,10 +148,6 @@ private:
     Actions action;
 };
 
-/// Download packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
-void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir);
-void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir);
-
 void run_transaction(libdnf::rpm::Transaction & transaction);
 
 /// Returns the names of matching packages and paths of matching package file names and directories.

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -196,8 +196,8 @@ sdbus::MethodReply Goal::get_transaction_problems(sdbus::MethodCall & call) {
 
 
 // TODO (mblaha) callbacks to report the status
-void download_packages(libdnf::base::Transaction & transaction) {
-    libdnf::repo::PackageDownloader downloader;
+void download_packages(Session & session, libdnf::base::Transaction & transaction) {
+    libdnf::repo::PackageDownloader downloader(session.get_base()->get_weak_ptr());
 
     // container is owner of package callbacks user_data
     std::vector<std::unique_ptr<dnf5daemon::DownloadUserData>> user_data;
@@ -225,7 +225,7 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
 
     auto * transaction = session.get_transaction();
 
-    download_packages(*transaction);
+    download_packages(session, *transaction);
 
     std::string comment;
     if (options.find("comment") != options.end()) {

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -93,9 +93,11 @@ public:
     /// Download all inbound packages (packages that are being installed on the
     /// system). Fails immediately on the first package download failure. Will
     /// try to resume downloads of any partially-downloaded RPMs.
-    /// @param dest_dir Destination directory for downloaded RPMs. Default is
-    /// the standard location of repo cachedir/packages.
-    void download(const std::string & dest_dir = {});
+    ///
+    /// The destination directory for downloaded RPMs is taken from the `destdir`
+    /// configuration option. If it's not specified, the standard location of
+    /// repo cachedir/packages is used.
+    void download();
 
     /// Check the transaction by running it with RPMTRANS_FLAG_TEST. The import
     /// of any necessary public keys will be requested, and transaction checks

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -36,7 +36,8 @@ class PackageDownloadError : public Error {
 
 class PackageDownloader {
 public:
-    PackageDownloader();
+    explicit PackageDownloader(const libdnf::BaseWeakPtr & base);
+    explicit PackageDownloader(libdnf::Base & base);
     ~PackageDownloader();
 
     /// Adds a package to download to the standard location of repo cachedir/packages.

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/package.hpp"
 
 #include <memory>
+#include <optional>
 
 namespace libdnf::repo {
 
@@ -56,9 +57,19 @@ public:
     /// @param resume Whether to try to resume the download if a destination package already exists.
     void download(bool fail_fast, bool resume);
 
+    /// Explicitly setup the behavior related to packages caching.
+    /// By default, the `keepcache` configuration option is used to determine whether to keep
+    /// downloaded packages even after following successful transaction.
+    ///
+    /// @param value If true, packages will be kept on the disk after downloading
+    /// regardless the `keepcache` option value, if false, it enforces packages removal after
+    /// the next successful transaction.
+    void force_keep_packages(bool value) { keep_packages = value; }
+
 private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
+    std::optional<bool> keep_packages;
 };
 
 /// Wraps librepo PackageTarget

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -281,15 +281,10 @@ std::string Transaction::transaction_result_to_string(const TransactionRunResult
 
 void Transaction::download() {
     libdnf::repo::PackageDownloader downloader(p_impl->base);
-    auto & destdir_option = p_impl->base->get_config().get_destdir_option();
     for (auto & tspkg : this->get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action()) &&
             tspkg.get_package().get_repo()->get_type() != libdnf::repo::Repo::Type::COMMANDLINE) {
-            if (destdir_option.empty()) {
-                downloader.add(tspkg.get_package());
-            } else {
-                downloader.add(tspkg.get_package(), destdir_option.get_value().c_str());
-            }
+            downloader.add(tspkg.get_package());
         }
     }
     downloader.download(true, true);

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "rpm/transaction.hpp"
 
 #include "base_impl.hpp"
+#include "repo/temp_files_memory.hpp"
 #include "rpm/package_set_impl.hpp"
 #include "solv/pool.hpp"
 #include "solver_problems_internal.hpp"
@@ -777,6 +778,20 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     plugins.post_transaction(*transaction);
 
     if (ret == 0) {
+        // removes any temporarily stored packages from the system
+        libdnf::repo::TempFilesMemory temp_files_memory(config.get_cachedir_option().get_value());
+        auto temp_files = temp_files_memory.get_files();
+        for (auto & file : temp_files) {
+            try {
+                if (!std::filesystem::remove(file)) {
+                    logger->debug("Temporary file \"{}\" doesn't exist.", file);
+                }
+            } catch (const std::filesystem::filesystem_error & ex) {
+                logger->debug("An error occurred when trying to remove a temporary file \"{}\": {}", file, ex.what());
+            }
+        }
+        temp_files_memory.clear();
+
         return TransactionRunResult::SUCCESS;
     } else {
         for (auto it : rpm_transaction.get_problems()) {

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -279,15 +279,16 @@ std::string Transaction::transaction_result_to_string(const TransactionRunResult
     return {};
 }
 
-void Transaction::download(const std::string & dest_dir) {
+void Transaction::download() {
     libdnf::repo::PackageDownloader downloader(p_impl->base);
+    auto & destdir_option = p_impl->base->get_config().get_destdir_option();
     for (auto & tspkg : this->get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action()) &&
             tspkg.get_package().get_repo()->get_type() != libdnf::repo::Repo::Type::COMMANDLINE) {
-            if (dest_dir.empty()) {
+            if (destdir_option.empty()) {
                 downloader.add(tspkg.get_package());
             } else {
-                downloader.add(tspkg.get_package(), dest_dir.c_str());
+                downloader.add(tspkg.get_package(), destdir_option.get_value().c_str());
             }
         }
     }

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -279,7 +279,7 @@ std::string Transaction::transaction_result_to_string(const TransactionRunResult
 }
 
 void Transaction::download(const std::string & dest_dir) {
-    libdnf::repo::PackageDownloader downloader;
+    libdnf::repo::PackageDownloader downloader(p_impl->base);
     for (auto & tspkg : this->get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action()) &&
             tspkg.get_package().get_repo()->get_type() != libdnf::repo::Repo::Type::COMMANDLINE) {

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -106,7 +106,13 @@ PackageDownloader::~PackageDownloader() = default;
 
 
 void PackageDownloader::add(const libdnf::rpm::Package & package, void * user_data) {
-    add(package, std::filesystem::path(package.get_repo()->get_cachedir()) / "packages", user_data);
+    auto default_path = std::filesystem::path(package.get_repo()->get_cachedir()) / "packages";
+    auto & destdir_option = p_impl->base->get_config().get_destdir_option();
+    if (destdir_option.empty()) {
+        add(package, default_path, user_data);
+    } else {
+        add(package, destdir_option.get_value(), user_data);
+    }
 }
 
 

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -168,8 +168,10 @@ void PackageDownloader::download(bool fail_fast, bool resume) try {
 
     // Store file paths of packages we don't want to keep cached.
     auto & config = p_impl->base->get_config();
-    auto keepcache = config.get_keepcache_option().get_value();
-    if (!keepcache) {
+    auto removal_configured = !config.get_keepcache_option().get_value();
+    auto removal_enforced = keep_packages.has_value() && !keep_packages.value();
+    auto keep_enforced = keep_packages.has_value() && keep_packages.value();
+    if (removal_enforced || (!keep_enforced && removal_configured)) {
         std::vector<std::string> package_paths;
         std::transform(
             p_impl->targets.begin(),

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -122,6 +122,10 @@ void PackageDownloader::add(const libdnf::rpm::Package & package, const std::str
 
 
 void PackageDownloader::download(bool fail_fast, bool resume) try {
+    if (p_impl->targets.empty()) {
+        return;
+    }
+
     GError * err{nullptr};
 
     std::vector<std::unique_ptr<LrPackageTarget>> lr_targets;

--- a/libdnf/repo/temp_files_memory.cpp
+++ b/libdnf/repo/temp_files_memory.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "temp_files_memory.hpp"
+
+#include "utils/bgettext/bgettext-mark-domain.h"
+#include "utils/fs/file.hpp"
+
+#include "libdnf/common/exception.hpp"
+
+#include <toml.hpp>
+
+
+namespace libdnf::repo {
+
+TempFilesMemory::TempFilesMemory(const std::string & parent_dir)
+    : full_memory_path(std::filesystem::path(parent_dir) / MEMORY_FILENAME) {}
+
+TempFilesMemory::~TempFilesMemory() = default;
+
+std::vector<std::string> TempFilesMemory::get_files() const {
+    if (!std::filesystem::exists(full_memory_path)) {
+        return {};
+    }
+
+    try {
+        auto toml_data = toml::parse(full_memory_path);
+        return toml::get<std::vector<std::string>>(toml_data[FILE_PATHS_TOML_KEY]);
+    } catch (const toml::exception & e) {
+        throw libdnf::Error(
+            M_("An error occurred when parsing the temporary files memory file at '{}': {}"),
+            full_memory_path.string(),
+            std::string(e.what()));
+    }
+}
+
+void TempFilesMemory::add_files(const std::vector<std::string> & paths) {
+    auto files = get_files();
+    files.insert(files.end(), paths.begin(), paths.end());
+
+    // sort and deduplicate resulting vector
+    std::sort(files.begin(), files.end());
+    files.erase(std::unique(files.begin(), files.end()), files.end());
+
+    utils::fs::File(full_memory_path, "w").write(toml::format(toml::value({{FILE_PATHS_TOML_KEY, files}})));
+}
+
+void TempFilesMemory::clear() {
+    std::filesystem::remove(full_memory_path);
+}
+
+}  //namespace libdnf::repo

--- a/libdnf/repo/temp_files_memory.cpp
+++ b/libdnf/repo/temp_files_memory.cpp
@@ -58,7 +58,10 @@ void TempFilesMemory::add_files(const std::vector<std::string> & paths) {
     std::sort(files.begin(), files.end());
     files.erase(std::unique(files.begin(), files.end()), files.end());
 
-    utils::fs::File(full_memory_path, "w").write(toml::format(toml::value({{FILE_PATHS_TOML_KEY, files}})));
+    // write new contents to a temporary file and then move the new file atomically
+    auto temporary_path = full_memory_path.string() + ".temp";
+    utils::fs::File(temporary_path, "w").write(toml::format(toml::value({{FILE_PATHS_TOML_KEY, files}})));
+    std::filesystem::rename(temporary_path, full_memory_path);
 }
 
 void TempFilesMemory::clear() {

--- a/libdnf/repo/temp_files_memory.cpp
+++ b/libdnf/repo/temp_files_memory.cpp
@@ -30,7 +30,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::repo {
 
 TempFilesMemory::TempFilesMemory(const std::string & parent_dir)
-    : full_memory_path(std::filesystem::path(parent_dir) / MEMORY_FILENAME) {}
+    : full_memory_path(std::filesystem::path(parent_dir) / MEMORY_FILENAME) {
+    std::filesystem::create_directories(parent_dir);
+}
 
 TempFilesMemory::~TempFilesMemory() = default;
 

--- a/libdnf/repo/temp_files_memory.hpp
+++ b/libdnf/repo/temp_files_memory.hpp
@@ -39,6 +39,8 @@ public:
 
     /// @brief Create the object for managing temporary files' paths.
     /// @param parent_dir Path to a directory where the memory file is or will be stored.
+    ///                   If the directory doesn't exist yet, it will be created.
+    /// @exception std::filesystem::filesystem_error When an error occurs during creating the parent directory.
     TempFilesMemory(const std::string & parent_dir);
     ~TempFilesMemory();
 

--- a/libdnf/repo/temp_files_memory.hpp
+++ b/libdnf/repo/temp_files_memory.hpp
@@ -1,0 +1,71 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_REPO_TEMP_FILES_MEMORY_HPP
+#define LIBDNF_REPO_TEMP_FILES_MEMORY_HPP
+
+#include <filesystem>
+#include <vector>
+
+
+namespace libdnf::repo {
+
+/// @brief A class for storing paths of temporary files in a TOML file.
+/// It behaves in a stateless way, meaning no data are cached within the
+/// class.
+class TempFilesMemory {
+public:
+    /// @brief Filename in which the paths are stored.
+    static constexpr const char * MEMORY_FILENAME = "temporary_files.toml";
+
+    /// @brief TOML key used for the array of stored paths.
+    static constexpr const char * FILE_PATHS_TOML_KEY = "files";
+
+    /// @brief Create the object for managing temporary files' paths.
+    /// @param parent_dir Path to a directory where the memory file is or will be stored.
+    TempFilesMemory(const std::string & parent_dir);
+    ~TempFilesMemory();
+
+    /// @brief Retrieve stored paths of temporary files.
+    /// @return A vector of parsed paths of temporary files.
+    /// @exception libdnf::Error When an error occurs during parsing of the file with temporary files.
+    /// @exception std::filesystem::filesystem_error When an error occurs during accessing the memory file.
+    std::vector<std::string> get_files() const;
+
+    /// @brief Add a list of file paths into the memory file.
+    /// The memory file is created if it didn't exist before.
+    /// Existing paths are loaded first using the `get_files()` method.
+    /// The resulting list contains both existing and new paths and it's sorted and deduplicated before storing in the file.
+    /// @param paths A list of file paths to be added into the memory file.
+    /// @exception libdnf::Error When an error occurs during parsing of the file with temporary files.
+    /// @exception std::filesystem::filesystem_error When an error occurs during accessing or writing the memory file.
+    void add_files(const std::vector<std::string> & paths);
+
+    /// @brief Deletes the memory file.
+    /// @exception std::filesystem::filesystem_error When an error occurs during deleting the memory file.
+    void clear();
+
+private:
+    std::filesystem::path full_memory_path;
+};
+
+
+}  // namespace libdnf::repo
+
+#endif  // LIBDNF_REPO_TEMP_FILES_MEMORY_HPP

--- a/test/libdnf/repo/test_package_downloader.cpp
+++ b/test/libdnf/repo/test_package_downloader.cpp
@@ -72,7 +72,7 @@ void PackageDownloaderTest::test_package_downloader() {
     query.filter_arch({"noarch"});
     CPPUNIT_ASSERT_EQUAL((size_t)1, query.size());
 
-    auto downloader = libdnf::repo::PackageDownloader();
+    auto downloader = libdnf::repo::PackageDownloader(base);
 
     auto cbs_unique_ptr = std::make_unique<DownloadCallbacks>();
     auto cbs = cbs_unique_ptr.get();

--- a/test/libdnf/repo/test_package_downloader.hpp
+++ b/test/libdnf/repo/test_package_downloader.hpp
@@ -28,10 +28,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 class PackageDownloaderTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(PackageDownloaderTest);
     CPPUNIT_TEST(test_package_downloader);
+    CPPUNIT_TEST(test_package_downloader_temp_files_memory);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void test_package_downloader();
+    void test_package_downloader_temp_files_memory();
 };
 
 #endif

--- a/test/libdnf/repo/test_temp_files_memory.cpp
+++ b/test/libdnf/repo/test_temp_files_memory.cpp
@@ -1,0 +1,122 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_temp_files_memory.hpp"
+
+#include "../shared/utils.hpp"
+#include "repo/temp_files_memory.hpp"
+
+#include "libdnf/common/exception.hpp"
+
+#include <fmt/format.h>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TempFilesMemoryTest);
+
+using namespace libdnf::repo;
+
+
+void TempFilesMemoryTest::setUp() {
+    CppUnit::TestCase::setUp();
+    temp_dir = std::make_unique<libdnf::utils::fs::TempDir>("libdnf_test_filesmemory");
+    parent_dir_path = temp_dir->get_path();
+    full_path = parent_dir_path / TempFilesMemory::MEMORY_FILENAME;
+}
+
+void TempFilesMemoryTest::tearDown() {
+    temp_dir.reset();
+    CppUnit::TestCase::tearDown();
+}
+
+void TempFilesMemoryTest::test_get_files_is_empty_when_path_not_exists() {
+    TempFilesMemory memory(temp_dir->get_path() / "unknown/path");
+    CPPUNIT_ASSERT(memory.get_files().empty());
+}
+
+void TempFilesMemoryTest::test_get_files_throws_exception_when_invalid_format() {
+    libdnf::utils::fs::File(full_path, "w").write("");
+    TempFilesMemory memory_empty(parent_dir_path);
+    CPPUNIT_ASSERT_THROW(memory_empty.get_files(), libdnf::Error);
+
+    libdnf::utils::fs::File(full_path, "w").write("[\"path1\", \"path2\", \"path3\"]");
+    TempFilesMemory memory_invalid(parent_dir_path);
+    CPPUNIT_ASSERT_THROW(memory_invalid.get_files(), libdnf::Error);
+}
+
+void TempFilesMemoryTest::test_get_files_returns_stored_values() {
+    libdnf::utils::fs::File(full_path, "w")
+        .write(fmt::format(
+            "{} = [\"path/to/package1.rpm\", \"different/path/to/package2.rpm\"]",
+            TempFilesMemory::FILE_PATHS_TOML_KEY));
+    TempFilesMemory memory(parent_dir_path);
+    std::vector<std::string> expected = {"path/to/package1.rpm", "different/path/to/package2.rpm"};
+    CPPUNIT_ASSERT_EQUAL(expected, memory.get_files());
+}
+
+void TempFilesMemoryTest::test_add_files_when_empty_storage() {
+    std::vector<std::string> new_paths = {"path1", "path2"};
+
+    TempFilesMemory memory(parent_dir_path);
+    CPPUNIT_ASSERT(memory.get_files().empty());
+
+    memory.add_files(new_paths);
+    CPPUNIT_ASSERT_EQUAL(new_paths, memory.get_files());
+}
+
+void TempFilesMemoryTest::test_add_files_when_existing_storage() {
+    std::vector<std::string> new_paths = {"path3", "path4"};
+    libdnf::utils::fs::File(full_path, "w")
+        .write(fmt::format("{} = [\"path1\", \"path2\"]", TempFilesMemory::FILE_PATHS_TOML_KEY));
+
+    TempFilesMemory memory(parent_dir_path);
+    memory.add_files(new_paths);
+    std::vector<std::string> expected = {"path1", "path2", "path3", "path4"};
+    CPPUNIT_ASSERT_EQUAL(expected, memory.get_files());
+}
+
+void TempFilesMemoryTest::test_add_files_deduplicates_and_sorts_data() {
+    std::vector<std::string> new_paths = {"path1", "path2", "path4", "path1"};
+    libdnf::utils::fs::File(full_path, "w")
+        .write(fmt::format("{} = [\"path4\", \"path1\", \"path4\", \"path3\"]", TempFilesMemory::FILE_PATHS_TOML_KEY));
+
+    TempFilesMemory memory(parent_dir_path);
+    memory.add_files(new_paths);
+    std::vector<std::string> expected = {"path1", "path2", "path3", "path4"};
+    CPPUNIT_ASSERT_EQUAL(expected, memory.get_files());
+}
+
+void TempFilesMemoryTest::test_clear_deletes_storage_content() {
+    libdnf::utils::fs::File(full_path, "w")
+        .write(fmt::format(
+            "{} = [\"/path/to/package1.rpm\", \"/different-path/to/package2.rpm\", "
+            "\"/another-path/leading/to/pkg3.rpm\"]",
+            TempFilesMemory::FILE_PATHS_TOML_KEY));
+    TempFilesMemory memory(parent_dir_path);
+    std::vector<std::string> expected = {
+        "/path/to/package1.rpm", "/different-path/to/package2.rpm", "/another-path/leading/to/pkg3.rpm"};
+    CPPUNIT_ASSERT_EQUAL(expected, memory.get_files());
+
+    memory.clear();
+    CPPUNIT_ASSERT(memory.get_files().empty());
+}
+
+void TempFilesMemoryTest::test_clear_when_empty_storage() {
+    TempFilesMemory memory(temp_dir->get_path() / "non-existing/path");
+    memory.clear();
+}

--- a/test/libdnf/repo/test_temp_files_memory.cpp
+++ b/test/libdnf/repo/test_temp_files_memory.cpp
@@ -44,7 +44,14 @@ void TempFilesMemoryTest::tearDown() {
     CppUnit::TestCase::tearDown();
 }
 
-void TempFilesMemoryTest::test_get_files_is_empty_when_path_not_exists() {
+void TempFilesMemoryTest::test_directory_is_created_when_not_exists() {
+    auto test_path = temp_dir->get_path() / "some/new/path";
+    CPPUNIT_ASSERT(!std::filesystem::exists(test_path));
+    TempFilesMemory memory(test_path);
+    CPPUNIT_ASSERT(std::filesystem::exists(test_path));
+}
+
+void TempFilesMemoryTest::test_get_files_when_empty_storage() {
     TempFilesMemory memory(temp_dir->get_path() / "unknown/path");
     CPPUNIT_ASSERT(memory.get_files().empty());
 }

--- a/test/libdnf/repo/test_temp_files_memory.hpp
+++ b/test/libdnf/repo/test_temp_files_memory.hpp
@@ -30,7 +30,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 class TempFilesMemoryTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(TempFilesMemoryTest);
-    CPPUNIT_TEST(test_get_files_is_empty_when_path_not_exists);
+    CPPUNIT_TEST(test_directory_is_created_when_not_exists);
+    CPPUNIT_TEST(test_get_files_when_empty_storage);
     CPPUNIT_TEST(test_get_files_throws_exception_when_invalid_format);
     CPPUNIT_TEST(test_get_files_returns_stored_values);
     CPPUNIT_TEST(test_add_files_when_empty_storage);
@@ -44,7 +45,8 @@ public:
     void setUp() override;
     void tearDown() override;
 
-    void test_get_files_is_empty_when_path_not_exists();
+    void test_directory_is_created_when_not_exists();
+    void test_get_files_when_empty_storage();
     void test_get_files_throws_exception_when_invalid_format();
     void test_get_files_returns_stored_values();
     void test_add_files_when_empty_storage();

--- a/test/libdnf/repo/test_temp_files_memory.hpp
+++ b/test/libdnf/repo/test_temp_files_memory.hpp
@@ -1,0 +1,62 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_TEST_REPO_TEMP_FILES_MEMORY_HPP
+#define LIBDNF_TEST_REPO_TEMP_FILES_MEMORY_HPP
+
+#include "utils/fs/temp.hpp"
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <filesystem>
+
+
+class TempFilesMemoryTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(TempFilesMemoryTest);
+    CPPUNIT_TEST(test_get_files_is_empty_when_path_not_exists);
+    CPPUNIT_TEST(test_get_files_throws_exception_when_invalid_format);
+    CPPUNIT_TEST(test_get_files_returns_stored_values);
+    CPPUNIT_TEST(test_add_files_when_empty_storage);
+    CPPUNIT_TEST(test_add_files_when_existing_storage);
+    CPPUNIT_TEST(test_add_files_deduplicates_and_sorts_data);
+    CPPUNIT_TEST(test_clear_deletes_storage_content);
+    CPPUNIT_TEST(test_clear_when_empty_storage);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+
+    void test_get_files_is_empty_when_path_not_exists();
+    void test_get_files_throws_exception_when_invalid_format();
+    void test_get_files_returns_stored_values();
+    void test_add_files_when_empty_storage();
+    void test_add_files_when_existing_storage();
+    void test_add_files_deduplicates_and_sorts_data();
+    void test_clear_deletes_storage_content();
+    void test_clear_when_empty_storage();
+
+private:
+    std::unique_ptr<libdnf::utils::fs::TempDir> temp_dir;
+    std::filesystem::path parent_dir_path;
+    std::filesystem::path full_path;
+};
+
+#endif

--- a/test/libdnf/rpm/test_transaction.hpp
+++ b/test/libdnf/rpm/test_transaction.hpp
@@ -30,10 +30,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 class RpmTransactionTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(RpmTransactionTest);
     CPPUNIT_TEST(test_transaction);
+    CPPUNIT_TEST(test_transaction_temp_files_cleanup);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void test_transaction();
+    void test_transaction_temp_files_cleanup();
 };
 
 #endif

--- a/test/python3/libdnf5/repo/test_package_downloader.py
+++ b/test/python3/libdnf5/repo/test_package_downloader.py
@@ -33,7 +33,7 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
         query.filter_arch(["noarch"])
         self.assertEqual(query.size(), 1)
 
-        downloader = libdnf5.repo.PackageDownloader()
+        downloader = libdnf5.repo.PackageDownloader(self.base)
 
         class PackageDownloadCallbacks(libdnf5.repo.DownloadCallbacks):
             end_cnt = 0

--- a/test/ruby/libdnf5/repo/test_package_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_package_downloader.rb
@@ -66,7 +66,7 @@ class TestPackageDownloader < BaseTestCase
         query.filter_arch(["noarch"])
         assert_equal(1, query.size())
 
-        downloader = Repo::PackageDownloader.new()
+        downloader = Repo::PackageDownloader.new(@base)
 
         cbs = PackageDownloadCallbacks.new()
         @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(cbs))


### PR DESCRIPTION
This is a follow-up to previous "simple" solution from https://github.com/rpm-software-management/dnf5/pull/377.

Current behavior should be more robust compared to the original PR. Now all package files that were downloaded when user requested the `keepcache=False` mode are tracked in the special TOML file and they are removed after the next successful transaction run.

Download command has an exception with overridden behavior to always keep downloaded packages on the system as this is matching the existing DNF behavior.

The list of the packages is created before the actual download begins, so then if any error is encountered and any data has been already downloaded, they are still removed after the next transaction.

Additionally, when user runs the `dnf5 clean all` command, all metadata downloaded under the `cachedir`, including the file tracking downloaded packages, are removed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2176384.
CI tests and fixes: https://github.com/rpm-software-management/ci-dnf-stack/pull/1239