### PR TITLE
swig: Fix group packages getter

### DIFF
--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -44,6 +44,7 @@
 
 %include "libdnf/comps/group/package.hpp"
 %include "libdnf/comps/group/group.hpp"
+%template(VectorPackage) std::vector<libdnf::comps::Package>;
 %template(SetConstIteratorGroup) libdnf::SetConstIterator<libdnf::comps::Group>;
 %template(SetGroup) libdnf::Set<libdnf::comps::Group>;
 %template(SackQueryGroup) libdnf::sack::Query<libdnf::comps::Group>;

--- a/test/python3/libdnf5/comps/test_group.py
+++ b/test/python3/libdnf5/comps/test_group.py
@@ -35,3 +35,9 @@ class TestGroup(base_test_case.BaseTestCase):
 
         # Try to create a group query without running base.setup()
         self.assertRaises(RuntimeError, libdnf5.comps.GroupQuery, base)
+
+    def test_group_get_packages(self):
+        self.add_repo_repomd("repomd-comps-core")
+        query = libdnf5.comps.GroupQuery(self.base)
+        core_group = next(iter(query))
+        self.assertEqual(5, len(core_group.get_packages()))


### PR DESCRIPTION
Add wrapper for a vector of `libdnf::comps::Package`. Unit test is included.

Closes #590.