### PR TITLE
packit: keep rpm macros in specfile

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@ actions:
     bash -c "sed -i -r \"s/^%global project_version_major (\s*)\S+/%global project_version_major \1`echo ${PACKIT_PROJECT_VERSION} | cut -d. -f1`/\" dnf5.spec"
     bash -c "sed -i -r \"s/^%global project_version_minor (\s*)\S+/%global project_version_minor \1`echo ${PACKIT_PROJECT_VERSION} | cut -d. -f2`/\" dnf5.spec"
     bash -c "sed -i -r \"s/^%global project_version_patch (\s*)\S+/%global project_version_patch \1`echo ${PACKIT_PROJECT_VERSION} | cut -d. -f3`/\" dnf5.spec"
+    bash -c "sed -i -r \"s/^Version:.*/Version:\t\t%{project_version_major}.%{project_version_minor}.%{project_version_patch}/\" dnf5.spec"
 
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: dnf5


### PR DESCRIPTION
Without this change, the version number will be replaced explicitly.
See here.
https://src.fedoraproject.org/rpms/dnf5/pull-request/13

This is not a big deal, but to keep all the specfles in sync it is required.