### PR TITLE
Add provides for dnf5-command(<command-name>)

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -31,6 +31,35 @@ Provides:       yum = %{version}-%{release}
 Obsoletes:      yum < 5
 %endif
 
+Provides:       dnf5-command(install)
+Provides:       dnf5-command(upgrade)
+Provides:       dnf5-command(remove)
+Provides:       dnf5-command(distro-sync)
+Provides:       dnf5-command(downgrade)
+Provides:       dnf5-command(reinstall)
+Provides:       dnf5-command(swap)
+Provides:       dnf5-command(mark)
+Provides:       dnf5-command(autoremove)
+Provides:       dnf5-command(check-upgrade)
+
+Provides:       dnf5-command(leaves)
+Provides:       dnf5-command(repoquery)
+Provides:       dnf5-command(search)
+Provides:       dnf5-command(list)
+Provides:       dnf5-command(info)
+
+Provides:       dnf5-command(group)
+Provides:       dnf5-command(environment)
+Provides:       dnf5-command(module)
+Provides:       dnf5-command(history)
+Provides:       dnf5-command(repo)
+Provides:       dnf5-command(advisory)
+
+Provides:       dnf5-command(clean)
+Provides:       dnf5-command(download)
+Provides:       dnf5-command(makecache)
+
+
 # ========== build options ==========
 
 %bcond_without dnf5daemon_client

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -570,6 +570,10 @@ Package management service with a DBus interface.
 Summary:        Plugins for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
+Provides:       dnf5-command(builddep)
+Provides:       dnf5-command(changelog)
+Provides:       dnf5-command(copr)
+Provides:       dnf5-command(repoclosure)
 
 %description -n dnf5-plugins
 Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclosure commands.

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -738,6 +738,14 @@ int main(int argc, char * argv[]) try {
                 }
             }
             std::cerr << ex.what() << _(". Add \"--help\" for more information about the arguments.") << std::endl;
+            if (auto * unknown_arg_ex = dynamic_cast<libdnf5::cli::ArgumentParserUnknownArgumentError *>(&ex)) {
+                if (unknown_arg_ex->get_command() == "dnf5") {
+                    std::cout << fmt::format(
+                                     "It could be a command provided by a plugin, try: dnf install dnf5-command({})",
+                                     unknown_arg_ex->get_argument())
+                              << std::endl;
+                }
+            }
             return static_cast<int>(libdnf5::cli::ExitCode::ARGPARSER_ERROR);
         }
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -739,7 +739,7 @@ int main(int argc, char * argv[]) try {
             }
             std::cerr << ex.what() << _(". Add \"--help\" for more information about the arguments.") << std::endl;
             if (auto * unknown_arg_ex = dynamic_cast<libdnf5::cli::ArgumentParserUnknownArgumentError *>(&ex)) {
-                if (unknown_arg_ex->get_command() == "dnf5") {
+                if (unknown_arg_ex->get_command() == "dnf5" && unknown_arg_ex->get_argument()[0] != '-') {
                     std::cout << fmt::format(
                                      "It could be a command provided by a plugin, try: dnf install dnf5-command({})",
                                      unknown_arg_ex->get_argument())

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -64,9 +64,22 @@ class ArgumentParserPositionalArgumentFormatError : public ArgumentParserError {
 
 /// Exception is generated in the case of an unexpected argument.
 class ArgumentParserUnknownArgumentError : public ArgumentParserError {
+private:
+    std::string command;
+    std::string argument;
+
 public:
     using ArgumentParserError::ArgumentParserError;
+
+    template <typename... Ss>
+    ArgumentParserUnknownArgumentError(
+        const std::string command, const std::string argument, const BgettextMessage & format, Ss &&... args)
+        : ArgumentParserError(format, std::forward<Ss>(args)...),
+          command(command),
+          argument(argument) {}
     const char * get_name() const noexcept override { return "ArgumentParserUnknownArgumentError"; }
+    const std::string & get_command() const { return command; };
+    const std::string & get_argument() const { return argument; };
 };
 
 

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -585,7 +585,8 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
             used = true;
         }
         if (!used) {
-            throw ArgumentParserUnknownArgumentError(M_("Unknown argument \"{}\" for command \"{}\""), argv[i], id);
+            throw ArgumentParserUnknownArgumentError(
+                std::string(id), std::string(argv[i]), M_("Unknown argument \"{}\" for command \"{}\""), argv[i], id);
         }
     }
     ++parse_count;
@@ -708,7 +709,8 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
             used = true;
         }
         if (!used) {
-            throw ArgumentParserUnknownArgumentError(M_("Unknown argument \"{}\" for command \"{}\""), argv[i], id);
+            throw ArgumentParserUnknownArgumentError(
+                std::string(id), std::string(argv[i]), M_("Unknown argument \"{}\" for command \"{}\""), argv[i], id);
         }
     }
     ++parse_count;


### PR DESCRIPTION
This adds `Provide`s for `dnf5-command(<command-name>)` for all the commands in `dnf5`, and all the commands provided by `dnf5-plugins`.

Also adds a hint like we had for DNF 4, so when trying to run a missing command:

```
$ dnf foo
Unknown argument "foo" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf install dnf5-command(foo)
```

Resolves https://github.com/rpm-software-management/dnf5/issues/566