### PR TITLE
[dnf5-plugins] --allowerasing support for builddep command.

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -59,6 +59,8 @@ void BuildDepCommand::set_argument_parser() {
     });
     cmd.register_positional_arg(specs);
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
+
     auto defs = parser.add_new_named_arg("rpm_macros");
     defs->set_short_name('D');
     defs->set_long_name("define");
@@ -247,6 +249,8 @@ void BuildDepCommand::run() {
 
     // fill the goal with build dependencies
     auto goal = get_context().get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
+    
     for (const auto & spec : install_specs) {
         if (libdnf::rpm::Reldep::is_rich_dependency(spec)) {
             goal->add_provide_install(spec);

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -59,8 +59,6 @@ void BuildDepCommand::set_argument_parser() {
     });
     cmd.register_positional_arg(specs);
 
-    allow_erasing = std::make_unique<AllowErasingOption>(*this);
-
     auto defs = parser.add_new_named_arg("rpm_macros");
     defs->set_short_name('D');
     defs->set_long_name("define");
@@ -82,6 +80,7 @@ void BuildDepCommand::set_argument_parser() {
         });
     cmd.register_named_arg(defs);
 
+    auto allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
 }
 

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -59,6 +59,9 @@ void BuildDepCommand::set_argument_parser() {
     });
     cmd.register_positional_arg(specs);
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+
     auto defs = parser.add_new_named_arg("rpm_macros");
     defs->set_short_name('D');
     defs->set_long_name("define");
@@ -79,9 +82,6 @@ void BuildDepCommand::set_argument_parser() {
             return true;
         });
     cmd.register_named_arg(defs);
-
-    auto allow_erasing = std::make_unique<AllowErasingOption>(*this);
-    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
 }
 
 void BuildDepCommand::configure() {

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <vector>
@@ -53,6 +54,8 @@ private:
     std::vector<std::string> spec_file_paths{};
     std::vector<std::string> srpm_file_paths{};
     std::vector<std::pair<std::string, std::string>> rpm_macros{};
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 };
 
 


### PR DESCRIPTION
This PR closes #461, by adding support for the --allowerasing option for the builddep command.