### PR TITLE
gpgcheck security and usability fixes

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -445,10 +445,8 @@ void Context::download_and_run(libdnf5::base::Transaction & transaction) {
     if (result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
         std::cerr << "Transaction failed: " << libdnf5::base::Transaction::transaction_result_to_string(result)
                   << std::endl;
-        if (result == libdnf5::base::Transaction::TransactionRunResult::ERROR_GPG_CHECK) {
-            for (auto const & entry : transaction.get_gpg_signature_problems()) {
-                std::cerr << entry << std::endl;
-            }
+        for (auto const & entry : transaction.get_gpg_signature_problems()) {
+            std::cerr << entry << std::endl;
         }
         for (auto & problem : transaction.get_transaction_problems()) {
             std::cerr << "  - " << problem << std::endl;
@@ -456,6 +454,9 @@ void Context::download_and_run(libdnf5::base::Transaction & transaction) {
         throw libdnf5::cli::SilentCommandExitError(1);
     }
 
+    for (auto const & entry : transaction.get_gpg_signature_problems()) {
+        std::cerr << entry << std::endl;
+    }
     // TODO(mblaha): print a summary of successful transaction
 }
 

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -77,7 +77,7 @@ protected:
 
 class RpmSignature {
 public:
-    enum class CheckResult { OK, FAILED_KEY_MISSING, FAILED_NOT_TRUSTED, FAILED_NOT_SIGNED, FAILED };
+    enum class CheckResult { OK, SKIPPED, FAILED_KEY_MISSING, FAILED_NOT_TRUSTED, FAILED_NOT_SIGNED, FAILED };
 
     explicit RpmSignature(const libdnf5::BaseWeakPtr & base) : base(base) {}
     explicit RpmSignature(Base & base) : RpmSignature(base.get_weak_ptr()) {}
@@ -86,6 +86,7 @@ public:
     /// Check signature of the `package` using public keys stored in rpm database.
     /// @param package: package to check.
     /// @return CheckResult::OK - the check passed
+    ///         CheckResult::SKIPPED - the check was skipped
     ///         CheckResult::FAILED_KEY_MISSING - no corresponding key found in rpmdb
     ///         CheckResult::FAILED_NOT_TRUSTED - signature is valid but the key is not trusted
     ///         CheckResult::FAILED_NOT_SIGNED - package is not signed but signature is required

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -979,7 +979,7 @@ bool Transaction::Impl::check_gpg_signatures() {
                         signature_problems.push_back(
                             err_msg + import_repo_keys_result_to_string(ImportRepoKeysResult::ALREADY_PRESENT));
                         result = false;
-                        continue;
+                        break;
                     }
                     processed_repos.emplace(repo_id);
 
@@ -989,14 +989,17 @@ bool Transaction::Impl::check_gpg_signatures() {
                         if (check_again != libdnf5::rpm::RpmSignature::CheckResult::OK) {
                             signature_problems.push_back(err_msg + _("Import of the key didn't help, wrong key?"));
                             result = false;
+                            break;
                         }
                     } else {
                         signature_problems.push_back(err_msg + import_repo_keys_result_to_string(import_result));
                         result = false;
+                        break;
                     }
                 } else {
                     signature_problems.push_back(err_msg + rpm_signature.check_result_to_string(check_result));
                     result = false;
+                    break;
                 }
             }
         }

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -951,11 +951,6 @@ ImportRepoKeysResult Transaction::Impl::import_repo_keys(libdnf5::repo::Repo & r
 
 bool Transaction::Impl::check_gpg_signatures() {
     bool result{true};
-    auto & config = base->get_config();
-    if (!config.get_gpgcheck_option().get_value()) {
-        // gpg check switched off by configuration / command line option
-        return result;
-    }
     // TODO(mblaha): DNSsec key verification
     libdnf5::rpm::RpmSignature rpm_signature(base);
     std::set<std::string> processed_repos{};

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -108,12 +108,12 @@ RpmSignature::CheckResult RpmSignature::check_package_signature(rpm::Package pkg
     auto repo = pkg.get_repo();
     if (repo->get_type() == libdnf5::repo::Repo::Type::COMMANDLINE) {
         if (!base->get_config().get_localpkg_gpgcheck_option().get_value()) {
-            return CheckResult::OK;
+            return CheckResult::SKIPPED;
         }
     } else {
         auto & repo_config = repo->get_config();
         if (!repo_config.get_gpgcheck_option().get_value()) {
-            return CheckResult::OK;
+            return CheckResult::SKIPPED;
         }
     }
 
@@ -241,6 +241,7 @@ std::vector<KeyInfo> RpmSignature::parse_key_file(const std::string & key_url) {
 std::string RpmSignature::check_result_to_string(CheckResult result) {
     switch (result) {
         case CheckResult::OK:
+        case CheckResult::SKIPPED:
             return {};
         case CheckResult::FAILED_KEY_MISSING:
         case CheckResult::FAILED_NOT_TRUSTED:

--- a/test/libdnf5/base/test_transaction.cpp
+++ b/test/libdnf5/base/test_transaction.cpp
@@ -36,7 +36,9 @@ void BaseTransactionTest::test_check_gpg_signatures_no_gpgcheck() {
 
     CPPUNIT_ASSERT_EQUAL((size_t)1, transaction.get_transaction_packages_count());
     CPPUNIT_ASSERT(transaction.check_gpg_signatures());
-    CPPUNIT_ASSERT(transaction.get_gpg_signature_problems().empty());
+    CPPUNIT_ASSERT_EQUAL((size_t)1, transaction.get_gpg_signature_problems().size());
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("Warning: skipped PGP checks for 1 package(s)."), transaction.get_gpg_signature_problems()[0]);
 }
 
 void BaseTransactionTest::test_check_gpg_signatures_fail() {

--- a/test/python3/libdnf5/base/test_transaction.py
+++ b/test/python3/libdnf5/base/test_transaction.py
@@ -32,7 +32,8 @@ class TestTransaction(base_test_case.BaseTestCase):
 
         self.assertEqual(1, transaction.get_transaction_packages_count())
         self.assertTrue(transaction.check_gpg_signatures())
-        self.assertEqual((), transaction.get_gpg_signature_problems())
+        self.assertEqual(('Warning: skipped PGP checks for 1 package(s).',),
+                         transaction.get_gpg_signature_problems())
 
     def test_check_gpg_signatures_fail(self):
         self.base.get_config().gpgcheck = True

--- a/test/python3/libdnf5/rpm/test_rpm_signature.py
+++ b/test/python3/libdnf5/rpm/test_rpm_signature.py
@@ -35,7 +35,7 @@ class TestRpmSignature(base_test_case.BaseTestCase):
 
         rpm_sign = libdnf5.rpm.RpmSignature(self.base)
         result = rpm_sign.check_package_signature(package)
-        self.assertEqual(result, libdnf5.rpm.RpmSignature.CheckResult_OK)
+        self.assertEqual(result, libdnf5.rpm.RpmSignature.CheckResult_SKIPPED)
 
     def test_key_files_vector_wrapper(self):
         # Test wrapper for std::vector<KeyInfo>


### PR DESCRIPTION
As enumerated by Panu here: https://github.com/rpm-software-management/dnf5/issues/617#issuecomment-1592633793:

- [x] The gpgcheck option in the main config should not override the per-repo setting.
- [x] DNF 5 should not print the misleading message "Verifying PGP signatures" to the console when in fact GPG checking is off.
  - This message is not present as of bfedca82d84d5588f4f57142fe7953b520eedefb, but we may want to print a warning to the console anyway, ideally after the transaction is run so it's visible to the user
- [x] When key import fails, a more specific error message should be displayed. For the test case in #617, DNF 4 prints "The certificate is expired: The primary key is not live" whereas DNF 5 just shows "Failed to import public key". The underlying issue is that DNF 5 swallows output from rpm-sequoia, mentioned here: https://github.com/rpm-software-management/dnf5/issues/457.
- [x] Transaction should stop immediately after key import fails

Resolves https://github.com/rpm-software-management/dnf5/issues/617.