### PR TITLE
Fix doxygen warnings

### DIFF
--- a/include/libdnf-cli/exception.hpp
+++ b/include/libdnf-cli/exception.hpp
@@ -72,8 +72,8 @@ public:
     /// message.
     ///
     /// @param exit_code The exit code
-    /// @format The format string for the message
-    /// @args The format arguments
+    /// @param format The format string for the message
+    /// @param args The format arguments
     template <typename... Ss>
     explicit CommandExitError(int exit_code, BgettextMessage format, Ss &&... args)
         : Error(format, std::forward<Ss>(args)...),
@@ -95,8 +95,8 @@ public:
     /// message.
     ///
     /// @param exit_code The exit code
-    /// @format The format string for the message
-    /// @args The format arguments
+    /// @param format The format string for the message
+    /// @param args The format arguments
     template <typename... Ss>
     explicit SilentCommandExitError(int exit_code, BgettextMessage format, Ss &&... args)
         : Error(format, std::forward<Ss>(args)...),

--- a/include/libdnf-cli/output/pkg_colorizer.hpp
+++ b/include/libdnf-cli/output/pkg_colorizer.hpp
@@ -40,7 +40,7 @@ public:
     /// @param color_not_found Color returned in case package's name.arch is not in `base_versions`
     /// @param color_lt Color returned in case package's version is lower then the one in `base_versions`
     /// @param color_eq Color returned in case package's version is equal to the one in `base_versions`
-    /// @param color_lt Color returned in case package's version is greater then the one in `base_versions`
+    /// @param color_gt Color returned in case package's version is greater then the one in `base_versions`
     PkgColorizer(
         const libdnf::rpm::PackageSet & base_versions,
         const std::string & color_not_found,

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -176,7 +176,9 @@ public:
     /// @since 5.0
     bool get_value() const { return conf->get_value(); }
 
-    /// @set bool value with priority for the option
+    /// Set bool value with priority for the option
+    /// @param priority Priority
+    /// @param value Value
     /// @since 5.0
     void set(libdnf::Option::Priority priority, bool value) { return conf->set(priority, value); }
 

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -125,7 +125,7 @@ public:
     /// Important for queries that resolve SPEC
     bool with_filenames{true};
     /// Important for queries that resolve SPEC
-    /// It will check whether SPEC is a binary -> /usr/(s)bin/<SPEC>
+    /// It will check whether SPEC is a binary -> `/usr/(s)bin/<SPEC>`
     bool with_binaries{true};
     /// Important for queries that resolve SPEC
     std::vector<libdnf::rpm::Nevra::Form> nevra_forms{};

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -34,7 +34,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 /// An assert macro that throws `libdnf::AssertionError`.
 ///
-/// @param format The format string for the message.
+/// @param msg_format The format string for the message.
 /// @param ... The format arguments.
 /// @exception libdnf::AssertionError Thrown always.
 #define libdnf_throw_assertion(msg_format, ...) \
@@ -43,7 +43,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 /// An assert macro that throws `libdnf::AssertionError` when `condition` is not met.
 ///
 /// @param condition The assertion condition. Throws AssertionError if it's not met.
-/// @param format The format string for the message.
+/// @param msg_format The format string for the message.
 /// @param ... The format arguments.
 /// @exception libdnf::AssertionError Thrown when condition is not met.
 #define libdnf_assert(condition, msg_format, ...) \
@@ -54,7 +54,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 /// An assert macro that throws `libdnf::UserAssertionError` when `condition` is not met.
 ///
 /// @param condition The assertion condition. Throws UserAssertionError if it's not met.
-/// @param format The format string for the message.
+/// @param msg_format The format string for the message.
 /// @param ... The format arguments.
 /// @exception libdnf::UserAssertionError Thrown when condition is not met.
 #define libdnf_user_assert(condition, msg_format, ...) \

--- a/include/libdnf/comps/environment/environment.hpp
+++ b/include/libdnf/comps/environment/environment.hpp
@@ -99,7 +99,7 @@ public:
     // TODO(pkratoch): Either remove this method, or return a vector of the weak pointers to the repo objects
     std::set<std::string> get_repos() const;
 
-    /// @return `true` if the Environment is installed (belongs to the @System repo).
+    /// @return `true` if the Environment is installed (belongs to the \@System repo).
     /// @since 5.0
     bool get_installed() const;
 

--- a/include/libdnf/comps/group/group.hpp
+++ b/include/libdnf/comps/group/group.hpp
@@ -118,7 +118,7 @@ public:
     // TODO(pkratoch): Either remove this method, or return a vector of the weak pointers to the repo objects
     std::set<std::string> get_repos() const;
 
-    /// @return `true` if the Group is installed (belongs to the @System repo).
+    /// @return `true` if the Group is installed (belongs to the \@System repo).
     /// @since 5.0
     bool get_installed() const;
 

--- a/include/libdnf/conf/option.hpp
+++ b/include/libdnf/conf/option.hpp
@@ -58,11 +58,11 @@ public:
 
 
 /// Option class is an abstract class. Parent of all options. Options are used to store a configuration.
-/// @replaces libdnf:conf/Option.hpp:class:Option
+// @replaces libdnf:conf/Option.hpp:class:Option
 class Option {
 public:
     // TODO(jrohel): Prioroties are under discussion and probably will be modified.
-    /// @replaces libdnf:conf/Option.hpp:enum class:Option::Priority
+    // @replaces libdnf:conf/Option.hpp:enum class:Option::Priority
     enum class Priority {
         EMPTY = 0,
         DEFAULT = 10,
@@ -82,27 +82,27 @@ public:
     virtual ~Option() = default;
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/Option.hpp:method:Option.clone()
+    // @replaces libdnf:conf/Option.hpp:method:Option.clone()
     virtual Option * clone() const = 0;
 
     /// Returns priority (source) of the stored value.
-    /// @replaces libdnf:conf/Option.hpp:method:Option.getPriority()
+    // @replaces libdnf:conf/Option.hpp:method:Option.getPriority()
     virtual Priority get_priority() const;
 
     /// Parses input string and sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/Option.hpp:method:Option.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/Option.hpp:method:Option.set(Priority priority, const std::string & value)
     virtual void set(Priority priority, const std::string & value) = 0;
 
     /// Parses input string and sets new value and runtime priority.
     virtual void set(const std::string & value) = 0;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/Option.hpp:method:Option.getValueString()
+    // @replaces libdnf:conf/Option.hpp:method:Option.getValueString()
     virtual std::string get_value_string() const = 0;
 
     /// Checks if the option is empty (has no stored value).
-    /// @replaces libdnf:conf/Option.hpp:method:Option.empty()
+    // @replaces libdnf:conf/Option.hpp:method:Option.empty()
     virtual bool empty() const noexcept;
 
     /// Locks the option.

--- a/include/libdnf/conf/option_bool.hpp
+++ b/include/libdnf/conf/option_bool.hpp
@@ -33,17 +33,17 @@ namespace libdnf {
 /// Supports default value.
 /// Conversion from string to bool is done according to vectors which contains strings of true and false values.
 /// Conversion is case insensitive for input. Values must be lower case in vectors.
-/// @replaces libdnf:conf/OptionBool.hpp:class:OptionBool
+// @replaces libdnf:conf/OptionBool.hpp:class:OptionBool
 class OptionBool : public Option {
 public:
     using ValueType = bool;
 
     /// Constructor that sets default value.
-    /// @replaces libdnf:conf/OptionBool.hpp:ctor:OptionBool.OptionBool(bool default_value)
+    // @replaces libdnf:conf/OptionBool.hpp:ctor:OptionBool.OptionBool(bool default_value)
     explicit OptionBool(bool default_value);
 
     /// Constructor that sets default value and vectors for conversion from string.
-    /// @replaces libdnf:conf/OptionBool.hpp:ctor:OptionBool.OptionBool(bool defaultValue, const char * const trueVals[], const char * const falseVals[]);
+    // @replaces libdnf:conf/OptionBool.hpp:ctor:OptionBool.OptionBool(bool defaultValue, const char * const trueVals[], const char * const falseVals[]);
     OptionBool(
         bool default_value, const std::vector<std::string> & true_vals, const std::vector<std::string> & false_vals);
 
@@ -55,12 +55,12 @@ public:
     OptionBool & operator=(OptionBool && src) noexcept = default;
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.clone()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.clone()
     OptionBool * clone() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, bool value)
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, bool value)
     void set(Priority priority, bool value);
 
     /// Sets new value with the runtime priority.
@@ -68,50 +68,50 @@ public:
 
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValue()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValue()
     bool get_value() const noexcept;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValueString()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValueString()
     bool get_default_value() const noexcept;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValueString()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getValueString()
     std::string get_value_string() const override;
 
     /// Returns vector with default strings used for conversion from string to "true" bool value.
-    /// @replaces libdnf:conf/OptionBool.hpp:global_const:defTrueValues[]
+    // @replaces libdnf:conf/OptionBool.hpp:global_const:defTrueValues[]
     static const std::vector<std::string> & get_default_true_values() noexcept;
 
     /// Returns vector with default strings used for conversion from string to "false" bool value.
-    /// @replaces libdnf:conf/OptionBool.hpp:global_const:defFalseValues[]
+    // @replaces libdnf:conf/OptionBool.hpp:global_const:defFalseValues[]
     static const std::vector<std::string> & get_default_false_values() noexcept;
 
     /// Returns vector with strings used for conversion from string to "true" bool value.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getTrueValues()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getTrueValues()
     const std::vector<std::string> & get_true_values() const noexcept;
 
     /// Returns vector with strings used for conversion from string to "false" bool value.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getFalseValues()
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.getFalseValues()
     const std::vector<std::string> & get_false_values() const noexcept;
 
     /// Does nothing. But it must be present for compatibility with other option types.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.test(bool /*unused*/)
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.test(bool /*unused*/)
     void test(bool /*unused*/) const;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.fromString(const std::string & value)
     bool from_string(const std::string & value) const;
 
     /// Converts input value to the string.
-    /// @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.toString(bool value)
+    // @replaces libdnf:conf/OptionBool.hpp:method:OptionBool.toString(bool value)
     std::string to_string(bool value) const;
 
 private:

--- a/include/libdnf/conf/option_child.hpp
+++ b/include/libdnf/conf/option_child.hpp
@@ -28,25 +28,25 @@ namespace libdnf {
 /// Option that links option to another option. It uses default value and parameters from linked option.
 /// If it is empty (has no stored value), uses value from the linked option (parent).
 /// Parent option type is template parameter.
-/// @replaces libdnf:conf/OptionChild.hpp:class:OptionChild<T>
+// @replaces libdnf:conf/OptionChild.hpp:class:OptionChild<T>
 template <class ParentOptionType, class Enable = void>
 class OptionChild : public Option {
 public:
     /// Constructor takes reference to parent option.
-    /// @replaces libdnf:conf/OptionChild.hpp:ctor:OptionChild<T>.OptionChild(const ParentOptionType & parent)
+    // @replaces libdnf:conf/OptionChild.hpp:ctor:OptionChild<T>.OptionChild(const ParentOptionType & parent)
     explicit OptionChild(const ParentOptionType & parent);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.clone()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.clone()
     OptionChild * clone() const override;
 
     /// Returns priority (source) of the stored value. If no value is stored, priority from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getPriority()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getPriority()
     Priority get_priority() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, bool value)
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, bool value)
     void set(Priority priority, const typename ParentOptionType::ValueType & value);
 
     /// Sets new value and runtime priority.
@@ -54,26 +54,26 @@ public:
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, std::string value)
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.set(Priority priority, std::string value)
     void set(Priority priority, const std::string & value) override;
 
     /// Sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value. If no value is stored, value from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValue()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValue()
     typename ParentOptionType::ValueType get_value() const;
 
     /// Gets the default value from parent. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValueString()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValueString()
     typename ParentOptionType::ValueType get_default_value() const;
 
     /// Gets a string representation of the stored value. If no value is stored, value from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValueString()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.getValueString()
     std::string get_value_string() const override;
 
     /// Checks if the option is empty (has no stored value). If it is empty, checks status of the parent.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.empty()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<T>.empty()
     bool empty() const noexcept override;
 
 private:
@@ -85,7 +85,7 @@ private:
 /// If it is empty (has no stored value), uses value from the linked option (parent).
 /// Parent option type is template parameter.
 /// This is specialization for parent with std::string ValueType.
-/// @replaces libdnf:conf/OptionChild.hpp:class:OptionChild<std::string>
+// @replaces libdnf:conf/OptionChild.hpp:class:OptionChild<std::string>
 template <class ParentOptionType>
 class OptionChild<
     ParentOptionType,
@@ -93,39 +93,39 @@ class OptionChild<
     : public Option {
 public:
     /// Constructor takes reference to parent option.
-    /// @replaces libdnf:conf/OptionChild.hpp:ctor:OptionChild.OptionChild<std::string>(const ParentOptionType & parent)
+    // @replaces libdnf:conf/OptionChild.hpp:ctor:OptionChild.OptionChild<std::string>(const ParentOptionType & parent)
     explicit OptionChild(const ParentOptionType & parent);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.clone()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.clone()
     OptionChild * clone() const override;
 
     /// Returns priority (source) of the stored value. If no value is stored, priority from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getPriority()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getPriority()
     Priority get_priority() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.set(Priority priority, std::string value)
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.set(Priority priority, std::string value)
     void set(Priority priority, const std::string & value) override;
 
     /// Sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value. If no value is stored, value from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValue()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValue()
     const std::string & get_value() const;
 
     /// Gets the default value from parent. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValueString()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValueString()
     const std::string & get_default_value() const;
 
     /// Gets a string representation of the stored value. If no value is stored, value from the parent is returned.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValueString()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.getValueString()
     std::string get_value_string() const override;
 
     /// Checks if the option is empty (has no stored value). If it is empty, checks status of the parent.
-    /// @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.empty()
+    // @replaces libdnf:conf/OptionChild.hpp:method:OptionChild<std::string>.empty()
     bool empty() const noexcept override;
 
 private:

--- a/include/libdnf/conf/option_enum.hpp
+++ b/include/libdnf/conf/option_enum.hpp
@@ -30,7 +30,7 @@ namespace libdnf {
 
 /// Option that stores value from enumeration. The type of value is template parameter.
 /// Support default value and user defined function for conversion from string.
-/// @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<T>
+// @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<T>
 template <typename T>
 class OptionEnum : public Option {
 public:
@@ -43,12 +43,12 @@ public:
     OptionEnum(ValueType default_value, std::vector<ValueType> && enum_vals, FromStringFunc && from_string_func);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.clone()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.clone()
     OptionEnum * clone() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, bool value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, bool value)
     void set(Priority priority, ValueType value);
 
     /// Sets new value and runtime priority.
@@ -56,34 +56,34 @@ public:
 
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValue()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValue()
     T get_value() const;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
     T get_default_value() const;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
     std::string get_value_string() const override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.test(ValueType value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.test(ValueType value)
     void test(ValueType value) const;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.fromString(const std::string & value)
     ValueType from_string(const std::string & value) const;
 
     /// Converts input value to the string.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.toString(ValueType value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.toString(ValueType value)
     std::string to_string(ValueType value) const;
 
 private:
@@ -97,7 +97,7 @@ private:
 /// Option that stores value from enumeration. Specialized template for enumeration of strings.
 /// It supports default value.
 /// It supports user defined function for conversion from string.
-/// @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<std::string>
+// @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<std::string>
 template <>
 class OptionEnum<std::string> : public Option {
 public:
@@ -108,35 +108,35 @@ public:
     OptionEnum(const std::string & default_value, std::vector<ValueType> enum_vals, FromStringFunc && from_string_func);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.clone()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.clone()
     OptionEnum * clone() const override;
 
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValue()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValue()
     const std::string & get_value() const;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValueString()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValueString()
     const std::string & get_default_value() const;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValueString()
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.getValueString()
     std::string get_value_string() const override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.test(const std::string & value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.test(const std::string & value)
     void test(const std::string & value) const;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.fromString(const std::string & value)
     std::string from_string(const std::string & value) const;
 
 private:

--- a/include/libdnf/conf/option_number.hpp
+++ b/include/libdnf/conf/option_number.hpp
@@ -29,7 +29,7 @@ namespace libdnf {
 
 /// Option that stores numerical value. The type of value is template parameter.
 /// Support default value, minimal and maximal values, user defined function for conversion from string.
-/// @replaces libdnf:conf/OptionNumber.hpp:class:OptionNumber<T>
+// @replaces libdnf:conf/OptionNumber.hpp:class:OptionNumber<T>
 template <typename T>
 class OptionNumber : public Option {
 public:
@@ -37,36 +37,36 @@ public:
     using FromStringFunc = std::function<ValueType(const std::string &)>;
 
     /// Constructor that sets default value and limits for min and max values.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, T max)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, T max)
     OptionNumber(T default_value, T min, T max);
 
     /// Constructor that sets default value and limit for min value.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min)
     OptionNumber(T default_value, T min);
 
     /// Constructor that sets default value.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value)
     explicit OptionNumber(T default_value);
 
     /// Constructor that sets default value and limits for min and max values and input parsing function.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, T max, FromStringFunc && fromStringFunc)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, T max, FromStringFunc && fromStringFunc)
     OptionNumber(T default_value, T min, T max, FromStringFunc && from_string_func);
 
     /// Constructor that sets default value and limit for min value and input parsing function.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, FromStringFunc && fromStringFunc)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, FromStringFunc && fromStringFunc)
     OptionNumber(T default_value, T min, FromStringFunc && from_string_func);
 
     /// Constructor that sets default value and input parsing function.
-    /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, FromStringFunc && fromStringFunc)
+    // @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, FromStringFunc && fromStringFunc)
     OptionNumber(T default_value, FromStringFunc && from_string_func);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionBoo<T>.clone()
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionBoo<T>.clone()
     OptionNumber * clone() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, bool value)
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, bool value)
     void set(Priority priority, ValueType value);
 
     /// Sets new value and runtime priority.
@@ -74,34 +74,34 @@ public:
 
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValue()
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValue()
     T get_value() const;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValueString()
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValueString()
     T get_default_value() const;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValueString()
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.getValueString()
     std::string get_value_string() const override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.test(ValueType value)
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.test(ValueType value)
     void test(ValueType value) const;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.fromString(const std::string & value)
     T from_string(const std::string & value) const;
 
     /// Converts input value to the string.
-    /// @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.toString(ValueType value)
+    // @replaces libdnf:conf/OptionNumber.hpp:method:OptionNumber<T>.toString(ValueType value)
     std::string to_string(ValueType value) const;
 
 private:

--- a/include/libdnf/conf/option_path.hpp
+++ b/include/libdnf/conf/option_path.hpp
@@ -35,19 +35,19 @@ public:
 
 /// Option that stores file/directory path.
 /// Support default value, and path verification (absolute, existence).
-/// @replaces libdnf:conf/OptionPath.hpp:class:OptionPath
+// @replaces libdnf:conf/OptionPath.hpp:class:OptionPath
 class OptionPath : public OptionString {
 public:
     /// Constructor sets default value and conditons.
-    /// @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const std::string & defaultValue, bool exists = false, bool absPath = false)
+    // @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const std::string & defaultValue, bool exists = false, bool absPath = false)
     explicit OptionPath(const std::string & default_value, bool exists = false, bool abs_path = false);
 
     /// Constructor sets default value and conditons.
-    /// @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const char * defaultValue, bool exists = false, bool absPath = false)
+    // @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const char * defaultValue, bool exists = false, bool absPath = false)
     explicit OptionPath(const char * default_value, bool exists = false, bool abs_path = false);
 
     /// Constructor sets default value and conditons.
-    /// @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const std::string & defaultValue, const std::string & regex, bool icase, bool exists = false, bool absPath = false)
+    // @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const std::string & defaultValue, const std::string & regex, bool icase, bool exists = false, bool absPath = false)
     OptionPath(
         const std::string & default_value,
         const std::string & regex,
@@ -56,25 +56,25 @@ public:
         bool abs_path = false);
 
     /// Constructor sets default value and conditons.
-    /// @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const char * defaultValue, const std::string & regex, bool icase, bool exists = false, bool absPath = false)
+    // @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const char * defaultValue, const std::string & regex, bool icase, bool exists = false, bool absPath = false)
     OptionPath(
         const char * default_value, const std::string & regex, bool icase, bool exists = false, bool abs_path = false);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.clone()
+    // @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.clone()
     OptionPath * clone() const override;
 
     /// Parses input string and sets new value and priority.
     /// According setting passed in constructor it can verify that the path is absolute, exists and match regex.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.test(const std::string & value)
+    // @replaces libdnf:conf/OptionPath.hpp:method:OptionPath.test(const std::string & value)
     void test(const std::string & value) const;
 
 private:

--- a/include/libdnf/conf/option_seconds.hpp
+++ b/include/libdnf/conf/option_seconds.hpp
@@ -27,7 +27,7 @@ namespace libdnf {
 
 /// Option that stores an integer value of seconds.
 /// Support default value, minimal and maximal values.
-/// @replaces libdnf:conf/OptionSeconds.hpp:class:OptionSeconds
+// @replaces libdnf:conf/OptionSeconds.hpp:class:OptionSeconds
 class OptionSeconds : public OptionNumber<std::int32_t> {
 public:
     OptionSeconds(ValueType default_value, ValueType min, ValueType max);
@@ -35,7 +35,7 @@ public:
     explicit OptionSeconds(ValueType default_value);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.clone()
+    // @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.clone()
     OptionSeconds * clone() const override;
 
     using OptionNumber<std::int32_t>::set;
@@ -44,14 +44,14 @@ public:
     /// Valid inputs: 100, 1.5m, 90s, 1.2d, 1d, 0xF, 0.1, -1, never.
     /// Invalid inputs: -10, -0.1, 45.6Z, 1d6h, 1day, 1y.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionSeconds.hpp:method:OptionSeconds.fromString(const std::string & value)
     ValueType from_string(const std::string & value) const;
 };
 

--- a/include/libdnf/conf/option_string.hpp
+++ b/include/libdnf/conf/option_string.hpp
@@ -27,7 +27,7 @@ namespace libdnf {
 
 /// Option that stores string value.
 /// Support default value, and check of an input value using the regular expression
-/// @replaces libdnf:conf/OptionString.hpp:class:OptionString
+// @replaces libdnf:conf/OptionString.hpp:class:OptionString
 class OptionString : public Option {
 public:
     using ValueType = std::string;
@@ -38,35 +38,35 @@ public:
     OptionString(const char * default_value, std::string regex, bool icase);
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.clone()
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.clone()
     OptionString * clone() const override;
 
     /// Sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Sets new value and runtime priority.
     void set(const std::string & value) override;
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValue()
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValue()
     const std::string & get_value() const;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValueString()
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValueString()
     const std::string & get_default_value() const noexcept;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValueString()
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.getValueString()
     std::string get_value_string() const override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.test(const std::string & value)
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.test(const std::string & value)
     void test(const std::string & value) const;
 
     /// Returns copy of input string. Must be present for compatibility with other option types.
-    /// @replaces libdnf:conf/OptionString.hpp:method:OptionString.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionString.hpp:method:OptionString.fromString(const std::string & value)
     std::string from_string(const std::string & value) const;
 
 protected:

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -32,7 +32,7 @@ namespace libdnf {
 
 /// Option that stores a container of strings. The type of the container is a template parameter.
 /// Support default value, and check of an input value using the regular expression
-/// @replaces libdnf:conf/OptionStringList.hpp:class:OptionStringList
+// @replaces libdnf:conf/OptionStringList.hpp:class:OptionStringList
 template <typename T>
 class OptionStringContainer : public Option {
 public:
@@ -52,12 +52,12 @@ public:
     OptionStringContainer & operator=(OptionStringContainer && src) noexcept = default;
 
     /// Makes copy (clone) of this object.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.clone()
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.clone()
     OptionStringContainer * clone() const override;
 
     /// Sets new value and priority (source).
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionStingList.hpp:method:OptionStringList.set(Priority priority, bool value)
+    // @replaces libdnf:conf/OptionStingList.hpp:method:OptionStringList.set(Priority priority, bool value)
     virtual void set(Priority priority, const ValueType & value);
 
     /// Sets new value and runtime priority.
@@ -65,7 +65,7 @@ public:
 
     /// Parses input string and sets new value and priority.
     /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.set(Priority priority, const std::string & value)
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.set(Priority priority, const std::string & value)
     void set(Priority priority, const std::string & value) override;
 
     /// Parses input string and sets new value and runtime priority.
@@ -80,27 +80,27 @@ public:
     void add_item(const std::string & item);
 
     /// Gets the stored value.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValue()
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValue()
     const ValueType & get_value() const;
 
     /// Gets the default value. Default value is used until it is replaced by set() method.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValueString()
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValueString()
     const ValueType & get_default_value() const;
 
     /// Gets a string representation of the stored value.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValueString()
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.getValueString()
     std::string get_value_string() const override;
 
     /// Tests input value and throws exception if the value is not allowed.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.test(const std::vector<std::string> & value)
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.test(const std::vector<std::string> & value)
     void test(const ValueType & value) const;
 
     /// Parses input string and returns result.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.fromString(const std::string & value)
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.fromString(const std::string & value)
     ValueType from_string(std::string value) const;
 
     /// Converts input value to the string.
-    /// @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.toString(const ValueType & value)
+    // @replaces libdnf:conf/OptionStringList.hpp:method:OptionStringList.toString(const ValueType & value)
     std::string to_string(const ValueType & value) const;
 
     /// Returns the default delimiters

--- a/include/libdnf/module/module_item.hpp
+++ b/include/libdnf/module/module_item.hpp
@@ -206,6 +206,7 @@ private:
 
     // TODO(pkratoch): Make this private once it's not used in tests.
     /// @return The string representing module dependencies (e.g. "ninja;platform:[f29]" or "nodejs:[-11]").
+    /// @param md_stream Module stream
     /// @param remove_platform When true, the method will not return dependencies with stream "platform"
     ///                        (default is false).
     /// @since 5.0

--- a/include/libdnf/module/module_query.hpp
+++ b/include/libdnf/module/module_query.hpp
@@ -39,11 +39,13 @@ public:
     /// Create a new ModuleQuery instance.
     ///
     /// @param base     A weak pointer to Base
+    /// @param empty    `true` to create empty query, `false` to create query with all modules
     explicit ModuleQuery(const libdnf::BaseWeakPtr & base, bool empty = false);
 
     /// Create a new ModuleQuery instance.
     ///
     /// @param base     Reference to Base
+    /// @param empty    `true` to create empty query, `false` to create query with all modules
     explicit ModuleQuery(libdnf::Base & base, bool empty = false);
 
     /// @return Weak pointer to the Base object.
@@ -53,7 +55,7 @@ public:
     /// Filter ModuleItems by their `name`.
     ///
     /// @param pattern          A string the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_name(const std::string & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -61,7 +63,7 @@ public:
     /// Filter ModuleItems by their `name`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_name(
@@ -70,7 +72,7 @@ public:
     /// Filter ModuleItems by their `stream`.
     ///
     /// @param pattern          A string the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_stream(const std::string & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -78,7 +80,7 @@ public:
     /// Filter ModuleItems by their `stream`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_stream(
@@ -87,7 +89,7 @@ public:
     /// Filter ModuleItems by their `version`.
     ///
     /// @param pattern          A string the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_version(const std::string & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -95,7 +97,7 @@ public:
     /// Filter ModuleItems by their `version`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_version(
@@ -104,7 +106,7 @@ public:
     /// Filter ModuleItems by their `context`.
     ///
     /// @param pattern          A string the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_context(const std::string & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -112,7 +114,7 @@ public:
     /// Filter ModuleItems by their `context`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_context(
@@ -121,7 +123,7 @@ public:
     /// Filter ModuleItems by their `arch`.
     ///
     /// @param pattern          A string the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_arch(const std::string & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -129,7 +131,7 @@ public:
     /// Filter ModuleItems by their `arch`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     void filter_arch(

--- a/include/libdnf/repo/file_downloader.hpp
+++ b/include/libdnf/repo/file_downloader.hpp
@@ -46,6 +46,7 @@ public:
     /// @param repo The repository whose settings are to be used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
+    /// @param user_data User data.
     void add(
         libdnf::repo::RepoWeakPtr & repo,
         const std::string & url,
@@ -55,6 +56,7 @@ public:
     /// Adds a file (URL) to download. The settings from ConfigMain passed in the FileDownloader constructor are used.
     /// @param url The file (url) to download.
     /// @param destination The file path to which to download the file.
+    /// @param user_data User data.
     void add(const std::string & url, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added files (URLs).

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -41,11 +41,13 @@ public:
 
     /// Adds a package to download to the standard location of repo cachedir/packages.
     /// @param package The package to download.
+    /// @param user_data User data.
     void add(const libdnf::rpm::Package & package, void * user_data = nullptr);
 
     /// Adds a package to download to a specific destination directory.
     /// @param package The package to download.
     /// @param destination The directory to which to download the package.
+    /// @param user_data User data.
     void add(const libdnf::rpm::Package & package, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added packages.

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -74,7 +74,7 @@ public:
     };
 
     /// Verify repo ID
-    /// @param id repo ID to verify
+    /// @param repo_id repo ID to verify
     /// @return   index of the first invalid character in the repo ID (if present) or std::string::npos
     // @replaces libdnf:repo/Repo.hpp:method:Repo.verifyId(const std::string & id)
     static std::string::size_type verify_id(const std::string & repo_id);
@@ -208,7 +208,7 @@ public:
     int64_t get_age() const;
 
     /// Return path to the particular downloaded repository metadata in cache
-    /// @param metadataType metadata type (filelists, other, productid...)
+    /// @param metadata_type metadata type (filelists, other, productid...)
     /// @return file path or empty string in case the requested metadata does not exist
     // @replaces libdnf:repo/Repo.hpp:method:Repo.getMetadataPath(const std::string & metadataType)
     std::string get_metadata_path(const std::string & metadata_type);
@@ -251,8 +251,8 @@ public:
     /// of the local downloaded files (repository metadata and packages) to match those from
     /// the remote files.
     /// This feature is by default switched off.
-    /// @param preserveRemoteTime true - use remote file timestamp, false - use the current time
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setPreserveRemoteTime(bool preserveRemoteTime)
+    /// @param preserve_remote_time true - use remote file timestamp, false - use the current time
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setPreserveRemoteTime(bool preserveRemoteTime)
     void set_preserve_remote_time(bool preserve_remote_time);
 
     // @replaces libdnf:repo/Repo.hpp:method:Repo.getPreserveRemoteTime()

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -76,7 +76,7 @@ public:
     /// Verify repo ID
     /// @param id repo ID to verify
     /// @return   index of the first invalid character in the repo ID (if present) or std::string::npos
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.verifyId(const std::string & id)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.verifyId(const std::string & id)
     static std::string::size_type verify_id(const std::string & repo_id);
 
     /// Construct the Repo object
@@ -97,7 +97,7 @@ public:
     Type get_type() const noexcept;
 
     /// Registers a class that implements callback methods (fastest mirror detection, download state, key import).
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setCallbacks(std::unique_ptr<RepoCallbacks> && callbacks)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setCallbacks(std::unique_ptr<RepoCallbacks> && callbacks)
     void set_callbacks(std::unique_ptr<libdnf::repo::RepoCallbacks> && callbacks);
 
     /// @brief Sets the associated user data. These are used in callbacks.
@@ -110,41 +110,41 @@ public:
 
     /// Verify repo object configuration
     /// Will throw exception if Repo has no mirror or baseurl set or if Repo type is unsupported.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.verify()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.verify()
     void verify() const;
 
     /// Returns pointer to the repository configuration
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getConfig()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getConfig()
     ConfigRepo & get_config() noexcept;
 
     /// Returns pointer to the repository configuration
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getConfig()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getConfig()
     const ConfigRepo & get_config() const noexcept;
 
     /// Returns repository id
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getId()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getId()
     std::string get_id() const noexcept;
 
     /// Enable the repository
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.enable()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.enable()
     void enable();
 
     /// Disable the repository
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.disable()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.disable()
     void disable();
 
     /// Return whether the repository is enabled.
     /// @return true if enabled
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.isEnabled()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.isEnabled()
     bool is_enabled() const;
 
     /// Return whether the repository is local.
     /// @return true if local
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.isLocal()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.isLocal()
     bool is_local() const;
 
     /// Reads metadata from local cache.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.loadCache(bool throwExcept)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.loadCache(bool throwExcept)
     void read_metadata_cache();
 
     /// Checks whether the locally downloaded metadata are in sync with the origin.
@@ -152,7 +152,7 @@ public:
     bool is_in_sync();
 
     /// Downloads repository metadata.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
     void download_metadata(const std::string & destdir);
 
     /// Loads the repository objects into sacks.
@@ -166,16 +166,16 @@ public:
 
     /// Returns whether the using of "includes" is enabled
     /// If enabled, only packages listed in the "includepkgs" will be used from the repository.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getUseIncludes()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getUseIncludes()
     bool get_use_includes() const;
 
     /// Enables/disables using of "includes"
     /// If enabled, only packages listed in the "includepkgs" will be used from the repository.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setUseIncludes(bool enabled)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setUseIncludes(bool enabled)
     void set_use_includes(bool enabled);
 
     /// Returns repository cost
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getCost()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getCost()
     /// TODO(jrohel): Remove it? It is only shortcut for get_config()->cost()->get_value()
     int get_cost() const;
 
@@ -188,7 +188,7 @@ public:
     void set_cost(int value, Option::Priority priority = Option::Priority::RUNTIME);
 
     /// Returns repository priority
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getPriority()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getPriority()
     /// TODO(jrohel): Remove it? It is only shortcut for get_config()->cost()->get_value()
     int get_priority() const;
 
@@ -200,50 +200,50 @@ public:
     /// @param priority Optional argument
     void set_priority(int value, Option::Priority priority = Option::Priority::RUNTIME);
 
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getRevision()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getRevision()
     const std::string & get_revision() const;
 
     /// Gets age of the local cache
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getAge()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getAge()
     int64_t get_age() const;
 
     /// Return path to the particular downloaded repository metadata in cache
     /// @param metadataType metadata type (filelists, other, productid...)
     /// @return file path or empty string in case the requested metadata does not exist
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getMetadataPath(const std::string & metadataType)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getMetadataPath(const std::string & metadataType)
     std::string get_metadata_path(const std::string & metadata_type);
 
     /// Mark whatever is in the current cache expired.
     /// This repo instance will alway try to fetch a fresh metadata after this
     /// method is called.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.expire()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.expire()
     void expire();
 
     /// @brief Return whether the cached metadata is expired.
     /// @return bool
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.isExpired()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.isExpired()
     bool is_expired() const;
 
     /// @brief Get the number of seconds after which the cached metadata will expire.
     /// Negative number means the metadata has expired already.
     /// @return Seconds to expiration
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getExpiresIn()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getExpiresIn()
     int get_expires_in() const;
 
     /// Gets repository freshness
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.fresh()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.fresh()
     bool fresh();
 
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setMaxMirrorTries(int maxMirrorTries)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setMaxMirrorTries(int maxMirrorTries)
     void set_max_mirror_tries(int max_mirror_tries);
 
     /// Gets timestamp of metadata "primary" file
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getTimestamp()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getTimestamp()
     int64_t get_timestamp() const;
 
     /// Gets the highest timestamp from repomd records
     /// TODO(jrohel): Used in DNF repolist: displayed as "Repo-updated time" base.py: "using metadata from" in debug messages Is it correct?
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getMaxTimestamp()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getMaxTimestamp()
     int get_max_timestamp();
 
     /// Try to preserve remote side timestamps
@@ -255,25 +255,25 @@ public:
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.setPreserveRemoteTime(bool preserveRemoteTime)
     void set_preserve_remote_time(bool preserve_remote_time);
 
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getPreserveRemoteTime()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getPreserveRemoteTime()
     bool get_preserve_remote_time() const;
 
     /// TODO(jrohel): Used by DNF repolist. Do we need it?
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getContentTags()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getContentTags()
     const std::vector<std::string> & get_content_tags();
 
     /// TODO(jrohel): Used by DNF repolist. Do we need it?
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getDistroTags()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getDistroTags()
     const std::vector<std::pair<std::string, std::string>> & get_distro_tags();
 
     /// Get list of relative locations of metadata files inside the repo
     /// e.g. [('primary', 'repodata/primary.xml.gz'), ('filelists', 'repodata/filelists.xml.gz')...]
     /// @return vector of (metadata_type, location) string pairs
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getMetadataLocations()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getMetadataLocations()
     const std::vector<std::pair<std::string, std::string>> get_metadata_locations() const;
 
     /// Gets path to the repository cache directory
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getCacheDir()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getCacheDir()
     std::string get_cachedir() const;
 
     /// Gets path to the repository persistent directory
@@ -283,46 +283,46 @@ public:
     /// Alias
     std::string get_name() { return this->get_config().get_name_option().get_value(); };
     /// Sets repository configuration file path
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setRepoFilePath(const std::string & path)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setRepoFilePath(const std::string & path)
     void set_repo_file_path(const std::string & path);
 
     /// Gets repository configuration file path
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getRepoFilePath()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getRepoFilePath()
     const std::string & get_repo_file_path() const noexcept;
 
     /// Sets repository synchronisation strategy
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setSyncStrategy(SyncStrategy strategy)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setSyncStrategy(SyncStrategy strategy)
     void set_sync_strategy(SyncStrategy strategy);
 
     /// Returns repository synchronisation strategy
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getSyncStrategy()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getSyncStrategy()
     SyncStrategy get_sync_strategy() const noexcept;
 
     /// Downloads file from URL into given opened file descriptor.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.downloadUrl(const char * url, int fd)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadUrl(const char * url, int fd)
     /// TODO(lukash) fd seems like an inconvenient API for this function, use target path instead?
     ///              It also needs defining what it means downloading an URL through a particular repo
     //void download_url(const char * url, int fd);
 
     /// Set http headers.
     /// @param headers A vector of full headers ("header: value")
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setHttpHeaders(const char * headers[])
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setHttpHeaders(const char * headers[])
     void set_http_headers(const std::vector<std::string> & headers);
 
     /// Get http headers.
     /// @return A vector of full headers ("header: value")
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getHttpHeaders()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getHttpHeaders()
     std::vector<std::string> get_http_headers() const;
 
     /// Returns mirrorlist associated with the repository.
     /// Mirrors on this list are mirrors parsed from mirrorlist/metalink specified by LRO_MIRRORLIST or
     /// from mirrorlist specified by LRO_MIRROSLISTURL and metalink specified by LRO_METALINKURL.
     /// No URLs specified by LRO_URLS are included in this list.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.getMirrors()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.getMirrors()
     std::vector<std::string> get_mirrors() const;
 
     /// Sets substitutions. Substitutions are used to substitute variables in repository configuration.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.setSubstitutions(const std::map<std::string, std::string> & substitutions)
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.setSubstitutions(const std::map<std::string, std::string> & substitutions)
     void set_substitutions(const std::map<std::string, std::string> & substitutions);
 
     void add_libsolv_testcase(const std::string & path);
@@ -357,7 +357,7 @@ private:
 
     /// Downloads repository metadata from the origin or reads the local metadata cache if still valid.
     /// @return true if fresh metadata were downloaded, false otherwise.
-    /// @replaces libdnf:repo/Repo.hpp:method:Repo.load()
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.load()
     bool fetch_metadata();
 
     void make_solv_repo();

--- a/include/libdnf/repo/repo_query.hpp
+++ b/include/libdnf/repo/repo_query.hpp
@@ -86,9 +86,9 @@ public:
     /// @since 5.0
     void filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
-    /// Filter repos by their `name`.
+    /// Filter repositories by whether they are local
     ///
-    /// @param pattern  A string the filter is matched against.
+    /// @param local  `true` returns local repos, `false` remote repos.
     /// @since 5.0
     void filter_local(bool local);
 

--- a/include/libdnf/repo/repo_query.hpp
+++ b/include/libdnf/repo/repo_query.hpp
@@ -81,7 +81,7 @@ public:
 
     /// Filter repos by their `id`.
     ///
-    /// @param pattern  A vector of strings the filter is matched against.
+    /// @param patterns A vector of strings the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
     void filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
@@ -101,14 +101,14 @@ public:
 
     /// Filter repos by their `name`.
     ///
-    /// @param pattern  A vector of strings the filter is matched against.
+    /// @param patterns A vector of strings the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
     void filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
     /// Filter repos by their `type`.
     ///
-    /// @param pattern  A type the filter is matched against.
+    /// @param type     A type the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
     void filter_type(Repo::Type type, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);

--- a/include/libdnf/rpm/nevra.hpp
+++ b/include/libdnf/rpm/nevra.hpp
@@ -37,7 +37,7 @@ struct NevraIncorrectInputError : public Error {
 };
 
 
-/// @replaces hawkey:hawkey/__init__.py:class:Nevra
+// @replaces hawkey:hawkey/__init__.py:class:Nevra
 struct Nevra {
 public:
     enum class Form { NEVRA = 1, NEVR = 2, NEV = 3, NA = 4, NAME = 5 };
@@ -67,19 +67,19 @@ public:
 
     void clear() noexcept;
 
-    /// @replaces hawkey:hawkey/__init__.py:attribute:Nevra.name
+    // @replaces hawkey:hawkey/__init__.py:attribute:Nevra.name
     const std::string & get_name() const noexcept { return name; }
 
-    /// @replaces hawkey:hawkey/__init__.py:attribute:Nevra.epoch
+    // @replaces hawkey:hawkey/__init__.py:attribute:Nevra.epoch
     const std::string & get_epoch() const noexcept { return epoch; }
 
-    /// @replaces hawkey:hawkey/__init__.py:attribute:Nevra.version
+    // @replaces hawkey:hawkey/__init__.py:attribute:Nevra.version
     const std::string & get_version() const noexcept { return version; }
 
-    /// @replaces hawkey:hawkey/__init__.py:attribute:Nevra.release
+    // @replaces hawkey:hawkey/__init__.py:attribute:Nevra.release
     const std::string & get_release() const noexcept { return release; }
 
-    /// @replaces hawkey:hawkey/__init__.py:attribute:Nevra.arch
+    // @replaces hawkey:hawkey/__init__.py:attribute:Nevra.arch
     const std::string & get_arch() const noexcept { return arch; }
 
     void set_name(const std::string & value) { name = value; }
@@ -96,7 +96,7 @@ public:
 
     // TODO(jmracek) Add comperators ==
 
-    /// @replaces hawkey:hawkey/__init__.py:method:Nevra.has_just_name()
+    // @replaces hawkey:hawkey/__init__.py:method:Nevra.has_just_name()
     bool has_just_name() const;
 
 private:

--- a/include/libdnf/rpm/nevra.hpp
+++ b/include/libdnf/rpm/nevra.hpp
@@ -44,12 +44,19 @@ public:
 
     /// The default forms and their order determine pkg_spec matching
     static const std::vector<Form> & get_default_pkg_spec_forms();
+
     /// Parse string into Nevra struct
-    /// @param - string to parse
-    /// @return - Vector with parsed Nevra
-    /// @exception - IncorrectNevraString
+    /// @param nevra_str String to parse
+    /// @return Vector with parsed Nevra
+    /// @exception IncorrectNevraString
     /// @since - 1.0.0
     static std::vector<Nevra> parse(const std::string & nevra_str);
+
+    /// Parse string into Nevra struct using given forms
+    /// @param nevra_str String to parse
+    /// @param forms Allowed forms used for parsing
+    /// @return Vector with parsed Nevra
+    /// @exception IncorrectNevraString
     static std::vector<Nevra> parse(const std::string & nevra_str, const std::vector<Form> & forms);
 
     Nevra() = default;

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -75,7 +75,7 @@ public:
     /// Filter packages by their `name`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
@@ -87,7 +87,7 @@ public:
     /// Filter packages by their `name` based on names of the packages in the `package_set`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     void filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -95,7 +95,7 @@ public:
     /// Filter packages by their `epoch`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -107,7 +107,7 @@ public:
     /// Filter packages by their `epoch`.
     ///
     /// @param patterns         A vector of numbers the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     /// @since 5.0
     void filter_epoch(
@@ -116,7 +116,7 @@ public:
     /// Filter packages by their `version`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -128,7 +128,7 @@ public:
     /// Filter packages by their `release`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -140,7 +140,7 @@ public:
     /// Filter packages by their `arch`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     void filter_arch(
@@ -149,7 +149,7 @@ public:
     /// Filter packages by their `name` and `arch` based on names and arches of the packages in the `package_set`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     void filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -157,7 +157,7 @@ public:
     /// Filter packages by their `epoch:version-release`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `GT`, `LT`, `GTE`, `LTE`, `EQ`.
     /// @since 5.0
     //
@@ -169,7 +169,7 @@ public:
     /// Filter packages by their `name-[epoch:]version-release.arch`. The following matches are tolerant to omitted 0 epoch: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`, `IGLOB`, `NOT_IGLOB`, `IEXACT`, `NOT_IEXACT`.
     /// @since 5.0
     //
@@ -184,7 +184,7 @@ public:
     /// Only the attributes that are not blank are used in the filter.
     ///
     /// @param nevra            A Nevra object the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `IGLOB`, `NOT_IGLOB`.
     /// @since 5.0
     void filter_nevra(const libdnf::rpm::Nevra & nevra, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -207,7 +207,7 @@ public:
     /// Filter packages by their `sourcerpm`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SOURCERPM
@@ -218,7 +218,7 @@ public:
     /// Filter packages by their `url`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
@@ -230,7 +230,7 @@ public:
     /// Filter packages by their `summary`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
@@ -242,7 +242,7 @@ public:
     /// Filter packages by their `summary`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
@@ -254,7 +254,7 @@ public:
     /// Filter packages by their `provides`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -265,7 +265,7 @@ public:
     /// Filter packages by their `provides`.
     ///
     /// @param reldep           RelDep object the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     void filter_provides(const Reldep & reldep, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
@@ -273,7 +273,7 @@ public:
     /// Filter packages by their `provides`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -285,7 +285,7 @@ public:
     /// Filter packages by their `requires`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -296,7 +296,7 @@ public:
     /// Filter packages by their `requires`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -308,7 +308,7 @@ public:
     /// Filter packages by their `requires`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -318,7 +318,7 @@ public:
     /// Filter packages by their `conflicts`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -329,7 +329,7 @@ public:
     /// Filter packages by their `conflicts`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -341,7 +341,7 @@ public:
     /// Filter packages by their `conflicts`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -351,7 +351,7 @@ public:
     /// Filter packages by their `obsoletes`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -362,7 +362,7 @@ public:
     /// Filter packages by their `obsoletes`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -374,7 +374,7 @@ public:
     /// Filter packages by their `obsoletes`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -384,7 +384,7 @@ public:
     /// Filter packages by their `recommends`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -396,7 +396,7 @@ public:
     /// Filter packages by their `recommends`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -408,7 +408,7 @@ public:
     /// Filter packages by their `recommends`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -419,7 +419,7 @@ public:
     /// Filter packages by their `suggests`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -430,7 +430,7 @@ public:
     /// Filter packages by their `suggests`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -442,7 +442,7 @@ public:
     /// Filter packages by their `suggests`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -452,7 +452,7 @@ public:
     /// Filter packages by their `enhances`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -463,7 +463,7 @@ public:
     /// Filter packages by their `enhances`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -475,7 +475,7 @@ public:
     /// Filter packages by their `enhances`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -485,7 +485,7 @@ public:
     /// Filter packages by their `supplements`.
     ///
     /// @param reldep_list      ReldepList with RelDep objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -497,7 +497,7 @@ public:
     /// Filter packages by their `supplements`.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -509,7 +509,7 @@ public:
     /// Filter packages by their `supplements`.
     ///
     /// @param package_set      PackageSet with Package objects the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -520,7 +520,7 @@ public:
     /// Filter packages by `files` they contain.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
@@ -531,7 +531,7 @@ public:
 
     /// Filter packages by their `location`.
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
@@ -544,7 +544,7 @@ public:
     /// Filter packages by `id` of the Repo they belong to.
     ///
     /// @param patterns         A vector of strings the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
@@ -556,7 +556,7 @@ public:
     /// Filter packages by advisories they are included in.
     ///
     /// @param advisory_query   AdvisoryQuery with Advisories that contain package lists the filter is matched against.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     /// @since 5.0
     //
@@ -571,7 +571,7 @@ public:
     ///
     /// @param advisory_query   AdvisoryQuery with Advisories that contain package lists the filter is matched against.
     /// @param installed        PackageQuery with currently installed packages.
-    /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     /// @since 5.0
     void filter_latest_unresolved_advisories(

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -44,21 +44,21 @@ class SolvMap;
 
 namespace libdnf::rpm {
 
-/// @replaces libdnf:sack/packageset.hpp:struct:PackageSet
+// @replaces libdnf:sack/packageset.hpp:struct:PackageSet
 class PackageSet {
 public:
     using iterator = PackageSetIterator;
 
-    /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_new(DnfSack * sack)
+    // @replaces libdnf:hy-packageset.h:function:dnf_packageset_new(DnfSack * sack)
     explicit PackageSet(const libdnf::BaseWeakPtr & base);
     explicit PackageSet(libdnf::Base & base);
 
-    /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_clone(DnfPackageSet * pset)
+    // @replaces libdnf:hy-packageset.h:function:dnf_packageset_clone(DnfPackageSet * pset)
     PackageSet(const PackageSet & pset);
 
     PackageSet(PackageSet && pset) noexcept;
 
-    /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_free(DnfPackageSet * pset)
+    // @replaces libdnf:hy-packageset.h:function:dnf_packageset_free(DnfPackageSet * pset)
     ~PackageSet();
 
     PackageSet & operator=(const PackageSet & src);

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -51,9 +51,9 @@ public:
 
     /// @brief Creates a reldep from Char*. If parsing fails it raises std::runtime_error.
     ///
-    /// @param sack p_sack:...
-    /// @param dependency p_dependency:...
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(Sack * sack, const std::string & dependency)
+    /// @param base Instance of Base class
+    /// @param reldep_string String with the dependency
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(Sack * sack, const std::string & dependency)
     Reldep(const libdnf::BaseWeakPtr & base, const std::string & reldep_string);
     Reldep(libdnf::Base & base, const std::string & reldep_string);
 
@@ -108,9 +108,9 @@ private:
     /// @param base: The Base
     /// @param name p_name: Required
     /// @param version p_version: Can be also NULL
-    /// @param cmpType p_cmpType: ComparisonType, and their combinations
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:get_id()
-    /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_new(DnfSack *sack, const char *name, int cmp_type, const char *evr)
+    /// @param cmp_type p_cmpType: ComparisonType, and their combinations
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:get_id()
+    // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_new(DnfSack *sack, const char *name, int cmp_type, const char *evr)
     Reldep(const BaseWeakPtr & base, const char * name, const char * version, CmpType cmp_type);
 
     /// @brief Returns Id of parsed reldep
@@ -118,7 +118,7 @@ private:
     /// @param base: The Base
     /// @param name p_name: Required
     /// @param version p_version: Can be also NULL
-    /// @param cmpType p_cmpType: ComparisonType, and their combinations
+    /// @param cmp_type p_cmpType: ComparisonType, and their combinations
     /// @param create Whether a new Id should be created when name does not exist
     /// @return DependencyId
     // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char *name, const char *version, int cmpType)
@@ -128,7 +128,7 @@ private:
     /// @brief Returns Id of reldep or raises std::runtime_error if parsing fails
     ///
     /// @param base: The Base
-    /// @param reldepStr p_reldepStr: const Char* of reldep
+    /// @param reldep_str p_reldepStr: const Char* of reldep
     /// @return DependencyId
     /// @param create Whether a new Id should be created when name does not exist
     // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char * reldepStr)

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -113,12 +113,13 @@ private:
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_new(DnfSack *sack, const char *name, int cmp_type, const char *evr)
     Reldep(const BaseWeakPtr & base, const char * name, const char * version, CmpType cmp_type);
 
-    /// @brief Returns Id of reldep
+    /// @brief Returns Id of parsed reldep
     ///
     /// @param base: The Base
     /// @param name p_name: Required
     /// @param version p_version: Can be also NULL
     /// @param cmpType p_cmpType: ComparisonType, and their combinations
+    /// @param create Whether a new Id should be created when name does not exist
     /// @return DependencyId
     // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char *name, const char *version, int cmpType)
     static ReldepId get_reldep_id(
@@ -129,6 +130,7 @@ private:
     /// @param base: The Base
     /// @param reldepStr p_reldepStr: const Char* of reldep
     /// @return DependencyId
+    /// @param create Whether a new Id should be created when name does not exist
     // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char * reldepStr)
     static ReldepId get_reldep_id(const BaseWeakPtr & base, const std::string & reldep_str, int create = 1);
 

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -42,9 +42,9 @@ public:
 
 /// @brief Represent a relational dependency from libsolv
 ///
-/// @replaces libdnf/dnf-reldep.h:struct:DnfReldep
-/// @replaces libdnf/repo/solvable/Dependency.hpp:struct:Dependency
-/// @replaces hawkey:hawkey/__init__.py:class:Reldep
+// @replaces libdnf/dnf-reldep.h:struct:DnfReldep
+// @replaces libdnf/repo/solvable/Dependency.hpp:struct:Dependency
+// @replaces hawkey:hawkey/__init__.py:class:Reldep
 class Reldep {
 public:
     enum class CmpType { NONE = 0, GT = (1 << 0), EQ = (1 << 1), GTE = (GT | EQ), LT = (1 << 2), LTE = (LT | EQ) };
@@ -57,12 +57,12 @@ public:
     Reldep(const libdnf::BaseWeakPtr & base, const std::string & reldep_string);
     Reldep(libdnf::Base & base, const std::string & reldep_string);
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(const Dependency & dependency);
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(const Dependency & dependency);
     Reldep(const Reldep & reldep) = default;
     Reldep(Reldep && reldep);
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:~Dependency();
-    /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:~Dependency();
+    // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
     ~Reldep() = default;
 
     bool operator==(const Reldep & other) const noexcept;
@@ -70,21 +70,21 @@ public:
     Reldep & operator=(const Reldep & other) = default;
     Reldep & operator=(Reldep && other) = delete;
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getName()
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getName()
     const char * get_name() const;
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getRelation()
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getRelation()
     const char * get_relation() const;
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getVersion()
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getVersion()
     const char * get_version() const;
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:toString()
-    /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:toString()
+    // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
     std::string to_string() const;
 
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getId()
-    /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getId()
+    // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
     ReldepId get_id() const noexcept { return id; };
 
     /// Return weak pointer to base
@@ -96,7 +96,7 @@ public:
 
 protected:
     /// @brief Creates a reldep from Id
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(Sack * sack, Id id)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(Sack * sack, Id id)
     Reldep(const BaseWeakPtr & base, ReldepId dependency_id);
 
 private:
@@ -120,7 +120,7 @@ private:
     /// @param version p_version: Can be also NULL
     /// @param cmpType p_cmpType: ComparisonType, and their combinations
     /// @return DependencyId
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char *name, const char *version, int cmpType)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char *name, const char *version, int cmpType)
     static ReldepId get_reldep_id(
         const BaseWeakPtr & base, const char * name, const char * version, CmpType cmp_type, int create = 1);
 
@@ -129,7 +129,7 @@ private:
     /// @param base: The Base
     /// @param reldepStr p_reldepStr: const Char* of reldep
     /// @return DependencyId
-    /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char * reldepStr)
+    // @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char * reldepStr)
     static ReldepId get_reldep_id(const BaseWeakPtr & base, const std::string & reldep_str, int create = 1);
 
     BaseWeakPtr base;

--- a/include/libdnf/rpm/reldep_list.hpp
+++ b/include/libdnf/rpm/reldep_list.hpp
@@ -68,7 +68,7 @@ public:
     /// @brief Adds a reldep from Char*. Only globs in name are proccessed. The proccess is slow
     /// therefore if reldepStr is not a glob please use addReldep() instead.
     ///
-    /// @param reldepStr p_reldepStr: Char*
+    /// @param reldep_str p_reldepStr: Char*
     /// @return bool - false if parsing or reldep creation fails
     ///
     // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldepWithGlob(const char *reldepStr)
@@ -76,7 +76,7 @@ public:
 
     /// @brief Adds a reldep from Char*. It does not support globs.
     ///
-    /// @param reldepStr p_reldepStr: Char*
+    /// @param reldep_str p_reldepStr: Char*
     /// @return bool false if parsing or reldep creation fails
     ///
     // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldep(const char *reldepStr)

--- a/include/libdnf/rpm/reldep_list.hpp
+++ b/include/libdnf/rpm/reldep_list.hpp
@@ -31,22 +31,22 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm {
 
-/// @replaces libdnf/dnf-reldep-list.h:struct:DnfReldepList
-/// @replaces libdnf/repo/solvable/DependencyContainer.hpp:struct:DependencyContainer
+// @replaces libdnf/dnf-reldep-list.h:struct:DnfReldepList
+// @replaces libdnf/repo/solvable/DependencyContainer.hpp:struct:DependencyContainer
 class ReldepList {
 public:
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:DependencyContainer(const DependencyContainer &src)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:DependencyContainer(const DependencyContainer &src)
     ReldepList(const ReldepList & src);
 
     ReldepList(ReldepList && src) noexcept;
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_new(DnfSack *sack)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:DependencyContainer(DnfSack *sack)
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_new(DnfSack *sack)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:DependencyContainer(DnfSack *sack)
     explicit ReldepList(const libdnf::BaseWeakPtr & base);
     explicit ReldepList(libdnf::Base & base);
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_free(DnfReldepList *reldep_list)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:~DependencyContainer()
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_free(DnfReldepList *reldep_list)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:~DependencyContainer()
     ~ReldepList();
 
     using iterator = ReldepListIterator;
@@ -58,11 +58,11 @@ public:
     ReldepList & operator=(const ReldepList & src);
     ReldepList & operator=(ReldepList && src) noexcept;
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_add(DnfReldepList *reldep_list, DnfReldep *reldep)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:add(Dependency *dependency)
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_add(DnfReldepList *reldep_list, DnfReldep *reldep)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:add(Dependency *dependency)
     void add(const Reldep & reldep);
 
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:add(Id id))
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:add(Id id))
     void add(ReldepId id);
 
     /// @brief Adds a reldep from Char*. Only globs in name are proccessed. The proccess is slow
@@ -71,7 +71,7 @@ public:
     /// @param reldepStr p_reldepStr: Char*
     /// @return bool - false if parsing or reldep creation fails
     ///
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldepWithGlob(const char *reldepStr)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldepWithGlob(const char *reldepStr)
     bool add_reldep_with_glob(const std::string & reldep_str);
 
     /// @brief Adds a reldep from Char*. It does not support globs.
@@ -79,23 +79,23 @@ public:
     /// @param reldepStr p_reldepStr: Char*
     /// @return bool false if parsing or reldep creation fails
     ///
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldep(const char *reldepStr)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldep(const char *reldepStr)
     bool add_reldep(const std::string & reldep_str);
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_extend(DnfReldepList *rl1, DnfReldepList *rl2)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:extend(DependencyContainer *container)
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_extend(DnfReldepList *rl1, DnfReldepList *rl2)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:extend(DependencyContainer *container)
     void append(ReldepList & source);
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_index(DnfReldepList *reldep_list, gint index)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:get(int index)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:getPtr(int index)
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_index(DnfReldepList *reldep_list, gint index)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:get(int index)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:getPtr(int index)
     Reldep get(int index) const noexcept;
 
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:getId(int index)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:getId(int index)
     ReldepId get_id(int index) const noexcept;
 
-    /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_count(DnfReldepList *reldep_list)
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:count()
+    // @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_count(DnfReldepList *reldep_list)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:count()
     int size() const noexcept;
 
     /// Return true if container is empty
@@ -118,7 +118,7 @@ private:
     /// @param create p_create: int 0 or 1 allowed. When 0 it will not create reldep for unknown name
     /// @return bool false if parsing or reldep creation fails
     ///
-    /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldep(const char *reldepStr)
+    // @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:addReldep(const char *reldepStr)
     bool add_reldep(const std::string & reldep_str, int create);
 
     class Impl;

--- a/include/libdnf/transaction/comps_environment.hpp
+++ b/include/libdnf/transaction/comps_environment.hpp
@@ -48,42 +48,42 @@ private:
 
     explicit CompsEnvironment(const Transaction & trans);
 
-    /// Get text id of the environment (xml element: <comps><environment><id>VALUE</id>...)
+    /// Get text id of the environment (xml element: `<comps><environment><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getEnvironmentId()
     const std::string & get_environment_id() const noexcept { return environment_id; }
 
-    /// Set text id of the environment (xml element: <comps><environment><id>VALUE</id>...)
+    /// Set text id of the environment (xml element: `<comps><environment><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setEnvironmentId(const std::string & value)
     void set_environment_id(const std::string & value) { environment_id = value; }
 
-    /// Get name of the environment (xml element: <comps><environment><name>VALUE</name>...)
+    /// Get name of the environment (xml element: `<comps><environment><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getName()
     const std::string & get_name() const noexcept { return name; }
 
-    /// Set name of the environment (xml element: <comps><environment><name>VALUE</name>...)
+    /// Set name of the environment (xml element: `<comps><environment><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
-    /// Get translated name of the environment in the current locale (xml element: <comps><environment><name xml:lang="...">VALUE</name>...)
+    /// Get translated name of the environment in the current locale (xml element: `<comps><environment><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getTranslatedName()
     const std::string & get_translated_name() const noexcept { return translated_name; }
 
-    /// Set translated name of the environment in the current locale (xml element: <comps><environment><name xml:lang="...">VALUE</name>...)
+    /// Set translated name of the environment in the current locale (xml element: `<comps><environment><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setTranslatedName(const std::string & value)
     void set_translated_name(const std::string & value) { translated_name = value; }
 
-    /// Get types of the packages to be installed with the environment (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Get types of the packages to be installed with the environment (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getPackageTypes()
     libdnf::comps::PackageType get_package_types() const noexcept { return package_types; }
 
-    /// Set types of the packages to be installed with the environment (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Set types of the packages to be installed with the environment (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setPackageTypes(libdnf::CompsPackageType value)
     void set_package_types(libdnf::comps::PackageType value) { package_types = value; }
@@ -131,12 +131,12 @@ private:
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setId(int64_t value)
     void set_id(int64_t value) { id = value; }
 
-    /// Get groupid of a group associated with a comps environment (xml element: <comps><environment><grouplist><groupid>VALUE</groupid>)
+    /// Get groupid of a group associated with a comps environment (xml element: `<comps><environment><grouplist><groupid>VALUE</groupid>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupId()
     const std::string & get_group_id() const noexcept { return group_id; }
 
-    /// Set groupid of a group associated with a comps environment (xml element: <comps><environment><grouplist><groupid>VALUE</groupid>)
+    /// Set groupid of a group associated with a comps environment (xml element: `<comps><environment><grouplist><groupid>VALUE</groupid>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupId(const std::string & value)
     void set_group_id(const std::string & value) { group_id = value; }

--- a/include/libdnf/transaction/comps_environment.hpp
+++ b/include/libdnf/transaction/comps_environment.hpp
@@ -39,7 +39,7 @@ class CompsEnvironmentGroupDbUtils;
 /// CompsEnvironment contains a copy of important data from comps::CompsEnvironment that is used
 /// to perform comps transaction and then stored in the transaction (history) database.
 ///
-/// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentItem
+// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentItem
 class CompsEnvironment : public TransactionItem {
 private:
     friend Transaction;
@@ -50,42 +50,42 @@ private:
 
     /// Get text id of the environment (xml element: <comps><environment><id>VALUE</id>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getEnvironmentId()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getEnvironmentId()
     const std::string & get_environment_id() const noexcept { return environment_id; }
 
     /// Set text id of the environment (xml element: <comps><environment><id>VALUE</id>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setEnvironmentId(const std::string & value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setEnvironmentId(const std::string & value)
     void set_environment_id(const std::string & value) { environment_id = value; }
 
     /// Get name of the environment (xml element: <comps><environment><name>VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getName()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getName()
     const std::string & get_name() const noexcept { return name; }
 
     /// Set name of the environment (xml element: <comps><environment><name>VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setName(const std::string & value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
     /// Get translated name of the environment in the current locale (xml element: <comps><environment><name xml:lang="...">VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getTranslatedName()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getTranslatedName()
     const std::string & get_translated_name() const noexcept { return translated_name; }
 
     /// Set translated name of the environment in the current locale (xml element: <comps><environment><name xml:lang="...">VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setTranslatedName(const std::string & value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setTranslatedName(const std::string & value)
     void set_translated_name(const std::string & value) { translated_name = value; }
 
     /// Get types of the packages to be installed with the environment (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getPackageTypes()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getPackageTypes()
     libdnf::comps::PackageType get_package_types() const noexcept { return package_types; }
 
     /// Set types of the packages to be installed with the environment (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setPackageTypes(libdnf::CompsPackageType value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setPackageTypes(libdnf::CompsPackageType value)
     void set_package_types(libdnf::comps::PackageType value) { package_types = value; }
 
     /// Create a new CompsEnvironmentGroup object and return a reference to it.
@@ -94,7 +94,7 @@ private:
 
     /// Get list of groups associated with the environment.
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getGroups()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getGroups()
     std::vector<CompsEnvironmentGroup> & get_groups() { return groups; }
 
     // TODO(dmach): rewrite into TransactionSack.list_installed_environments(); how to deal with references to different transactions? We don't want all of them loaded into memory.
@@ -105,7 +105,7 @@ private:
 
     /// Get string representation of the object, which equals to environment_id
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.toStr()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.toStr()
     std::string to_string() const { return get_environment_id(); }
 
     std::string environment_id;
@@ -116,49 +116,49 @@ private:
 };
 
 
-/// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentGroup
+// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentGroup
 class CompsEnvironmentGroup {
 private:
     friend CompsEnvironmentGroupDbUtils;
 
     /// Get database id (primary key)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getId()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getId()
     int64_t get_id() const noexcept { return id; }
 
     /// Set database id (primary key)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setId(int64_t value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setId(int64_t value)
     void set_id(int64_t value) { id = value; }
 
     /// Get groupid of a group associated with a comps environment (xml element: <comps><environment><grouplist><groupid>VALUE</groupid>)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupId()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupId()
     const std::string & get_group_id() const noexcept { return group_id; }
 
     /// Set groupid of a group associated with a comps environment (xml element: <comps><environment><grouplist><groupid>VALUE</groupid>)
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupId(const std::string & value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupId(const std::string & value)
     void set_group_id(const std::string & value) { group_id = value; }
 
     /// Get a flag that determines if the group was present after the transaction it's associated with has finished.
     /// If the group was installed before running the transaction, it's still counted as installed.
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getInstalled()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getInstalled()
     bool get_installed() const noexcept { return installed; }
 
     /// Set a flag that determines if the group was present after the transaction it's associated with has finished.
     /// If the group was installed before running the transaction, it's still counted as installed.
     ///
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setInstalled(bool value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setInstalled(bool value)
     void set_installed(bool value) { installed = value; }
 
     // TODO(dmach): this is not entirely clear; investigate and document
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupType()
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupType()
     libdnf::comps::PackageType get_group_type() const noexcept { return group_type; }
 
     // TODO(dmach): this is not entirely clear; investigate and document
-    /// @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupType(libdnf::CompsPackageType value)
+    // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupType(libdnf::CompsPackageType value)
     void set_group_type(libdnf::comps::PackageType value) { group_type = value; }
 
     int64_t id = 0;

--- a/include/libdnf/transaction/comps_group.hpp
+++ b/include/libdnf/transaction/comps_group.hpp
@@ -39,7 +39,7 @@ class CompsGroupPackageDbUtils;
 /// CompsGroup contains a copy of important data from comps::CompsGroup that is used
 /// to perform comps transaction and then stored in the transaction (history) database.
 ///
-/// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupItem
+// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupItem
 class CompsGroup : public TransactionItem {
 private:
     friend Transaction;
@@ -51,42 +51,42 @@ private:
 
     /// Get text id of the group (xml element: <comps><group><id>VALUE</id>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getGroupId()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getGroupId()
     const std::string & get_group_id() const noexcept { return group_id; }
 
     /// Get text id of the group (xml element: <comps><group><id>VALUE</id>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setGroupId(const std::string & value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setGroupId(const std::string & value)
     void set_group_id(const std::string & value) { group_id = value; }
 
     /// Get name of the group (xml element: <comps><group><name>VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getName()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getName()
     const std::string & get_name() const noexcept { return name; }
 
     /// Set name of the group (xml element: <comps><group><name>VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setName(const std::string & value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
     /// Get translated name of the group in the current locale (xml element: <comps><group><name xml:lang="...">VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getTranslatedName()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getTranslatedName()
     const std::string & get_translated_name() const noexcept { return translated_name; }
 
     /// Set translated name of the group in the current locale (xml element: <comps><group><name xml:lang="...">VALUE</name>...)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setTranslatedName(const std::string & value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setTranslatedName(const std::string & value)
     void set_translated_name(const std::string & value) { translated_name = value; }
 
     /// Get types of the packages to be installed with the group (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackageTypes()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackageTypes()
     libdnf::comps::PackageType get_package_types() const noexcept { return package_types; }
 
     /// Set types of the packages to be installed with the group (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setPackageTypes(libdnf::CompsPackageType value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setPackageTypes(libdnf::CompsPackageType value)
     void set_package_types(libdnf::comps::PackageType value) { package_types = value; }
 
     /// Create a new CompsGroupPackage object and return a reference to it.
@@ -95,7 +95,7 @@ private:
 
     /// Get list of packages associated with the group.
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackages()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackages()
     std::vector<CompsGroupPackage> & get_packages() { return packages; }
 
     // TODO(dmach): rewrite into TransactionSack.list_installed_groups(); how to deal with references to different transactions? We don't want all of them loaded into memory.
@@ -105,7 +105,7 @@ private:
 
     /// Get string representation of the object, which equals to group_id
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.toStr()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.toStr()
     std::string to_string() const { return get_group_id(); }
 
     std::string group_id;
@@ -118,7 +118,7 @@ private:
 
 /// CompsGroupPackage represents a package associated with a comps group
 ///
-/// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupPackage
+// @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupPackage
 class CompsGroupPackage {
 private:
     friend Transaction;
@@ -126,46 +126,46 @@ private:
 
     /// Get database id (primary key)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getId()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getId()
     int64_t get_id() const noexcept { return id; }
 
     /// Set database id (primary key)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setId(int64_t value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setId(int64_t value)
     void set_id(int64_t value) { id = value; }
 
     /// Get name of a package associated with a comps group (xml element: <comps><group><packagelist><packagereq>VALUE</packagereq>)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getName()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getName()
     const std::string & get_name() const noexcept { return name; }
 
     /// Set name of a package associated with a comps group (xml element: <comps><group><packagelist><packagereq>VALUE</packagereq>)
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setName(const std::string & value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
     /// Get a flag that determines if the package was present after the transaction it's associated with has finished.
     /// If the package was installed before running the transaction, it's still counted as installed.
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getInstalled()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getInstalled()
     bool get_installed() const noexcept { return installed; }
 
     /// Set a flag that determines if the package was present after the transaction it's associated with has finished.
     /// If the package was installed before running the transaction, it's still counted as installed.
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setInstalled(bool value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setInstalled(bool value)
     void set_installed(bool value) { installed = value; }
 
     /// Get type of package associated with a comps group (xml element: <comps><group><packagelist><packagereq type="VALUE" ...>)
     /// See `enum class comps::PackageType` documentation for more details.
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getPackageType()
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getPackageType()
     libdnf::comps::PackageType get_package_type() const noexcept { return package_type; }
 
     /// Set type of package associated with a comps group (xml element: <comps><group><packagelist><packagereq type="VALUE" ...>)
     /// See `enum class libdnf::comps::PackageType` documentation for more details.
     ///
-    /// @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setPackageType(libdnf::PackageType value)
+    // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setPackageType(libdnf::PackageType value)
     void set_package_type(libdnf::comps::PackageType value) { package_type = value; }
 
     int64_t id = 0;

--- a/include/libdnf/transaction/comps_group.hpp
+++ b/include/libdnf/transaction/comps_group.hpp
@@ -49,42 +49,42 @@ private:
 
     explicit CompsGroup(const Transaction & trans);
 
-    /// Get text id of the group (xml element: <comps><group><id>VALUE</id>...)
+    /// Get text id of the group (xml element: `<comps><group><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getGroupId()
     const std::string & get_group_id() const noexcept { return group_id; }
 
-    /// Get text id of the group (xml element: <comps><group><id>VALUE</id>...)
+    /// Get text id of the group (xml element: `<comps><group><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setGroupId(const std::string & value)
     void set_group_id(const std::string & value) { group_id = value; }
 
-    /// Get name of the group (xml element: <comps><group><name>VALUE</name>...)
+    /// Get name of the group (xml element: `<comps><group><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getName()
     const std::string & get_name() const noexcept { return name; }
 
-    /// Set name of the group (xml element: <comps><group><name>VALUE</name>...)
+    /// Set name of the group (xml element: `<comps><group><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
-    /// Get translated name of the group in the current locale (xml element: <comps><group><name xml:lang="...">VALUE</name>...)
+    /// Get translated name of the group in the current locale (xml element: `<comps><group><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getTranslatedName()
     const std::string & get_translated_name() const noexcept { return translated_name; }
 
-    /// Set translated name of the group in the current locale (xml element: <comps><group><name xml:lang="...">VALUE</name>...)
+    /// Set translated name of the group in the current locale (xml element: `<comps><group><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setTranslatedName(const std::string & value)
     void set_translated_name(const std::string & value) { translated_name = value; }
 
-    /// Get types of the packages to be installed with the group (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Get types of the packages to be installed with the group (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackageTypes()
     libdnf::comps::PackageType get_package_types() const noexcept { return package_types; }
 
-    /// Set types of the packages to be installed with the group (related xml elements: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Set types of the packages to be installed with the group (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setPackageTypes(libdnf::CompsPackageType value)
     void set_package_types(libdnf::comps::PackageType value) { package_types = value; }
@@ -134,12 +134,12 @@ private:
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setId(int64_t value)
     void set_id(int64_t value) { id = value; }
 
-    /// Get name of a package associated with a comps group (xml element: <comps><group><packagelist><packagereq>VALUE</packagereq>)
+    /// Get name of a package associated with a comps group (xml element: `<comps><group><packagelist><packagereq>VALUE</packagereq>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getName()
     const std::string & get_name() const noexcept { return name; }
 
-    /// Set name of a package associated with a comps group (xml element: <comps><group><packagelist><packagereq>VALUE</packagereq>)
+    /// Set name of a package associated with a comps group (xml element: `<comps><group><packagelist><packagereq>VALUE</packagereq>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
@@ -156,13 +156,13 @@ private:
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setInstalled(bool value)
     void set_installed(bool value) { installed = value; }
 
-    /// Get type of package associated with a comps group (xml element: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Get type of package associated with a comps group (xml element: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     /// See `enum class comps::PackageType` documentation for more details.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getPackageType()
     libdnf::comps::PackageType get_package_type() const noexcept { return package_type; }
 
-    /// Set type of package associated with a comps group (xml element: <comps><group><packagelist><packagereq type="VALUE" ...>)
+    /// Set type of package associated with a comps group (xml element: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     /// See `enum class libdnf::comps::PackageType` documentation for more details.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setPackageType(libdnf::PackageType value)

--- a/include/libdnf/transaction/rpm_package.hpp
+++ b/include/libdnf/transaction/rpm_package.hpp
@@ -36,37 +36,37 @@ class RpmDbUtils;
 /// Package contains a copy of important data from rpm::Package that is used
 /// to perform rpm transaction and then stored in the transaction (history) database.
 ///
-/// @replaces libdnf:transaction/RPMItem.hpp:class:RPMItem
+// @replaces libdnf:transaction/RPMItem.hpp:class:RPMItem
 class Package : public TransactionItem {
 public:
     /// Get package name
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getName()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getName()
     const std::string & get_name() const noexcept { return name; }
 
     /// Get package epoch
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getEpoch()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getEpoch()
     const std::string & get_epoch() const noexcept { return epoch; }
 
     /// Get package release
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getRelease()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getRelease()
     const std::string & get_release() const noexcept { return release; }
 
     /// Get package arch
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getArch()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getArch()
     const std::string & get_arch() const noexcept { return arch; }
 
     /// Get package version
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getVersion()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getVersion()
     const std::string & get_version() const noexcept { return version; }
 
     /// Get string representation of the object, which equals to package NEVRA
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.toStr()
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.toStr()
     std::string to_string() const;
 
 private:
@@ -77,7 +77,7 @@ private:
 
     /// Set package name
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setName(const std::string & value)
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setName(const std::string & value)
     void set_name(const std::string & value) { name = value; }
 
     /// Get package epoch as an integer
@@ -85,22 +85,22 @@ private:
 
     /// Set package epoch
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setEpoch(int32_t value)
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setEpoch(int32_t value)
     void set_epoch(const std::string & value) { epoch = value; }
 
     /// Set package version
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setVersion(const std::string & value)
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setVersion(const std::string & value)
     void set_version(const std::string & value) { version = value; }
 
     /// Set package release
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setRelease(const std::string & value)
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setRelease(const std::string & value)
     void set_release(const std::string & value) { release = value; }
 
     /// Set package arch
     ///
-    /// @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setArch(const std::string & value)
+    // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setArch(const std::string & value)
     void set_arch(const std::string & value) { arch = value; }
 
     /*

--- a/include/libdnf/transaction/transaction.hpp
+++ b/include/libdnf/transaction/transaction.hpp
@@ -101,13 +101,13 @@ public:
     int64_t get_dt_end() const noexcept { return dt_end; }
 
     /// Get RPM database version before the transaction
-    /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
+    /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_begin()
     const std::string & get_rpmdb_version_begin() const noexcept { return rpmdb_version_begin; }
 
     /// Get RPM database version after the transaction
-    /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
+    /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_end()
     const std::string & get_rpmdb_version_end() const noexcept { return rpmdb_version_end; }
@@ -206,13 +206,13 @@ private:
     void set_releasever(const std::string & value) { releasever = value; }
 
     /// Set RPM database version after the transaction
-    /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
+    /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionEnd(const std::string & value)
     void set_rpmdb_version_end(const std::string & value) { rpmdb_version_end = value; }
 
     /// Set RPM database version before the transaction
-    /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
+    /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionBegin(const std::string & value)
     void set_rpmdb_version_begin(const std::string & value) { rpmdb_version_begin = value; }

--- a/include/libdnf/transaction/transaction.hpp
+++ b/include/libdnf/transaction/transaction.hpp
@@ -52,7 +52,7 @@ class Transformer;
 class TransactionHistory;
 
 
-/// @replaces libdnf:transaction/Types.hpp:enum:TransactionState
+// @replaces libdnf:transaction/Types.hpp:enum:TransactionState
 enum class TransactionState : int { STARTED = 1, OK = 2, ERROR = 3 };
 
 std::string transaction_state_to_string(TransactionState state);
@@ -73,7 +73,7 @@ public:
 /// from the transaction history database as well as for performing a transaction
 /// to change packages on disk.
 ///
-/// @replaces libdnf:transaction/Transaction.hpp:class:Transaction
+// @replaces libdnf:transaction/Transaction.hpp:class:Transaction
 class Transaction {
 public:
     using State = TransactionState;
@@ -87,44 +87,44 @@ public:
     /// Get Transaction database id (primary key)
     /// Return 0 if the id wasn't set yet
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getId()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getId()
     int64_t get_id() const noexcept { return id; }
 
     /// Get date and time of the transaction start
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
     int64_t get_dt_start() const noexcept { return dt_begin; }
 
     /// Get date and time of the transaction end
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
     int64_t get_dt_end() const noexcept { return dt_end; }
 
     /// Get RPM database version before the transaction
     /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_begin()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_begin()
     const std::string & get_rpmdb_version_begin() const noexcept { return rpmdb_version_begin; }
 
     /// Get RPM database version after the transaction
     /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_end()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_end()
     const std::string & get_rpmdb_version_end() const noexcept { return rpmdb_version_end; }
 
     /// Get $releasever variable value that was used during the transaction
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_releasever()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_releasever()
     const std::string & get_releasever() const noexcept { return releasever; }
 
     /// Get UID of a user that started the transaction
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_user_id()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_user_id()
     uint32_t get_user_id() const noexcept { return user_id; }
 
     /// Get the description of the transaction (e.g. the CLI command that was executed)
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_cmdline()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_cmdline()
     const std::string & get_description() const noexcept { return description; }
 
     /// Get a user-specified comment describing the transaction
@@ -132,22 +132,22 @@ public:
 
     /// Get transaction state
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getState()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getState()
     State get_state() const noexcept { return state; }
 
     /// Return all comps environments associated with the transaction
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
     std::vector<CompsEnvironment> & get_comps_environments();
 
     /// Return all comps groups associated with the transaction
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
     std::vector<CompsGroup> & get_comps_groups();
 
     /// Return all rpm packages associated with the transaction
     ///
-    /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
+    // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getItems()
     std::vector<Package> & get_packages();
 
 private:
@@ -174,7 +174,7 @@ private:
 
     /// Set Transaction database id (primary key)
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setId(int64_t value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setId(int64_t value)
     void set_id(int64_t value) { id = value; }
 
     /// Set a user-specified comment describing the transaction
@@ -182,50 +182,50 @@ private:
 
     /// Set date and time of the transaction start
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtBegin(int64_t value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtBegin(int64_t value)
     void set_dt_start(int64_t value) { dt_begin = value; }
 
     /// Set date and time of the transaction end
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtEnd(int64_t value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtEnd(int64_t value)
     void set_dt_end(int64_t value) { dt_end = value; }
 
     /// Set the description of the transaction (e.g. the CLI command that was executed)
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setCmdline(const std::string & value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setCmdline(const std::string & value)
     void set_description(const std::string & value) { description = value; }
 
     /// Set UID of a user that started the transaction
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setUserId(uint32_t value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setUserId(uint32_t value)
     void set_user_id(uint32_t value) { user_id = value; }
 
     /// Set $releasever variable value that was used during the transaction
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setReleasever(const std::string & value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setReleasever(const std::string & value)
     void set_releasever(const std::string & value) { releasever = value; }
 
     /// Set RPM database version after the transaction
     /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionEnd(const std::string & value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionEnd(const std::string & value)
     void set_rpmdb_version_end(const std::string & value) { rpmdb_version_end = value; }
 
     /// Set RPM database version before the transaction
     /// Format: <rpm_count>:<sha1 of sorted SHA1HEADER fields of installed RPMs>
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionBegin(const std::string & value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionBegin(const std::string & value)
     void set_rpmdb_version_begin(const std::string & value) { rpmdb_version_begin = value; }
 
     /// Set transaction state
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setState(libdnf::TransactionState value)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setState(libdnf::TransactionState value)
     void set_state(State value) { state = value; }
 
     /// Create a new rpm package in the transaction and return a reference to it.
     /// The package is owned by the transaction.
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
     Package & new_package();
 
     /// Fill the transaction packages.
@@ -239,23 +239,23 @@ private:
     /// Create a new comps group in the transaction and return a reference to it.
     /// The group is owned by the transaction.
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
     CompsGroup & new_comps_group();
 
     /// Create a new comps environment in the transaction and return a reference to it.
     /// The environment is owned by the transaction.
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.addItem(std::shared_ptr<Item> item, const std::string & repoid, libdnf::TransactionItemAction action, libdnf::TransactionItemReason reason)
     CompsEnvironment & new_comps_environment();
 
     /// Start the transaction by inserting it into the database
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.begin()
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.begin()
     void start();
 
     /// Finish the transaction by updating it's state in the database
     ///
-    /// @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.finish(libdnf::TransactionState state)
+    // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.finish(libdnf::TransactionState state)
     void finish(TransactionState state);
 
     int64_t id{0};

--- a/include/libdnf/transaction/transaction_item.hpp
+++ b/include/libdnf/transaction/transaction_item.hpp
@@ -49,22 +49,22 @@ public:
 
     /// Get action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
     Action get_action() const noexcept { return action; }
 
     /// Get reason of the action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
     Reason get_reason() const noexcept { return reason; }
 
     /// Get transaction item repoid (text identifier of a repository)
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getRepoid()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getRepoid()
     const std::string & get_repoid() const noexcept { return repoid; }
 
     /// Get transaction item state
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
     State get_state() const noexcept { return state; }
 
 private:
@@ -89,42 +89,42 @@ private:
 
     /// Set action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setAction(libdnf::TransactionItemAction value)
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setAction(libdnf::TransactionItemAction value)
     void set_action(Action value) { action = value; }
 
     /// Get name of the action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getActionName()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getActionName()
     std::string get_action_name();
 
     /// Get abbreviated name of the action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getActionShort()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getActionShort()
     std::string get_action_short();
 
     /// Set reason of the action associated with the transaction item in the transaction
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setReason(libdnf::TransactionItemReason value)
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setReason(libdnf::TransactionItemReason value)
     void set_reason(Reason value) { reason = value; }
 
     /// Set transaction item state
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setState(libdnf::TransactionItemState value)
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setState(libdnf::TransactionItemState value)
     void set_state(State value) { state = value; }
 
     /// Get transaction item repoid (text identifier of a repository)
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setRepoid(const std::string & value)
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setRepoid(const std::string & value)
     void set_repoid(const std::string & value) { repoid = value; }
 
     /// Has the item appeared on the system during the transaction?
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.isForwardAction()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.isForwardAction()
     bool is_inbound_action() const;
 
     /// Has the item got removed from the system during the transaction?
     ///
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.isBackwardAction()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.isBackwardAction()
     bool is_outbound_action() const;
 
     // TODO(dmach): Reimplement in Package class; it's most likely not needed in Comps{Group,Environment}
@@ -140,7 +140,7 @@ private:
     //void saveState();
 
     // TODO(dmach): move to sack, resolve for all packages; return the user who initially installed the package
-    /// @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItem.getInstalledBy()
+    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItem.getInstalledBy()
     uint32_t getInstalledBy() const;
 
     /// Get database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)


### PR DESCRIPTION
Mostly escaping special characters, fixing parameter names to match function declarations, adding missing parameters.

There is still a lot of warning on undocumented classes and methods, but this is out of scope of the PR.