### PR TITLE
Filter latest per argument for download command

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -249,7 +249,7 @@ void BuildDepCommand::run() {
     // fill the goal with build dependencies
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
-    
+
     for (const auto & spec : install_specs) {
         if (libdnf::rpm::Reldep::is_rich_dependency(spec)) {
             goal->add_provide_install(spec);

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -109,10 +109,11 @@ void DownloadCommand::run() {
         libdnf::rpm::PackageQuery package_query(full_package_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
         package_query.resolve_pkg_spec(option->get_value(), {}, true);
+        package_query.filter_priority();
+        package_query.filter_latest_evr();
         result_query |= package_query;
     }
-    result_query.filter_priority();
-    result_query.filter_latest_evr();
+
     if (resolve_option->get_value()) {
         auto goal = std::make_unique<libdnf::Goal>(ctx.base);
         libdnf::GoalJobSettings settings;

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -57,6 +57,8 @@ void DownloadCommand::set_argument_parser() {
 
     alldeps_option = dynamic_cast<libdnf::OptionBool *>(
         parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
+    destdir_option =
+        dynamic_cast<libdnf::OptionString *>(parser.add_init_value(std::make_unique<libdnf::OptionString>(".")));
 
     auto resolve = parser.add_new_named_arg("resolve");
     resolve->set_long_name("resolve");
@@ -71,8 +73,17 @@ void DownloadCommand::set_argument_parser() {
     alldeps->set_const_value("true");
     alldeps->link_value(alldeps_option);
 
-    cmd.register_named_arg(resolve);
+    auto destdir = parser.add_new_named_arg("destdir");
+    destdir->set_long_name("destdir");
+    destdir->set_description(
+        "Set directory used for downloading packages to. Default location is to the current working directory");
+    destdir->set_has_value(true);
+    destdir->set_arg_value_help("DESTDIR");
+    destdir->link_value(destdir_option);
+
     cmd.register_named_arg(alldeps);
+    cmd.register_named_arg(destdir);
+    cmd.register_named_arg(resolve);
     cmd.register_positional_arg(keys);
 }
 
@@ -141,8 +152,9 @@ void DownloadCommand::run() {
         }
     }
 
+    printf("tests %s\n", destdir_option->get_value().c_str());
     if (!download_pkgs.empty()) {
-        download_packages(download_pkgs, ".");
+        download_packages(download_pkgs, destdir_option->get_value().c_str());
     }
 }
 

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -113,8 +113,7 @@ void DownloadCommand::run() {
     auto & ctx = get_context();
 
     std::vector<libdnf::rpm::Package> download_pkgs;
-    libdnf::rpm::PackageQuery result_query =
-        libdnf::rpm::PackageQuery(ctx.base, libdnf::sack::ExcludeFlags::APPLY_EXCLUDES, true);
+    libdnf::rpm::PackageSet result_query(ctx.base);
     libdnf::rpm::PackageQuery full_package_query(ctx.base);
     for (auto & pattern : *patterns_to_download_options) {
         libdnf::rpm::PackageQuery package_query(full_package_query);
@@ -152,7 +151,6 @@ void DownloadCommand::run() {
         }
     }
 
-    printf("tests %s\n", destdir_option->get_value().c_str());
     if (!download_pkgs.empty()) {
         download_packages(download_pkgs, destdir_option->get_value().c_str());
     }

--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -42,6 +42,7 @@ public:
 private:
     libdnf::OptionBool * resolve_option{nullptr};
     libdnf::OptionBool * alldeps_option{nullptr};
+    libdnf::OptionString * destdir_option{nullptr};
 
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_download_options{nullptr};
 };

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -44,6 +44,8 @@ Options
 ``--alldeps``
     | To be used together with ``--resolve``, it downloads all dependencies, not skipping the already installed ones.
 
+``--destdir=<path>``
+    Set directory used for downloading packages to. Default location is to the current working directory.
 
 Examples
 ========
@@ -57,6 +59,8 @@ Examples
 ``dnf5 download maven-compiler-plugin --resolve --alldeps``
     | Download the ``maven-compiler-plugin`` package with all its dependencies.
 
+``dnf5 download --destdir /tmp/my_packages maven-compiler-plugin``
+    | Download the ``maven-compiler-plugin`` package to ``/tmp/my_packages`` directory.
 
 See Also
 ========


### PR DESCRIPTION
It fixes the issue when `dnf download pkg-1 pkg-2` where the previous implementation will download only pkg-2.