### PR TITLE
Add placeholder test to test/python3/libdnf5_cli

### DIFF
--- a/test/python3/libdnf5_cli/test_placeholder.py
+++ b/test/python3/libdnf5_cli/test_placeholder.py
@@ -1,0 +1,10 @@
+import unittest
+
+import libdnf5_cli
+
+# See https://discuss.python.org/t/unittest-fail-if-zero-tests-were-discovered/21498, https://github.com/pytest-dev/pytest/issues/2393
+
+
+class TestPlaceholder(unittest.TestCase):
+    def test_placeholder(self):
+        pass


### PR DESCRIPTION
The tests started failing after updating to Python 3.12 because of this change in unittest:
https://discuss.python.org/t/unittest-fail-if-zero-tests-were-discovered/21498 If no tests are discovered, unittest now fails with a nonzero exit code.

This adds a "placeholder" test that does nothing, just to get unittest to succeed.