### PR TITLE
swig: Return None for unset options in Python

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -128,7 +128,10 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 import re
 
 def _config_option_getter(config_object, option_name):
-    return getattr(config_object, option_name)().get_value()
+    try:
+        return getattr(config_object, option_name)().get_value()
+    except RuntimeError:
+        return None
 
 def _config_option_setter(config_object, option_name, value):
     getattr(config_object, option_name)().set(value)

--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -70,3 +70,12 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
         option.lock('')
 
         self.assertRaises(RuntimeError, option.set, False)
+
+    def test_get_unset_option_by_attribute(self):
+        config = self.base.get_config()
+        destdir = config.destdir
+        self.assertEqual(destdir, None)
+
+    def test_get_unknown_option_by_attribute(self):
+        config = self.base.get_config()
+        self.assertRaises(AttributeError, lambda: config.xyz)


### PR DESCRIPTION
When using Python bindings, return a `None` value when accessing values of unset configuration options.

The solution is simplified to do so if any runtime error occurred within the `get_value()` option call.

API unit tests included.

Closes #594.