### PR TITLE
repoquery: add `-l`/`--list` alias for `--files` for rpm compat

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -287,3 +287,10 @@ source = 'upgrade.cves'
 type = 'cloned_named_arg'
 long_name = 'qf'
 source = 'repoquery.queryformat'
+
+['repoquery.list']
+type = 'cloned_named_arg'
+long_name = 'list'
+short_name = 'l'
+source = 'repoquery.files'
+group_id = 'repoquery_formatting'


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/696

In order to match rpm options again add `-l` and `--list`.