### PR TITLE
aliases: don't complete ls alias

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -115,7 +115,7 @@ type = 'command'
 attached_command = 'list'
 descr = "Alias for 'list'"
 group_id = 'commands-compatibility-aliases'
-complete = true
+complete = false
 
 ['rei']
 type = 'command'


### PR DESCRIPTION
No other 2-character aliases are completed.  To be consistent, don't complete the `ls` alias either.

In #568, it was noted that completion is not generally enabled for these shortcut aliases.  That seems like a good reason to disable completion of the `ls` alias as well.