### PR TITLE
downloaders: Pass fail_fast and resume by setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next release
+
+- Improve the download methods API
+  - Switch to parameterless download methods and introduce setters for fail_fast and resume
+  - Affected classes: libdnf::repo::FileDownloader, libdnf::repo::PackageDownloader
+
 # 5.0.13
 
 - Fix resolve behavior for `download`

--- a/dnf5-plugins/copr_plugin/download_file.cpp
+++ b/dnf5-plugins/copr_plugin/download_file.cpp
@@ -26,5 +26,5 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 void download_file(libdnf::Base & base, const std::string & url, const std::filesystem::path & path) {
     libdnf::repo::FileDownloader downloader(base);
     downloader.add(url, path);
-    downloader.download(true, true);
+    downloader.download();
 }

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -157,7 +157,7 @@ void DownloadCommand::run() {
         }
 
         std::cout << "Downloading Packages:" << std::endl;
-        downloader.download(true, true);
+        downloader.download();
         std::cout << std::endl;
     }
 }

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -219,7 +219,7 @@ void download_packages(Session & session, libdnf::base::Transaction & transactio
         }
     }
 
-    downloader.download(true, true);
+    downloader.download();
 }
 
 sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {

--- a/include/libdnf/repo/file_downloader.hpp
+++ b/include/libdnf/repo/file_downloader.hpp
@@ -60,9 +60,17 @@ public:
     void add(const std::string & url, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added files (URLs).
-    /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.
-    /// @param resume Whether to try to resume the download if a destination package already exists.
-    void download(bool fail_fast, bool resume);
+    void download();
+
+    /// Configure whether to fail the whole download on a first error or keep downloading.
+    /// @param value If true, download will fail on the first error, otherwise it continues.
+    /// This is set to true by default.
+    void set_fail_fast(bool value);
+
+    /// Configure whether to try resuming the download if a destination package already exists.
+    /// @param value If true, download is tried to be resumed, otherwise it starts over.
+    /// This is set to true by default.
+    void set_resume(bool value);
 
 private:
     class Impl;

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -72,12 +72,11 @@ public:
     /// @param value If true, packages will be kept on the disk after downloading
     /// regardless the `keepcache` option value, if false, it enforces packages removal after
     /// the next successful transaction.
-    void force_keep_packages(bool value) { keep_packages = value; }
+    void force_keep_packages(bool value);
 
 private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
-    std::optional<bool> keep_packages;
 };
 
 /// Wraps librepo PackageTarget

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -53,9 +53,17 @@ public:
     void add(const libdnf::rpm::Package & package, const std::string & destination, void * user_data = nullptr);
 
     /// Download the previously added packages.
-    /// @param fail_fast Whether to fail the whole download on a first error or keep downloading.
-    /// @param resume Whether to try to resume the download if a destination package already exists.
-    void download(bool fail_fast, bool resume);
+    void download();
+
+    /// Configure whether to fail the whole download on a first error or keep downloading.
+    /// @param value If true, download will fail on the first error, otherwise it continues.
+    /// This is set to true by default.
+    void set_fail_fast(bool value);
+
+    /// Configure whether to try resuming the download if a destination package already exists.
+    /// @param value If true, download is tried to be resumed, otherwise it starts over.
+    /// This is set to true by default.
+    void set_resume(bool value);
 
     /// Explicitly setup the behavior related to packages caching.
     /// By default, the `keepcache` configuration option is used to determine whether to keep

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -294,7 +294,7 @@ void Transaction::download() {
             downloader.add(tspkg.get_package());
         }
     }
-    downloader.download(true, true);
+    downloader.download();
 }
 
 Transaction::TransactionRunResult Transaction::test() {

--- a/libdnf/repo/file_downloader.cpp
+++ b/libdnf/repo/file_downloader.cpp
@@ -104,7 +104,12 @@ static int mirror_failure_callback(void * data, const char * msg, const char * u
 class FileDownloader::Impl {
 public:
     Impl(const BaseWeakPtr & base) : base(base), fail_fast(true), resume(true) {}
+
+private:
+    friend FileDownloader;
+
     BaseWeakPtr base;
+
     std::vector<FileTarget> targets;
     bool fail_fast;
     bool resume;

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -94,9 +94,14 @@ static int mirror_failure_callback(void * data, const char * msg, const char * u
 class PackageDownloader::Impl {
 public:
     Impl(const BaseWeakPtr & base) : base(base), fail_fast(true), resume(true) {}
-    BaseWeakPtr base;
+
+private:
     friend PackageDownloader;
+
+    BaseWeakPtr base;
+
     std::vector<PackageTarget> targets;
+    std::optional<bool> keep_packages;
     bool fail_fast;
     bool resume;
 };
@@ -181,8 +186,8 @@ void PackageDownloader::download() try {
     // Store file paths of packages we don't want to keep cached.
     auto & config = p_impl->base->get_config();
     auto removal_configured = !config.get_keepcache_option().get_value();
-    auto removal_enforced = keep_packages.has_value() && !keep_packages.value();
-    auto keep_enforced = keep_packages.has_value() && keep_packages.value();
+    auto removal_enforced = p_impl->keep_packages.has_value() && !p_impl->keep_packages.value();
+    auto keep_enforced = p_impl->keep_packages.has_value() && p_impl->keep_packages.value();
     if (removal_enforced || (!keep_enforced && removal_configured)) {
         std::vector<std::string> package_paths;
         std::transform(
@@ -212,6 +217,10 @@ void PackageDownloader::set_fail_fast(bool value) {
 
 void PackageDownloader::set_resume(bool value) {
     p_impl->resume = value;
+}
+
+void PackageDownloader::force_keep_packages(bool value) {
+    p_impl->keep_packages = value;
 }
 
 }  // namespace libdnf::repo

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -160,7 +160,7 @@ std::map<std::string, libdnf::rpm::Package> RepoSack::add_cmdline_packages(
             // TODO(mblaha): temporarily used the dummy DownloadCallbacks instance
             downloader.add(std::string{url}, dest_path.string());
         }
-        downloader.download(true, true);
+        downloader.download();
 
         // fill the command line repo with downloaded URLs
         for (const auto & [url, path] : url_to_path) {
@@ -337,10 +337,14 @@ void RepoSack::update_and_load_repos(libdnf::repo::RepoQuery & repos, bool impor
             if (!remote_keys_files.empty()) {
                 // download remote keys files to local temporary files
                 FileDownloader downloader(base);
+                downloader.set_fail_fast(false);
+                downloader.set_resume(false);
+
                 for (const auto & [repo, key_url, key_file] : remote_keys_files) {
                     downloader.add(key_url, key_file.get_path(), repo->get_user_data());
                 }
-                downloader.download(false, false);
+
+                downloader.download();
 
                 // import downloaded keys files
                 for (const auto & [repo, key_url, temp_file] : remote_keys_files) {

--- a/libdnf/rpm/rpm_signature.cpp
+++ b/libdnf/rpm/rpm_signature.cpp
@@ -220,7 +220,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
             downloaded_key = std::make_unique<libdnf::utils::fs::TempFile>("rpmkey");
             libdnf::repo::FileDownloader downloader(base);
             downloader.add(key_url, downloaded_key->get_path());
-            downloader.download(true, true);
+            downloader.download();
             key_path = downloaded_key->get_path();
         }
     } else {

--- a/test/libdnf/repo/test_package_downloader.cpp
+++ b/test/libdnf/repo/test_package_downloader.cpp
@@ -84,7 +84,7 @@ void PackageDownloaderTest::test_package_downloader() {
 
     downloader.add(*query.begin());
 
-    downloader.download(true, true);
+    downloader.download();
 
     CPPUNIT_ASSERT_EQUAL(1, cbs->end_cnt);
     CPPUNIT_ASSERT_EQUAL(DownloadCallbacks::TransferStatus::SUCCESSFUL, cbs->end_status);
@@ -116,7 +116,7 @@ void PackageDownloaderTest::test_package_downloader_temp_files_memory() {
     for (const auto & package : query) {
         downloader.add(package);
     }
-    downloader.download(true, true);
+    downloader.download();
 
     auto paths_prefix = std::filesystem::path(repo->get_cachedir()) / std::filesystem::path("packages");
     const std::vector<std::string> expected = {

--- a/test/python3/libdnf5/repo/test_package_downloader.py
+++ b/test/python3/libdnf5/repo/test_package_downloader.py
@@ -63,7 +63,7 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
 
         downloader.add(query.begin().value())
 
-        downloader.download(True, True)
+        downloader.download()
 
         # forcefully deallocate the downloader, to check cbs is still valid
         downloader = None

--- a/test/ruby/libdnf5/repo/test_package_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_package_downloader.rb
@@ -73,7 +73,7 @@ class TestPackageDownloader < BaseTestCase
 
         downloader.add(query.begin().value)
 
-        downloader.download(true, true)
+        downloader.download()
 
         # forcefully deallocate the downloader, to check cbs is still valid
         downloader = nil


### PR DESCRIPTION
To make the API and code usages more explicit.

Closes #528.
CI tests fix: https://github.com/rpm-software-management/ci-dnf-stack/pull/1297.