### PR TITLE
Make private one method and remove unused one

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -111,9 +111,6 @@ public:
     /// Gets base variables. They can be used in configuration files. Syntax in the config - ${var_name} or $var_name.
     VarsWeakPtr get_vars() { return VarsWeakPtr(&vars, &vars_gurad); }
 
-    void add_plugin(plugin::IPlugin & iplugin_instance);
-    void load_plugins();
-
     libdnf::BaseWeakPtr get_weak_ptr() { return BaseWeakPtr(this, &base_guard); }
 
     class Impl;
@@ -145,6 +142,10 @@ private:
     /// Loads main configuration from files with ".conf" extension from directory defined by the current configuration.
     /// The files in the directory are read in alphabetical order.
     void load_config_from_dir();
+
+    /// Load plugins according to configuration
+    void load_plugins();
+
 
     WeakPtrGuard<Base, false> base_guard;
     // Impl has to be the second data member (right after base_guard which is needed for its construction) because it

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -144,10 +144,6 @@ void Base::load_config_from_dir() {
     load_config_from_dir(conf_dir);
 }
 
-void Base::add_plugin(plugin::IPlugin & iplugin_instance) {
-    p_impl->plugins.register_plugin(std::make_unique<plugin::Plugin>(iplugin_instance));
-}
-
 void Base::load_plugins() {
     const char * plugins_config_dir = std::getenv("LIBDNF_PLUGINS_CONFIG_DIR");
     if (plugins_config_dir && config.get_pluginconfpath_option().get_priority() < Option::Priority::COMMANDLINE) {


### PR DESCRIPTION
Plugin loading is handled by Base::setup() therefore it is not required to have the method on API.