### PR TITLE
Support --forcearch for many commands

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -52,6 +52,7 @@ void DistroSyncCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
+    create_forcearch_option(*this);
 }
 
 void DistroSyncCommand::configure() {

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -79,6 +79,7 @@ void DownloadCommand::set_argument_parser() {
 
     cmd.register_named_arg(alldeps);
     create_destdir_option(*this);
+    create_forcearch_option(*this);
     cmd.register_named_arg(resolve);
     cmd.register_positional_arg(keys);
 }

--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -25,6 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "group_remove.hpp"
 #include "group_upgrade.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 void GroupCommand::set_parent_command() {
@@ -36,6 +38,7 @@ void GroupCommand::set_parent_command() {
 
 void GroupCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Manage comps groups");
+    create_forcearch_option(*this);
 }
 
 void GroupCommand::register_subcommands() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -54,6 +54,7 @@ void InstallCommand::set_argument_parser() {
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     create_downloadonly_option(*this);
+    create_forcearch_option(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/bgettext/bgettext-mark-domain.h"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf5-cli/output/package_list_sections.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 
@@ -56,6 +57,8 @@ void ListCommand::set_argument_parser() {
         });
     specs->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, true, false, false); });
     cmd.register_positional_arg(specs);
+
+    create_forcearch_option(*this);
 
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "makecache.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <fmt/format.h>
 
 #include <iostream>
@@ -35,6 +36,7 @@ void MakeCacheCommand::set_parent_command() {
 
 void MakeCacheCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Generate the metadata cache");
+    create_forcearch_option(*this);
 }
 
 void MakeCacheCommand::run() {

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_info.hpp"
 #include "repo_list.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 void RepoCommand::set_parent_command() {
@@ -33,6 +35,7 @@ void RepoCommand::set_parent_command() {
 
 void RepoCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Manage repositories");
+    create_forcearch_option(*this);
 }
 
 void RepoCommand::register_subcommands() {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/utils/patterns.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf5/advisory/advisory_query.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_string.hpp>
@@ -234,6 +235,7 @@ void RepoqueryCommand::set_argument_parser() {
         "",
         false,
         ",");
+    create_forcearch_option(*this);
     arch = std::make_unique<libdnf5::cli::session::AppendStringListOption>(
         *this, "arch", '\0', "Limit to packages of these architectures.", "ARCH,...", "", false, ",");
     file = std::make_unique<libdnf5::cli::session::AppendStringListOption>(

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "search_processor.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf5-cli/output/search.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/rpm/package_query.hpp>
@@ -47,6 +48,8 @@ void SearchCommand::set_argument_parser() {
 
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
+
+    create_forcearch_option(*this);
 }
 
 void SearchCommand::configure() {

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "swap.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace fs = std::filesystem;
 
 namespace dnf5 {
@@ -66,6 +68,7 @@ void SwapCommand::set_argument_parser() {
     cmd.register_positional_arg(install_spec_arg);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    create_forcearch_option(*this);
 }
 
 void SwapCommand::configure() {

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -59,12 +59,16 @@ public:
 };
 
 /// Create two options (`--allow-downgrade` and `--no-allow-downgrade`) for a command provided as an argument command.
-/// The values are atored in the `allow_downgrade` configuration option
+/// The values are stored in the `allow_downgrade` configuration option
 void create_allow_downgrade_options(dnf5::Command & command);
 
 /// Create the `--destdir` option for a command provided as an argument.
 /// The values are stored in the `destdir` configuration option
 void create_destdir_option(dnf5::Command & command);
+
+/// Create the `--forcearch` option for a command provided as an argument.
+/// The values are stored in the `forcearch` configuration option
+void create_forcearch_option(dnf5::Command & command);
 
 /// Create the `--downloadonly` option for a command provided as an argument.
 /// The values are stored in the `downloadonly` configuration option

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -69,11 +69,11 @@ void create_forcearch_option(dnf5::Command & command) {
     forcearch->set_has_value(true);
     forcearch->set_arg_value_help("FORCEARCH");
     forcearch->set_parse_hook_func([&ctx](
-                                       [[maybe_unused]] libdnf::cli::ArgumentParser::NamedArg * arg,
+                                       [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
                                        [[maybe_unused]] const char * option,
                                        const char * value) {
-        ctx.base.get_config().get_ignorearch_option().set(libdnf::Option::Priority::COMMANDLINE, true);
-        ctx.base.get_vars()->set("arch", value, libdnf::Vars::Priority::COMMANDLINE);
+        ctx.base.get_config().get_ignorearch_option().set(libdnf5::Option::Priority::COMMANDLINE, true);
+        ctx.base.get_vars()->set("arch", value, libdnf5::Vars::Priority::COMMANDLINE);
         return true;
     });
     command.get_argument_parser_command()->register_named_arg(forcearch);

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -60,6 +60,25 @@ void create_destdir_option(dnf5::Command & command) {
     command.get_argument_parser_command()->register_named_arg(destdir);
 }
 
+void create_forcearch_option(dnf5::Command & command) {
+    auto & ctx = command.get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto forcearch = parser.add_new_named_arg("forcearch");
+    forcearch->set_long_name("forcearch");
+    forcearch->set_description("Force the use of a different architecture.");
+    forcearch->set_has_value(true);
+    forcearch->set_arg_value_help("FORCEARCH");
+    forcearch->set_parse_hook_func([&ctx](
+                                       [[maybe_unused]] libdnf::cli::ArgumentParser::NamedArg * arg,
+                                       [[maybe_unused]] const char * option,
+                                       const char * value) {
+        ctx.base.get_config().get_ignorearch_option().set(libdnf::Option::Priority::COMMANDLINE, true);
+        ctx.base.get_vars()->set("arch", value, libdnf::Vars::Priority::COMMANDLINE);
+        return true;
+    });
+    command.get_argument_parser_command()->register_named_arg(forcearch);
+}
+
 void create_downloadonly_option(dnf5::Command & command) {
     auto & parser = command.get_context().get_argument_parser();
     auto downloadonly = parser.add_new_named_arg("downloadonly");

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -44,6 +44,10 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 
 Examples
 ========

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -47,6 +47,11 @@ Options
 ``--destdir=<path>``
     Set directory used for downloading packages to. Default location is to the current working directory.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
+
 Examples
 ========
 

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -91,6 +91,11 @@ Options
 ``--contains-pkgs``
     | Show only groups containing packges with specified names. List option, supports globs.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
+
 Examples
 ========
 

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -74,6 +74,10 @@ Options
 ``--newpackage``
     | Consider only content contained in newpackage advisories.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 
 Examples
 ========

--- a/doc/commands/makecache.8.rst
+++ b/doc/commands/makecache.8.rst
@@ -36,3 +36,11 @@ for enabled repositories.
 
 It tries to avoid downloading whenever possible, e.g. when the local metadata hasn't
 expired yet or when the metadata timestamp hasn't changed.
+
+
+Options
+=======
+
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.

--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -58,6 +58,10 @@ Options
 ``--disabled``
     | Show information only about disabled repositories.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 
 Examples
 ========

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -99,6 +99,10 @@ Options
 ``--info``
     | Use the verbose format for the output.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 
 Examples
 ========

--- a/doc/commands/search.8.rst
+++ b/doc/commands/search.8.rst
@@ -46,6 +46,10 @@ Options
     | Search patterns also inside `Description` and `URL` fields.
     | By applying this option the search lists packages that match at least one of the keys (OR operation).
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 
 Examples
 ========

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -41,6 +41,11 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
+
 
 Examples
 ========

--- a/doc/misc/forcearch.7.rst
+++ b/doc/misc/forcearch.7.rst
@@ -1,0 +1,43 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _forcearch_misc_ref-label:
+
+####################
+ Forcearch Parameter
+####################
+
+Description
+===========
+
+The ``--forcearch=<arch>`` parameter overrides the system architecture detected by DNF 5. It allows querying repositories for packages not compatible with your host system and installing them. Any architecture can be specified, but using a package with an architecture not supported natively by your CPU will require emulation of some kind, e.g. using qemu-user-static.
+
+``--forcearch`` is supported by the following commands: ``distro-sync``, ``download``, ``group``,  ``info``, ``install``, ``list``, ``makecache``, ``repo``, ``repoquery``, ``search``, and ``swap``.
+
+
+Examples
+========
+
+``dnf5 install --forcearch=aarch64 my-example-package``
+    Installs the version of ``my-example-package`` for the AArch64 architecture, regardless of the architecture of the host system.
+
+``dnf5 download --forcearch=s390x hello``
+    Downloads the ``hello`` package for the s390x architecture.
+
+``dnf5 repoquery --forcearch=aarch64 --arch=aarch64``
+    Query all packages available for the AArch64 architecture. If your system has a different native architecture, then both ``--arch`` and ``--forcearch`` are necessary here. ``--arch`` will filter for only packages with the ``aarch64`` architecture, and ``--forcearch`` sets the "arch" and "basearch" substitution variables to ensure the correct repositories are queried.

--- a/doc/misc/index.rst
+++ b/doc/misc/index.rst
@@ -7,6 +7,7 @@ Miscellaneous
     :maxdepth: 1
 
     comps.7
+    forcearch.7
     installroot.7
     specs.7
 

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -178,6 +178,9 @@ int Transaction::run() {
     if (downgrade_requested) {
         ignore_set |= RPMPROB_FILTER_OLDPACKAGE;
     }
+    if (base->get_config().get_ignorearch_option().get_value()) {
+        ignore_set |= RPMPROB_FILTER_IGNOREARCH;
+    }
     rpmtsSetNotifyStyle(ts, 1);
     rpmtsSetNotifyCallback(ts, ts_callback, &callbacks_holder);
     auto rc = rpmtsRun(ts, nullptr, ignore_set);


### PR DESCRIPTION
Added --forcearch to:

- `dnf5 distro-sync`
- `dnf5 download`
- `dnf5 group`
- `dnf5 install`
- `dnf5 makecache`
- `dnf5 repo`
- `dnf5 repoquery`
- `dnf5 search`
- `dnf5 swap`

The --forcearch=<arch> argument overrides the "arch" and "basearch" substitution vars and tells librpm to allow installations of packages not matching the architecture of the host system. It enables several use cases, including:

- Install packages to be used with something like qemu-user-static
- Search repos for packages built for a different architecture
- Download packages to be installed on another system

Resolves https://github.com/rpm-software-management/dnf5/issues/112.

A good Fedora package to test this with is `Random123-doc` since it has a version for `x86_64` and `aarch64` (though it probably should be `noarch` since it's documentation?) but has no dependencies.

The `forcearch` argument/conf option should override the `arch` and `basearch` vars as well as the `ignorearch` conf option, but there didn't seem to be a standard place we do post-processing of config like this. I put the logic  [here](https://github.com/evan-goode/dnf5/blob/ac70b2c810d73eecb3724deefb32630af779e44a/libdnf/base/base.cpp#L193) in `Base::setup()` since it needs to happen in after config is loaded and before the RPM pool is set up with the architecture. But maybe there should be a `Base::apply_vars_overrides()` or something so `Base::setup()` doesn't get so cluttered.

If this looks good, I can add the docs changes to this PR. Tests are also still on the way, there don't seem to be any tests in dnf-ci-stack already for `--forcearch`.