### PR TITLE
clang-format: use grep -E instead of egrep

### DIFF
--- a/clang-format
+++ b/clang-format
@@ -27,9 +27,9 @@ fi
 EXCLUDE=":!:test/tutorial"
 
 if [ -n "`git diff --name-only`" ]; then
-    FILES=`git diff --name-only -- "$@" $EXCLUDE | egrep '\.(c|cpp|h|hpp)$'`
+    FILES=`git diff --name-only -- "$@" $EXCLUDE | grep -E '\.(c|cpp|h|hpp)$'`
 else
-    FILES=`git ls-files -- "$@" $EXCLUDE | egrep '\.(c|cpp|h|hpp)$'`
+    FILES=`git ls-files -- "$@" $EXCLUDE | grep -E '\.(c|cpp|h|hpp)$'`
 fi
 
 for FILE in $FILES; do


### PR DESCRIPTION
The GNU grep installation on Fedora 38 throws this warning: egrep: warning: egrep is obsolescent; using grep -E