### PR TITLE
[dnf5] Support for "--userinstalled" argument in repoquery

### DIFF
--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -47,6 +47,7 @@ private:
 
     libdnf::OptionBool * available_option{nullptr};
     libdnf::OptionBool * installed_option{nullptr};
+    libdnf::OptionBool * userinstalled_option{nullptr};
     libdnf::OptionBool * leaves_option{nullptr};
     libdnf::OptionBool * info_option{nullptr};
     libdnf::OptionNumber<std::int32_t> * latest_limit_option{nullptr};

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -78,6 +78,11 @@ Options
 ``--installed``
     | Display only installed packages.
 
+``--userinstalled``
+    | Limit to packages that are not installed as dependencies or weak dependencies.
+    | This means limit to packages that were installed at the user request or indirectly as a part of a module profile or comps group. Additionally it returns packages with unknown reason.
+    | The result may be influenced by the "exclude" option in the configuration file.
+
 ``--leaves``
     | Display only leaf packages.
 


### PR DESCRIPTION
Part of https://github.com/rpm-software-management/dnf5/issues/122