### PR TITLE
Use PROJECT_VERSION in pc.in files.

### DIFF
--- a/libdnf-cli/libdnf-cli.pc.in
+++ b/libdnf-cli/libdnf-cli.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/include
 
 Name: libdnf-cli
 Description: Library for working with a terminal in a command-line package manager
-Version: @PROGRAM_VERSION@
+Version: @PROJECT_VERSION@
 Requires: @LIBDNF_CLI_PC_REQUIRES_STRING@
 Requires.private: @LIBDNF_CLI_PC_REQUIRES_PRIVATE_STRING@
 Libs: -L${libdir} -ldnf-cli

--- a/libdnf/libdnf.pc.in
+++ b/libdnf/libdnf.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/include
 
 Name: libdnf
 Description: Package management library
-Version: @PROGRAM_VERSION@
+Version: @PROJECT_VERSION@
 Requires: @LIBDNF_PC_REQUIRES_STRING@
 Requires.private: @LIBDNF_PC_REQUIRES_PRIVATE_STRING@
 Libs: -L${libdir} -ldnf


### PR DESCRIPTION
On Fedora 38, /usr/lib64/pkgconfig/libdnf.pc has a "Version:" field with no value.  I'm guessing that this is an indication that PROGRAM_VERSION is undefined and that PROJECT_VERSION is the appropriate replacement.

(I have not tested the result of this PR.  Please treat is as a bug report and a suggestion.)