### PR TITLE
test: Add cachedir to python3 bindings tutorial

### DIFF
--- a/test/python3/libdnf5/tutorial/session/create_base.py
+++ b/test/python3/libdnf5/tutorial/session/create_base.py
@@ -28,6 +28,12 @@ base.load_config_from_file()
 base_config = base.get_config()
 base_config.installroot = installroot
 
+# Optionally set cachedir.
+#
+# By default, system cachedir or user cachedir is used, but we can set it to a
+# different location. This is useful for tests.
+base_config.cachedir = cachedir
+
 # Load vars and do other initialization (of libsolv pool, etc.) based on the
 # configuration.  Locks the installroot and varsdir configuration values so
 # that they can't be changed.

--- a/test/python3/libdnf5/tutorial/test_tutorial.py
+++ b/test/python3/libdnf5/tutorial/test_tutorial.py
@@ -38,7 +38,7 @@ class TestTutorial(base_test_case.BaseTestCase):
         with open("tutorial/session/create_base.py", "r") as f:
             file += f.read()
 
-        exec(file, {'installroot': self.installroot})
+        exec(file, {'installroot': self.installroot, 'cachedir': self.cachedir})
 
     def test_load_repo(self):
         file = ""
@@ -48,7 +48,8 @@ class TestTutorial(base_test_case.BaseTestCase):
         with open("tutorial/repo/load_repo.py", "r") as f:
             file += f.read()
 
-        exec(file, {'installroot': self.installroot, 'baseurl': self.baseurl})
+        exec(file, {'installroot': self.installroot,
+                    'cachedir': self.cachedir, 'baseurl': self.baseurl})
 
     def test_load_system_repo(self):
         # TODO(nsella) This example does not 'compile' yet
@@ -73,7 +74,8 @@ class TestTutorial(base_test_case.BaseTestCase):
         with open("tutorial/query/query.py", "r") as f:
             file += f.read()
 
-        exec(file, {'installroot': self.installroot, 'baseurl': self.baseurl})
+        exec(file, {'installroot': self.installroot,
+                    'cachedir': self.cachedir, 'baseurl': self.baseurl})
 
     def test_transaction(self):
         file = ""
@@ -86,4 +88,5 @@ class TestTutorial(base_test_case.BaseTestCase):
         with open("tutorial/transaction/transaction.py", "r") as f:
             file += f.read()
 
-        exec(file, {'installroot': self.installroot, 'baseurl': self.baseurl})
+        exec(file, {'installroot': self.installroot,
+                    'cachedir': self.cachedir, 'baseurl': self.baseurl})


### PR DESCRIPTION
Without setting cachedir to a temporary directory, when testing the python3 bindings tutorial, the user cache directory is used and the test repository rpm-repo1 is cached there. When dnf5 is then built second time, the newly created repository metadata differ from the cached ones and the tests fail with:

terminate called after throwing an instance of 'Swig::DirectorMethodException'
  what():  SWIG director method error. Error detected when calling 'DownloadCallbacks.mirror_failure'

Resolves: https://github.com/rpm-software-management/dnf5/issues/572