### PR TITLE
downgrade: Adjust stderr message

### DIFF
--- a/libdnf5/base/log_event.cpp
+++ b/libdnf5/base/log_event.cpp
@@ -123,7 +123,7 @@ std::string LogEvent::to_string(
                 throw std::invalid_argument("Incorrect number of elements for INSTALLED_LOWEST_VERSION");
             }
             return ret.append(utils::sformat(
-                _("Package \"{}\" of lowest version already installed, cannot downgrade it."),
+                _("The lowest available version of the \"{}\" package is already installed, cannot downgrade it."),
                 *additional_data.begin()));
         }
         case GoalProblem::INSTALLED_IN_DIFFERENT_VERSION:

--- a/libdnf5/po/libdnf5.pot
+++ b/libdnf5/po/libdnf5.pot
@@ -80,7 +80,7 @@ msgstr ""
 
 #: base/log_event.cpp:104
 msgid ""
-"Package \"{}\" of lowest version already installed, cannot downgrade it."
+"The lowest available version of the \"{}\" package is already installed, cannot downgrade it."
 msgstr ""
 
 #: base/log_event.cpp:110


### PR DESCRIPTION
downgrade: Adjust stderr message when the lowest available version is already installed.
NOTE: upstream tests dnf/downgrade.feature and  dnf/shell-downgrade.feature has to be updated accordingly.