### PR TITLE
dnf5: Replacement of old "dnf group mark install/remove" commands

### DIFF
--- a/dnf5/commands/group/arguments.hpp
+++ b/dnf5/commands/group/arguments.hpp
@@ -66,6 +66,12 @@ public:
 };
 
 
+class GroupNoPackagesOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit GroupNoPackagesOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "no-packages", '\0', _("Operate on groups only, no packages are changed."), false) {}
+};
+
 }  // namespace dnf5
 
 

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -36,6 +36,7 @@ void GroupInstallCommand::set_argument_parser() {
     cmd.set_description("Install comp groups, including their packages");
 
     with_optional = std::make_unique<GroupWithOptionalOption>(*this);
+    no_packages = std::make_unique<GroupNoPackagesOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
 
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
@@ -54,6 +55,9 @@ void GroupInstallCommand::run() {
     auto goal = ctx.get_goal();
 
     libdnf::GoalJobSettings settings;
+    if (no_packages->get_value()) {
+        settings.group_no_packages = true;
+    }
     if (with_optional->get_value()) {
         auto group_package_types =
             libdnf::comps::package_type_from_string(ctx.base.get_config().get_group_package_types_option().get_value());

--- a/dnf5/commands/group/group_install.hpp
+++ b/dnf5/commands/group/group_install.hpp
@@ -39,6 +39,7 @@ public:
     void run() override;
 
     std::unique_ptr<GroupWithOptionalOption> with_optional{nullptr};
+    std::unique_ptr<GroupNoPackagesOption> no_packages{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
 
 protected:

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -34,6 +34,7 @@ void GroupRemoveCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_description("Remove comp groups, including their packages");
 
+    no_packages = std::make_unique<GroupNoPackagesOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
 }
 
@@ -49,6 +50,9 @@ void GroupRemoveCommand::run() {
     auto goal = ctx.get_goal();
 
     libdnf::GoalJobSettings settings;
+    if (no_packages->get_value()) {
+        settings.group_no_packages = true;
+    }
     for (const auto & spec : group_specs->get_value()) {
         goal->add_group_remove(spec, libdnf::transaction::TransactionItemReason::USER, settings);
     }

--- a/dnf5/commands/group/group_remove.hpp
+++ b/dnf5/commands/group/group_remove.hpp
@@ -35,6 +35,7 @@ public:
     void configure() override;
     void run() override;
 
+    std::unique_ptr<GroupNoPackagesOption> no_packages{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
 
 protected:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -81,21 +81,28 @@ Autoremove command
  * Dropped `<spec>` positional argument since the usecase is sufficiently covered by the `remove` command.
  * Specific `autoremove-n`, `autoremove-na`, and `autoremove-nevra` variants of the command are not supported.
 
+Group command
+-------------
+ * Dropped `group mark install` and `group mark remove` subcommands in favour of the
+   new `--no-packages` option of the `group install/remove` commands. So for example
+   to mark a group as installed without touching any packages,
+   `dnf5 group install --no-packages <group_id>` command can be used.
+
 List command
 ------------
  * Dropped `--all` option since this behavior is now the default one.
  * Changed the list of `--available` packages. Previously, dnf4 only listed packages that are either not installed, or
- whose version is higher than the installed version. Now this behaviour is kept when no modifier is used - to skip
- packages already listed in the `Installed Packages` section to reduce duplicities. But if the `--available` modifier
- is used, dnf5 considers all versions available in the enabled repositories, regardless of which version is installed.
+   whose version is higher than the installed version. Now this behaviour is kept when no modifier is used - to skip
+   packages already listed in the `Installed Packages` section to reduce duplicities. But if the `--available` modifier
+   is used, dnf5 considers all versions available in the enabled repositories, regardless of which version is installed.
 
 Repoquery command
 -----------------
  * Dropped: `-a/--all`, `--alldeps`, `--nevra` options, their behavior is and has been the default for both dnf4 and
- dnf5. The options are no longer needed.
+   dnf5. The options are no longer needed.
  * Dopped: `--nvr`, `--envra` options. They are no longer supported.
 
 Upgrade command
 ---------------
  * New dnf5 option `--minimal` (`upgrade-minimal` command still exists as a compatibility alias for
- `upgrade --minimal`).
+   `upgrade --minimal`).

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -40,15 +40,35 @@ Optional ``group-spec`` arguments could be passed to filter only groups with giv
 Subcommands
 ===========
 
-``install``
-    | Install comps groups, including their packages.
-
 ``list``
-    | List available groups.
+    List all matching groups, either among installed or available groups. If
+    nothing is specified, list all known groups. ``--installed`` and ``--available``
+    options narrow down the requested list. If ``--hidden`` option is used, also
+    hidden groups are included in the list.
 
 ``info``
-    | Print details about groups.
+    Print detailed information about groups.
+    The command accepts the same options as the ``list`` subcommand.
 
+``install``
+    Mark the specified groups installed and install packages it contains.
+    Also include optional packages of the group if the ``--with-optional`` option is
+    specified. All `Mandatory` and `Default` packages will be installed whenever
+    possible. `Conditional` packages are installed if they meet their requirement.
+    If the group is already (partially) installed, the command  installs the missing
+    packages from the group.
+
+    If the ``--no-packages`` option is used, no new packages will be installed by
+    this command. Only currently installed group packages are considered to be installed
+    with the group.
+
+``remove``
+    Mark the group removed and remove those packages in the group  from  the
+    system  which  do not belong to another installed group and were not installed
+    explicitly by the user.
+
+    If the ``--no-packages`` option is used, no packages will be removed by this
+    command.
 
 Options
 =======
@@ -64,6 +84,9 @@ Options
 
 ``--with-optional``
     | Used with ``install`` command to include optional packages from the groups.
+
+``--no-packages``
+    | Used with ``install`` and ``remove`` commands to operate exclusively on the groups without manipulating any packages.
 
 Examples
 ========

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -159,6 +159,10 @@ public:
         return group_package_types ? &group_package_types.value() : nullptr;
     }
 
+    /// If set to true, group operations (install / remove) will only work
+    /// with the group itself, but will not add to the transaction any packages.
+    bool group_no_packages{false};
+
     /// Set whether hints should be reported
     bool report_hint{true};
     /// Set skip_broken, AUTO means that it is handled according to the default behavior

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -1394,6 +1394,10 @@ void Goal::Impl::add_group_install_to_goal(
     pkg_settings.with_filenames = false;
     pkg_settings.nevra_forms.push_back(rpm::Nevra::Form::NAME);
     for (auto group : group_query) {
+        rpm_goal.add_group(group, transaction::TransactionItemAction::INSTALL, reason, allowed_package_types);
+        if (settings.group_no_packages) {
+            continue;
+        }
         std::vector<libdnf::comps::Package> packages;
         // TODO(mblaha): filter packages by p.arch attribute when supported by comps
         for (const auto & p : group.get_packages()) {
@@ -1426,7 +1430,6 @@ void Goal::Impl::add_group_install_to_goal(
                 }
             }
         }
-        rpm_goal.add_group(group, transaction::TransactionItemAction::INSTALL, reason, allowed_package_types);
     }
 }
 
@@ -1453,6 +1456,10 @@ void Goal::Impl::add_group_remove_to_goal(
     rpm::PackageSet remove_candidates(base);
     for (auto & [spec, reason, group_query, settings] : groups_to_remove) {
         for (const auto & group : group_query) {
+            rpm_goal.add_group(group, transaction::TransactionItemAction::REMOVE, reason, {});
+            if (settings.group_no_packages) {
+                continue;
+            }
             // get all packages installed by the group
             rpm::PackageQuery group_packages(query_installed);
             group_packages.filter_name(system_state.get_group_state(group.get_groupid()).packages);
@@ -1477,7 +1484,6 @@ void Goal::Impl::add_group_remove_to_goal(
 
                 remove_candidates.add(pkg);
             }
-            rpm_goal.add_group(group, transaction::TransactionItemAction::REMOVE, reason, {});
         }
     }
     if (remove_candidates.empty()) {


### PR DESCRIPTION
This is replacement of "dnf group mark install/remove" commands. I certainly can implement those as standalone commands, but it would introduce a lot of code duplicity. `dnf group mark install` is basically the same command (including all command line switches) as `dnf group install`. The only difference is that the former needs to set one GoalJobSettings flag more (`settings.group_no_packages = true`). This will ensure, that only groups are going to be part of the transaction and no packages are changed (and similarly the `dnf group mark remove`).
If needed, I think a compatible alias can be introduced later - `dnf group mark install` -> `dnf group install --no-packages`.

For https://github.com/rpm-software-management/dnf5/issues/138