### PR TITLE
tutorials: set installroot before loading config file

### DIFF
--- a/test/python3/libdnf5/tutorial/session/create_base.py
+++ b/test/python3/libdnf5/tutorial/session/create_base.py
@@ -3,12 +3,20 @@ import libdnf5
 # Create a new Base object
 base = libdnf5.base.Base()
 
+# Optionally set installroot.
+#
+# Installroot is set to '/' when we're working with the system, but we can set
+# it to a different location. The Base instance will then work with the
+# installroot directory tree as its root for the rest of its lifetime.
+base_config = base.get_config()
+base_config.installroot = installroot
+
 # Optionally load configuration from the config file.
 #
 # The Base's config is initialized with default values, one of which is
 # `config_file_path()`. This contains the default path to the config file
-# ("/etc/dnf/dnf.conf"). Set a custom value and call the below method to load
-# configuration from a different location.
+# ("/etc/dnf/dnf.conf"). Set a custom value relative to installroot and
+# call the below method to load configuration from a different location.
 base.load_config_from_file()
 
 # Optionally you can set and get vars
@@ -19,14 +27,6 @@ base.load_config_from_file()
 # print(vars.get_value('releasever'))
 #
 # There are plans in the future to support the methods get() or get_priority()
-
-# Optionally set installroot.
-#
-# Installroot is set to '/' when we're working with the system, but we can set
-# it to a different location. The Base instance will then work with the
-# installroot directory tree as its root for the rest of its lifetime.
-base_config = base.get_config()
-base_config.installroot = installroot
 
 # Optionally set cachedir.
 #

--- a/test/tutorial/session/create_base.cpp
+++ b/test/tutorial/session/create_base.cpp
@@ -5,20 +5,20 @@
 // Create a new Base object.
 libdnf5::Base base;
 
-// Optionally load configuration from the config file.
-//
-// The Base's config is initialized with default values, one of which is
-// `config_file_path()`. This contains the default path to the config file
-// ("/etc/dnf/dnf.conf"). Set a custom value and call the below method to load
-// configuration from a different location.
-base.load_config_from_file();
-
 // Optionally set installroot.
 //
 // Installroot is set to '/' when we're working with the system, but we can set
 // it to a different location. The Base instance will then work with the
 // installroot directory tree as its root for the rest of its lifetime.
 base.get_config().get_installroot_option().set(installroot);
+
+// Optionally load configuration from the config file.
+//
+// The Base's config is initialized with default values, one of which is
+// `config_file_path()`. This contains the default path to the config file
+// ("/etc/dnf/dnf.conf"). Set a custom value relative to installroot and
+// call the below method to load configuration from a different location.
+base.load_config_from_file();
 
 // Load vars and do other initialization (of libsolv pool, etc.) based on the
 // configuration.  Locks the installroot and varsdir configuration values so


### PR DESCRIPTION
Otherwise we load the host system config file during execution in tests which might be broken or invalid resulting in failing tests (build).

All unittests already use their own installroot we just need to set it for the tutorials code as well.

Closes: https://github.com/rpm-software-management/dnf5/issues/588