### PR TITLE
repoquery: add `--disable-modular-filtering` and `--location`

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -308,6 +308,7 @@ void RepoqueryCommand::set_argument_parser() {
         "supplements",
         "files",
         "sourcerpm",
+        "location",
         "",  // empty when option is not used
     };
     pkg_attr_option = dynamic_cast<libdnf5::OptionEnum<std::string> *>(

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -74,6 +74,7 @@ private:
     std::unique_ptr<libdnf5::cli::session::BoolOption> recent{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> installonly{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> srpm{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> disable_modular_filtering{nullptr};
 
     libdnf5::OptionBool * querytags_option{nullptr};
     libdnf5::OptionString * query_format_option{nullptr};

--- a/include/libdnf5/rpm/package.hpp
+++ b/include/libdnf5/rpm/package.hpp
@@ -27,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/repo/repo_weak.hpp"
 #include "libdnf5/transaction/transaction_item_reason.hpp"
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -380,6 +381,14 @@ public:
     // @replaces dnf:dnf/package.py:attribute:Package.relativepath
     // @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_location(DnfPackage * pkg)
     std::string get_location() const;
+
+    /// @return RPM package remote location where the package can be download from.
+    /// Returns empty vector for installed and commandline packages.
+    /// @since 5.1
+    //
+    // @replaces dnf:dnf/package.py:attribute:Package.remote_location
+    std::vector<std::string> get_remote_locations(
+        const std::set<std::string> & protocols = {"https", "http", "ftp", "file"}) const;
 
     /// @return Checksum object representing RPM package checksum and its type (`<checksum type="type">checksum</checksum>`).
     /// @since 5.0


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/122
For: https://github.com/rpm-software-management/dnf5/issues/589
For: https://github.com/rpm-software-management/dnf5/issues/366
It should also be used for: https://github.com/rpm-software-management/dnf5/issues/497

Unlike the dnf4 version the package now returns a `std::vector` of all its remote locations.
It also takes into account pkg baseurl (if there is one) which should ensure that the returned location is always the same one which dnf (librepo) would attempt to download first.

Tests update: https://github.com/rpm-software-management/ci-dnf-stack/pull/1328