### PR TITLE
changelog: Fix handling of the --since option

### DIFF
--- a/dnf5-plugins/changelog_plugin/CMakeLists.txt
+++ b/dnf5-plugins/changelog_plugin/CMakeLists.txt
@@ -1,3 +1,6 @@
+# set gettext domain for translations
+add_definitions(-DGETTEXT_DOMAIN=\"dnf5_cmd_changelog\")
+
 add_library(changelog_cmd_plugin MODULE changelog.cpp changelog_cmd_plugin.cpp)
 # disable the 'lib' prefix in order to create changelog_cmd_plugin.so
 set_target_properties(changelog_cmd_plugin PROPERTIES PREFIX "")

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -19,6 +19,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "changelog.hpp"
 
+#include "utils/bgettext/bgettext-mark-domain.h"
+
+#include <libdnf5-cli/argument_parser.hpp>
 #include <libdnf5-cli/output/changelogs.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_string.hpp>
@@ -54,7 +57,8 @@ void ChangelogCommand::set_argument_parser() {
                 std::istringstream ss(value);
                 ss >> std::get_time(&time_m, "%Y-%m-%d");
                 if (ss.fail()) {
-                    throw std::runtime_error(fmt::format("Invalid date: {}", value));
+                    throw libdnf5::cli::ArgumentParserError(
+                        M_("Invalid date passed: \"{}\". Dates in \"YYYY-MM-DD\" format are expected"), value);
                 }
                 return static_cast<int64_t>(mktime(&time_m));
             }))));

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -50,7 +50,7 @@ void ChangelogCommand::set_argument_parser() {
     since_option = dynamic_cast<libdnf5::OptionNumber<std::int64_t> *>(
         parser.add_init_value(std::unique_ptr<libdnf5::OptionNumber<std::int64_t>>(
             new libdnf5::OptionNumber<int64_t>(0, [](const std::string & value) {
-                struct tm time_m;
+                struct tm time_m = {};
                 std::istringstream ss(value);
                 ss >> std::get_time(&time_m, "%Y-%m-%d");
                 if (ss.fail()) {


### PR DESCRIPTION
Use the `libdnf::cli::ArgumentParserError` exception instead of the generic runtime error for invalid date format with `--since` option. This way it is processed in `main` instead of aborting and dumping the core.

Also initialize the `time_m` struct with default values, otherwise it results in returning random values.

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1322.
Closes: #627.