### PR TITLE
advisory: Add missing methods to AdvisoryPackage

### DIFF
--- a/include/libdnf5/advisory/advisory_package.hpp
+++ b/include/libdnf5/advisory/advisory_package.hpp
@@ -54,10 +54,20 @@ public:
     /// @return Name of this AdvisoryPackage as std::string.
     std::string get_name() const;
 
+    /// Get epoch of this AdvisoryPackage.
+    ///
+    /// @return Epoch of this AdvisoryPackage as std::string.
+    std::string get_epoch() const;
+
     /// Get version of this AdvisoryPackage.
     ///
     /// @return Version of this AdvisoryPackage as std::string.
     std::string get_version() const;
+
+    /// Get release version of this AdvisoryPackage.
+    ///
+    /// @return Release of this AdvisoryPackage as std::string.
+    std::string get_release() const;
 
     /// Get evr of this AdvisoryPackage.
     ///

--- a/libdnf5/advisory/advisory_package.cpp
+++ b/libdnf5/advisory/advisory_package.cpp
@@ -43,8 +43,16 @@ std::string AdvisoryPackage::get_name() const {
     return p_impl->get_name();
 }
 
+std::string AdvisoryPackage::get_epoch() const {
+    return p_impl->get_epoch();
+}
+
 std::string AdvisoryPackage::get_version() const {
     return p_impl->get_version();
+}
+
+std::string AdvisoryPackage::get_release() const {
+    return p_impl->get_release();
 }
 
 std::string AdvisoryPackage::get_evr() const {
@@ -102,9 +110,19 @@ std::string AdvisoryPackage::Impl::get_name() const {
     return get_rpm_pool(base).id2str(name);
 }
 
+std::string AdvisoryPackage::Impl::get_epoch() const {
+    auto & pool = get_rpm_pool(base);
+    return pool.split_evr(pool.id2str(evr)).e_def();
+}
+
 std::string AdvisoryPackage::Impl::get_version() const {
     auto & pool = get_rpm_pool(base);
     return pool.split_evr(pool.id2str(evr)).v;
+}
+
+std::string AdvisoryPackage::Impl::get_release() const {
+    auto & pool = get_rpm_pool(base);
+    return pool.split_evr(pool.id2str(evr)).r;
 }
 
 std::string AdvisoryPackage::Impl::get_evr() const {

--- a/libdnf5/advisory/advisory_package_private.hpp
+++ b/libdnf5/advisory/advisory_package_private.hpp
@@ -36,7 +36,9 @@ namespace libdnf5::advisory {
 class AdvisoryPackage::Impl {
 public:
     std::string get_name() const;
+    std::string get_epoch() const;
     std::string get_version() const;
+    std::string get_release() const;
     std::string get_evr() const;
     std::string get_arch() const;
     Id get_name_id() const { return name; };


### PR DESCRIPTION
Adds missing methods get_epoch() and get_release().
This way the AdvisoryPackage object's nevra can be compared with
another AdvisoryPackage (or Nevra, or rpm::Package).