### PR TITLE
Fix nightly builds on different archs than x86_64

### DIFF
--- a/test/libdnf/base/test_transaction.cpp
+++ b/test/libdnf/base/test_transaction.cpp
@@ -34,6 +34,7 @@ void BaseTransactionTest::test_check_gpg_signatures_no_gpgcheck() {
     goal.add_rpm_install("pkg");
     auto transaction = goal.resolve();
 
+    CPPUNIT_ASSERT_EQUAL((size_t)1, transaction.get_transaction_packages_count());
     CPPUNIT_ASSERT(transaction.check_gpg_signatures());
     CPPUNIT_ASSERT(transaction.get_gpg_signature_problems().empty());
 }
@@ -47,6 +48,7 @@ void BaseTransactionTest::test_check_gpg_signatures_fail() {
     goal.add_rpm_install("pkg");
     auto transaction = goal.resolve();
 
+    CPPUNIT_ASSERT_EQUAL((size_t)1, transaction.get_transaction_packages_count());
     CPPUNIT_ASSERT(!transaction.check_gpg_signatures());
     CPPUNIT_ASSERT(!transaction.get_gpg_signature_problems().empty());
 }

--- a/test/python3/libdnf5/base/test_transaction.py
+++ b/test/python3/libdnf5/base/test_transaction.py
@@ -30,6 +30,7 @@ class TestTransaction(base_test_case.BaseTestCase):
         goal.add_rpm_install("pkg")
         transaction = goal.resolve()
 
+        self.assertEqual(1, transaction.get_transaction_packages_count())
         self.assertTrue(transaction.check_gpg_signatures())
         self.assertEqual((), transaction.get_gpg_signature_problems())
 
@@ -40,5 +41,6 @@ class TestTransaction(base_test_case.BaseTestCase):
         goal.add_rpm_install("pkg")
         transaction = goal.resolve()
 
+        self.assertEqual(1, transaction.get_transaction_packages_count())
         self.assertFalse(transaction.check_gpg_signatures())
         self.assertTrue(len(transaction.get_gpg_signature_problems()) > 0)

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -38,6 +38,9 @@ class BaseTestCase(unittest.TestCase):
         self.base.get_config().cachedir = os.path.join(self.temp_dir, "cache")
         self.base.get_config().optional_metadata_types = libdnf5.conf.OPTIONAL_METADATA_TYPES
 
+        vars = self.base.get_vars().get()
+        vars.set("arch", "x86_64")
+
         self.base.setup()
 
         self.repo_sack = self.base.get_repo_sack()

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -34,9 +34,10 @@ class BaseTestCase(unittest.TestCase):
 
         self.temp_dir = tempfile.mkdtemp(prefix="libdnf5_python3_unittest.")
 
-        self.base.get_config().installroot = os.path.join(self.temp_dir, "installroot")
-        self.base.get_config().cachedir = os.path.join(self.temp_dir, "cache")
-        self.base.get_config().optional_metadata_types = libdnf5.conf.OPTIONAL_METADATA_TYPES
+        config = self.base.get_config()
+        config.installroot = os.path.join(self.temp_dir, "installroot")
+        config.cachedir = os.path.join(self.temp_dir, "cache")
+        config.optional_metadata_types = libdnf5.conf.OPTIONAL_METADATA_TYPES
 
         vars = self.base.get_vars().get()
         vars.set("arch", "x86_64")


### PR DESCRIPTION
Following up to the fix from https://github.com/rpm-software-management/dnf5/pull/95, I've also set up a `x86_64` arch for Python API tests as we use these packages there.

Also some small refactoring and unification in unit tests included.