### PR TITLE
advisory: add running kernel before pkg_specs filtering

### DIFF
--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -46,8 +46,6 @@ void AdvisoryInfoCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, packages);
-
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
     }
 

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -28,7 +28,9 @@ namespace dnf5 {
 using namespace libdnf5::cli;
 
 void AdvisoryListCommand::process_and_print_queries(
-    Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) {
+    [[maybe_unused]] Context & ctx,
+    libdnf5::advisory::AdvisoryQuery & advisories,
+    libdnf5::rpm::PackageQuery & packages) {
     std::vector<libdnf5::advisory::AdvisoryPackage> installed_pkgs;
     std::vector<libdnf5::advisory::AdvisoryPackage> not_installed_pkgs;
 
@@ -47,8 +49,6 @@ void AdvisoryListCommand::process_and_print_queries(
     } else {  // available is the default
         packages.filter_installed();
         packages.filter_latest_evr();
-
-        add_running_kernel_packages(ctx.base, packages);
 
         not_installed_pkgs = advisories.get_advisory_packages_sorted(packages, libdnf5::sack::QueryCmp::GT);
     }

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -60,7 +60,7 @@ void AdvisorySubCommand::set_argument_parser() {
 // When the running kernel has available advisories show them because the system
 // is vulnerable (even if the newer fixed version of kernel is already installed).
 // DNF4 bug with behavior description: https://bugzilla.redhat.com/show_bug.cgi?id=1728004
-void AdvisorySubCommand::add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query) {
+static void add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query) {
     auto kernel = base.get_rpm_package_sack()->get_running_kernel();
     if (kernel.get_id().id > 0) {
         libdnf5::rpm::PackageQuery kernel_query(base);
@@ -82,6 +82,13 @@ void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
     libdnf5::rpm::PackageQuery package_query(ctx.base);
+
+    // When running with the default filter (available)
+    if (!all->get_value() && !installed->get_value() && !updates->get_value()) {
+        add_running_kernel_packages(ctx.base, package_query);
+    }
+
+
     auto package_specs_strs = contains_pkgs->get_value();
     // Filter packages by name patterns if given
     if (package_specs_strs.size() > 0) {

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -40,8 +40,6 @@ protected:
     virtual void process_and_print_queries(
         Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) = 0;
 
-    void add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query);
-
     std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
     std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
     std::unique_ptr<AdvisoryAllOption> all{nullptr};

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -49,8 +49,6 @@ void AdvisorySummaryCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, packages);
-
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
         mode = _("Available");
     }


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/628

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1333