### PR TITLE
transaction: Fix iterator over RPM problems

### DIFF
--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -533,9 +533,8 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     libdnf::rpm::Transaction rpm_transaction(base);
     rpm_transaction.fill(*transaction);
     if (!rpm_transaction.check()) {
-        auto problems = rpm_transaction.get_problems();
-        for (auto it = problems.begin(); it != problems.end(); ++it) {
-            transaction_problems.emplace_back((*it).to_string());
+        for (auto it : rpm_transaction.get_problems()) {
+            transaction_problems.emplace_back(it.to_string());
         }
         return TransactionRunResult::ERROR_CHECK;
     }
@@ -567,9 +566,8 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     //rpm_transaction.set_callbacks(std::move(callbacks));
     auto ret = rpm_transaction.run();
     if (ret != 0) {
-        auto problems = rpm_transaction.get_problems();
-        for (auto it = problems.begin(); it != problems.end(); ++it) {
-            transaction_problems.emplace_back((*it).to_string());
+        for (auto it : rpm_transaction.get_problems()) {
+            transaction_problems.emplace_back(it.to_string());
         }
         return TransactionRunResult::ERROR_RPM_RUN;
     }
@@ -781,9 +779,8 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     if (ret == 0) {
         return TransactionRunResult::SUCCESS;
     } else {
-        auto problems = rpm_transaction.get_problems();
-        for (auto it = problems.begin(); it != problems.end(); ++it) {
-            transaction_problems.emplace_back((*it).to_string());
+        for (auto it : rpm_transaction.get_problems()) {
+            transaction_problems.emplace_back(it.to_string());
         }
         return TransactionRunResult::ERROR_RPM_RUN;
     }

--- a/libdnf/rpm/transaction.hpp
+++ b/libdnf/rpm/transaction.hpp
@@ -147,7 +147,7 @@ public:
 
     private:
         friend RpmProblemSet;
-        explicit Iterator(rpmps problem_set) : iter(rpmpsInitIterator(problem_set)) {}
+        explicit Iterator(rpmps problem_set) : iter(rpmpsInitIterator(problem_set)) { rpmpsiNext(iter); }
 
         void free() {
             rpmpsFreeIterator(iter);

--- a/libdnf/rpm/transaction.hpp
+++ b/libdnf/rpm/transaction.hpp
@@ -141,7 +141,7 @@ public:
         // TODO(jrohel): postfix operator ++, Bad iterator support in the librpm
         // iterator operator++(int);
 
-        bool operator==(Iterator & other) const { return rpmpsGetProblem(iter) == rpmpsGetProblem(other.iter); }
+        bool operator!=(Iterator & other) const { return rpmpsGetProblem(iter) != rpmpsGetProblem(other.iter); }
 
         RpmProblem operator*() { return RpmProblem(rpmpsGetProblem(iter)); }
 


### PR DESCRIPTION
Iterator needs to be moved using the next function after the initialization in order to work properly. Also simplified iterator usage in order to use the range-based for loop.

CI tests PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1275.
Closes https://github.com/rpm-software-management/dnf5/issues/515.