### PR TITLE
Bump Fedora versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build in Copr
         run: |
-          CHROOTS="fedora-36-x86_64, fedora-37-x86_64, fedora-rawhide-x86_64"
+          CHROOTS="fedora-37-x86_64, fedora-38-x86_64, fedora-rawhide-x86_64"
           PROJECT_NAME="CI-libdnf5-pr${{github.event.pull_request.number}}"
           if [[ -n "${{matrix.compiler}}" ]]; then
             PROJECT_NAME+="-${{matrix.compiler}}"


### PR DESCRIPTION
Fedora 36 is not supported by copr any more.