### PR TITLE
remove: Document removal of --noautoremove option

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -109,6 +109,11 @@ List command
    packages already listed in the `Installed Packages` section to reduce duplicities. But if the `--available` modifier
    is used, dnf5 considers all versions available in the enabled repositories, regardless of which version is installed.
 
+Remove command
+--------------
+ * Dropped `--noautoremove` option. The behavior for automatic removing of dependencies is now controlled by the
+   `clean_requirements_on_remove` configuration option which is set to `True` by default.
+
 Repoclosure command
 -------------------
  * Dropped `--pkg`` option. Positional arguments can be used to specify packages to check closure for.

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -32,8 +32,8 @@ Description
 ===========
 
 The ``remove`` command in ``DNF5`` is used for removing installed packages from the system.
-If you want to remove also all dependencies that are no longer needed by any other package,
-set the ``clean_requirements_on_remove`` configuration parameter to ``True``.
+If you want to keep the dependencies that were installed together with the given package,
+set the ``clean_requirements_on_remove`` configuration option to ``False``.
 
 
 Examples


### PR DESCRIPTION
Improve the documentation around the dropped `--noautoremove` option.