### PR TITLE
group info/list: add `--contains-pkgs` option

### DIFF
--- a/dnf5/commands/group/arguments.hpp
+++ b/dnf5/commands/group/arguments.hpp
@@ -50,6 +50,18 @@ public:
 };
 
 
+class GroupContainsPkgsOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit GroupContainsPkgsOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "contains-pkgs",
+              '\0',
+              _("Show only groups containing packages with specified names. List option, supports globs."),
+              "PACKAGE_NAME,...") {}
+};
+
+
 class GroupSpecArguments : public libdnf::cli::session::StringArgumentList {
 public:
     GroupSpecArguments(libdnf::cli::session::Command & command, int nargs)

--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -38,6 +38,7 @@ void GroupInfoCommand::set_argument_parser() {
     // TODO(dmach): set_conflicting_args({available, installed});
     hidden = std::make_unique<GroupHiddenOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this);
+    group_pkg_contains = std::make_unique<GroupContainsPkgsOption>(*this);
 }
 
 void GroupInfoCommand::configure() {
@@ -68,6 +69,9 @@ void GroupInfoCommand::run() {
     }
     if (available->get_value()) {
         query.filter_installed(false);
+    }
+    if (!group_pkg_contains->get_value().empty()) {
+        query.filter_package_name(group_pkg_contains->get_value(), libdnf::sack::QueryCmp::IGLOB);
     }
 
     for (auto group : query.list()) {

--- a/dnf5/commands/group/group_info.hpp
+++ b/dnf5/commands/group/group_info.hpp
@@ -42,6 +42,7 @@ public:
     std::unique_ptr<GroupInstalledOption> installed{nullptr};
     std::unique_ptr<GroupHiddenOption> hidden{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
+    std::unique_ptr<GroupContainsPkgsOption> group_pkg_contains{nullptr};
 };
 
 

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -38,6 +38,7 @@ void GroupListCommand::set_argument_parser() {
     // TODO(dmach): set_conflicting_args({available, installed});
     hidden = std::make_unique<GroupHiddenOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this);
+    group_pkg_contains = std::make_unique<GroupContainsPkgsOption>(*this);
 }
 
 void GroupListCommand::configure() {
@@ -68,6 +69,9 @@ void GroupListCommand::run() {
     }
     if (available->get_value()) {
         query.filter_installed(false);
+    }
+    if (!group_pkg_contains->get_value().empty()) {
+        query.filter_package_name(group_pkg_contains->get_value(), libdnf::sack::QueryCmp::IGLOB);
     }
 
     libdnf::cli::output::print_grouplist_table(query.list());

--- a/dnf5/commands/group/group_list.hpp
+++ b/dnf5/commands/group/group_list.hpp
@@ -44,6 +44,7 @@ public:
     std::unique_ptr<GroupInstalledOption> installed{nullptr};
     std::unique_ptr<GroupHiddenOption> hidden{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
+    std::unique_ptr<GroupContainsPkgsOption> group_pkg_contains{nullptr};
 };
 
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -105,6 +105,7 @@ Repoquery command
  * Dropped: `-a/--all`, `--alldeps`, `--nevra` options, their behavior is and has been the default for both dnf4 and
    dnf5. The options are no longer needed.
  * Dopped: `--nvr`, `--envra` options. They are no longer supported.
+ * Moved `--groupmember` option to the Group info and list commands and renamed to `--contains-pkgs`.
 
 Upgrade command
 ---------------

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -88,6 +88,9 @@ Options
 ``--no-packages``
     | Used with ``install`` and ``remove`` commands to operate exclusively on the groups without manipulating any packages.
 
+``--contains-pkgs``
+    | Show only groups containing packges with specified names. List option, supports globs.
+
 Examples
 ========
 

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -54,6 +54,14 @@ public:
         filter(F::name, pattern, cmp);
     }
 
+    /// Filter groups by packages they contain. Keep only groups that contain packages with given names.
+    ///
+    /// @param patterns         A vector of strings (package names) the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    /// @since 5.12
+    void filter_package_name(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+
     void filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
         filter(F::name, patterns, cmp);
     }

--- a/test/libdnf/comps/test_group_query.cpp
+++ b/test/libdnf/comps/test_group_query.cpp
@@ -136,3 +136,17 @@ void CompsGroupQueryTest::test_query_filter_default() {
     expected = {get_group("core"), get_group("standard")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(q_groups));
 }
+
+
+void CompsGroupQueryTest::test_query_filter_package_name() {
+    // Filter groups which contain given packages
+    GroupQuery q_groups(base);
+    q_groups.filter_package_name(std::vector<std::string>({"chrony"}));
+    std::vector<Group> expected = {get_group("standard")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(q_groups));
+
+    q_groups = GroupQuery(base);
+    q_groups.filter_package_name(std::vector<std::string>({"chrony", "fprintd*"}), libdnf::sack::QueryCmp::IGLOB);
+    expected = {get_group("critical-path-standard"), get_group("standard")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(q_groups));
+}

--- a/test/libdnf/comps/test_group_query.hpp
+++ b/test/libdnf/comps/test_group_query.hpp
@@ -34,6 +34,7 @@ class CompsGroupQueryTest : public BaseTestCase {
     CPPUNIT_TEST(test_query_filter_name);
     CPPUNIT_TEST(test_query_filter_uservisible);
     CPPUNIT_TEST(test_query_filter_default);
+    CPPUNIT_TEST(test_query_filter_package_name);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -43,6 +44,7 @@ public:
     void test_query_filter_name();
     void test_query_filter_uservisible();
     void test_query_filter_default();
+    void test_query_filter_package_name();
 };
 
 #endif


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/122

The option is moved from `repoquery` to group info/list commands.
It fits much better into the group sub-commands.