### PR TITLE
Connect destdir cmd option with configuration

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -42,7 +42,6 @@ public:
 private:
     libdnf::OptionBool * resolve_option{nullptr};
     libdnf::OptionBool * alldeps_option{nullptr};
-    libdnf::OptionString * destdir_option{nullptr};
 
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_download_options{nullptr};
 };

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -62,6 +62,10 @@ public:
 /// The values are atored in the `allow_downgrade` configuration option
 void create_allow_downgrade_options(dnf5::Command & command);
 
+/// Create the `--destdir` option for a command provided as an argument.
+/// The values are stored in the `destdir` configuration option
+void create_destdir_option(dnf5::Command & command);
+
 
 }  // namespace dnf5
 

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -48,5 +48,17 @@ void create_allow_downgrade_options(dnf5::Command & command) {
     allow_downgrade->add_conflict_argument(*no_allow_downgrade);
 }
 
+void create_destdir_option(dnf5::Command & command) {
+    auto & parser = command.get_context().get_argument_parser();
+    auto destdir = parser.add_new_named_arg("destdir");
+    destdir->set_long_name("destdir");
+    destdir->set_description(
+        "Set directory used for downloading packages to. Default location is to the current working directory");
+    destdir->set_has_value(true);
+    destdir->set_arg_value_help("DESTDIR");
+    destdir->link_value(&command.get_context().base.get_config().get_destdir_option());
+    command.get_argument_parser_command()->register_named_arg(destdir);
+}
+
 
 }  // namespace dnf5


### PR DESCRIPTION
It unify approach how to use destdir variable inside dnf5. Using only configuration value is more transparent.