### PR TITLE
Verify transaction PGP signatures automatically

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -77,6 +77,10 @@ public:
         return libdnf5::cli::utils::userconfirm::userconfirm(*config);
     }
 
+    void repokey_imported([[maybe_unused]] const libdnf5::rpm::KeyInfo & key_info) override {
+        std::cout << _("The key was successfully imported.") << std::endl;
+    }
+
 private:
     libdnf5::ConfigMain * config;
 };

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -105,9 +105,6 @@ public:
     void print_info(std::string_view msg) const;
 
 private:
-    /// Check GPG signatures of packages that are going to be installed
-    bool check_gpg_signatures(libdnf5::base::Transaction & transaction);
-
     /// Program arguments.
     size_t argc{0};
     const char * const * argv{nullptr};

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -218,9 +218,9 @@ void DownloadCB::key_import(sdbus::Signal & signal) {
         std::string url;
         signal >> key_id >> user_ids >> fingerprint >> url;
 
-        std::cout << "Importing PGP key: " + key_id << std::endl;
+        std::cout << std::endl << "Importing PGP key 0x" + key_id << ":\n";
         for (auto & user_id : user_ids) {
-            std::cout << " Userid     : " + user_id << std::endl;
+            std::cout << " Userid     : \"" + user_id << "\"\n";
         }
         std::cout << " Fingerprint: " + fingerprint << std::endl;
         std::cout << " From       : " + url << std::endl;
@@ -237,7 +237,6 @@ void DownloadCB::key_import(sdbus::Signal & signal) {
         } catch (const sdbus::Error & ex) {
             std::cerr << ex.what() << std::endl;
         }
-        print();
     }
 }
 

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -109,7 +109,7 @@ bool KeyImportRepoCB::repokey_import(const libdnf5::rpm::KeyInfo & key_info) {
         signal << key_info.get_short_key_id() << key_info.get_user_ids() << key_info.get_fingerprint()
                << key_info.get_url() << static_cast<int64_t>(key_info.get_timestamp());
         // wait for client's confirmation
-        confirmed = session.wait_for_key_confirmation(key_info.get_key_id(), signal);
+        confirmed = session.wait_for_key_confirmation(key_info.get_short_key_id(), signal);
     } catch (...) {
         confirmed = false;
     }

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -102,18 +102,14 @@ int DownloadCB::mirror_failure(void * user_cb_data, const char * msg, const char
 }
 
 
-bool KeyImportRepoCB::repokey_import(
-    const std::string & id,
-    const std::vector<std::string> & user_ids,
-    const std::string & fingerprint,
-    const std::string & url,
-    long int timestamp) {
+bool KeyImportRepoCB::repokey_import(const libdnf5::rpm::KeyInfo & key_info) {
     bool confirmed;
     try {
         auto signal = create_signal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST);
-        signal << id << user_ids << fingerprint << url << static_cast<int64_t>(timestamp);
+        signal << key_info.get_short_key_id() << key_info.get_user_ids() << key_info.get_fingerprint()
+               << key_info.get_url() << static_cast<int64_t>(key_info.get_timestamp());
         // wait for client's confirmation
-        confirmed = session.wait_for_key_confirmation(id, signal);
+        confirmed = session.wait_for_key_confirmation(key_info.get_key_id(), signal);
     } catch (...) {
         confirmed = false;
     }

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/repo/download_callbacks.hpp>
 #include <libdnf5/repo/package_downloader.hpp>
 #include <libdnf5/repo/repo_callbacks.hpp>
+#include <libdnf5/rpm/rpm_signature.hpp>
 #include <libdnf5/rpm/transaction_callbacks.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
@@ -83,12 +84,7 @@ class KeyImportRepoCB : public DbusCallback, public libdnf5::repo::RepoCallbacks
 public:
     KeyImportRepoCB(Session & session) : DbusCallback(session) {}
 
-    bool repokey_import(
-        const std::string & id,
-        const std::vector<std::string> & user_ids,
-        const std::string & fingerprint,
-        const std::string & url,
-        long int timestamp) override;
+    bool repokey_import(const libdnf5::rpm::KeyInfo & key_info) override;
 };
 
 

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -64,6 +64,7 @@ public:
         ERROR_LOCK,
         ERROR_CHECK,
         ERROR_RPM_RUN,
+        ERROR_GPG_CHECK,
     };
 
     Transaction(const Transaction & transaction);

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -150,24 +150,10 @@ public:
 
     /// @brief Check signatures of packages in the resolved transaction.
     ///
-    /// @param import_keys When the parameter is on, problems related to missing GPG keys are
-    /// tried to be automatically recovered by importing the missing ones.
-    ///
     /// @return True if all packages have correct signatures or checking is turned off with `gpgcheck` option,
     /// otherwise false. More info about occurred problems can be retrieved using the `get_gpg_signature_problems`
     /// method.
-    bool check_gpg_signatures(bool import_keys = true);
-
-    /// @brief Check signatures of packages in the resolved transaction.
-    ///
-    /// @param import_confirm_func This function is used for deciding whether to import the given GPG key
-    /// when a problem related to missing keys occurs.
-    ///
-    /// @return True if all packages have correct signatures or checking is turned off with `gpgcheck` option,
-    /// otherwise false. More info about occurred problems can be retrieved using the `get_gpg_signature_problems`
-    /// method.
-    // TODO(jkolarik): To be reworked as we don't want std::function exposed on the public API
-    bool check_gpg_signatures(std::function<bool(const libdnf5::rpm::KeyInfo &)> & import_confirm_func);
+    bool check_gpg_signatures();
 
     /// Retrieve a list of the problems that occurred during `check_gpg_signatures` procedure.
     std::vector<std::string> get_gpg_signature_problems() const noexcept;

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -100,6 +100,9 @@ public:
     // @replaces libdnf:repo/Repo.hpp:method:Repo.setCallbacks(std::unique_ptr<RepoCallbacks> && callbacks)
     void set_callbacks(std::unique_ptr<libdnf5::repo::RepoCallbacks> && callbacks);
 
+    /// Returns the currently registered callbacks for the repo.
+    std::unique_ptr<libdnf5::repo::RepoCallbacks> & get_callbacks();
+
     /// @brief Sets the associated user data. These are used in callbacks.
     /// @param user_data  Pointer to user data
     void set_user_data(void * user_data) noexcept;

--- a/include/libdnf5/repo/repo_callbacks.hpp
+++ b/include/libdnf5/repo/repo_callbacks.hpp
@@ -23,6 +23,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+namespace libdnf5::rpm {
+class KeyInfo;
+}
+
+
 namespace libdnf5::repo {
 
 /// Base class for repository callbacks.
@@ -40,20 +45,9 @@ public:
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
     /// GPG key import callback. Allows to confirm or deny the import.
-    /// @param id the key id
-    /// @param user_ids the list of the key user IDs
-    /// @param fingerprint the fingerprint of the key
-    /// @param url the URL from which the key was downloaded
-    /// @param timestamp the timestamp of the key
+    /// @param key_info The key that is about to be imported
     /// @return `true` to import the key, `false` to not import
-    virtual bool repokey_import(
-        const std::string & id,
-        const std::vector<std::string> & user_ids,
-        const std::string & fingerprint,
-        const std::string & url,
-        long int timestamp) {
-        return true;
-    }
+    virtual bool repokey_import(const libdnf5::rpm::KeyInfo & key_info) { return true; }
 #pragma GCC diagnostic pop
 };
 

--- a/include/libdnf5/repo/repo_callbacks.hpp
+++ b/include/libdnf5/repo/repo_callbacks.hpp
@@ -48,6 +48,10 @@ public:
     /// @param key_info The key that is about to be imported
     /// @return `true` to import the key, `false` to not import
     virtual bool repokey_import(const libdnf5::rpm::KeyInfo & key_info) { return true; }
+    /// Called on successfull repo key import.
+    /// @param key_info The key that was successfully imported
+    virtual void repokey_imported(const libdnf5::rpm::KeyInfo & key_info) {}
+
 #pragma GCC diagnostic pop
 };
 

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -53,8 +53,10 @@ public:
     const std::string & get_fingerprint() const noexcept { return fingerprint; }
     const std::string & get_url() const noexcept { return key_url; }
     const std::string & get_path() const noexcept { return key_path; }
+    const std::string & get_raw_key() const noexcept { return raw_key; }
+    const long int & get_timestamp() const noexcept { return timestamp; }
 
-private:
+protected:
     friend class RpmSignature;
     KeyInfo(
         const std::string & key_url,
@@ -62,12 +64,14 @@ private:
         const std::string & key_id,
         const std::vector<std::string> & user_ids,
         const std::string & fingerprint,
-        std::string raw_key);
+        long int timestamp,
+        const std::string & raw_key);
     std::string key_url;
     std::string key_path;
     std::string key_id;
     std::vector<std::string> user_ids;
     std::string fingerprint;
+    long int timestamp;
     std::string raw_key;
 };
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -920,6 +920,9 @@ ImportRepoKeysResult Transaction::Impl::import_repo_keys(libdnf5::repo::Repo & r
 
             try {
                 if (rpm_signature.import_key(key_info)) {
+                    if (callbacks) {
+                        callbacks->repokey_imported(key_info);
+                    }
                     continue;
                 }
             } catch (const libdnf5::rpm::KeyImportError & ex) {

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -114,9 +114,8 @@ private:
         const std::string & comment,
         const bool test_only);
 
-    bool check_gpg_signatures(std::function<bool(const libdnf5::rpm::KeyInfo &)> & import_confirm_func);
-    ImportRepoKeysResult import_repo_keys(
-        libdnf5::repo::Repo & repo, std::function<bool(const libdnf5::rpm::KeyInfo &)> & import_confirm_func);
+    bool check_gpg_signatures();
+    ImportRepoKeysResult import_repo_keys(libdnf5::repo::Repo & repo);
 };
 
 

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -113,6 +113,10 @@ void Repo::set_callbacks(std::unique_ptr<RepoCallbacks> && callbacks) {
     downloader->set_callbacks(std::move(callbacks));
 }
 
+std::unique_ptr<libdnf5::repo::RepoCallbacks> & Repo::get_callbacks() {
+    return downloader->callbacks;
+}
+
 void Repo::set_user_data(void * user_data) noexcept {
     downloader->set_user_data(user_data);
 }

--- a/libdnf5/repo/repo_pgp.cpp
+++ b/libdnf5/repo/repo_pgp.cpp
@@ -142,6 +142,9 @@ void RepoPgp::import_key(int fd, const std::string & url) {
             throw_repo_pgp_error(M_("Failed to import pgp keys: {}"), err);
         }
 
+        if (callbacks) {
+            callbacks->repokey_imported(key_info);
+        }
         logger.debug("Imported pgp key 0x{} for repository {}.", key_info.get_key_id(), config.get_id());
     }
 }

--- a/libdnf5/repo/repo_pgp.hpp
+++ b/libdnf5/repo/repo_pgp.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/repo/config_repo.hpp"
 #include "libdnf5/repo/repo_callbacks.hpp"
+#include "libdnf5/rpm/rpm_signature.hpp"
 
 #include <librepo/librepo.h>
 
@@ -34,23 +35,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::repo {
 
-class Key {
+class Key : public libdnf5::rpm::KeyInfo {
 public:
-    Key(const LrGpgKey * key, const LrGpgSubkey * subkey);
-
-    const std::string & get_id() const noexcept { return id; }
-    const std::vector<std::string> & get_user_ids() const noexcept { return user_ids; }
-    const std::string & get_fingerprint() const noexcept { return fingerprint; }
-    long int get_timestamp() const noexcept { return timestamp; }
-    const std::string & get_raw_key() const noexcept { return raw_key; }
-
-
-private:
-    std::string id;
-    std::string fingerprint;
-    std::vector<std::string> user_ids;
-    long int timestamp;
-    std::string raw_key;
+    Key(const LrGpgKey * key, const LrGpgSubkey * subkey, const std::string & url, const std::string & path);
 };
 
 /// Wraps pgp in a higher-level interface.
@@ -64,7 +51,7 @@ public:
     std::filesystem::path get_keyring_dir() const { return std::filesystem::path(config.get_cachedir()) / "pubring"; }
 
     void import_key(int fd, const std::string & url);
-    static std::vector<Key> rawkey2infos(int fd);
+    static std::vector<Key> rawkey2infos(int fd, const std::string & url, const std::string & path = "");
 
 private:
     std::vector<std::string> load_keys_ids_from_keyring();

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -88,12 +88,14 @@ KeyInfo::KeyInfo(
     const std::string & key_id,
     const std::vector<std::string> & user_ids,
     const std::string & fingerprint,
-    std::string raw_key)
+    long int timestamp,
+    const std::string & raw_key)
     : key_url(key_url),
       key_path(key_path),
       key_id(key_id),
       user_ids(user_ids),
       fingerprint(fingerprint),
+      timestamp(timestamp),
       raw_key(raw_key) {}
 
 std::string KeyInfo::get_short_key_id() const {
@@ -229,15 +231,8 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
 
     std::vector<KeyInfo> keys;
     utils::fs::File key_file(key_path, "r");
-    for (auto & key_info : repo::RepoPgp::rawkey2infos(key_file.get_fd())) {
-        KeyInfo key{
-            key_url,
-            key_path,
-            key_info.get_id(),
-            key_info.get_user_ids(),
-            key_info.get_fingerprint(),
-            key_info.get_raw_key()};
-        keys.emplace_back(std::move(key));
+    for (auto & key_info : repo::RepoPgp::rawkey2infos(key_file.get_fd(), key_url, key_path)) {
+        keys.emplace_back(key_info);
     }
 
     return keys;

--- a/test/libdnf5/repo/test_repo.cpp
+++ b/test/libdnf5/repo/test_repo.cpp
@@ -91,12 +91,7 @@ public:
 
 class RepoCallbacks : public libdnf5::repo::RepoCallbacks {
 public:
-    bool repokey_import(
-        [[maybe_unused]] const std::string & id,
-        [[maybe_unused]] const std::vector<std::string> & user_ids,
-        [[maybe_unused]] const std::string & fingerprint,
-        [[maybe_unused]] const std::string & url,
-        [[maybe_unused]] long int timestamp) override {
+    bool repokey_import([[maybe_unused]] const libdnf5::rpm::KeyInfo & key_info) override {
         ++repokey_import_cnt;
         return true;
     }


### PR DESCRIPTION
Currently signatures verification requires to manually call `transaction.check_gpg_signatures()` API.
This PR removes the API and changes the workflow so that the signature verification is done automatically during the transaction run.

Resolves: https://github.com/rpm-software-management/dnf5/issues/556
Resolves: https://github.com/rpm-software-management/dnf5/issues/574
Resolves: https://github.com/rpm-software-management/dnf5/issues/557

Tests adujstments: https://github.com/rpm-software-management/ci-dnf-stack/pull/1314