### PR TITLE
Implementation of cacheonly functionality

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -144,6 +144,15 @@ void RootCommand::set_argument_parser() {
     });
     global_options_group->register_argument(quiet);
 
+    auto cacheonly = parser.add_new_named_arg("cacheonly");
+    cacheonly->set_long_name("cacheonly");
+    cacheonly->set_short_name('C');
+    cacheonly->set_description(
+        "Run entirely from system cache, don't update the cache and use it even in case it is expired.");
+    cacheonly->set_const_value("all");
+    cacheonly->link_value(&config.get_cacheonly_option());
+    global_options_group->register_argument(cacheonly);
+
     // --repofrompath argument
     auto repofrompath = parser.add_new_named_arg("repofrompath");
     repofrompath->set_long_name("repofrompath");

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -150,6 +150,10 @@ Following options are applicable in the general context for any ``dnf5`` command
     directly requested (e.g. as a command line arguments), and the solver may use older
     versions of dependencies to meet their requirements.
 
+``-C, --cacheonly``
+    | Use only cached data for working with packages and repository metadata.
+    | Cache won't be updated, even if it is expired.
+
 ``--comment=COMMENT``
     | Add a comment to the transaction history.
 
@@ -204,6 +208,9 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``-q, --quiet``
     In combination with a non-interactive command, shows just the relevant content.
     Suppresses messages notifying about the current state or actions of ``DNF5``.
+
+``--refresh``
+    | Force refreshing metadata before running the command.
 
 ``--repo=REPO_ID,...``
     | Enable just specified repositories.

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -70,8 +70,8 @@ public:
     const OptionBool & get_reset_nice_option() const;
     OptionPath & get_system_cachedir_option();
     const OptionPath & get_system_cachedir_option() const;
-    OptionBool & get_cacheonly_option();
-    const OptionBool & get_cacheonly_option() const;
+    OptionEnum<std::string> & get_cacheonly_option();
+    const OptionEnum<std::string> & get_cacheonly_option() const;
     OptionBool & get_keepcache_option();
     const OptionBool & get_keepcache_option() const;
     OptionPath & get_logdir_option();

--- a/include/libdnf5/repo/repo_errors.hpp
+++ b/include/libdnf5/repo/repo_errors.hpp
@@ -32,6 +32,13 @@ class RepoError : public Error {
 };
 
 
+class RepoCacheonlyError : public RepoError {
+public:
+    using RepoError::RepoError;
+    const char * get_name() const noexcept override { return "RepoCacheonlyError"; }
+};
+
+
 class RepoDownloadError : public RepoError {
 public:
     using RepoError::RepoError;

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -176,7 +176,7 @@ class ConfigMain::Impl {
     OptionNumber<std::int32_t> recent{7, 0};
     OptionBool reset_nice{true};
     OptionPath system_cachedir{SYSTEM_CACHEDIR};
-    OptionBool cacheonly{false};
+    OptionEnum<std::string> cacheonly{"none", {"all", "metadata", "none"}};
     OptionBool keepcache{false};
     OptionPath logdir{geteuid() == 0 ? "/var/log" : libdnf5::xdg::get_user_state_dir()};
     OptionNumber<std::int32_t> log_size{1024 * 1024, str_to_bytes};
@@ -689,10 +689,10 @@ const OptionPath & ConfigMain::get_system_cachedir_option() const {
     return p_impl->system_cachedir;
 }
 
-OptionBool & ConfigMain::get_cacheonly_option() {
+OptionEnum<std::string> & ConfigMain::get_cacheonly_option() {
     return p_impl->cacheonly;
 }
-const OptionBool & ConfigMain::get_cacheonly_option() const {
+const OptionEnum<std::string> & ConfigMain::get_cacheonly_option() const {
     return p_impl->cacheonly;
 }
 

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -99,6 +99,10 @@ Repo::Repo(const BaseWeakPtr & base, const std::string & id, Repo::Type type)
             throw RepoError(M_("Invalid repository id \"{}\": unexpected character '{}'"), id, id[idx]);
         }
     }
+    auto & cacheonly = base->get_config().get_cacheonly_option().get_value();
+    if (cacheonly != "none") {
+        sync_strategy = SyncStrategy::ONLY_CACHE;
+    }
 }
 
 Repo::Repo(Base & base, const std::string & id, Repo::Type type) : Repo(base.get_weak_ptr(), id, type) {}

--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -66,7 +66,7 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
     def test_writing_to_locked_option(self):
         config = self.base.get_config()
 
-        option = config.get_cacheonly_option()
+        option = config.get_keepcache_option()
         option.lock('')
 
         self.assertRaises(RuntimeError, option.set, False)


### PR DESCRIPTION
- Add `cacheonly` configuration option with: `all`, `metadata` and `none` values (`none` is default)
- Add `--cacheonly` parameter which sets the `cacheonly=all`
- Add `--refresh` parameter to expire all repo metadata and so forcing downloading fresh data from remotes

When `metadata` or `all` is set, repositories' `sync_strategy` is set to `ONLY_CACHE`.
When `all` is set, packages to be downloaded are checked and any attempt to download remote package results in an error. Also downloading any remote file results in an error.

Follow-ups:
- Better documentation: https://github.com/rpm-software-management/dnf5/issues/668

Other things to discuss:
- Inform user about `cacheonly` activated **before** confirming the transaction?
- Combination with the `clean` command?
- Read-only access to the system cache when running as user?
  - Could be handled in a follow-up PR / issue.

CI tests:
- https://github.com/rpm-software-management/ci-dnf-stack/pull/1329
- https://github.com/rpm-software-management/ci-dnf-stack/pull/1330

Closes https://github.com/rpm-software-management/dnf5/issues/191.
Closes https://github.com/rpm-software-management/dnf5/issues/227.