### PR TITLE
Prevent repositories from being loaded multiple times

### DIFF
--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -468,6 +468,12 @@ void RepoSack::update_and_load_repos(libdnf5::repo::RepoQuery & repos, bool impo
 
 
 void RepoSack::update_and_load_enabled_repos(bool load_system) {
+    static bool called = false;
+
+    if (called) {
+        libdnf_throw_assertion("RepoSack::updated_and_load_enabled_repos has already been called.");
+    }
+
     if (load_system) {
         // create the system repository if it does not exist
         base->get_repo_sack()->get_system_repo();
@@ -484,6 +490,8 @@ void RepoSack::update_and_load_enabled_repos(bool load_system) {
 
     // TODO(jmracek) Replace by call that will resolve active modules and apply modular filterring
     base->get_module_sack()->p_impl->module_filtering();
+
+    called = true;
 }
 
 


### PR DESCRIPTION
Adds a flag to prevent
`RepoSack#update_and_load_enabled_repos`
from being called multiple times. It can only be called once during the lifetime of the application. If it is called multiple times, an assertion error is thrown.

Fixes #439