### PR TITLE
cli: Return error exit code on RPM transaction failure

### DIFF
--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -181,7 +181,7 @@ void CheckUpgradeCommand::run() {
         if (changelogs->get_value()) {
             libdnf::cli::output::print_changelogs(upgrades_query, full_package_query, true, 0, 0);
         }
-        throw libdnf::cli::SilentCommandExitError(100, M_(""));
+        throw libdnf::cli::SilentCommandExitError(100);
     } else if (
         // Otherwise, main() will exit with code 0.
         size_before_filter_advisories > 0 &&

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -461,6 +461,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         for (auto & problem : transaction.get_transaction_problems()) {
             std::cout << "  - " << problem << std::endl;
         }
+        throw libdnf::cli::SilentCommandExitError(1, M_(""));
     }
 
     // TODO(mblaha): print a summary of successful transaction

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -461,7 +461,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
         for (auto & problem : transaction.get_transaction_problems()) {
             std::cout << "  - " << problem << std::endl;
         }
-        throw libdnf::cli::SilentCommandExitError(1, M_(""));
+        throw libdnf::cli::SilentCommandExitError(1);
     }
 
     // TODO(mblaha): print a summary of successful transaction

--- a/include/libdnf-cli/exception.hpp
+++ b/include/libdnf-cli/exception.hpp
@@ -88,19 +88,13 @@ private:
     int exit_code;
 };
 
-/// Exception used when non-standard exit code should be returned
+/// Exception used when non-standard exit code should be returned without displaying any message to the user
 class SilentCommandExitError : public Error {
 public:
-    /// Constructs the error with given exit code and with custom formatted error
-    /// message.
+    /// Constructs the error with given exit code.
     ///
     /// @param exit_code The exit code
-    /// @param format The format string for the message
-    /// @param args The format arguments
-    template <typename... Ss>
-    explicit SilentCommandExitError(int exit_code, BgettextMessage format, Ss &&... args)
-        : Error(format, std::forward<Ss>(args)...),
-          exit_code(exit_code) {}
+    explicit SilentCommandExitError(int exit_code);
 
     const char * get_name() const noexcept override { return "SilentCommandExitError"; }
 

--- a/libdnf-cli/exception.cpp
+++ b/libdnf-cli/exception.cpp
@@ -45,4 +45,6 @@ const char * GoalResolveError::what() const noexcept {
     return message.c_str();
 }
 
+SilentCommandExitError::SilentCommandExitError(int exit_code) : Error(M_("")), exit_code(exit_code) {}
+
 }  // namespace libdnf::cli


### PR DESCRIPTION
When an error occurred during the RPM transaction, dnf command should return non-zero exit code.

CI tests fix: https://github.com/rpm-software-management/ci-dnf-stack/pull/1305.
Closes #525.