### PR TITLE
nevra: Fix evrcpm to work with empty epoch

### DIFF
--- a/include/libdnf5/rpm/nevra.hpp
+++ b/include/libdnf5/rpm/nevra.hpp
@@ -197,7 +197,10 @@ int rpmvercmp(const char * lhs, const char * rhs);
 /// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
 template <typename L, typename R>
 int evrcmp(const L & lhs, const R & rhs) {
-    int r = rpmvercmp(lhs.get_epoch().c_str(), rhs.get_epoch().c_str());
+    // handle empty epoch the same way as 0 epoch
+    auto lepoch = lhs.get_epoch();
+    auto repoch = rhs.get_epoch();
+    int r = rpmvercmp(lepoch.empty() ? "0" : lepoch.c_str(), repoch.empty() ? "0" : repoch.c_str());
     if (r != 0) {
         return r;
     }

--- a/test/libdnf5/rpm/test_nevra.cpp
+++ b/test/libdnf5/rpm/test_nevra.cpp
@@ -222,6 +222,13 @@ void NevraTest::test_evrcmp() {
     TestPackage foo_0_1_2_noarch("foo-1-2.noarch");
     TestPackage foo_0_1_4_noarch("foo-1-4.noarch");
     TestPackage foo_0_1_1_1_noarch("foo-1.1-1.noarch");
+    TestPackage bar__1_1_noarch("bar-1-1.noarch");
+    TestPackage bar_0_1_1_noarch("bar-0:1-1.noarch");
+
+    // compare empty epoch with zero epoch
+    CPPUNIT_ASSERT_MESSAGE(
+        "Empty and zero epoch are considered different.",
+        libdnf5::rpm::cmp_nevra(bar__1_1_noarch, bar_0_1_1_noarch) == 0);
 
     // order by epoch
     std::vector<TestPackage> actual = {foo_1_1_1_noarch, foo_0_2_1_noarch};


### PR DESCRIPTION
The evrcmp template function can work also with Nevra objects which can
have empty epoch. Comparing such object to another object with epoch=0
produces incorrect results.