### PR TITLE
dnf5: Fix printing advisories for the running kernel

### DIFF
--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -29,7 +29,11 @@ namespace dnf5 {
 using namespace libdnf5::cli;
 
 void AdvisoryInfoCommand::process_and_print_queries(
-    Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) {
+    Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, const std::vector<std::string> & package_specs) {
+    libdnf5::rpm::PackageQuery packages(ctx.base);
+    if (package_specs.size() > 0) {
+        packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);
+    }
     if (all->get_value()) {
         packages.filter_installed();
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::LTE);
@@ -43,12 +47,17 @@ void AdvisoryInfoCommand::process_and_print_queries(
         packages.filter_upgradable();
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
     } else {  // available is the default
-        packages.filter_installed();
-        packages.filter_latest_evr();
+        libdnf5::rpm::PackageQuery installed_packages(ctx.base);
+        installed_packages.filter_installed();
+        installed_packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, packages);
+        add_running_kernel_packages(ctx.base, installed_packages);
 
-        advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
+        if (package_specs.size() > 0) {
+            installed_packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);
+        }
+
+        advisories.filter_packages(installed_packages, libdnf5::sack::QueryCmp::GT);
     }
 
     for (auto advisory : advisories) {

--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -46,6 +46,8 @@ void AdvisoryInfoCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
+        add_running_kernel_packages(ctx.base, packages);
+
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
     }
 

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -35,7 +35,9 @@ public:
 
 protected:
     void process_and_print_queries(
-        Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) override;
+        Context & ctx,
+        libdnf5::advisory::AdvisoryQuery & advisories,
+        const std::vector<std::string> & package_specs) override;
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -28,9 +28,7 @@ namespace dnf5 {
 using namespace libdnf5::cli;
 
 void AdvisoryListCommand::process_and_print_queries(
-    [[maybe_unused]] Context & ctx,
-    libdnf5::advisory::AdvisoryQuery & advisories,
-    libdnf5::rpm::PackageQuery & packages) {
+    Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) {
     std::vector<libdnf5::advisory::AdvisoryPackage> installed_pkgs;
     std::vector<libdnf5::advisory::AdvisoryPackage> not_installed_pkgs;
 
@@ -49,6 +47,8 @@ void AdvisoryListCommand::process_and_print_queries(
     } else {  // available is the default
         packages.filter_installed();
         packages.filter_latest_evr();
+
+        add_running_kernel_packages(ctx.base, packages);
 
         not_installed_pkgs = advisories.get_advisory_packages_sorted(packages, libdnf5::sack::QueryCmp::GT);
     }

--- a/dnf5/commands/advisory/advisory_list.hpp
+++ b/dnf5/commands/advisory/advisory_list.hpp
@@ -35,7 +35,9 @@ public:
 
 protected:
     void process_and_print_queries(
-        Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) override;
+        Context & ctx,
+        libdnf5::advisory::AdvisoryQuery & advisories,
+        const std::vector<std::string> & package_specs) override;
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -81,13 +81,6 @@ void AdvisorySubCommand::configure() {
 void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::rpm::PackageQuery package_query(ctx.base);
-    auto package_specs_strs = contains_pkgs->get_value();
-    // Filter packages by name patterns if given
-    if (package_specs_strs.size() > 0) {
-        package_query.filter_name(package_specs_strs, libdnf5::sack::QueryCmp::IGLOB);
-    }
-
     auto advisories_opt = advisory_query_from_cli_input(
         ctx.base,
         advisory_specs->get_value(),
@@ -108,7 +101,7 @@ void AdvisorySubCommand::run() {
         advisories.filter_reference("*", {"cve"}, libdnf5::sack::QueryCmp::IGLOB);
     }
 
-    process_and_print_queries(ctx, advisories, package_query);
+    process_and_print_queries(ctx, advisories, contains_pkgs->get_value());
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -60,7 +60,7 @@ void AdvisorySubCommand::set_argument_parser() {
 // When the running kernel has available advisories show them because the system
 // is vulnerable (even if the newer fixed version of kernel is already installed).
 // DNF4 bug with behavior description: https://bugzilla.redhat.com/show_bug.cgi?id=1728004
-static void add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query) {
+void AdvisorySubCommand::add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query) {
     auto kernel = base.get_rpm_package_sack()->get_running_kernel();
     if (kernel.get_id().id > 0) {
         libdnf5::rpm::PackageQuery kernel_query(base);
@@ -82,13 +82,6 @@ void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
     libdnf5::rpm::PackageQuery package_query(ctx.base);
-
-    // When running with the default filter (available)
-    if (!all->get_value() && !installed->get_value() && !updates->get_value()) {
-        add_running_kernel_packages(ctx.base, package_query);
-    }
-
-
     auto package_specs_strs = contains_pkgs->get_value();
     // Filter packages by name patterns if given
     if (package_specs_strs.size() > 0) {

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -40,6 +40,8 @@ protected:
     virtual void process_and_print_queries(
         Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) = 0;
 
+    void add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query);
+
     std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
     std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
     std::unique_ptr<AdvisoryAllOption> all{nullptr};

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -38,7 +38,9 @@ public:
 
 protected:
     virtual void process_and_print_queries(
-        Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) = 0;
+        Context & ctx,
+        libdnf5::advisory::AdvisoryQuery & advisories,
+        const std::vector<std::string> & package_specs) = 0;
 
     void add_running_kernel_packages(libdnf5::Base & base, libdnf5::rpm::PackageQuery & package_query);
 

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -49,6 +49,8 @@ void AdvisorySummaryCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
+        add_running_kernel_packages(ctx.base, packages);
+
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
         mode = _("Available");
     }

--- a/dnf5/commands/advisory/advisory_summary.hpp
+++ b/dnf5/commands/advisory/advisory_summary.hpp
@@ -35,7 +35,9 @@ public:
 
 protected:
     void process_and_print_queries(
-        Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, libdnf5::rpm::PackageQuery & packages) override;
+        Context & ctx,
+        libdnf5::advisory::AdvisoryQuery & advisories,
+        const std::vector<std::string> & package_specs) override;
 };
 
 }  // namespace dnf5


### PR DESCRIPTION
The main problem was that --contains-pkgs values for default
(--available) behavior need to be applied after running kernel packages are
injected to packages query.

Unfortunately the problem was not caught, because the test for printing
advisories for the running kernel was also incorrect.
Fix for the test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1339