### PR TITLE
Use <> instead of " in include header files on more places

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/string.hpp"
 
-#include "libdnf5-cli/exception.hpp"
-
 #include <dnf5/shared_options.hpp>
+#include <libdnf5-cli/exception.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <rpm/rpmbuild.h>

--- a/dnf5-plugins/copr_plugin/download_file.cpp
+++ b/dnf5-plugins/copr_plugin/download_file.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "download_file.hpp"
 
-#include "libdnf5/repo/file_downloader.hpp"
+#include <libdnf5/repo/file_downloader.hpp>
 
 #include <filesystem>
 

--- a/dnf5-plugins/copr_plugin/json.hpp
+++ b/dnf5-plugins/copr_plugin/json.hpp
@@ -20,9 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_COPR_JSON_HPP
 #define DNF5_COMMANDS_COPR_JSON_HPP
 
-#include "libdnf5/base/base.hpp"
-
 #include <json.h>
+#include <libdnf5/base/base.hpp>
 
 
 class Json {

--- a/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
@@ -19,14 +19,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repoclosure.hpp"
 
-#include "libdnf5-cli/argument_parser.hpp"
-
-#include "libdnf5/conf/const.hpp"
-#include "libdnf5/rpm/package.hpp"
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/utils/format.hpp"
-
+#include <libdnf5-cli/argument_parser.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/rpm/package.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/format.hpp>
 
 #include <iostream>
 

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -19,8 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_list.hpp"
 
-#include "libdnf5-cli/output/advisorylist.hpp"
-
+#include <libdnf5-cli/output/advisorylist.hpp>
 #include <libdnf5/advisory/advisory_package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 

--- a/dnf5/commands/advisory_shared.hpp
+++ b/dnf5/commands/advisory_shared.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/string.hpp"
 
-#include "libdnf5/base/base_weak.hpp"
-
 #include <libdnf5-cli/session.hpp>
 #include <libdnf5/advisory/advisory_query.hpp>
+#include <libdnf5/base/base_weak.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 #include <optional>

--- a/dnf5/commands/history/transaction_id.hpp
+++ b/dnf5/commands/history/transaction_id.hpp
@@ -21,8 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_TRANSACTION_ID_HPP
 #define DNF5_COMMANDS_HISTORY_TRANSACTION_ID_HPP
 
-#include "libdnf5/common/exception.hpp"
-#include "libdnf5/transaction/transaction_history.hpp"
+#include <libdnf5/common/exception.hpp>
+#include <libdnf5/transaction/transaction_history.hpp>
 
 #include <cstdint>
 #include <string>

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repo_info.hpp"
 
-#include "libdnf5-cli/output/repo_info.hpp"
+#include <libdnf5-cli/output/repo_info.hpp>
 
 #include <iostream>
 

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repo_list.hpp"
 
-#include "libdnf5-cli/output/repolist.hpp"
+#include <libdnf5-cli/output/repolist.hpp>
 
 namespace dnf5 {
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -19,18 +19,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repoquery.hpp"
 
-#include "libdnf5-cli/output/changelogs.hpp"
-#include "libdnf5-cli/output/repoquery.hpp"
-
-#include "libdnf5/utils/patterns.hpp"
-
 #include <dnf5/shared_options.hpp>
+#include <libdnf5-cli/output/changelogs.hpp>
+#include <libdnf5-cli/output/repoquery.hpp>
 #include <libdnf5/advisory/advisory_query.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/utils/patterns.hpp>
 
 #include <iostream>
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -24,11 +24,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 #include "utils/url.hpp"
 
-#include "libdnf5-cli/utils/userconfirm.hpp"
-
 #include <fmt/format.h>
 #include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
 #include <libdnf5-cli/tty.hpp>
+#include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/base/goal.hpp>
 #include <libdnf5/conf/const.hpp>

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -47,15 +47,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "plugins.hpp"
 #include "utils.hpp"
 
-#include "libdnf5-cli/output/transaction_table.hpp"
-#include "libdnf5-cli/utils/userconfirm.hpp"
-
 #include <fcntl.h>
 #include <fmt/format.h>
 #include <libdnf5-cli/argument_parser.hpp>
 #include <libdnf5-cli/exception.hpp>
 #include <libdnf5-cli/exit-codes.hpp>
+#include <libdnf5-cli/output/transaction_table.hpp>
 #include <libdnf5-cli/session.hpp>
+#include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/common/xdg.hpp>
 #include <libdnf5/logger/factory.hpp>

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -21,11 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "context.hpp"
 
-#include "libdnf5-cli/utils/userconfirm.hpp"
-
 #include <dnf5daemon-server/dbus.hpp>
 #include <dnf5daemon-server/transaction.hpp>
 #include <libdnf5-cli/tty.hpp>
+#include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/repo/download_callbacks.hpp>
 #include <libdnf5/repo/package_downloader.hpp>
 #include <sdbus-c++/sdbus-c++.h>

--- a/dnf5daemon-client/commands/command.cpp
+++ b/dnf5daemon-client/commands/command.cpp
@@ -26,11 +26,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "wrappers/dbus_goal_wrapper.hpp"
 #include "wrappers/dbus_package_wrapper.hpp"
 
-#include "libdnf5-cli/exception.hpp"
-#include "libdnf5-cli/output/transaction_table.hpp"
-#include "libdnf5-cli/utils/userconfirm.hpp"
-
 #include <dnf5daemon-server/dbus.hpp>
+#include <libdnf5-cli/exception.hpp>
+#include <libdnf5-cli/output/transaction_table.hpp>
+#include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/goal.hpp>
 
 #include <iostream>

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -22,10 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "context.hpp"
 #include "wrappers/dbus_package_wrapper.hpp"
 
-#include "libdnf5-cli/output/repoquery.hpp"
-
 #include <dnf5daemon-server/dbus.hpp>
 #include <fmt/format.h>
+#include <libdnf5-cli/output/repoquery.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>

--- a/dnf5daemon-client/exception.hpp
+++ b/dnf5daemon-client/exception.hpp
@@ -16,10 +16,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5DAEMON_CLIENT_EXCEPTION_HPP
 #define DNF5DAEMON_CLIENT_EXCEPTION_HPP
 
-#include "libdnf5-cli/exception.hpp"
-#include "libdnf5-cli/exit-codes.hpp"
-
-#include "libdnf5/common/exception.hpp"
+#include <libdnf5-cli/exception.hpp>
+#include <libdnf5-cli/exit-codes.hpp>
+#include <libdnf5/common/exception.hpp>
 
 namespace dnfdaemon::client {
 

--- a/dnf5daemon-server/services/repoconf/configuration.hpp
+++ b/dnf5daemon-server/services/repoconf/configuration.hpp
@@ -23,9 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "session.hpp"
 
-#include "libdnf5/conf/config_main.hpp"
-#include "libdnf5/conf/config_parser.hpp"
-#include "libdnf5/repo/config_repo.hpp"
+#include <libdnf5/conf/config_main.hpp>
+#include <libdnf5/conf/config_parser.hpp>
+#include <libdnf5/repo/config_repo.hpp>
 
 #include <map>
 #include <memory>

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/exception.hpp"
 
-#include "libdnf5/conf/option.hpp"
+#include <libdnf5/conf/option.hpp>
 
 #include <functional>
 #include <memory>

--- a/include/libdnf5-cli/exception.hpp
+++ b/include/libdnf5-cli/exception.hpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "exit-codes.hpp"
 
-#include "libdnf5/base/transaction.hpp"
-#include "libdnf5/common/exception.hpp"
+#include <libdnf5/base/transaction.hpp>
+#include <libdnf5/common/exception.hpp>
 
 namespace libdnf5::cli {
 

--- a/include/libdnf5-cli/output/advisoryinfo.hpp
+++ b/include/libdnf5-cli/output/advisoryinfo.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/output/key_value_table.hpp"
 
-#include "libdnf5/advisory/advisory.hpp"
+#include <libdnf5/advisory/advisory.hpp>
 
 
 namespace libdnf5::cli::output {

--- a/include/libdnf5-cli/output/advisorylist.hpp
+++ b/include/libdnf5-cli/output/advisorylist.hpp
@@ -21,8 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_OUTPUT_ADVISORYLIST_HPP
 #define LIBDNF5_CLI_OUTPUT_ADVISORYLIST_HPP
 
-#include "libdnf5/advisory/advisory_package.hpp"
-#include "libdnf5/advisory/advisory_reference.hpp"
+#include <libdnf5/advisory/advisory_package.hpp>
+#include <libdnf5/advisory/advisory_reference.hpp>
 
 namespace libdnf5::cli::output {
 

--- a/include/libdnf5-cli/output/advisorysummary.hpp
+++ b/include/libdnf5-cli/output/advisorysummary.hpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_OUTPUT_ADVISORYSUMMARY_HPP
 #define LIBDNF5_CLI_OUTPUT_ADVISORYSUMMARY_HPP
 
-#include "libdnf5/advisory/advisory_query.hpp"
+#include <libdnf5/advisory/advisory_query.hpp>
 
 namespace libdnf5::cli::output {
 

--- a/include/libdnf5-cli/output/package_info_sections.hpp
+++ b/include/libdnf5-cli/output/package_info_sections.hpp
@@ -23,8 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "package_list_sections.hpp"
 
-#include "libdnf5/rpm/package_set.hpp"
-
+#include <libdnf5/rpm/package_set.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 #include <string>

--- a/include/libdnf5-cli/output/package_list_sections.hpp
+++ b/include/libdnf5-cli/output/package_list_sections.hpp
@@ -23,8 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "pkg_colorizer.hpp"
 
-#include "libdnf5/rpm/package_set.hpp"
-
+#include <libdnf5/rpm/package_set.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 #include <string>

--- a/include/libdnf5-cli/output/pkg_colorizer.hpp
+++ b/include/libdnf5-cli/output/pkg_colorizer.hpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_OUTPUT_PKG_COLORIZER_HPP
 #define LIBDNF5_CLI_OUTPUT_PKG_COLORIZER_HPP
 
-#include "libdnf5/rpm/package_set.hpp"
-
 #include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <map>
 #include <string>

--- a/include/libdnf5-cli/output/repoquery.hpp
+++ b/include/libdnf5-cli/output/repoquery.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_OUTPUT_REPOQUERY_HPP
 #define LIBDNF5_CLI_OUTPUT_REPOQUERY_HPP
 
-#include "libdnf5/rpm/package_set.hpp"
-
+#include <libdnf5/rpm/package_set.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 namespace libdnf5::cli::output {

--- a/include/libdnf5-cli/output/transaction_table.hpp
+++ b/include/libdnf5-cli/output/transaction_table.hpp
@@ -24,12 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5-cli/tty.hpp"
 #include "libdnf5-cli/utils/units.hpp"
 
-#include "libdnf5/common/exception.hpp"
-#include "libdnf5/utils/to_underlying.hpp"
-
 #include <fmt/format.h>
 #include <libdnf5/base/transaction.hpp>
+#include <libdnf5/common/exception.hpp>
 #include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/utils/to_underlying.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 #include <iostream>

--- a/include/libdnf5-cli/output/transactioninfo.hpp
+++ b/include/libdnf5-cli/output/transactioninfo.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/output/key_value_table.hpp"
 
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/transaction/transaction.hpp>
 
 
 namespace libdnf5::cli::output {

--- a/include/libdnf5-cli/utils/userconfirm.hpp
+++ b/include/libdnf5-cli/utils/userconfirm.hpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_UTILS_USERCONFIRM_HPP
 #define LIBDNF5_CLI_UTILS_USERCONFIRM_HPP
 
-#include "libdnf5/conf/config_main.hpp"
+#include <libdnf5/conf/config_main.hpp>
 
 #include <iostream>
 #include <string>

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -23,9 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "output/argument_parser.hpp"
 #include "utils/string.hpp"
 
-#include "libdnf5/common/exception.hpp"
-
 #include <fmt/format.h>
+#include <libdnf5/common/exception.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 

--- a/libdnf5-cli/output/advisoryinfo.cpp
+++ b/libdnf5-cli/output/advisoryinfo.cpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/string.hpp"
 
-#include "libdnf5/advisory/advisory_collection.hpp"
-#include "libdnf5/advisory/advisory_reference.hpp"
+#include <libdnf5/advisory/advisory_collection.hpp>
+#include <libdnf5/advisory/advisory_reference.hpp>
 
 namespace libdnf5::cli::output {
 

--- a/libdnf5-cli/output/changelogs.cpp
+++ b/libdnf5-cli/output/changelogs.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/tty.hpp"
 
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <ctime>
 #include <iomanip>

--- a/libdnf5-cli/output/package_info_sections.cpp
+++ b/libdnf5-cli/output/package_info_sections.cpp
@@ -24,9 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5-cli/tty.hpp"
 #include "libdnf5-cli/utils/units.hpp"
 
-#include "libdnf5/rpm/nevra.hpp"
-#include "libdnf5/rpm/package_set.hpp"
-
+#include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 #include <algorithm>

--- a/libdnf5-cli/output/package_list_sections.cpp
+++ b/libdnf5-cli/output/package_list_sections.cpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/tty.hpp"
 
-#include "libdnf5/rpm/nevra.hpp"
-#include "libdnf5/rpm/package_set.hpp"
-
+#include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 #include <libsmartcols/libsmartcols.h>
 
 #include <algorithm>

--- a/test/libdnf5-cli/output/test_repoquery.cpp
+++ b/test/libdnf5-cli/output/test_repoquery.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_repoquery.hpp"
 
-#include "libdnf5-cli/output/repoquery.hpp"
+#include <libdnf5-cli/output/repoquery.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RepoqueryTest);

--- a/test/libdnf5-cli/output/test_repoquery.hpp
+++ b/test/libdnf5-cli/output/test_repoquery.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../../shared/base_test_case.hpp"
 
-#include "libdnf5/rpm/package_query.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/rpm/package_query.hpp>
 
 #include <string>
 

--- a/test/libdnf5-cli/test_argument_parser.cpp
+++ b/test/libdnf5-cli/test_argument_parser.cpp
@@ -22,10 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5-cli/argument_parser.hpp"
-
-#include "libdnf5/conf/option_bool.hpp"
-#include "libdnf5/conf/option_string.hpp"
+#include <libdnf5-cli/argument_parser.hpp>
+#include <libdnf5/conf/option_bool.hpp>
+#include <libdnf5/conf/option_string.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ArgumentParserTest);

--- a/test/libdnf5-cli/utils/test_utf8.hpp
+++ b/test/libdnf5-cli/utils/test_utf8.hpp
@@ -22,10 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define TEST_LIBDNF5_CLI_UTILS_UTF8_HPP
 
 
-#include "libdnf5/rpm/package_set.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <string>
 

--- a/test/libdnf5/advisory/test_advisory.cpp
+++ b/test/libdnf5/advisory/test_advisory.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_advisory.hpp"
 
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <filesystem>
 #include <set>

--- a/test/libdnf5/advisory/test_advisory.hpp
+++ b/test/libdnf5/advisory/test_advisory.hpp
@@ -24,9 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/advisory/advisory_collection.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_collection.hpp>
 
 class AdvisoryAdvisoryTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryTest);

--- a/test/libdnf5/advisory/test_advisory_module.hpp
+++ b/test/libdnf5/advisory/test_advisory_module.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/advisory/advisory_collection.hpp"
-#include "libdnf5/advisory/advisory_module.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_collection.hpp>
+#include <libdnf5/advisory/advisory_module.hpp>
 
 class AdvisoryAdvisoryModuleTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryModuleTest);

--- a/test/libdnf5/advisory/test_advisory_package.hpp
+++ b/test/libdnf5/advisory/test_advisory_package.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/advisory/advisory_collection.hpp"
-#include "libdnf5/advisory/advisory_package.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_collection.hpp>
+#include <libdnf5/advisory/advisory_package.hpp>
 
 class AdvisoryAdvisoryPackageTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryPackageTest);

--- a/test/libdnf5/advisory/test_advisory_query.cpp
+++ b/test/libdnf5/advisory/test_advisory_query.cpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <filesystem>
 #include <set>

--- a/test/libdnf5/advisory/test_advisory_reference.cpp
+++ b/test/libdnf5/advisory/test_advisory_reference.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_advisory_reference.hpp"
 
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <filesystem>
 #include <set>

--- a/test/libdnf5/advisory/test_advisory_reference.hpp
+++ b/test/libdnf5/advisory/test_advisory_reference.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/advisory/advisory_collection.hpp"
-#include "libdnf5/advisory/advisory_reference.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_collection.hpp>
+#include <libdnf5/advisory/advisory_reference.hpp>
 
 class AdvisoryAdvisoryReferenceTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryReferenceTest);

--- a/test/libdnf5/advisory/test_advisory_set.cpp
+++ b/test/libdnf5/advisory/test_advisory_set.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_advisory_set.hpp"
 
-#include "libdnf5/advisory/advisory.hpp"
+#include <libdnf5/advisory/advisory.hpp>
 
 #include <filesystem>
 #include <vector>

--- a/test/libdnf5/advisory/test_advisory_set.hpp
+++ b/test/libdnf5/advisory/test_advisory_set.hpp
@@ -24,9 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/advisory/advisory_set.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_set.hpp>
 
 #include <memory>
 

--- a/test/libdnf5/base/test_base.cpp
+++ b/test/libdnf5/base/test_base.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_base.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/rpm/package_query.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(BaseTest);

--- a/test/libdnf5/base/test_goal.cpp
+++ b/test/libdnf5/base/test_goal.cpp
@@ -22,9 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/base/goal.hpp"
-#include "libdnf5/base/transaction_package.hpp"
-
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/base/transaction_package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 
 

--- a/test/libdnf5/base/test_transaction.cpp
+++ b/test/libdnf5/base/test_transaction.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/base/goal.hpp"
+#include <libdnf5/base/goal.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(BaseTransactionTest);

--- a/test/libdnf5/comps/test_environment.cpp
+++ b/test/libdnf5/comps/test_environment.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_environment.hpp"
 
-#include "libdnf5/comps/comps.hpp"
-#include "libdnf5/comps/environment/query.hpp"
+#include <libdnf5/comps/comps.hpp>
+#include <libdnf5/comps/environment/query.hpp>
 
 #include <filesystem>
 #include <fstream>

--- a/test/libdnf5/comps/test_environment_query.cpp
+++ b/test/libdnf5/comps/test_environment_query.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/comps/environment/query.hpp"
+#include <libdnf5/comps/environment/query.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(CompsEnvironmentQueryTest);

--- a/test/libdnf5/comps/test_group.cpp
+++ b/test/libdnf5/comps/test_group.cpp
@@ -23,9 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../shared/utils.hpp"
 #include "utils/fs/file.hpp"
 
-#include "libdnf5/comps/comps.hpp"
-#include "libdnf5/comps/group/package.hpp"
-#include "libdnf5/comps/group/query.hpp"
+#include <libdnf5/comps/comps.hpp>
+#include <libdnf5/comps/group/package.hpp>
+#include <libdnf5/comps/group/query.hpp>
 
 #include <filesystem>
 

--- a/test/libdnf5/comps/test_group_query.cpp
+++ b/test/libdnf5/comps/test_group_query.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/comps/group/query.hpp"
+#include <libdnf5/comps/group/query.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(CompsGroupQueryTest);

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/repo/config_repo.hpp"
+#include <libdnf5/repo/config_repo.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ConfTest);

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -23,10 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/test_case_fixture.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/logger/log_router.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/logger/log_router.hpp>
 
 
 class ConfTest : public TestCaseFixture {

--- a/test/libdnf5/conf/test_option.cpp
+++ b/test/libdnf5/conf/test_option.cpp
@@ -22,14 +22,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/conf/option_bool.hpp"
-#include "libdnf5/conf/option_child.hpp"
-#include "libdnf5/conf/option_enum.hpp"
-#include "libdnf5/conf/option_number.hpp"
-#include "libdnf5/conf/option_path.hpp"
-#include "libdnf5/conf/option_seconds.hpp"
-#include "libdnf5/conf/option_string.hpp"
-#include "libdnf5/conf/option_string_list.hpp"
+#include <libdnf5/conf/option_bool.hpp>
+#include <libdnf5/conf/option_child.hpp>
+#include <libdnf5/conf/option_enum.hpp>
+#include <libdnf5/conf/option_number.hpp>
+#include <libdnf5/conf/option_path.hpp>
+#include <libdnf5/conf/option_seconds.hpp>
+#include <libdnf5/conf/option_string.hpp>
+#include <libdnf5/conf/option_string_list.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(OptionTest);

--- a/test/libdnf5/conf/test_vars.hpp
+++ b/test/libdnf5/conf/test_vars.hpp
@@ -23,9 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/test_case_fixture.hpp"
 
-#include "libdnf5/base/base.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/base/base.hpp>
 
 
 class VarsTest : public TestCaseFixture {

--- a/test/libdnf5/impl_ptr/test_impl_ptr.cpp
+++ b/test/libdnf5/impl_ptr/test_impl_ptr.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_impl_ptr.hpp"
 
-#include "libdnf5/common/impl_ptr.hpp"
+#include <libdnf5/common/impl_ptr.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/test/libdnf5/logger/test_file_logger.cpp
+++ b/test/libdnf5/logger/test_file_logger.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_file_logger.hpp"
 
-#include "libdnf5/logger/factory.hpp"
+#include <libdnf5/logger/factory.hpp>
 
 
 using namespace std::filesystem;

--- a/test/libdnf5/logger/test_loggers.cpp
+++ b/test/libdnf5/logger/test_loggers.cpp
@@ -19,9 +19,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_loggers.hpp"
 
-#include "libdnf5/logger/log_router.hpp"
-#include "libdnf5/logger/memory_buffer_logger.hpp"
-#include "libdnf5/logger/stream_logger.hpp"
+#include <libdnf5/logger/log_router.hpp>
+#include <libdnf5/logger/memory_buffer_logger.hpp>
+#include <libdnf5/logger/stream_logger.hpp>
 
 #include <memory>
 #include <sstream>

--- a/test/libdnf5/module/test_module.cpp
+++ b/test/libdnf5/module/test_module.cpp
@@ -24,12 +24,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "module/module_db.hpp"
 #include "utils/fs/file.hpp"
 
-#include "libdnf5/module/module_errors.hpp"
-#include "libdnf5/module/module_item.hpp"
-#include "libdnf5/module/module_query.hpp"
-#include "libdnf5/module/module_sack.hpp"
-#include "libdnf5/module/nsvcap.hpp"
-#include "libdnf5/utils/format.hpp"
+#include <libdnf5/module/module_errors.hpp>
+#include <libdnf5/module/module_item.hpp>
+#include <libdnf5/module/module_query.hpp>
+#include <libdnf5/module/module_sack.hpp>
+#include <libdnf5/module/nsvcap.hpp>
+#include <libdnf5/utils/format.hpp>
 
 #include <filesystem>
 #include <fstream>

--- a/test/libdnf5/preserve_order_map/test_preserve_order_map.cpp
+++ b/test/libdnf5/preserve_order_map/test_preserve_order_map.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_preserve_order_map.hpp"
 
-#include "libdnf5/common/preserve_order_map.hpp"
+#include <libdnf5/common/preserve_order_map.hpp>
 
 #include <string>
 #include <vector>

--- a/test/libdnf5/query/test_query.cpp
+++ b/test/libdnf5/query/test_query.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_query.hpp"
 
-#include "libdnf5/common/sack/query.hpp"
+#include <libdnf5/common/sack/query.hpp>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(QueryTest);
 

--- a/test/libdnf5/repo/test_package_downloader.cpp
+++ b/test/libdnf5/repo/test_package_downloader.cpp
@@ -24,9 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/fs/file.hpp"
 #include "utils/string.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/repo/package_downloader.hpp"
-#include "libdnf5/rpm/package_query.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/repo/package_downloader.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 #include <filesystem>
 

--- a/test/libdnf5/repo/test_repo.cpp
+++ b/test/libdnf5/repo/test_repo.cpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/string.hpp"
 
-#include "libdnf5/base/base.hpp"
+#include <libdnf5/base/base.hpp>
 
 #include <filesystem>
 

--- a/test/libdnf5/repo/test_repo_query.cpp
+++ b/test/libdnf5/repo/test_repo_query.cpp
@@ -19,8 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_repo_query.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/repo/repo_sack.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/repo/repo_sack.hpp>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RepoQueryTest);
 

--- a/test/libdnf5/repo/test_temp_files_memory.cpp
+++ b/test/libdnf5/repo/test_temp_files_memory.cpp
@@ -22,9 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../shared/utils.hpp"
 #include "repo/temp_files_memory.hpp"
 
-#include "libdnf5/common/exception.hpp"
-
 #include <fmt/format.h>
+#include <libdnf5/common/exception.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TempFilesMemoryTest);

--- a/test/libdnf5/rpm/test_nevra.cpp
+++ b/test/libdnf5/rpm/test_nevra.cpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/nevra.hpp"
+#include <libdnf5/rpm/nevra.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(NevraTest);

--- a/test/libdnf5/rpm/test_package.cpp
+++ b/test/libdnf5/rpm/test_package.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/nevra.hpp"
+#include <libdnf5/rpm/nevra.hpp>
 
 #include <vector>
 

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <filesystem>
 #include <set>

--- a/test/libdnf5/rpm/test_package_sack.cpp
+++ b/test/libdnf5/rpm/test_package_sack.cpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/package_sack.hpp"
-#include "libdnf5/rpm/package_set.hpp"
+#include <libdnf5/rpm/package_sack.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <filesystem>
 #include <set>

--- a/test/libdnf5/rpm/test_package_sack.hpp
+++ b/test/libdnf5/rpm/test_package_sack.hpp
@@ -24,9 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/rpm/package_set.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/rpm/package_set.hpp>
 
 
 class RpmPackageSackTest : public BaseTestCase {

--- a/test/libdnf5/rpm/test_package_set.cpp
+++ b/test/libdnf5/rpm/test_package_set.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_package_set.hpp"
 
-#include "libdnf5/rpm/package.hpp"
+#include <libdnf5/rpm/package.hpp>
 
 #include <filesystem>
 #include <vector>

--- a/test/libdnf5/rpm/test_package_set.hpp
+++ b/test/libdnf5/rpm/test_package_set.hpp
@@ -24,9 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/rpm/package_set.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <memory>
 

--- a/test/libdnf5/rpm/test_reldep.cpp
+++ b/test/libdnf5/rpm/test_reldep.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_reldep.hpp"
 
-#include "libdnf5/rpm/reldep.hpp"
+#include <libdnf5/rpm/reldep.hpp>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ReldepTest);
 

--- a/test/libdnf5/rpm/test_reldep_list.cpp
+++ b/test/libdnf5/rpm/test_reldep_list.cpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/rpm/reldep_list.hpp"
+#include <libdnf5/rpm/reldep_list.hpp>
 
 
 using libdnf5::rpm::Reldep;

--- a/test/libdnf5/rpm/test_reldep_list.hpp
+++ b/test/libdnf5/rpm/test_reldep_list.hpp
@@ -23,10 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/rpm/package_sack.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/rpm/package_sack.hpp>
 
 
 class ReldepListTest : public BaseTestCase {

--- a/test/libdnf5/rpm/test_transaction.cpp
+++ b/test/libdnf5/rpm/test_transaction.cpp
@@ -22,11 +22,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/base/goal.hpp"
-#include "libdnf5/base/transaction_package.hpp"
-#include "libdnf5/repo/package_downloader.hpp"
-#include "libdnf5/rpm/transaction_callbacks.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/base/transaction_package.hpp>
+#include <libdnf5/repo/package_downloader.hpp>
+#include <libdnf5/rpm/transaction_callbacks.hpp>
 
 #include <filesystem>
 

--- a/test/libdnf5/run_tests.cpp
+++ b/test/libdnf5/run_tests.cpp
@@ -20,9 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/base_test_case.hpp"
 
-#include "libdnf5/logger/memory_buffer_logger.hpp"
-#include "libdnf5/logger/stream_logger.hpp"
-
 #include <cppunit/BriefTestProgressListener.h>
 #include <cppunit/CompilerOutputter.h>
 #include <cppunit/TestFailure.h>
@@ -30,6 +27,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <cppunit/TestResultCollector.h>
 #include <cppunit/TestRunner.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
+#include <libdnf5/logger/memory_buffer_logger.hpp>
+#include <libdnf5/logger/stream_logger.hpp>
 
 #include <chrono>
 #include <iostream>

--- a/test/libdnf5/sack/test_match_int64.cpp
+++ b/test/libdnf5/sack/test_match_int64.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_match_int64.hpp"
 
-#include "libdnf5/common/exception.hpp"
-#include "libdnf5/common/sack/match_int64.hpp"
+#include <libdnf5/common/exception.hpp>
+#include <libdnf5/common/sack/match_int64.hpp>
 
 
 using namespace libdnf5::sack;

--- a/test/libdnf5/sack/test_match_string.cpp
+++ b/test/libdnf5/sack/test_match_string.cpp
@@ -20,8 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_match_string.hpp"
 
-#include "libdnf5/common/exception.hpp"
-#include "libdnf5/common/sack/match_string.hpp"
+#include <libdnf5/common/exception.hpp>
+#include <libdnf5/common/sack/match_string.hpp>
 
 
 using namespace libdnf5::sack;

--- a/test/libdnf5/set/test_set.cpp
+++ b/test/libdnf5/set/test_set.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_set.hpp"
 
-#include "libdnf5/common/set.hpp"
+#include <libdnf5/common/set.hpp>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SetTest);
 

--- a/test/libdnf5/system/test_state.hpp
+++ b/test/libdnf5/system/test_state.hpp
@@ -26,9 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "system/state.hpp"
 #include "utils/fs/temp.hpp"
 
-#include "libdnf5/comps/group/package.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/comps/group/package.hpp>
 
 #include <memory>
 

--- a/test/libdnf5/transaction/MergedTransactionTest.cpp
+++ b/test/libdnf5/transaction/MergedTransactionTest.cpp
@@ -24,14 +24,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 
-//#include "libdnf5/hy-subject.h"
+//#include <libdnf5/hy-subject.h>
 #include "MergedTransactionTest.hpp"
 
-#include "libdnf5/rpm/nevra.hpp"
-#include "libdnf5/transaction/MergedTransaction.hpp"
-#include "libdnf5/transaction/Transformer.hpp"
-#include "libdnf5/transaction/rpm_package.hpp"
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/transaction/MergedTransaction.hpp>
+#include <libdnf5/transaction/Transformer.hpp>
+#include <libdnf5/transaction/rpm_package.hpp>
+#include <libdnf5/transaction/transaction.hpp>
 
 using namespace libdnf5::transaction;
 

--- a/test/libdnf5/transaction/MergedTransactionTest.hpp
+++ b/test/libdnf5/transaction/MergedTransactionTest.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_SWDB_MERGEDTRANSACTION_TEST_HPP
 #define LIBDNF5_SWDB_MERGEDTRANSACTION_TEST_HPP
 
-#include "libdnf5/utils/sqlite3/sqlite3.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/utils/sqlite3/sqlite3.hpp>
 
 class MergedTransactionTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(MergedTransactionTest);

--- a/test/libdnf5/transaction/TransactionItemReasonTest.cpp
+++ b/test/libdnf5/transaction/TransactionItemReasonTest.cpp
@@ -23,13 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "TransactionItemReasonTest.hpp"
 
-#include "libdnf5/transaction/Swdb.hpp"
-#include "libdnf5/transaction/Transformer.hpp"
-#include "libdnf5/transaction/comps_environment.hpp"
-#include "libdnf5/transaction/comps_group.hpp"
-#include "libdnf5/transaction/rpm_package.hpp"
-#include "libdnf5/transaction/transaction.hpp"
-#include "libdnf5/transaction/transaction_item.hpp"
+#include <libdnf5/transaction/Swdb.hpp>
+#include <libdnf5/transaction/Transformer.hpp>
+#include <libdnf5/transaction/comps_environment.hpp>
+#include <libdnf5/transaction/comps_group.hpp>
+#include <libdnf5/transaction/rpm_package.hpp>
+#include <libdnf5/transaction/transaction.hpp>
+#include <libdnf5/transaction/transaction_item.hpp>
 
 #include <cstdio>
 #include <iostream>

--- a/test/libdnf5/transaction/TransactionItemReasonTest.hpp
+++ b/test/libdnf5/transaction/TransactionItemReasonTest.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_SWDB_TRANSACTION_ITEM_REASON_TEST_HPP
 #define LIBDNF5_SWDB_TRANSACTION_ITEM_REASON_TEST_HPP
 
-#include "libdnf5/utils/sqlite3/sqlite3.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/utils/sqlite3/sqlite3.hpp>
 
 class TransactionItemReasonTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(TransactionItemReasonTest);

--- a/test/libdnf5/transaction/TransformerTest.cpp
+++ b/test/libdnf5/transaction/TransformerTest.cpp
@@ -23,12 +23,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "TransformerTest.hpp"
 
-#include "libdnf5/transaction/Swdb.hpp"
-#include "libdnf5/transaction/rpm_package.hpp"
-#include "libdnf5/transaction/transaction.hpp"
-#include "libdnf5/transaction/transaction_item.hpp"
-
 #include <json.h>
+#include <libdnf5/transaction/Swdb.hpp>
+#include <libdnf5/transaction/rpm_package.hpp>
+#include <libdnf5/transaction/transaction.hpp>
+#include <libdnf5/transaction/transaction_item.hpp>
 
 #include <set>
 #include <sstream>

--- a/test/libdnf5/transaction/TransformerTest.hpp
+++ b/test/libdnf5/transaction/TransformerTest.hpp
@@ -24,11 +24,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_SWDB_RPMITEM_TEST_HPP
 #define LIBDNF5_SWDB_RPMITEM_TEST_HPP
 
-#include "libdnf5/transaction/Transformer.hpp"
-#include "libdnf5/utils/sqlite3/sqlite3.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/transaction/Transformer.hpp>
+#include <libdnf5/utils/sqlite3/sqlite3.hpp>
 
 class TransformerMock : protected libdnf5::transaction::Transformer {
 public:

--- a/test/libdnf5/transaction/test_comps_environment.cpp
+++ b/test/libdnf5/transaction/test_comps_environment.cpp
@@ -22,9 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/comps/group/package.hpp"
-#include "libdnf5/transaction/comps_environment.hpp"
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/comps/group/package.hpp>
+#include <libdnf5/transaction/comps_environment.hpp>
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/test_comps_group.cpp
+++ b/test/libdnf5/transaction/test_comps_group.cpp
@@ -22,9 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/comps/group/package.hpp"
-#include "libdnf5/transaction/comps_group.hpp"
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/comps/group/package.hpp>
+#include <libdnf5/transaction/comps_group.hpp>
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/test_query.cpp
+++ b/test/libdnf5/transaction/test_query.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/test_rpm_package.cpp
+++ b/test/libdnf5/transaction/test_rpm_package.cpp
@@ -22,9 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/common/sack/query_cmp.hpp"
-#include "libdnf5/transaction/rpm_package.hpp"
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/common/sack/query_cmp.hpp>
+#include <libdnf5/transaction/rpm_package.hpp>
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/test_transaction.cpp
+++ b/test/libdnf5/transaction/test_transaction.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/test_workflow.cpp
+++ b/test/libdnf5/transaction/test_workflow.cpp
@@ -22,9 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/private_accessor.hpp"
 
-#include "libdnf5/common/sack/query_cmp.hpp"
-#include "libdnf5/comps/group/package.hpp"
-#include "libdnf5/transaction/transaction.hpp"
+#include <libdnf5/common/sack/query_cmp.hpp>
+#include <libdnf5/comps/group/package.hpp>
+#include <libdnf5/transaction/transaction.hpp>
 
 #include <string>
 

--- a/test/libdnf5/transaction/transaction_test_base.hpp
+++ b/test/libdnf5/transaction/transaction_test_base.hpp
@@ -24,10 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/fs/temp.hpp"
 
-#include "libdnf5/base/base.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/base/base.hpp>
 
 #include <memory>
 

--- a/test/libdnf5/utils/test_fs.cpp
+++ b/test/libdnf5/utils/test_fs.cpp
@@ -22,9 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/fs/utils.hpp"
 
-#include "libdnf5/common/exception.hpp"
-
 #include <fcntl.h>
+#include <libdnf5/common/exception.hpp>
 
 #include <filesystem>
 

--- a/test/libdnf5/weak_ptr/test_weak_ptr.cpp
+++ b/test/libdnf5/weak_ptr/test_weak_ptr.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_weak_ptr.hpp"
 
-#include "libdnf5/common/weak_ptr.hpp"
+#include <libdnf5/common/weak_ptr.hpp>
 
 #include <memory>
 #include <string>

--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -25,13 +25,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 #include "utils/string.hpp"
 
-#include "libdnf5/comps/environment/environment.hpp"
-#include "libdnf5/comps/environment/query.hpp"
-#include "libdnf5/comps/group/group.hpp"
-#include "libdnf5/comps/group/query.hpp"
-#include "libdnf5/conf/const.hpp"
-#include "libdnf5/rpm/nevra.hpp"
-#include "libdnf5/rpm/package_query.hpp"
+#include <libdnf5/comps/environment/environment.hpp>
+#include <libdnf5/comps/environment/query.hpp>
+#include <libdnf5/comps/group/group.hpp>
+#include <libdnf5/comps/group/query.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 #include <filesystem>
 #include <map>

--- a/test/shared/base_test_case.hpp
+++ b/test/shared/base_test_case.hpp
@@ -24,10 +24,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "test_case_fixture.hpp"
 #include "utils/fs/temp.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/repo/repo_sack.hpp"
-#include "libdnf5/rpm/package.hpp"
-#include "libdnf5/rpm/package_sack.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/repo/repo_sack.hpp>
+#include <libdnf5/rpm/package.hpp>
+#include <libdnf5/rpm/package_sack.hpp>
 
 #include <string>
 

--- a/test/shared/test_case_fixture.hpp
+++ b/test/shared/test_case_fixture.hpp
@@ -23,9 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/fs/temp.hpp"
 
-#include "libdnf5/base/base.hpp"
-
 #include <cppunit/TestCase.h>
+#include <libdnf5/base/base.hpp>
 
 
 class TestCaseFixture : public CppUnit::TestCase {

--- a/test/shared/utils.hpp
+++ b/test/shared/utils.hpp
@@ -23,17 +23,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "system/state.hpp"
 
-#include "libdnf5/advisory/advisory_set.hpp"
-#include "libdnf5/base/transaction.hpp"
-#include "libdnf5/base/transaction_package.hpp"
-#include "libdnf5/comps/environment/environment.hpp"
-#include "libdnf5/comps/environment/query.hpp"
-#include "libdnf5/comps/group/group.hpp"
-#include "libdnf5/comps/group/query.hpp"
-#include "libdnf5/rpm/package_query.hpp"
-#include "libdnf5/rpm/package_set.hpp"
-
 #include <cppunit/extensions/HelperMacros.h>
+#include <libdnf5/advisory/advisory_set.hpp>
+#include <libdnf5/base/transaction.hpp>
+#include <libdnf5/base/transaction_package.hpp>
+#include <libdnf5/comps/environment/environment.hpp>
+#include <libdnf5/comps/environment/query.hpp>
+#include <libdnf5/comps/group/group.hpp>
+#include <libdnf5/comps/group/query.hpp>
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_set.hpp>
 
 #include <iterator>
 #include <vector>

--- a/test/tutorial/test_tutorial.cpp
+++ b/test/tutorial/test_tutorial.cpp
@@ -20,10 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_tutorial.hpp"
 
-#include "libdnf5/base/base.hpp"
-#include "libdnf5/base/goal.hpp"
-#include "libdnf5/repo/package_downloader.hpp"
-#include "libdnf5/rpm/package_query.hpp"
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/repo/package_downloader.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TutorialTest);


### PR DESCRIPTION
libdnf5 is a library used in libdnf5-cli
libdnf5 and libdnf5-cli are libraries used in unit test and applications