### PR TITLE
Make strict behavior for several command

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -81,6 +81,16 @@ Autoremove command
  * Dropped `<spec>` positional argument since the usecase is sufficiently covered by the `remove` command.
  * Specific `autoremove-n`, `autoremove-na`, and `autoremove-nevra` variants of the command are not supported.
 
+Distro-sync command
+-------------------
+ * When any argument does not match any package or it is not installed, DNF5 fail. The behavior can be modified by
+   the `--skip-unavailable` option.
+
+Downgrade command
+-----------------
+ * When any argument does not match any package or it is not installed, DNF5 fail. The behavior can be modified by
+   the `--skip-unavailable` option.
+
 Group command
 -------------
  * Dropped `group mark install` and `group mark remove` subcommands in favour of the
@@ -111,3 +121,5 @@ Upgrade command
 ---------------
  * New dnf5 option `--minimal` (`upgrade-minimal` command still exists as a compatibility alias for
    `upgrade --minimal`).
+ * When any argument does not match any package or it is not installed, DNF5 fail. The behavior can be modified by
+   the `--skip-unavailable` option.

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -347,7 +347,8 @@ void BaseGoalTest::test_upgrade_not_available() {
     CPPUNIT_ASSERT_EQUAL(
         libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_clean_requirements_on_remove());
     CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::USED_TRUE, first_event.get_job_settings()->get_used_best());
-    CPPUNIT_ASSERT_EQUAL(libdnf::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_skip_unavailable());
+    CPPUNIT_ASSERT_EQUAL(
+        libdnf::GoalUsedSetting::USED_FALSE, first_event.get_job_settings()->get_used_skip_unavailable());
 }
 
 void BaseGoalTest::test_upgrade_all() {


### PR DESCRIPTION
After the change, upgrade, downgrade, distrosync will not ignore broken argument.