### PR TITLE
Remove duplicit lines from "group list" output

### DIFF
--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -35,7 +35,7 @@ void GroupInfoCommand::set_argument_parser() {
 
     available = std::make_unique<GroupAvailableOption>(*this);
     installed = std::make_unique<GroupInstalledOption>(*this);
-    // TODO(dmach): set_conflicting_args({available, installed});
+    available->arg->add_conflict_argument(*installed->arg);
     hidden = std::make_unique<GroupHiddenOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this);
     group_pkg_contains = std::make_unique<GroupContainsPkgsOption>(*this);

--- a/dnf5/commands/group/group_info.hpp
+++ b/dnf5/commands/group/group_info.hpp
@@ -20,29 +20,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_GROUP_GROUP_INFO_HPP
 #define DNF5_COMMANDS_GROUP_GROUP_INFO_HPP
 
-#include "arguments.hpp"
-
-#include <dnf5/context.hpp>
-
-#include <memory>
-#include <vector>
-
+#include "group_list.hpp"
 
 namespace dnf5 {
 
 
-class GroupInfoCommand : public Command {
+class GroupInfoCommand : public GroupListCommand {
 public:
-    explicit GroupInfoCommand(Context & context) : Command(context, "info") {}
-    void set_argument_parser() override;
-    void configure() override;
-    void run() override;
+    explicit GroupInfoCommand(Context & context) : GroupListCommand(context, "info") {}
 
-    std::unique_ptr<GroupAvailableOption> available{nullptr};
-    std::unique_ptr<GroupInstalledOption> installed{nullptr};
-    std::unique_ptr<GroupHiddenOption> hidden{nullptr};
-    std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
-    std::unique_ptr<GroupContainsPkgsOption> group_pkg_contains{nullptr};
+private:
+    void print(const libdnf::comps::GroupQuery & query) override;
 };
 
 

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -74,6 +74,10 @@ void GroupListCommand::run() {
         query.filter_package_name(group_pkg_contains->get_value(), libdnf::sack::QueryCmp::IGLOB);
     }
 
+    print(query);
+}
+
+void GroupListCommand::print(const libdnf::comps::GroupQuery & query) {
     libdnf::cli::output::print_grouplist_table(query.list());
 }
 

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -35,7 +35,7 @@ void GroupListCommand::set_argument_parser() {
 
     available = std::make_unique<GroupAvailableOption>(*this);
     installed = std::make_unique<GroupInstalledOption>(*this);
-    // TODO(dmach): set_conflicting_args({available, installed});
+    available->arg->add_conflict_argument(*installed->arg);
     hidden = std::make_unique<GroupHiddenOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this);
     group_pkg_contains = std::make_unique<GroupContainsPkgsOption>(*this);

--- a/dnf5/commands/group/group_list.hpp
+++ b/dnf5/commands/group/group_list.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
+#include <libdnf/comps/group/query.hpp>
 
 #include <memory>
-#include <vector>
 
 
 namespace dnf5 {
@@ -35,7 +34,7 @@ namespace dnf5 {
 
 class GroupListCommand : public Command {
 public:
-    explicit GroupListCommand(Context & context) : Command(context, "list") {}
+    explicit GroupListCommand(Context & context) : GroupListCommand(context, "list") {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;
@@ -45,6 +44,12 @@ public:
     std::unique_ptr<GroupHiddenOption> hidden{nullptr};
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
     std::unique_ptr<GroupContainsPkgsOption> group_pkg_contains{nullptr};
+
+protected:
+    GroupListCommand(Context & context, const std::string & name) : Command(context, name) {}
+
+private:
+    virtual void print(const libdnf::comps::GroupQuery & query);
 };
 
 


### PR DESCRIPTION
In case neither the --installed option nor the --available option was used, remove from the output all available groups with the same groupid as any of the installed groups. While it is technically correct (installed and available groups are different solvables), having both in the list output makes it harder to understand.

Resolves: https://github.com/rpm-software-management/dnf5/issues/470