### PR TITLE
update release action with custom dnf5 scripts

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Prepare release content
-        uses: packit/prepare-release@v1
+        uses: inknos/prepare-release@v1
         with:
           version: ${{ inputs.version }}
           specfiles: dnf5.spec


### PR DESCRIPTION
dnf5 uses global macros at the beginning of dnf5.spec that need to be updated with version numbers.
VERSION.cmake needs also to be updated