### PR TITLE
Do not download updateinfo and comps metadata by default

### DIFF
--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -86,6 +86,15 @@ void CheckUpgradeCommand::configure() {
         context.base.get_config().get_optional_metadata_types_option().add(
             libdnf5::Option::Priority::RUNTIME, libdnf5::OPTIONAL_METADATA_TYPES);
     }
+    context.update_repo_metadata_from_advisory_options(
+        advisory_name->get_value(),
+        advisory_security->get_value(),
+        advisory_bugfix->get_value(),
+        advisory_enhancement->get_value(),
+        advisory_newpackage->get_value(),
+        advisory_severity->get_value(),
+        advisory_bz->get_value(),
+        advisory_cve->get_value());
 }
 
 std::unique_ptr<libdnf5::cli::output::PackageListSections> CheckUpgradeCommand::create_output() {

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -84,7 +84,7 @@ void CheckUpgradeCommand::configure() {
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
     if (changelogs->get_value()) {
         context.base.get_config().get_optional_metadata_types_option().add(
-            libdnf5::Option::Priority::RUNTIME, libdnf5::OPTIONAL_METADATA_TYPES);
+            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_OTHER);
     }
     context.update_repo_metadata_from_advisory_options(
         advisory_name->get_value(),

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -74,14 +74,15 @@ void InstallCommand::configure() {
     auto & context = get_context();
     context.update_repo_metadata_from_specs(pkg_specs);
     context.set_load_system_repo(true);
-    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
-                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
-                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
-                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
-    if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(
-            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_UPDATEINFO);
-    }
+    context.update_repo_metadata_from_advisory_options(
+        advisory_name->get_value(),
+        advisory_security->get_value(),
+        advisory_bugfix->get_value(),
+        advisory_enhancement->get_value(),
+        advisory_newpackage->get_value(),
+        advisory_severity->get_value(),
+        advisory_bz->get_value(),
+        advisory_cve->get_value());
 
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -352,14 +352,15 @@ void RepoqueryCommand::configure() {
                          extras->get_value() || upgrades->get_value() || recent->get_value() ||
                          installonly->get_value();
     context.set_load_system_repo(system_repo_needed);
-    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
-                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
-                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
-                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
-    if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(
-            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_UPDATEINFO);
-    }
+    context.update_repo_metadata_from_advisory_options(
+        advisory_name->get_value(),
+        advisory_security->get_value(),
+        advisory_bugfix->get_value(),
+        advisory_enhancement->get_value(),
+        advisory_newpackage->get_value(),
+        advisory_severity->get_value(),
+        advisory_bz->get_value(),
+        advisory_cve->get_value());
     context.set_load_available_repos(
         // available_option is on by default, to check if user specified it we check priority
         available_option->get_priority() >= libdnf5::Option::Priority::COMMANDLINE || !system_repo_needed ||

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -82,14 +82,15 @@ void UpgradeCommand::configure() {
     auto & context = get_context();
     context.update_repo_metadata_from_specs(pkg_specs);
     context.set_load_system_repo(true);
-    bool updateinfo_needed = advisory_name->get_value().empty() || advisory_security->get_value() ||
-                             advisory_bugfix->get_value() || advisory_enhancement->get_value() ||
-                             advisory_newpackage->get_value() || advisory_severity->get_value().empty() ||
-                             advisory_bz->get_value().empty() || advisory_cve->get_value().empty();
-    if (updateinfo_needed) {
-        context.base.get_config().get_optional_metadata_types_option().add_item(
-            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_UPDATEINFO);
-    }
+    context.update_repo_metadata_from_advisory_options(
+        advisory_name->get_value(),
+        advisory_security->get_value(),
+        advisory_bugfix->get_value(),
+        advisory_enhancement->get_value(),
+        advisory_newpackage->get_value(),
+        advisory_severity->get_value(),
+        advisory_bz->get_value(),
+        advisory_cve->get_value());
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -136,6 +136,22 @@ void Context::update_repo_metadata_from_specs(const std::vector<std::string> & p
     }
 }
 
+void Context::update_repo_metadata_from_advisory_options(
+    const std::vector<std::string> & names,
+    bool security,
+    bool bugfix,
+    bool enhancement,
+    bool newpackage,
+    const std::vector<std::string> & severity,
+    const std::vector<std::string> & bzs,
+    const std::vector<std::string> & cves) {
+    bool updateinfo_needed = !names.empty() || security || bugfix || enhancement || newpackage || !severity.empty() ||
+                             !bzs.empty() || !cves.empty();
+    if (updateinfo_needed) {
+        base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_UPDATEINFO);
+    }
+}
 
 void Context::load_repos(bool load_system) {
     libdnf5::repo::RepoQuery repos(base);

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -133,6 +133,11 @@ void Context::update_repo_metadata_from_specs(const std::vector<std::string> & p
                 libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
             return;
         }
+        if (spec.starts_with('@')) {
+            base.get_config().get_optional_metadata_types_option().add_item(
+                libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
+            return;
+        }
     }
 }
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -55,6 +55,17 @@ public:
     /// Update required metadata types according to the provided `pkg_specs`.
     /// If a `pkg_spec` is a file pattern, the file lists need to be loaded.
     void update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs);
+    /// Update required metadata types according to the provided advisory options.
+    /// If any of the options is set we need to load updateinfo xml.
+    void update_repo_metadata_from_advisory_options(
+        const std::vector<std::string> & names,
+        bool security,
+        bool bugfix,
+        bool enhancement,
+        bool newpackage,
+        const std::vector<std::string> & severity,
+        const std::vector<std::string> & bzs,
+        const std::vector<std::string> & cves);
 
     /// Sets callbacks for repositories and loads them, updating metadata if necessary.
     void load_repos(bool load_system);


### PR DESCRIPTION
Updateinfo and comps metadata were always downloaded and loaded by default. This is not necessary because each command configures the `optional_metadata_types` to download/load only what it requires.

Also there was a bug in detection whether updateinfo metadata are needed.

For: https://bugzilla.redhat.com/show_bug.cgi?id=2214520

In my testing when loading updateinfo metadata memory requirements spike at ~623 MiB but without them its only ~132 MiB (on F38 with clean cache). I will further investigate why the updateinfo metadata use so much during libsolv loading, it seems unexpected to me given their size.