### PR TITLE
Modify libdnf5-devel to generate pkgconf(libdnf5)

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -316,7 +316,6 @@ Summary:        Development files for libdnf
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libsolv-devel%{?_isa} >= %{libsolv_version}
-Conflicts:      libdnf-devel < 5
 
 %description -n libdnf5-devel
 Development files for libdnf.
@@ -325,7 +324,7 @@ Development files for libdnf.
 %{_includedir}/libdnf/
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so
-%{_libdir}/pkgconfig/libdnf.pc
+%{_libdir}/pkgconfig/libdnf5.pc
 %license COPYING.md
 %license lgpl-2.1.txt
 

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -103,8 +103,8 @@ list(JOIN LIBDNF5_PC_REQUIRES_PRIVATE ", " LIBDNF5_PC_REQUIRES_PRIVATE_STRING)
 
 
 # create a .pc file
-configure_file("libdnf.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libdnf.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+configure_file("libdnf5.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
 
 # Makes an empty directory for libdnf cache
 install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/cache/libdnf)

--- a/libdnf/libdnf5.pc.in
+++ b/libdnf/libdnf5.pc.in
@@ -7,5 +7,5 @@ Description: Package management library
 Version: @PROJECT_VERSION@
 Requires: @LIBDNF5_PC_REQUIRES_STRING@
 Requires.private: @LIBDNF5_PC_REQUIRES_PRIVATE_STRING@
-Libs: -L${libdir} -ldnf
+Libs: -L${libdir} -ldnf5
 Cflags: -I${includedir}

--- a/libdnf/libdnf5.pc.in
+++ b/libdnf/libdnf5.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 Name: libdnf5
 Description: Package management library
 Version: @PROJECT_VERSION@
-Requires: @LIBDNF_PC_REQUIRES_STRING@
-Requires.private: @LIBDNF_PC_REQUIRES_PRIVATE_STRING@
+Requires: @LIBDNF5_PC_REQUIRES_STRING@
+Requires.private: @LIBDNF5_PC_REQUIRES_PRIVATE_STRING@
 Libs: -L${libdir} -ldnf
 Cflags: -I${includedir}

--- a/libdnf/libdnf5.pc.in
+++ b/libdnf/libdnf5.pc.in
@@ -2,7 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
-Name: libdnf
+Name: libdnf5
 Description: Package management library
 Version: @PROJECT_VERSION@
 Requires: @LIBDNF_PC_REQUIRES_STRING@


### PR DESCRIPTION
It also allow parallel installation of libdnf5-devel and libdnf-devel.