### PR TITLE
comps: Possibility to create an empty EnvironmentQuery

### DIFF
--- a/include/libdnf/comps/environment/query.hpp
+++ b/include/libdnf/comps/environment/query.hpp
@@ -39,8 +39,8 @@ using EnvironmentSackWeakPtr = WeakPtr<EnvironmentSack, false>;
 class EnvironmentQuery : public libdnf::sack::Query<Environment> {
 public:
     // Create new query with newly composed environments (using only solvables from currently enabled repositories)
-    explicit EnvironmentQuery(const libdnf::BaseWeakPtr & base);
-    explicit EnvironmentQuery(libdnf::Base & base);
+    explicit EnvironmentQuery(const libdnf::BaseWeakPtr & base, bool empty = false);
+    explicit EnvironmentQuery(libdnf::Base & base, bool empty = false);
 
     void filter_environmentid(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
         filter(F::environmentid, pattern, cmp);

--- a/libdnf/comps/environment/query.cpp
+++ b/libdnf/comps/environment/query.cpp
@@ -40,7 +40,11 @@ extern "C" {
 namespace libdnf::comps {
 
 
-EnvironmentQuery::EnvironmentQuery(const BaseWeakPtr & base) : base(base) {
+EnvironmentQuery::EnvironmentQuery(const BaseWeakPtr & base, bool empty) : base(base) {
+    if (empty) {
+        return;
+    }
+
     libdnf::solv::CompsPool & pool = get_comps_pool(base);
 
     // Map of available environments:
@@ -97,7 +101,7 @@ EnvironmentQuery::EnvironmentQuery(const BaseWeakPtr & base) : base(base) {
 }
 
 
-EnvironmentQuery::EnvironmentQuery(Base & base) : EnvironmentQuery(base.get_weak_ptr()) {}
+EnvironmentQuery::EnvironmentQuery(Base & base, bool empty) : EnvironmentQuery(base.get_weak_ptr(), empty) {}
 
 
 }  // namespace libdnf::comps


### PR DESCRIPTION
Sometimes we need to build a resulting query as a union of other queries. We might need to start with an empty one.