### PR TITLE
rpm::Package: rename get_package_size() to get_download_size()

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -582,7 +582,7 @@ static void print_transaction_size_stats(Context & context) {
     for (const auto & trans_pkg : context.get_transaction()->get_transaction_packages()) {
         const auto pkg = trans_pkg.get_package();
         if (transaction_item_action_is_inbound(trans_pkg.get_action())) {
-            const auto pkg_size = pkg.get_package_size();
+            const auto pkg_size = pkg.get_download_size();
             in_pkgs_size += pkg_size;
             if (!pkg.is_available_locally()) {
                 download_pkgs_size += pkg_size;

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -124,7 +124,7 @@ void RepoqueryCommand::run() {
              "arch",
              "repo",
              "install_size",
-             "package_size",
+             "download_size",
              "sourcerpm",
              "is_installed",
              "summary",

--- a/dnf5daemon-client/wrappers/dbus_package_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_package_wrapper.hpp
@@ -45,7 +45,7 @@ public:
     std::string get_evr() const { return rawdata.at("evr"); }
     bool is_installed() const { return rawdata.at("is_installed"); }
     uint64_t get_install_size() const { return rawdata.at("install_size"); }
-    uint64_t get_package_size() const { return rawdata.at("package_size"); }
+    uint64_t get_download_size() const { return rawdata.at("download_size"); }
     std::string get_sourcerpm() const { return rawdata.at("sourcerpm"); }
     std::string get_summary() const { return rawdata.at("summary"); }
     std::string get_url() const { return rawdata.at("url"); }

--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -35,7 +35,7 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"from_repo_id", PackageAttribute::from_repo_id},
     {"is_installed", PackageAttribute::is_installed},
     {"install_size", PackageAttribute::install_size},
-    {"package_size", PackageAttribute::package_size},
+    {"download_size", PackageAttribute::download_size},
     {"sourcerpm", PackageAttribute::sourcerpm},
     {"summary", PackageAttribute::summary},
     {"url", PackageAttribute::url},
@@ -114,8 +114,8 @@ dnfdaemon::KeyValueMap package_to_map(
             case PackageAttribute::install_size:
                 dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_install_size()));
                 break;
-            case PackageAttribute::package_size:
-                dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_package_size()));
+            case PackageAttribute::download_size:
+                dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_download_size()));
                 break;
             case PackageAttribute::sourcerpm:
                 dbus_package.emplace(attr, libdnf_package.get_sourcerpm());

--- a/dnf5daemon-server/package.hpp
+++ b/dnf5daemon-server/package.hpp
@@ -39,7 +39,7 @@ enum class PackageAttribute {
     from_repo_id,
     is_installed,
     install_size,
-    package_size,
+    download_size,
     sourcerpm,
     summary,
     url,

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -91,7 +91,7 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
             "arch",
             "repo_id",
             "from_repo_id",
-            "package_size",
+            "download_size",
             "install_size",
             "evr",
             "reason"};

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -121,7 +121,7 @@ dnfdaemon::KeyValueMap repo_to_map(
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.filter_repo_id(reponames);
                 for (auto pkg : query) {
-                    size += pkg.get_package_size();
+                    size += pkg.get_download_size();
                 }
                 dbus_repo.emplace(attr, size);
             } break;

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -21,7 +21,7 @@ The return type was changed from `unsigned long` to `std::string`.
 DNF: Package.size, libdnf: dnf_package_get_size()
 -------------------------------------------------
 The return value was ambiguous, returning either package or install size.
-Use Package::get_package_size() and Package::get_install_size() instead.
+Use Package::get_download_size() and Package::get_install_size() instead.
 
 
 dnf_sack_set_installonly, dnf_sack_get_installonly, dnf_sack_set_installonly_limit, dnf_sack_get_installonly_limit

--- a/include/libdnf-cli/output/repoquery.hpp
+++ b/include/libdnf-cli/output/repoquery.hpp
@@ -51,7 +51,7 @@ static struct libscols_table * create_package_info_table(Package & package) {
     add_line_into_package_info_table(table, "Architecture", package.get_arch().c_str());
     add_line_into_package_info_table(table, "Install size", std::to_string(package.get_install_size()).c_str());
     if (!package.is_installed()) {
-        add_line_into_package_info_table(table, "Package size", std::to_string(package.get_package_size()).c_str());
+        add_line_into_package_info_table(table, "Download size", std::to_string(package.get_download_size()).c_str());
     }
     add_line_into_package_info_table(table, "Source", package.get_sourcerpm().c_str());
     add_line_into_package_info_table(table, "Repository", package.get_repo_id().c_str());

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -162,7 +162,7 @@ public:
     //
     // @replaces dnf:dnf/package.py:attribute:Package.downloadsize
     // @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_downloadsize(DnfPackage * pkg)
-    unsigned long long get_package_size() const;
+    unsigned long long get_download_size() const;
 
     /// @return Size the RPM package should occupy after installing on disk (`RPMTAG_LONGSIZE`).
     ///         The information is always present - it is retrieved from rpmdb if the package is installed or from repodata if the package is available.

--- a/libdnf-cli/output/package_info_sections.cpp
+++ b/libdnf-cli/output/package_info_sections.cpp
@@ -91,7 +91,7 @@ bool PackageInfoSections::add_section(
             }
             if (!pkg.is_installed()) {
                 add_line(
-                    "Package size", utils::units::format_size_aligned(static_cast<int64_t>(pkg.get_package_size())));
+                    "Download size", utils::units::format_size_aligned(static_cast<int64_t>(pkg.get_download_size())));
             }
             add_line("Installed size", utils::units::format_size_aligned(static_cast<int64_t>(pkg.get_install_size())));
             if (pkg.get_arch() != "src") {

--- a/libdnf-cli/output/repoqueryformat.cpp
+++ b/libdnf-cli/output/repoqueryformat.cpp
@@ -46,7 +46,7 @@ static const std::unordered_map<std::string, Getter> NAME_TO_GETTER = {
     {"evr", &libdnf::rpm::Package::get_evr},
     {"full_nevra", &libdnf::rpm::Package::get_full_nevra},
     {"group", &libdnf::rpm::Package::get_group},
-    {"downloadsize", &libdnf::rpm::Package::get_package_size},
+    {"downloadsize", &libdnf::rpm::Package::get_download_size},
     {"installsize", &libdnf::rpm::Package::get_install_size},
     {"license", &libdnf::rpm::Package::get_license},
     {"source_name", &libdnf::rpm::Package::get_source_name},

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -137,7 +137,7 @@ void PackageDownloader::download(bool fail_fast, bool resume) try {
             pkg_target.user_cb_data = download_callbacks->add_new_download(
                 pkg_target.user_data,
                 pkg_target.package.get_full_nevra().c_str(),
-                static_cast<double>(pkg_target.package.get_package_size()));
+                static_cast<double>(pkg_target.package.get_download_size()));
         }
 
         auto * lr_target = lr_packagetarget_new_v3(
@@ -146,7 +146,7 @@ void PackageDownloader::download(bool fail_fast, bool resume) try {
             pkg_target.destination.c_str(),
             static_cast<LrChecksumType>(pkg_target.package.get_checksum().get_type()),
             pkg_target.package.get_checksum().get_checksum().c_str(),
-            static_cast<int64_t>(pkg_target.package.get_package_size()),
+            static_cast<int64_t>(pkg_target.package.get_download_size()),
             pkg_target.package.get_baseurl().empty() ? nullptr : pkg_target.package.get_baseurl().c_str(),
             resume,
             progress_callback,

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -99,7 +99,7 @@ std::string Package::get_group() const {
     return libdnf::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, SOLVABLE_GROUP));
 }
 
-unsigned long long Package::get_package_size() const {
+unsigned long long Package::get_download_size() const {
     return get_rpm_pool(base).lookup_num(id.id, SOLVABLE_DOWNLOADSIZE);
 }
 
@@ -331,7 +331,7 @@ bool Package::is_cached() const {
     if (auto fd = ::open(get_package_path().c_str(), O_RDONLY); fd != -1) {
         utils::OnScopeExit close_fd([fd]() noexcept { ::close(fd); });
         auto length = static_cast<unsigned long long>(lseek(fd, 0, SEEK_END));
-        if (length == get_package_size()) {
+        if (length == get_download_size()) {
             lseek(fd, 0, SEEK_SET);
             auto checksum = get_checksum();
             lr_checksum_fd_cmp(

--- a/test/dnf5daemon-server/support.py
+++ b/test/dnf5daemon-server/support.py
@@ -43,7 +43,7 @@ class InstallrootCase(unittest.TestCase):
             # between runs so we can't rely on the value
             pkg.pop('id')
             # also package size differs according to the builder
-            pkg.pop('package_size')
+            pkg.pop('download_size')
             # TODO(mblaha): calculate correct replaces value
             if "replaces" in trans_item_attrs:
                 trans_item_attrs.pop("replaces")

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -103,8 +103,8 @@ void RpmPackageTest::test_get_group() {
 }
 
 
-void RpmPackageTest::test_get_package_size() {
-    CPPUNIT_ASSERT_EQUAL(111LLU, get_pkg("pkg-1.2-3.x86_64").get_package_size());
+void RpmPackageTest::test_get_download_size() {
+    CPPUNIT_ASSERT_EQUAL(111LLU, get_pkg("pkg-1.2-3.x86_64").get_download_size());
 }
 
 

--- a/test/libdnf/rpm/test_package.hpp
+++ b/test/libdnf/rpm/test_package.hpp
@@ -40,7 +40,7 @@ class RpmPackageTest : public BaseTestCase {
     CPPUNIT_TEST(test_get_nevra);
     CPPUNIT_TEST(test_get_full_nevra);
     CPPUNIT_TEST(test_get_group);
-    CPPUNIT_TEST(test_get_package_size);
+    CPPUNIT_TEST(test_get_download_size);
     CPPUNIT_TEST(test_get_install_size);
     CPPUNIT_TEST(test_get_license);
     CPPUNIT_TEST(test_get_sourcerpm);
@@ -91,7 +91,7 @@ public:
     void test_get_nevra();
     void test_get_full_nevra();
     void test_get_group();
-    void test_get_package_size();
+    void test_get_download_size();
     void test_get_install_size();
     void test_get_license();
     void test_get_sourcerpm();


### PR DESCRIPTION
Since we have `rpm::Package::get_install_size()` it seems clearer to have `rpm::Package::get_download_size()` to complement it.

Also
- libsolv is using SOLVABLE_DOWNLOADSIZE
- dnf4 used Package.downloadsize
- queryformat uses `downloadsize` tag

Follow up for: https://github.com/rpm-software-management/dnf5/pull/508#discussion_r1203741313