### PR TITLE
state: Load environmental groups to system repo

### DIFF
--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -34,6 +34,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/comps/environment/query.hpp"
 #include "libdnf/comps/group/query.hpp"
 #include "libdnf/conf/config_parser.hpp"
 #include "libdnf/conf/option_bool.hpp"
@@ -597,7 +598,8 @@ void RepoSack::fix_group_missing_xml() {
     if (has_system_repo()) {
         auto & solv_repo = system_repo->solv_repo;
         auto & group_missing_xml = solv_repo->get_groups_missing_xml();
-        if (group_missing_xml.empty()) {
+        auto & environments_missing_xml = solv_repo->get_environments_missing_xml();
+        if (group_missing_xml.empty() && environments_missing_xml.empty()) {
             return;
         }
         auto & logger = *base->get_logger();
@@ -610,43 +612,80 @@ void RepoSack::fix_group_missing_xml() {
             logger.debug("Failed to create directory \"{}\": {}", comps_xml_dir.string(), ec.message());
             directory_exists = false;
         }
-        libdnf::comps::GroupQuery available_groups(base);
-        available_groups.filter_installed(false);
-        for (const auto & group_id : group_missing_xml) {
-            bool xml_saved = false;
-            if (directory_exists) {
-                // try to find the repoid in availables
-                libdnf::comps::GroupQuery group_query(available_groups);
-                group_query.filter_groupid(group_id);
-                if (group_query.size() == 1) {
-                    // GroupQuery is basically a set thus iterators and `.get()` method
-                    // return `const Group` objects.
-                    // To call non-const serialize method we need to make a copy here.
-                    libdnf::comps::Group group = group_query.get();
-                    auto xml_file_name = comps_xml_dir / (group_id + ".xml");
-                    logger.debug(
-                        "Re-creating installed group \"{}\" definition to file \"{}\".",
-                        group_id,
-                        xml_file_name.string());
-                    try {
-                        group.serialize(xml_file_name);
-                        xml_saved = true;
-                    } catch (utils::xml::XMLSaveError & ex) {
-                        logger.debug(ex.what());
-                    }
-                    if (xml_saved) {
-                        solv_repo->read_group_solvable_from_xml(xml_file_name);
+        if (!group_missing_xml.empty()) {
+            libdnf::comps::GroupQuery available_groups(base);
+            available_groups.filter_installed(false);
+            for (const auto & group_id : group_missing_xml) {
+                bool xml_saved = false;
+                if (directory_exists) {
+                    // try to find the group id in availables
+                    libdnf::comps::GroupQuery group_query(available_groups);
+                    group_query.filter_groupid(group_id);
+                    if (group_query.size() == 1) {
+                        // GroupQuery is basically a set thus iterators and `.get()` method
+                        // return `const Group` objects.
+                        // To call non-const serialize method we need to make a copy here.
+                        libdnf::comps::Group group = group_query.get();
+                        auto xml_file_name = comps_xml_dir / (group_id + ".xml");
+                        logger.debug(
+                            "Re-creating installed group \"{}\" definition to file \"{}\".",
+                            group_id,
+                            xml_file_name.string());
+                        try {
+                            group.serialize(xml_file_name);
+                            xml_saved = true;
+                        } catch (utils::xml::XMLSaveError & ex) {
+                            logger.debug(ex.what());
+                        }
+                        if (xml_saved) {
+                            solv_repo->read_group_solvable_from_xml(xml_file_name);
+                        }
                     }
                 }
+                if (!xml_saved) {
+                    // fall-back to creating solvables only from system state
+                    solv_repo->create_group_solvable(group_id, system_state.get_group_state(group_id));
+                }
             }
-            if (!xml_saved) {
-                // fall-back to creating solvables only from system state
-                solv_repo->create_group_solvable(group_id, system_state.get_group_state(group_id));
+        }
+        if (!environments_missing_xml.empty()) {
+            libdnf::comps::EnvironmentQuery available_environments(base);
+            available_environments.filter_installed(false);
+            for (const auto & environment_id : environments_missing_xml) {
+                bool xml_saved = false;
+                if (directory_exists) {
+                    // try to find the environment id in availables
+                    libdnf::comps::EnvironmentQuery environment_query(available_environments);
+                    environment_query.filter_environmentid(environment_id);
+                    if (environment_query.size() == 1) {
+                        libdnf::comps::Environment environment = environment_query.get();
+                        auto xml_file_name = comps_xml_dir / (environment_id + ".xml");
+                        logger.debug(
+                            "Re-creating installed environmental group \"{}\" definition to file \"{}\".",
+                            environment_id,
+                            xml_file_name.string());
+                        try {
+                            environment.serialize(xml_file_name);
+                            xml_saved = true;
+                        } catch (utils::xml::XMLSaveError & ex) {
+                            logger.debug(ex.what());
+                        }
+                        if (xml_saved) {
+                            solv_repo->read_group_solvable_from_xml(xml_file_name);
+                        }
+                    }
+                }
+                if (!xml_saved) {
+                    // fall-back to creating solvables only from system state
+                    solv_repo->create_environment_solvable(
+                        environment_id, system_state.get_environment_state(environment_id));
+                }
             }
         }
 
         // ensure we attempt to re-create xmls only once
         group_missing_xml.clear();
+        environments_missing_xml.clear();
     }
 }
 

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -96,13 +96,23 @@ public:
 
     void set_needs_internalizing() { needs_internalizing = true; };
 
+    /// @return  Vector of group ids of system repo groups without valid xml
     std::vector<std::string> & get_groups_missing_xml() { return groups_missing_xml; };
+
+    /// @return  Vector of environment ids of system repo environmental groups without valid xml
+    std::vector<std::string> & get_environments_missing_xml() { return environments_missing_xml; };
 
     /// Create a group solvable based on what's available in system state. Used in
     /// case we are not able to load metadata from xml file.
     /// @param groupid  Id of the group
     /// @param state    group state from the system state
     void create_group_solvable(const std::string & groupid, const libdnf::system::GroupState & state);
+
+    /// Create an environmental group solvable based on what's available in
+    /// system state. Used in case we are not able to load metadata from xml file.
+    /// @param environmentid  Id of the environment
+    /// @param state    environment state from the system state
+    void create_environment_solvable(const std::string & environmentid, const libdnf::system::EnvironmentState & state);
 
     /// Read comps group solvable from its xml file.
     /// @param path  Path to xml file.
@@ -137,6 +147,9 @@ private:
 
     /// List of system repo groups without valid file with xml definition
     std::vector<std::string> groups_missing_xml;
+
+    /// List of system repo environmental groups without valid file with xml definition
+    std::vector<std::string> environments_missing_xml;
 
 public:
     ::Repo * repo{nullptr};  // libsolv pool retains ownership

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -389,6 +389,7 @@ std::set<std::string> State::get_package_groups(const std::string & name) {
     }
 }
 
+
 std::vector<std::string> State::get_installed_groups() {
     std::vector<std::string> group_ids;
     group_ids.reserve(group_states.size());
@@ -396,6 +397,16 @@ std::vector<std::string> State::get_installed_groups() {
         group_ids.push_back(grp.first);
     }
     return group_ids;
+}
+
+
+std::vector<std::string> State::get_installed_environments() {
+    std::vector<std::string> environment_ids;
+    environment_ids.reserve(environment_states.size());
+    for (const auto & env : environment_states) {
+        environment_ids.push_back(env.first);
+    }
+    return environment_ids;
 }
 
 

--- a/libdnf/system/state.hpp
+++ b/libdnf/system/state.hpp
@@ -152,6 +152,10 @@ public:
     /// @since 5.0
     std::vector<std::string> get_installed_groups();
 
+    /// @return List of ids of installed environmental groups.
+    /// @since 5.0
+    std::vector<std::string> get_installed_environments();
+
     /// @return The path to the directory containing the installed groups xml data.
     /// @since 5.0
     std::filesystem::path get_group_xml_dir();


### PR DESCRIPTION
Uses similar approach we already have for groups.
System repo environments are loaded from xml files saved in the system state. In case the xml file with environment definition is missing (e.g. after upgrade from dnf4), a new one is created from available environmental group of the same id (with fallback to create a simple solvable based only on system state data).