### PR TITLE
Re-add build option to enable urpmreorder solver flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python
 option(WITH_COMPS "Build with comps groups and environments support" ON)
 option(WITH_MODULEMD "Build with modulemd modules support" ON)
 option(WITH_ZCHUNK "Build with zchunk delta compression support" ON)
+option(ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 
 # build options - documentation
 option(WITH_HTML "Build HTML documentation" ON)
@@ -94,6 +95,11 @@ add_definitions(-DPROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")
 add_definitions(-DPROJECT_VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
 add_definitions(-DPROJECT_VERSION_MINOR=${PROJECT_VERSION_MINOR})
 add_definitions(-DPROJECT_VERSION_PATCH=${PROJECT_VERSION_PATCH})
+
+# libsolv options
+if(ENABLE_SOLV_URPMREORDER)
+    add_definitions(-DLIBSOLV_FLAG_URPMREORDER=1)
+endif()
 
 if(WITH_SANITIZERS)
     message(WARNING "Building with sanitizers enabled!")

--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -103,7 +103,6 @@ void init_solver(libdnf5::solv::Pool & pool, libdnf5::solv::Solver & solver) {
     /* support package splits via obsoletes */
     solver.set_flag(SOLVER_FLAG_YUM_OBSOLETES, 1);
 
-// TODO Ask Neal whether it is needed. See https://bugs.mageia.org/show_bug.cgi?id=18315
 #if defined(LIBSOLV_FLAG_URPMREORDER)
     /* support urpm-like solution reordering */
     solver.set_flag(SOLVER_FLAG_URPM_REORDER, 1);


### PR DESCRIPTION
This optionally enables the urpm-style solution reordering required to ensure the proper subset of locale and kernel packages were being installed.

This was present in the older DNF stack and was ported over again as it is still needed.

Reference: https://bugs.mageia.org/show_bug.cgi?id=18315