### PR TITLE
Fix building with upcoming fmt-10 library

### DIFF
--- a/libdnf5/logger/logger.cpp
+++ b/libdnf5/logger/logger.cpp
@@ -24,18 +24,18 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
+using namespace std::chrono;
+
 void Logger::log_line(Level level, const std::string & message) noexcept {
-    write(std::chrono::system_clock::now(), getpid(), level, message);
+    write(system_clock::now(), getpid(), level, message);
 }
 
 
 void StringLogger::write(
-    const std::chrono::time_point<std::chrono::system_clock> & time,
-    pid_t pid,
-    Level level,
-    const std::string & message) noexcept {
+    const time_point<system_clock> & time, pid_t pid, Level level, const std::string & message) noexcept {
     try {
-        write(fmt::format("{:%FT%T%z} [{}] {} {}\n", time, pid, level_to_cstr(level), message).c_str());
+        write(fmt::format("{:%FT%T%z} [{}] {} {}\n", time_point_cast<seconds>(time), pid, level_to_cstr(level), message)
+                  .c_str());
     } catch (const std::exception & e) {
         write("Failed to format: ");
         write(message.c_str());

--- a/libdnf5/rpm/transaction.hpp
+++ b/libdnf5/rpm/transaction.hpp
@@ -36,6 +36,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
+// Required for building with fmt >= 10
+// See: https://github.com/fmtlib/fmt/blob/10.0.0/ChangeLog.rst?plain=1#L68
+inline uint32_t format_as(rpmCallbackType type) {
+    return static_cast<uint32_t>(type);
+}
+
 
 namespace libdnf5::rpm {
 


### PR DESCRIPTION
As implicit conversions for enums were deprecated in fmt 10.0.0, we need to explicitly do the conversion for custom enums. See: https://github.com/fmtlib/fmt/blob/10.0.0/ChangeLog.rst?plain=1#L68

Also, using fmt 10, `time_point<system_clock>` contains seconds represented as a floating-point number. In order to drop the decimal places, we need to explicitly do the conversion. This is also conformant with the currently used fmt-9.1 docs: https://fmt.dev/9.1.0/syntax.html#chrono-format-specifications.

Bugzilla ticket: https://bugzilla.redhat.com/show_bug.cgi?id=2218180.
Closes #675.