### PR TITLE
repoquery: queryformat improvements, --depends, --querytags,..

### DIFF
--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -107,7 +107,8 @@ void ChangelogCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add(libdnf::OPTIONAL_METADATA_TYPES);
+    context.base.get_config().get_optional_metadata_types_option().add(
+        libdnf::Option::Priority::RUNTIME, libdnf::OPTIONAL_METADATA_TYPES);
 }
 
 void ChangelogCommand::run() {

--- a/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
@@ -100,7 +100,8 @@ void RepoclosureCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(false);
     // filelists needed because there are packages in repos with file requirements
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -74,7 +74,8 @@ void AdvisorySubCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_UPDATEINFO);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_UPDATEINFO);
 }
 
 void AdvisorySubCommand::run() {

--- a/dnf5/commands/advisory/arguments.hpp
+++ b/dnf5/commands/advisory/arguments.hpp
@@ -73,10 +73,10 @@ public:
 };
 
 
-class AdvisoryContainsPkgsOption : public libdnf::cli::session::StringListOption {
+class AdvisoryContainsPkgsOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit AdvisoryContainsPkgsOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "contains-pkgs",
               '\0',

--- a/dnf5/commands/advisory_shared.hpp
+++ b/dnf5/commands/advisory_shared.hpp
@@ -104,10 +104,10 @@ inline std::optional<libdnf::advisory::AdvisoryQuery> advisory_query_from_cli_in
     return std::nullopt;
 }
 
-class AdvisoryOption : public libdnf::cli::session::StringListOption {
+class AdvisoryOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit AdvisoryOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "advisories",
               '\0',
@@ -144,10 +144,10 @@ public:
 };
 
 
-class AdvisorySeverityOption : public libdnf::cli::session::StringListOption {
+class AdvisorySeverityOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit AdvisorySeverityOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "advisory-severities",
               '\0',
@@ -159,7 +159,7 @@ public:
 
 
     std::vector<std::string> get_value() const {
-        auto vals = StringListOption::get_value();
+        auto vals = AppendStringListOption::get_value();
         std::transform(vals.begin(), vals.end(), vals.begin(), [](std::string val) -> std::string {
             val = libdnf::utils::string::tolower(val);
             val[0] = static_cast<char>(std::toupper(val[0]));
@@ -170,10 +170,10 @@ public:
     }
 };
 
-class BzOption : public libdnf::cli::session::StringListOption {
+class BzOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit BzOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "bzs",
               '\0',
@@ -181,10 +181,10 @@ public:
               _("BUGZILLA_ID,...")) {}
 };
 
-class CveOption : public libdnf::cli::session::StringListOption {
+class CveOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit CveOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "cves",
               '\0',

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -84,7 +84,8 @@ void CheckUpgradeCommand::configure() {
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
     if (changelogs->get_value()) {
-        context.base.get_config().get_optional_metadata_types_option().add(libdnf::OPTIONAL_METADATA_TYPES);
+        context.base.get_config().get_optional_metadata_types_option().add(
+            libdnf::Option::Priority::RUNTIME, libdnf::OPTIONAL_METADATA_TYPES);
     }
 }
 

--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -43,7 +43,8 @@ void EnvironmentInfoCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void EnvironmentInfoCommand::run() {

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -43,7 +43,8 @@ void EnvironmentListCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void EnvironmentListCommand::run() {

--- a/dnf5/commands/group/arguments.hpp
+++ b/dnf5/commands/group/arguments.hpp
@@ -50,10 +50,10 @@ public:
 };
 
 
-class GroupContainsPkgsOption : public libdnf::cli::session::StringListOption {
+class GroupContainsPkgsOption : public libdnf::cli::session::AppendStringListOption {
 public:
     explicit GroupContainsPkgsOption(libdnf::cli::session::Command & command)
-        : StringListOption(
+        : AppendStringListOption(
               command,
               "contains-pkgs",
               '\0',

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -48,7 +48,8 @@ void GroupInstallCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void GroupInstallCommand::run() {

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -45,7 +45,8 @@ void GroupListCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void GroupListCommand::run() {

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -42,7 +42,8 @@ void GroupRemoveCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void GroupRemoveCommand::run() {

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -46,7 +46,8 @@ void GroupUpgradeCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_COMPS);
+    context.base.get_config().get_optional_metadata_types_option().add_item(
+        libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_COMPS);
 }
 
 void GroupUpgradeCommand::run() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -77,7 +77,8 @@ void InstallCommand::configure() {
                              advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
                              advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
     if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_UPDATEINFO);
+        context.base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_UPDATEINFO);
     }
 
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -147,97 +147,92 @@ void RepoqueryCommand::set_argument_parser() {
         }
     });
 
-    whatdepends_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatdepends = parser.add_new_named_arg("whatdepends");
-    whatdepends->set_long_name("whatdepends");
-    whatdepends->set_description(
-        "Limit to packages that require, enhance, recommend, suggest or supplement any of <capabilities>.");
-    whatdepends->set_has_value(true);
-    whatdepends->link_value(whatdepends_option);
-    whatdepends->set_arg_value_help("CAPABILITY,...");
-
-    whatconflicts_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatconflicts = parser.add_new_named_arg("whatconflicts");
-    whatconflicts->set_long_name("whatconflicts");
-    whatconflicts->set_description("Limit to packages that conflict with any of <capabilities>.");
-    whatconflicts->set_has_value(true);
-    whatconflicts->link_value(whatconflicts_option);
-    whatconflicts->set_arg_value_help("CAPABILITY,...");
-
-    whatprovides_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatprovides = parser.add_new_named_arg("whatprovides");
-    whatprovides->set_long_name("whatprovides");
-    whatprovides->set_description("Limit to packages that provide any of <capabilities>.");
-    whatprovides->set_has_value(true);
-    whatprovides->link_value(whatprovides_option);
-    whatprovides->set_arg_value_help("CAPABILITY,...");
-
-    whatrequires_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatrequires = parser.add_new_named_arg("whatrequires");
-    whatrequires->set_long_name("whatrequires");
-    whatrequires->set_description(
-        "Limit to packages that require any of <capabilities>. Use --whatdepends if you want to "
-        "list all depending packages.");
-    whatrequires->set_has_value(true);
-    whatrequires->link_value(whatrequires_option);
-    whatrequires->set_arg_value_help("CAPABILITY,...");
-
-    whatobsoletes_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatobsoletes = parser.add_new_named_arg("whatobsoletes");
-    whatobsoletes->set_long_name("whatobsoletes");
-    whatobsoletes->set_description("Limit to packages that obsolete any of <capabilities>.");
-    whatobsoletes->set_has_value(true);
-    whatobsoletes->link_value(whatobsoletes_option);
-    whatobsoletes->set_arg_value_help("CAPABILITY,...");
-
-    whatrecommends_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatrecommends = parser.add_new_named_arg("whatrecommends");
-    whatrecommends->set_long_name("whatrecommends");
-    whatrecommends->set_description(
-        "Limit to packages that recommend any of <capabilities>. Use --whatdepends if you want "
-        "to list all depending packages.");
-    whatrecommends->set_has_value(true);
-    whatrecommends->link_value(whatrecommends_option);
-    whatrecommends->set_arg_value_help("CAPABILITY,...");
-
-    whatenhances_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatenhances = parser.add_new_named_arg("whatenhances");
-    whatenhances->set_long_name("whatenhances");
-    whatenhances->set_description(
+    whatdepends = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatdepends",
+        '\0',
+        "Limit to packages that require, enhance, recommend, suggest or supplement any of <capabilities>.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatconflicts = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatconflicts",
+        '\0',
+        "Limit to packages that conflict with any of <capabilities>.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatenhances = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatenhances",
+        '\0',
         "Limit to packages that enhance any of <capabilities>. Use --whatdepends if you want to "
-        "list all depending packages.");
-    whatenhances->set_has_value(true);
-    whatenhances->link_value(whatenhances_option);
-    whatenhances->set_arg_value_help("CAPABILITY,...");
-
-    whatsupplements_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatsupplements = parser.add_new_named_arg("whatsupplements");
-    whatsupplements->set_long_name("whatsupplements");
-    whatsupplements->set_description(
+        "list all depending packages.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatobsoletes = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatobsoletes",
+        '\0',
+        "Limit to packages that obsolete any of <capabilities>.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatprovides = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatprovides",
+        '\0',
+        "Limit to packages that provide any of <capabilities>.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatrecommends = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatrecommends",
+        '\0',
+        "Limit to packages that recommend any of <capabilities>. Use --whatdepends if you want "
+        "to list all depending packages.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatrequires = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatrequires",
+        '\0',
+        "Limit to packages that require any of <capabilities>. Use --whatdepends if you want to "
+        "list all depending packages.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatsupplements = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatsupplements",
+        '\0',
         "Limit to packages that supplement any of <capabilities>. Use --whatdepends if you "
-        "want to list all depending packages.");
-    whatsupplements->set_has_value(true);
-    whatsupplements->link_value(whatsupplements_option);
-    whatsupplements->set_arg_value_help("CAPABILITY,...");
-
-    whatsuggests_option = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), "", false, ",")));
-    auto * whatsuggests = parser.add_new_named_arg("whatsuggests");
-    whatsuggests->set_long_name("whatsuggests");
-    whatsuggests->set_description(
+        "want to list all depending packages.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
+    whatsuggests = std::make_unique<libdnf::cli::session::AppendStringListOption>(
+        *this,
+        "whatsuggests",
+        '\0',
         "Limit to packages that suggest any of <capabilities>. Use --whatdepends if you want to "
-        "list all depending packages.");
-    whatsuggests->set_has_value(true);
-    whatsuggests->link_value(whatsuggests_option);
-    whatsuggests->set_arg_value_help("CAPABILITY,...");
+        "list all depending packages.",
+        "CAPABILITY,...",
+        "",
+        false,
+        ",");
 
     exactdeps = std::make_unique<libdnf::cli::session::BoolOption>(
         *this,
@@ -318,17 +313,6 @@ void RepoqueryCommand::set_argument_parser() {
     cmd.register_named_arg(leaves);
     cmd.register_named_arg(latest_limit);
 
-    cmd.register_named_arg(whatdepends);
-    cmd.register_named_arg(whatconflicts);
-    cmd.register_named_arg(whatprovides);
-    cmd.register_named_arg(whatrequires);
-    cmd.register_named_arg(whatobsoletes);
-    cmd.register_named_arg(whatrecommends);
-    cmd.register_named_arg(whatenhances);
-    cmd.register_named_arg(whatsupplements);
-    cmd.register_named_arg(whatsuggests);
-
-
     cmd.register_positional_arg(keys);
 }
 
@@ -357,17 +341,17 @@ void RepoqueryCommand::configure() {
             libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
         return;
     }
-    for (const auto & option :
-         {whatrequires_option,
-          whatdepends_option,
-          whatconflicts_option,
-          whatprovides_option,
-          whatobsoletes_option,
-          whatrecommends_option,
-          whatenhances_option,
-          whatsupplements_option,
-          whatsuggests_option}) {
-        for (const auto & capability : option->get_value()) {
+    for (const auto & capabilities :
+         {whatrequires->get_value(),
+          whatdepends->get_value(),
+          whatconflicts->get_value(),
+          whatprovides->get_value(),
+          whatobsoletes->get_value(),
+          whatrecommends->get_value(),
+          whatenhances->get_value(),
+          whatsupplements->get_value(),
+          whatsuggests->get_value()}) {
+        for (const auto & capability : capabilities) {
             if (libdnf::utils::is_file_pattern(capability)) {
                 context.base.get_config().get_optional_metadata_types_option().add_item(
                     libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
@@ -434,9 +418,9 @@ void RepoqueryCommand::run() {
         full_package_query.filter_latest_evr(latest_limit_option->get_value());
     }
 
-    if (!whatdepends_option->get_value().empty()) {
+    if (!whatdepends->get_value().empty()) {
         auto matched_reldeps = libdnf::rpm::ReldepList(ctx.base);
-        for (const auto & reldep_glob : whatdepends_option->get_value()) {
+        for (const auto & reldep_glob : whatdepends->get_value()) {
             matched_reldeps.add_reldep_with_glob(reldep_glob);
         }
 
@@ -460,7 +444,7 @@ void RepoqueryCommand::run() {
 
         if (!exactdeps->get_value()) {
             auto pkgs_from_resolved_nevras =
-                resolve_nevras_to_packges(ctx.base, whatdepends_option->get_value(), full_package_query);
+                resolve_nevras_to_packges(ctx.base, whatdepends->get_value(), full_package_query);
 
             // Filter requires by packages from resolved nevras
             auto what_requires_resolved_nevras = full_package_query;
@@ -485,70 +469,70 @@ void RepoqueryCommand::run() {
 
         full_package_query = dependsquery;
     }
-    if (!whatprovides_option->get_value().empty()) {
+    if (!whatprovides->get_value().empty()) {
         auto provides_query = full_package_query;
-        provides_query.filter_provides(whatprovides_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        provides_query.filter_provides(whatprovides->get_value(), libdnf::sack::QueryCmp::GLOB);
         if (!provides_query.empty()) {
             full_package_query = provides_query;
         } else {
             // If provides query doesn't match anything try matching files
-            full_package_query.filter_file(whatprovides_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+            full_package_query.filter_file(whatprovides->get_value(), libdnf::sack::QueryCmp::GLOB);
         }
     }
-    if (!whatrequires_option->get_value().empty()) {
+    if (!whatrequires->get_value().empty()) {
         if (exactdeps->get_value()) {
-            full_package_query.filter_requires(whatrequires_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+            full_package_query.filter_requires(whatrequires->get_value(), libdnf::sack::QueryCmp::GLOB);
         } else {
             auto requires_resolved = full_package_query;
             requires_resolved.filter_requires(
-                resolve_nevras_to_packges(ctx.base, whatrequires_option->get_value(), full_package_query));
+                resolve_nevras_to_packges(ctx.base, whatrequires->get_value(), full_package_query));
 
-            full_package_query.filter_requires(whatrequires_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+            full_package_query.filter_requires(whatrequires->get_value(), libdnf::sack::QueryCmp::GLOB);
             full_package_query |= requires_resolved;
             //TODO(amatej): add recurisve option call
         }
     }
-    if (!whatobsoletes_option->get_value().empty()) {
-        full_package_query.filter_obsoletes(whatobsoletes_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+    if (!whatobsoletes->get_value().empty()) {
+        full_package_query.filter_obsoletes(whatobsoletes->get_value(), libdnf::sack::QueryCmp::GLOB);
     }
-    if (!whatconflicts_option->get_value().empty()) {
+    if (!whatconflicts->get_value().empty()) {
         auto conflicts_resolved = full_package_query;
         conflicts_resolved.filter_conflicts(
-            resolve_nevras_to_packges(ctx.base, whatconflicts_option->get_value(), full_package_query));
+            resolve_nevras_to_packges(ctx.base, whatconflicts->get_value(), full_package_query));
 
-        full_package_query.filter_conflicts(whatconflicts_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_conflicts(whatconflicts->get_value(), libdnf::sack::QueryCmp::GLOB);
         full_package_query |= conflicts_resolved;
     }
-    if (!whatrecommends_option->get_value().empty()) {
+    if (!whatrecommends->get_value().empty()) {
         auto recommends_resolved = full_package_query;
         recommends_resolved.filter_recommends(
-            resolve_nevras_to_packges(ctx.base, whatrecommends_option->get_value(), full_package_query));
+            resolve_nevras_to_packges(ctx.base, whatrecommends->get_value(), full_package_query));
 
-        full_package_query.filter_recommends(whatrecommends_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_recommends(whatrecommends->get_value(), libdnf::sack::QueryCmp::GLOB);
         full_package_query |= recommends_resolved;
     }
-    if (!whatenhances_option->get_value().empty()) {
+    if (!whatenhances->get_value().empty()) {
         auto enhances_resolved = full_package_query;
         enhances_resolved.filter_enhances(
-            resolve_nevras_to_packges(ctx.base, whatenhances_option->get_value(), full_package_query));
+            resolve_nevras_to_packges(ctx.base, whatenhances->get_value(), full_package_query));
 
-        full_package_query.filter_enhances(whatenhances_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_enhances(whatenhances->get_value(), libdnf::sack::QueryCmp::GLOB);
         full_package_query |= enhances_resolved;
     }
-    if (!whatsupplements_option->get_value().empty()) {
+    if (!whatsupplements->get_value().empty()) {
         auto supplements_resolved = full_package_query;
         supplements_resolved.filter_supplements(
-            resolve_nevras_to_packges(ctx.base, whatsupplements_option->get_value(), full_package_query));
+            resolve_nevras_to_packges(ctx.base, whatsupplements->get_value(), full_package_query));
 
-        full_package_query.filter_supplements(whatsupplements_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_supplements(whatsupplements->get_value(), libdnf::sack::QueryCmp::GLOB);
         full_package_query |= supplements_resolved;
     }
-    if (!whatsuggests_option->get_value().empty()) {
+    if (!whatsuggests->get_value().empty()) {
         auto suggests_resolved = full_package_query;
         suggests_resolved.filter_suggests(
-            resolve_nevras_to_packges(ctx.base, whatsuggests_option->get_value(), full_package_query));
+            resolve_nevras_to_packges(ctx.base, whatsuggests->get_value(), full_package_query));
 
-        full_package_query.filter_suggests(whatsuggests_option->get_value(), libdnf::sack::QueryCmp::GLOB);
+        full_package_query.filter_suggests(whatsuggests->get_value(), libdnf::sack::QueryCmp::GLOB);
         full_package_query |= suggests_resolved;
     }
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -350,7 +350,8 @@ void RepoqueryCommand::configure() {
             ? Context::LoadAvailableRepos::ENABLED
             : Context::LoadAvailableRepos::NONE);
 
-    if (pkg_attr_option->get_value() == "files") {
+    if ((pkg_attr_option->get_value() == "files") ||
+        (libdnf::cli::output::requires_filelists(query_format_option->get_value()))) {
         context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
         return;
     }

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -70,6 +70,10 @@ void RepoqueryCommand::set_argument_parser() {
     latest_limit_option = dynamic_cast<libdnf::OptionNumber<std::int32_t> *>(
         parser.add_init_value(std::make_unique<libdnf::OptionNumber<std::int32_t>>(0)));
 
+    querytags_option =
+        dynamic_cast<libdnf::OptionBool *>(parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+
+
     auto available = parser.add_new_named_arg("available");
     available->set_long_name("available");
     available->set_description("Limit to available packages (default).");
@@ -101,6 +105,12 @@ void RepoqueryCommand::set_argument_parser() {
     info->set_description("Show detailed information about the packages.");
     info->set_const_value("true");
     info->link_value(info_option);
+
+    auto query_tags = parser.add_new_named_arg("querytags");
+    query_tags->set_long_name("querytags");
+    query_tags->set_description("Display available tags for --queryformat.");
+    query_tags->set_const_value("true");
+    query_tags->link_value(querytags_option);
 
     auto query_format = parser.add_new_named_arg("queryformat");
     query_format->set_long_name("queryformat");
@@ -294,6 +304,8 @@ void RepoqueryCommand::set_argument_parser() {
     cmd.register_named_arg(info);
     repoquery_formatting->register_argument(query_format);
     cmd.register_named_arg(query_format);
+    repoquery_formatting->register_argument(query_tags);
+    cmd.register_named_arg(query_tags);
 
     cmd.register_named_arg(available);
     cmd.register_named_arg(installed);
@@ -539,7 +551,9 @@ void RepoqueryCommand::run() {
         }
     }
 
-    if (info_option->get_value()) {
+    if (querytags_option->get_value()) {
+        libdnf::cli::output::print_available_pkg_attrs(stdout);
+    } else if (info_option->get_value()) {
         for (auto package : result_pset) {
             libdnf::cli::output::print_package_info_table(package);
             std::cout << '\n';

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -276,7 +276,7 @@ void RepoqueryCommand::set_argument_parser() {
         "provides",
         "recommends",
         "requires",
-        "requires-pre",
+        "requires_pre",
         "suggests",
         "supplements",
         "",  // empty when option is not used
@@ -290,12 +290,14 @@ void RepoqueryCommand::set_argument_parser() {
 
     // remove the last empty ("") option, it should not be an arg
     pkg_attrs_options.pop_back();
-    for (const auto & pkg_attr : pkg_attrs_options) {
+    for (auto & pkg_attr : pkg_attrs_options) {
         auto * arg = parser.add_new_named_arg(pkg_attr);
-        arg->set_long_name(pkg_attr);
         arg->set_description("Like --queryformat=\"%{" + pkg_attr + "}\" but deduplicated and sorted.");
         arg->set_has_value(false);
         arg->set_const_value(pkg_attr);
+        // The option names use '-' separator instead of '_'
+        std::replace(pkg_attr.begin(), pkg_attr.end(), '_', '-');
+        arg->set_long_name(pkg_attr);
         arg->link_value(pkg_attr_option);
         repoquery_formatting->register_argument(arg);
         cmd.register_named_arg(arg);

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -260,6 +260,7 @@ void RepoqueryCommand::set_argument_parser() {
 
     std::vector<std::string> pkg_attrs_options{
         "conflicts",
+        "depends",
         "enhances",
         "obsoletes",
         "provides",

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/repoquery.hpp"
 
+#include "libdnf/utils/patterns.hpp"
+
 #include <libdnf/advisory/advisory_query.hpp>
 #include <libdnf/conf/const.hpp>
 #include <libdnf/conf/option_string.hpp>
@@ -346,6 +348,24 @@ void RepoqueryCommand::configure() {
         available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !only_system_repo_needed
             ? Context::LoadAvailableRepos::ENABLED
             : Context::LoadAvailableRepos::NONE);
+    for (const auto & option :
+         {whatrequires_option,
+          whatdepends_option,
+          whatconflicts_option,
+          whatprovides_option,
+          whatobsoletes_option,
+          whatrecommends_option,
+          whatenhances_option,
+          whatsupplements_option,
+          whatsuggests_option}) {
+        for (const auto & capability : option->get_value()) {
+            if (libdnf::utils::is_file_pattern(capability)) {
+                context.base.get_config().get_optional_metadata_types_option().add_item(
+                    libdnf::METADATA_TYPE_FILELISTS);
+                return;
+            }
+        }
+    }
 }
 
 void RepoqueryCommand::load_additional_packages() {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -281,6 +281,7 @@ void RepoqueryCommand::set_argument_parser() {
         "requires_pre",
         "suggests",
         "supplements",
+        "files",
         "",  // empty when option is not used
     };
     pkg_attr_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
@@ -348,6 +349,11 @@ void RepoqueryCommand::configure() {
         available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !only_system_repo_needed
             ? Context::LoadAvailableRepos::ENABLED
             : Context::LoadAvailableRepos::NONE);
+
+    if (pkg_attr_option->get_value() == "files") {
+        context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
+        return;
+    }
     for (const auto & option :
          {whatrequires_option,
           whatdepends_option,

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -343,7 +343,8 @@ void RepoqueryCommand::configure() {
                              advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
                              advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
     if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_UPDATEINFO);
+        context.base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_UPDATEINFO);
     }
     context.set_load_available_repos(
         available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !only_system_repo_needed
@@ -352,7 +353,8 @@ void RepoqueryCommand::configure() {
 
     if ((pkg_attr_option->get_value() == "files") ||
         (libdnf::cli::output::requires_filelists(query_format_option->get_value()))) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
+        context.base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
         return;
     }
     for (const auto & option :
@@ -368,7 +370,7 @@ void RepoqueryCommand::configure() {
         for (const auto & capability : option->get_value()) {
             if (libdnf::utils::is_file_pattern(capability)) {
                 context.base.get_config().get_optional_metadata_types_option().add_item(
-                    libdnf::METADATA_TYPE_FILELISTS);
+                    libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
                 return;
             }
         }

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -54,15 +54,15 @@ private:
     std::vector<std::string> pkg_specs;
     std::vector<libdnf::rpm::Package> cmdline_packages;
 
-    libdnf::OptionStringList * whatdepends_option{nullptr};
-    libdnf::OptionStringList * whatconflicts_option{nullptr};
-    libdnf::OptionStringList * whatenhances_option{nullptr};
-    libdnf::OptionStringList * whatobsoletes_option{nullptr};
-    libdnf::OptionStringList * whatprovides_option{nullptr};
-    libdnf::OptionStringList * whatrecommends_option{nullptr};
-    libdnf::OptionStringList * whatrequires_option{nullptr};
-    libdnf::OptionStringList * whatsuggests_option{nullptr};
-    libdnf::OptionStringList * whatsupplements_option{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatdepends{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatconflicts{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatenhances{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatobsoletes{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatprovides{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatrecommends{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatrequires{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatsuggests{nullptr};
+    std::unique_ptr<libdnf::cli::session::AppendStringListOption> whatsupplements{nullptr};
 
     std::unique_ptr<libdnf::cli::session::BoolOption> exactdeps{nullptr};
     std::unique_ptr<libdnf::cli::session::BoolOption> duplicates{nullptr};

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -68,6 +68,7 @@ private:
     std::unique_ptr<libdnf::cli::session::BoolOption> duplicates{nullptr};
     std::unique_ptr<libdnf::cli::session::BoolOption> unneeded{nullptr};
 
+    libdnf::OptionBool * querytags_option{nullptr};
     libdnf::OptionString * query_format_option{nullptr};
     libdnf::OptionEnum<std::string> * pkg_attr_option{nullptr};
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -86,7 +86,8 @@ void UpgradeCommand::configure() {
                              advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
                              advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
     if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_UPDATEINFO);
+        context.base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_UPDATEINFO);
     }
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -271,3 +271,12 @@ source = 'upgrade.bzs'
 type = 'cloned_named_arg'
 long_name = 'cve'
 source = 'upgrade.cves'
+
+########################################
+# Repoquery aliases
+########################################
+
+['repoquery.qf']
+type = 'cloned_named_arg'
+long_name = 'qf'
+source = 'repoquery.queryformat'

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -131,7 +131,8 @@ void Context::print_info(std::string_view msg) const {
 void Context::update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs) {
     for (auto & spec : pkg_specs) {
         if (libdnf::utils::is_file_pattern(spec)) {
-            base.get_config().get_optional_metadata_types_option().add_item(libdnf::METADATA_TYPE_FILELISTS);
+            base.get_config().get_optional_metadata_types_option().add_item(
+                libdnf::Option::Priority::RUNTIME, libdnf::METADATA_TYPE_FILELISTS);
             return;
         }
     }

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -106,6 +106,8 @@ Repoquery command
    dnf5. The options are no longer needed.
  * Dopped: `--nvr`, `--envra` options. They are no longer supported.
  * Moved `--groupmember` option to the Group info and list commands and renamed to `--contains-pkgs`.
+ * --queryformat/--qf no longer prints additional new line at the end of each formatted string, bringing it closer to
+   rpm --query behavior.
 
 Upgrade command
 ---------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -110,6 +110,7 @@ Repoquery command
    rpm --query behavior.
  * --queryformat no longer supports `size` tag because it was printing install size for installed packages and download
    size for not-installed packages. This could be confusing.
+ * Option `--list` which lists all files contained in packages was renamed to more appropriate `--files`.
 
 Upgrade command
 ---------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -108,6 +108,8 @@ Repoquery command
  * Moved `--groupmember` option to the Group info and list commands and renamed to `--contains-pkgs`.
  * --queryformat/--qf no longer prints additional new line at the end of each formatted string, bringing it closer to
    rpm --query behavior.
+ * --queryformat no longer supports `size` tag because it was printing install size for installed packages and download
+   size for not-installed packages. This could be confusing.
 
 Upgrade command
 ---------------

--- a/include/libdnf-cli/output/repoquery.hpp
+++ b/include/libdnf-cli/output/repoquery.hpp
@@ -77,6 +77,8 @@ void print_pkg_set_with_format(
 void print_pkg_attr_uniq_sorted(
     std::FILE * target, const libdnf::rpm::PackageSet & pkgs, const std::string & getter_name);
 
+void print_available_pkg_attrs(std::FILE * target);
+
 }  // namespace libdnf::cli::output
 
 #endif  // LIBDNF_CLI_OUTPUT_REPOQUERY_HPP

--- a/include/libdnf-cli/output/repoquery.hpp
+++ b/include/libdnf-cli/output/repoquery.hpp
@@ -71,6 +71,8 @@ static void print_package_info_table(Package & package) {
     scols_unref_table(table);
 }
 
+bool requires_filelists(const std::string & queryformat);
+
 void print_pkg_set_with_format(
     std::FILE * target, const libdnf::rpm::PackageSet & pkgs, const std::string & queryformat);
 

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -189,23 +189,27 @@ public:
 };
 
 
-class StringListOption : public Option {
+/// AppendStringListOption is a wrapper around NamedArg and OptionStringList
+/// which allows specifying the argument multiple times and merging their values.
+/// E.g. --whatrequires=tree --whatrequires=plant -> option contains: "tree, plant"
+class AppendStringListOption : public Option {
 public:
-    explicit StringListOption(
+    explicit AppendStringListOption(
         libdnf::cli::session::Command & command,
         const std::string & long_name,
         char short_name,
         const std::string & desc,
         const std::string & help);
 
-    explicit StringListOption(
+    explicit AppendStringListOption(
         libdnf::cli::session::Command & command,
         const std::string & long_name,
         char short_name,
         const std::string & desc,
         const std::string & help,
         const std::string & allowed_values_regex,
-        const bool icase);
+        const bool icase,
+        const std::string & delimiters = libdnf::OptionStringList::get_default_delimiters());
 
     /// @return Parsed value.
     /// @since 5.0

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -75,6 +75,10 @@ public:
     /// New items are stored in the container value
     void add(Priority priority, const ValueType & items);
 
+    /// Parses input string and adds new values and priority.
+    /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
+    void add(Priority priority, const std::string & value);
+
     /// Adds new item to the container.
     /// New item is stored in the container value
     void add_item(Priority priority, const std::string & item);

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -72,12 +72,12 @@ public:
     void set(const std::string & value) override;
 
     /// Adds items from an another container.
-    /// New items are stored in the container value and the runtime priority is set as this is intended to use only through the API.
-    void add(const ValueType & items);
+    /// New items are stored in the container value
+    void add(Priority priority, const ValueType & items);
 
     /// Adds new item to the container.
-    /// New item is stored in the container value and the runtime priority is set as this is intended to use only through the API.
-    void add_item(const std::string & item);
+    /// New item is stored in the container value
+    void add_item(Priority priority, const std::string & item);
 
     /// Gets the stored value.
     // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValue()

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -187,6 +187,29 @@ public:
     // @replaces dnf:dnf/package.py:attribute:Package.source_name
     std::string get_source_name() const;
 
+    /// @return name of the debugsource package for this package
+    /// E.g. krb5-libs -> krb5-debugsource
+    /// @since 5.0.10
+    //
+    // @replaces dnf:dnf/package.py:attribute:Package.debugsource_name
+    std::string get_debugsource_name() const;
+
+    /// @return name of the debuginfo package for source package of this package.
+    /// E.g. krb5-libs -> krb5-debuginfo
+    /// @since 5.0.10
+    //
+    // @replaces dnf:dnf/package.py:attribute:Package.debugsource_name
+    std::string get_debuginfo_name_of_source() const;
+
+    /// @return name of the debuginfo package for this package.
+    /// If this package is a debuginfo package, return its name.
+    /// If this package is a debugsource package, returns the debuginfo package for the base package.
+    /// E.g. kernel-PAE -> kernel-PAE-debuginfo
+    /// @since 5.0.10
+    //
+    // @replaces dnf:dnf/package.py:attribute:Package.debug_name
+    std::string get_debuginfo_name() const;
+
     /// @return RPM package source package filename (`RPMTAG_SOURCERPM`).
     /// @since 5.0
     //
@@ -459,9 +482,15 @@ public:
     /// @note This isn't the repository the package was installed from.
     //
     // @replaces dnf:dnf/package.py:attribute:Package.repoid
+    std::string get_repo_id() const;
+
+    /// @return Name of the repository the package belongs to.
+    /// @since 5.0.10
+    /// @note This isn't the repository the package was installed from.
+    //
     // @replaces dnf:dnf/package.py:attribute:Package.reponame
     // @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_reponame(DnfPackage * pkg)
-    std::string get_repo_id() const;
+    std::string get_repo_name() const;
 
     // TODO(dmach): getBugUrl() not possible due to lack of support in libsolv and metadata?
 
@@ -488,6 +517,9 @@ private:
     friend class libdnf::Goal;
     friend class libdnf::base::Transaction;
     friend class libdnf::rpm::Transaction;
+
+    static constexpr const char * DEBUGINFO_SUFFIX = "-debuginfo";
+    static constexpr const char * DEBUGSOURCE_SUFFIX = "-debugsource";
 
     // TODO(jrohel): Assumes unique `rpmdbid`. Support for opening more rpm databases at once?
     Package(const BaseWeakPtr & base, unsigned long long rpmdbid);

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -316,6 +316,10 @@ public:
     // @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_supplements(DnfPackage * pkg)
     ReldepList get_supplements() const;
 
+    /// @return List of RPM package dependencies (requries + enhances + suggests + supplements + recommends).
+    /// @since 5.0.10
+    ReldepList get_depends() const;
+
     // ===== FILE LIST (filelists.xml) =====
 
     /// @return List of files and directories the RPM package contains (`RPMTAG_FILENAMES`).

--- a/libdnf-cli/output/repoqueryformat.cpp
+++ b/libdnf-cli/output/repoqueryformat.cpp
@@ -74,7 +74,15 @@ static const std::unordered_map<std::string, Getter> NAME_TO_GETTER = {
     {"repoid", &libdnf::rpm::Package::get_repo_id},
 };
 
-//TODO(amatej): Use keys of NAME_TO_GETTER for --querytags options
+void print_available_pkg_attrs(std::FILE * target) {
+    std::set<std::string> output;
+    for (const auto & pair : NAME_TO_GETTER) {
+        output.insert(pair.first);
+    }
+    for (const auto & line : output) {
+        fmt::print(target, "{}\n", line);
+    }
+}
 
 // Argument format contains partially copied and converted queryformat, for example: "name: %-30{{name".
 // We know the tag "name" is valid so this function check align spec "-30" and if it is valid

--- a/libdnf-cli/output/repoqueryformat.cpp
+++ b/libdnf-cli/output/repoqueryformat.cpp
@@ -68,6 +68,7 @@ static const std::unordered_map<std::string, Getter> NAME_TO_GETTER = {
     {"suggests", &libdnf::rpm::Package::get_suggests},
     {"enhances", &libdnf::rpm::Package::get_enhances},
     {"supplements", &libdnf::rpm::Package::get_supplements},
+    {"depends", &libdnf::rpm::Package::get_depends},
     {"from_repo", &libdnf::rpm::Package::get_from_repo_id},
     {"installtime", &libdnf::rpm::Package::get_install_time},
     {"repoid", &libdnf::rpm::Package::get_repo_id},

--- a/libdnf-cli/output/repoqueryformat.cpp
+++ b/libdnf-cli/output/repoqueryformat.cpp
@@ -58,8 +58,7 @@ static const std::unordered_map<std::string, Getter> NAME_TO_GETTER = {
     {"description", &libdnf::rpm::Package::get_description},
     {"provides", &libdnf::rpm::Package::get_provides},
     {"requires", &libdnf::rpm::Package::get_requires},
-    {"requires_pre", &libdnf::rpm::Package::get_requires_pre},  // this is for --repoformat="%{requires_pre}"
-    {"requires-pre", &libdnf::rpm::Package::get_requires_pre},  // this is for option --requires-pre
+    {"requires_pre", &libdnf::rpm::Package::get_requires_pre},
     {"conflicts", &libdnf::rpm::Package::get_conflicts},
     {"obsoletes", &libdnf::rpm::Package::get_obsoletes},
     {"prereq_ignoreinst", &libdnf::rpm::Package::get_prereq_ignoreinst},

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -125,17 +125,18 @@ BoolOption::BoolOption(
 }
 
 
-StringListOption::StringListOption(
+AppendStringListOption::AppendStringListOption(
     libdnf::cli::session::Command & command,
     const std::string & long_name,
     char short_name,
     const std::string & desc,
     const std::string & help,
     const std::string & allowed_values_regex,
-    const bool icase) {
+    const bool icase,
+    const std::string & delimiters) {
     auto & parser = command.get_session().get_argument_parser();
-    conf = dynamic_cast<libdnf::OptionStringList *>(parser.add_init_value(
-        std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), allowed_values_regex, icase)));
+    conf = dynamic_cast<libdnf::OptionStringList *>(parser.add_init_value(std::make_unique<libdnf::OptionStringList>(
+        std::vector<std::string>(), allowed_values_regex, icase, delimiters)));
     arg = parser.add_new_named_arg(long_name);
 
     if (!long_name.empty()) {
@@ -160,13 +161,13 @@ StringListOption::StringListOption(
 }
 
 
-StringListOption::StringListOption(
+AppendStringListOption::AppendStringListOption(
     libdnf::cli::session::Command & command,
     const std::string & long_name,
     char short_name,
     const std::string & desc,
     const std::string & help)
-    : StringListOption(command, long_name, short_name, desc, help, "", false) {}
+    : AppendStringListOption(command, long_name, short_name, desc, help, "", false) {}
 
 
 StringArgumentList::StringArgumentList(

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -152,12 +152,7 @@ StringListOption::StringListOption(
     arg->set_parse_hook_func(
         [this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
-            std::string conf_str_value = conf->get_value_string();
-            if (!conf_str_value.empty()) {
-                conf_str_value.append(",");
-            }
-            conf_str_value.append(value);
-            conf->set(libdnf::Option::Priority::COMMANDLINE, conf_str_value);
+            conf->add(libdnf::Option::Priority::COMMANDLINE, value);
             return true;
         });
 

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -209,6 +209,11 @@ void OptionStringContainer<T>::add(Priority priority, const ValueType & items) {
 }
 
 template <typename T>
+void OptionStringContainer<T>::add(Priority priority, const std::string & value) {
+    add(priority, from_string(value));
+}
+
+template <typename T>
 void OptionStringContainer<T>::add_item(Priority priority, const std::string & item) {
     assert_not_locked();
 

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -196,26 +196,26 @@ void OptionStringContainer<T>::set(const std::string & value) {
 }
 
 template <typename T>
-void OptionStringContainer<T>::add(const ValueType & items) {
+void OptionStringContainer<T>::add(Priority priority, const ValueType & items) {
     assert_not_locked();
 
     test(items);
     for (const auto & item : items) {
         value.insert(value.end(), item);
     }
-    if (get_priority() < Priority::RUNTIME) {
-        set_priority(Priority::RUNTIME);
+    if (get_priority() < priority) {
+        set_priority(priority);
     }
 }
 
 template <typename T>
-void OptionStringContainer<T>::add_item(const std::string & item) {
+void OptionStringContainer<T>::add_item(Priority priority, const std::string & item) {
     assert_not_locked();
 
     test_item(item);
     value.insert(value.end(), item);
-    if (get_priority() < Priority::RUNTIME) {
-        set_priority(Priority::RUNTIME);
+    if (get_priority() < priority) {
+        set_priority(priority);
     }
 }
 

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -69,6 +69,7 @@ OptionStringContainer<T>::OptionStringContainer(
       delimiters(std::move(delimiters)),
       default_value(default_value),
       value(this->default_value) {
+    init_regex_matcher();
     test(this->default_value);
 }
 

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -248,6 +248,16 @@ ReldepList Package::get_supplements() const {
     return list;
 }
 
+ReldepList Package::get_depends() const {
+    ReldepList list(base);
+    reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_REQUIRES);
+    reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_ENHANCES);
+    reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_SUGGESTS);
+    reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_SUPPLEMENTS);
+    reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_RECOMMENDS);
+    return list;
+}
+
 ReldepList Package::get_prereq_ignoreinst() const {
     ReldepList list(base);
     reldeps_for(get_rpm_pool(base).id2solvable(id.id), list.p_impl->queue, SOLVABLE_PREREQ_IGNOREINST);

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -120,6 +120,26 @@ std::string Package::get_sourcerpm() const {
     return libdnf::utils::string::c_to_str(get_rpm_pool(base).get_sourcerpm(id.id));
 }
 
+std::string Package::get_debugsource_name() const {
+    return get_source_name() + DEBUGSOURCE_SUFFIX;
+}
+
+std::string Package::get_debuginfo_name_of_source() const {
+    return get_source_name() + DEBUGINFO_SUFFIX;
+}
+
+std::string Package::get_debuginfo_name() const {
+    if (libdnf::utils::string::ends_with(get_name(), DEBUGINFO_SUFFIX)) {
+        return get_name();
+    }
+
+    auto name = get_name();
+    if (libdnf::utils::string::ends_with(name, DEBUGSOURCE_SUFFIX)) {
+        name.resize(name.size() - strlen(DEBUGSOURCE_SUFFIX));
+    }
+    return name + DEBUGINFO_SUFFIX;
+}
+
 unsigned long long Package::get_build_time() const {
     return get_rpm_pool(base).lookup_num(id.id, SOLVABLE_BUILDTIME);
 }
@@ -357,6 +377,10 @@ libdnf::repo::RepoWeakPtr Package::get_repo() const {
 
 std::string Package::get_repo_id() const {
     return get_rpm_pool(base).get_repo(id.id).get_id();
+}
+
+std::string Package::get_repo_name() const {
+    return get_rpm_pool(base).get_repo(id.id).get_name();
 }
 
 std::string Package::get_from_repo_id() const {

--- a/test/libdnf-cli/output/test_repoquery.cpp
+++ b/test/libdnf-cli/output/test_repoquery.cpp
@@ -177,3 +177,11 @@ void RepoqueryTest::test_pkg_attr_uniq_sorted() {
     CPPUNIT_ASSERT_EQUAL(std::string("456\n"), std::string(buf));
     free(buf);
 }
+
+void RepoqueryTest::test_requires_filelists() {
+    CPPUNIT_ASSERT_EQUAL(libdnf::cli::output::requires_filelists("asd"), false);
+    CPPUNIT_ASSERT_EQUAL(libdnf::cli::output::requires_filelists("file"), false);
+    CPPUNIT_ASSERT_EQUAL(libdnf::cli::output::requires_filelists("%{file}"), false);
+    CPPUNIT_ASSERT_EQUAL(libdnf::cli::output::requires_filelists("%{name}"), false);
+    CPPUNIT_ASSERT_EQUAL(libdnf::cli::output::requires_filelists("%{files}"), true);
+}

--- a/test/libdnf-cli/output/test_repoquery.hpp
+++ b/test/libdnf-cli/output/test_repoquery.hpp
@@ -40,6 +40,7 @@ class RepoqueryTest : public BaseTestCase {
     CPPUNIT_TEST(test_format_set_with_invalid_tags);
     CPPUNIT_TEST(test_format_set_with_tags_with_spacing);
     CPPUNIT_TEST(test_pkg_attr_uniq_sorted);
+    CPPUNIT_TEST(test_requires_filelists);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -51,6 +52,7 @@ public:
     void test_format_set_with_invalid_tags();
     void test_format_set_with_tags_with_spacing();
     void test_pkg_attr_uniq_sorted();
+    void test_requires_filelists();
 
 private:
     std::unique_ptr<libdnf::rpm::PackageQuery> pkgs;

--- a/test/libdnf/conf/test_option.cpp
+++ b/test/libdnf/conf/test_option.cpp
@@ -511,11 +511,11 @@ void OptionTest::test_options_list_add() {
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3"}) == option.get_value());
 
     OptionStringSet::ValueType another_set{"4", "5", "6"};
-    option.add(another_set);
+    option.add(libdnf::Option::Priority::RUNTIME, another_set);
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3", "4", "5", "6"}) == option.get_value());
 
     OptionStringSet::ValueType set_with_existing_values{"7", "5", "4"};
-    option.add(set_with_existing_values);
+    option.add(libdnf::Option::Priority::RUNTIME, set_with_existing_values);
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"1", "2", "3", "4", "5", "6", "7"}) == option.get_value());
 }
 
@@ -524,9 +524,9 @@ void OptionTest::test_options_list_add_item() {
     OptionStringSet option(initial);
     CPPUNIT_ASSERT(initial == option.get_value());
 
-    option.add_item("item2");
+    option.add_item(libdnf::Option::Priority::RUNTIME, "item2");
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"item1", "item2"}) == option.get_value());
 
-    option.add_item("item1");
+    option.add_item(libdnf::Option::Priority::RUNTIME, "item1");
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"item1", "item2"}) == option.get_value());
 }

--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -34,13 +34,13 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
     def test_container_add_item(self):
         auths_config = self.base.get_config().get_proxy_auth_method_option()
         auths_config.set(('basic', 'ntlm'))
-        auths_config.add_item('digest')
+        auths_config.add_item(libdnf5.conf.Option.Priority_RUNTIME, 'digest')
         self.assertEqual(auths_config.get_value(), ('basic', 'digest', 'ntlm'))
 
     def test_container_add(self):
         types_config = self.base.get_config().get_optional_metadata_types_option()
         types_config.set((libdnf5.conf.METADATA_TYPE_FILELISTS,))
-        types_config.add((libdnf5.conf.METADATA_TYPE_COMPS,
+        types_config.add(libdnf5.conf.Option.Priority_RUNTIME, (libdnf5.conf.METADATA_TYPE_COMPS,
                          libdnf5.conf.METADATA_TYPE_UPDATEINFO))
         self.assertEqual(types_config.get_value(), (libdnf5.conf.METADATA_TYPE_COMPS,
                          libdnf5.conf.METADATA_TYPE_FILELISTS, libdnf5.conf.METADATA_TYPE_UPDATEINFO))


### PR DESCRIPTION
Contains:
- Several repoquery improvements to `queryformat`.
- New arguments: `--depends` and `--querytags`.
- Specifying path to `--what*` arguments now pulls in filelists
- Allow using the same `--what*` option multiple times.

For: https://github.com/rpm-software-management/dnf5/issues/122

The PR got quite big but each commit should be fairly small and simple.