### PR TITLE
Add dnf5-unstable copr repo to dnf5 CI copr builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ -n "${{matrix.compiler}}" ]]; then
             PROJECT_NAME+="-${{matrix.compiler}}"
           fi
-          rpm-gitoverlay --gitdir=gits build-overlay -s overlays/dnf5-unstable rpm --with "${{matrix.compiler}}" copr --owner "${{steps.setup-ci.outputs.copr-user}}" --project "$PROJECT_NAME" --chroots "$CHROOTS" --delete-project-after-days=7 --additional-repos="copr://rpmsoftwaremanagement/dnf-nightly"
+          rpm-gitoverlay --gitdir=gits build-overlay -s overlays/dnf5-unstable rpm --with "${{matrix.compiler}}" copr --owner "${{steps.setup-ci.outputs.copr-user}}" --project "$PROJECT_NAME" --chroots "$CHROOTS" --delete-project-after-days=7 --additional-repos="copr://rpmsoftwaremanagement/dnf-nightly copr://rpmsoftwaremanagement/dnf5-unstable"
 
   copr-build:
     name: Copr Build


### PR DESCRIPTION
This is needed because since rpm-software-management/dnf#1937 new dnf-data (in dnf-nightly) requires `/etc/dnf/dnf.conf` but in rawhide and dnf-nightly nothing provides that. It is provided by new libdnf5 currently only present in dnf5-unstable.

It should make the CI Copr builds pass on rawhide.