### PR TITLE
man: Add a note about dnf5-plugins package

### DIFF
--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -118,6 +118,7 @@ Plugin commands
 ---------------
 
 Here is the list of the commands available as plugins.
+These are available after installing the ``dnf5-plugins`` package.
 
 :ref:`builddep <builddep_plugin_ref-label>`
     | Install missing dependencies for building an RPM package.


### PR DESCRIPTION
Add info about `dnf5-plugins` package into the main man page.

Related ticket: https://bugzilla.redhat.com/show_bug.cgi?id=2217933.