### PR TITLE
repoquery: update and unify repoquery manpage

### DIFF
--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -40,69 +40,231 @@ Options
 =======
 
 ``--advisories=ADVISORY_NAME,...``
-    | Consider only content contained in advisories with specified name.
+    | Limit to packages in advisories with specified name.
     | This is a list option.
     | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
 
 ``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Consider only content contained in advisories with specified severity.
+    | Limit to packages in advisories with specified severity.
     | This is a list option.
     | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
 
+``--arch=ARCH,...``
+    | Limit to packages of these architectures.
+    | This is a list option.
+
+``--available``
+    | Limit to available packages.
+    | This is the default behavior.
+
+``--bugfix``
+    | Limit to packages in bugfix advisories.
+
 ``--bzs=BUGZILLA_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID.
+    | Limit to packages in advisories that fix a Bugzilla ID.
     | This is a list option.
     | Expected values are numeric IDs, e.g. `123123`.
 
 ``--cves=CVE_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
+    | Limit to packages in advisories that fix a CVE (Common Vulnerabilities and Exposures) ID.
     | This is a list option.
     | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
 
-``--security``
-    | Consider only content contained in security advisories.
+``--disable-modular-filtering``
+    | Include packages of inactive module streams.
 
-``--bugfix``
-    | Consider only content contained in bugfix advisories.
+``--duplicates``
+    | Limit to installed duplicate packages (i.e. more package versions for  the  same  name and architecture).
+    | Installonly packages are excluded from this set.
 
 ``--enhancement``
-    | Consider only content contained in enhancement advisories.
+    | Limit to packages in enhancement advisories.
 
-``--newpackage``
-    | Consider only content contained in newpackage advisories.
+``--exactdeps``
+    | Limit to packages that require <capability> specified by --whatrequires or --whatdepends.
+    | This option is stackable with --whatrequires or --whatdepends only.
 
-``--available``
-    | Display all available packages.
-    | This is the default behavior.
+``--extras``
+    | Limit to installed packages that are not present in any available repository.
+
+``--file=FILE,...``
+    | Limit to packages that own these files.
+    | This is a list option.
+
+``--forcearch=<arch>``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
 
 ``--installed``
-    | Display only installed packages.
+    | Limit to installed packages.
+
+``--installonly``
+    | Limit to installed installonly packages.
+
+``--latest-limit=N``
+    | Limit to N latest packages for a given name.arch (or all except N latest if N is negative).
+
+``--leaves``
+    | Limit to groups of installed packages not required by other installed packages.
+
+``--newpackage``
+    | Limit to packages in newpackage advisories.
+
+``--recent``
+    | Limit to only recently changed packages.
+
+``--security``
+    | Limit to packages in security advisories.
+
+``--srpm``
+    | After filtering is finished use packages' corresponding source RPMs for output.
+    | Enables source repositories.
+
+``--unneeded``
+    | Limit to unneeded installed packages (i.e. packages that were installed as dependencies but are no longer needed).
+    | This switch lists packages that are going to be removed after executing the `autoremove` command.
+
+``--upgrades``
+    | Limit to packages that provide an upgrade for some already installed package.
 
 ``--userinstalled``
     | Limit to packages that are not installed as dependencies or weak dependencies.
     | This means limit to packages that were installed at the user request or indirectly as a part of a module profile or comps group. Additionally it returns packages with unknown reason.
     | The result may be influenced by the "exclude" option in the configuration file.
 
-``--leaves``
-    | Display only leaf packages.
+``--whatconflicts=CAPABILITY,...``
+    | Limit to packages that conflict with any of <capabilities>.
+    | This is a list option.
 
-``--unneeded``
-    | Limit the resulting set to leaves packages that were installed as dependencies
-    | so they are no longer needed. This switch lists packages that are going to be
-    | removed after executing the `autoremove` command.
+``--whatdepends=CAPABILITY,...``
+    | Limit to packages that require, enhance, recommend, suggest or supplement any of <capabilities>.
+    | This is a list option.
 
-``--nevra``
-    | Use the `NEVRA` format for the output.
-    | This is the default behavior.
-    | This can be useful for scripting or automation as the output is in machine-readable format.
+``--whatenhances=CAPABILITY,...``
+    | Limit to packages that enhance any of <capabilities>. Use --whatdepends if you want to list all depending packages.
+    | This is a list option.
+
+``--whatobsoletes=CAPABILITY,...``
+    | Limit to packages that obsolete any of <capabilities>.
+    | This is a list option.
+
+``--whatprovides=CAPABILITY,...``
+    | Limit to packages that provide any of <capabilities>.
+    | This is a list option.
+
+``--whatrecommends=CAPABILITY,...``
+    | Limit to packages that recommend any of <capabilities>. Use --whatdepends if you want to list all depending packages.
+    | This is a list option.
+
+``--whatrequires=CAPABILITY,...``
+    | Limit to packages that require any of <capabilities>. Use --whatdepends if you want to list all depending packages.
+    | This is a list option.
+
+``--whatsuggests=CAPABILITY,...``
+    | Limit to packages that suggest any of <capabilities>. Use --whatdepends if you want to list all depending packages.
+    | This is a list option.
+
+``--whatsupplements=CAPABILITY,...``
+    | Limit to packages that supplement any of <capabilities>. Use --whatdepends if you want to list all depending packages.
+    | This is a list option.
+
+Formatting Options
+==================
+
+Set what information is displayed about each package. The following are mutually exclusive, i.e. at most one can be specified. If no formatting option is given, selected packages are displayed in ``"%{full_nevra}"`` queryformat.
+
+``--conflicts``
+    | Like ``--qf "%{conflicts}"`` but deduplicated and sorted per line.
+
+``--depends``
+    | Like ``--qf "%{depends}"`` but deduplicated and sorted per line.
+
+``--enhances``
+    | Like ``--qf "%{enhances}"`` but deduplicated and sorted per line.
+
+``--files``
+    | Like ``--qf "%{files}"`` but deduplicated and sorted per line.
+
+``--obsoletes``
+    | Like ``--qf "%{obsoletes}"`` but deduplicated and sorted per line.
+
+``--provides``
+    | Like ``--qf "%{provides}"`` but deduplicated and sorted per line.
+
+``--recommends``
+    | Like ``--qf "%{recommends}"`` but deduplicated and sorted per line.
+
+``--requires``
+    | Like ``--qf "%{requires}"`` but deduplicated and sorted per line.
+
+``--requires-pre``
+    | Like ``--qf "%{requires_pre}"`` but deduplicated and sorted per line.
+
+``--sourcerpm``
+    | Like ``--qf "%{sourcerpm}"`` but deduplicated and sorted per line.
+
+``--suggests``
+    | Like ``--qf "%{suggests}"`` but deduplicated and sorted per line.
+
+``--supplements``
+    | Like ``--qf "%{supplements}"`` but deduplicated and sorted per line.
+
+``--location``
+    | Like ``--qf "%{location}"`` but deduplicated and sorted per line.
 
 ``--info``
-    | Use the verbose format for the output.
+    | Show detailed information about the package.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+``--changelogs``
+    | Print the package changelogs.
 
+``--querytags``
+    | Display available tags for --queryformat.
+
+``--queryformat=<format>``
+    | Display format for packages. The ``<format>`` string can contain tags (``%{<tag>}``) which are replaced with corresponding attributes of the package.
+    | Default is ``"%{full_nevra}"``. The ``<format>`` string is expanded and deduplicated for each package.
+    |
+    | * ``arch`` - Display architecture of the package.
+    | * ``buildtime`` - Display buildtime of the package in Unix time.
+    | * ``conflicts`` - Display capabilities that the package conflicts with. Separated by new lines.
+    | * ``debug_name`` - Display name of debuginfo package of the package.
+    | * ``depends`` - Display capabilities that the package depends on, enhances, recommends, suggests or supplements. Separated by new lines.
+    | * ``description`` - Display description of the package.
+    | * ``downloadsize`` - Display download size of the package.
+    | * ``enhances`` - Display capabilities enhanced by the package. Separated by new lines.
+    | * ``epoch`` - Display epoch of the package.
+    | * ``evr`` - Display epoch:version-release of the package. Epoch 0 is omitted.
+    | * ``files`` - Show files in the package. Separated by new lines.
+    | * ``from_repo`` - Display id of repository the package is installed from. Empty for not installed packages.
+    | * ``full_nevra`` - Display name-epoch:version-release.arch of the package. Even epoch 0 is included.
+    | * ``group`` - Display group of the package. This is not Comps group.
+    | * ``location`` - Display location of the package.
+    | * ``installsize`` - Display install size of the package.
+    | * ``installtime`` - Display install time of the package.
+    | * ``license`` - Display license of the package.
+    | * ``name`` - Display name of the package.
+    | * ``obsoletes`` - Display capabilities obsoleted by the package. Separated by new lines.
+    | * ``packager`` - Display packager of the package.
+    | * ``prereq_ignoreinst`` - Display safe to remove requires_pre requirements of an installed package. Empty for not installed packages. Separated by new lines.
+    | * ``provides`` - Display capabilities provided by the package. Separated by new lines.
+    | * ``reason`` - Display reason why the packages was installed.
+    | * ``recommends`` - Display capabilities recommended by the package. Separated by new lines.
+    | * ``regular_requires`` - Display capabilities requried by the package without its ``%pre``, ``%post``, ``%preun`` and ``%postun`` requirements. Separated by new lines.
+    | * ``release`` - Display release of the package.
+    | * ``repoid`` - Display id of repository the package is in.
+    | * ``reponame`` - Display name of repository the package is in.
+    | * ``requires`` - Display capabilities requried by the package (combines regular_requires and requires_pre).
+    | * ``requires_pre`` - For an installed package display capabilities that it depends on to run its ``%pre``, ``%post``, ``%preun`` and ``%postun`` scripts. For not installed package display just ``%pre`` and ``$post`` requirements. Separated by new lines.
+    | * ``source_debug_name`` - Display name of debuginfo package for source package of the package.
+    | * ``source_name`` - Display source RPM name of the package.
+    | * ``sourcerpm`` - Display source RPM of the package.
+    | * ``suggests`` - Display capabilities suggested by the package. Separated by new lines.
+    | * ``summary`` - Display summary of the package.
+    | * ``supplements`` - Display capabilities supplemented by the package. Separated by new lines.
+    | * ``url`` - Display url of the package.
+    | * ``vendor`` - Display vendor of the package.
+    | * ``version`` - Display version of the package.
 
 Examples
 ========


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/122

It also fixes a typo in userinstalled option description.