### PR TITLE
config: Add support for included configuration files

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -293,6 +293,7 @@ Package management library.
 %files -n libdnf5
 %if 0%{?fedora} > 38 || 0%{?rhel} > 9
 %config(noreplace) %{_sysconfdir}/dnf/dnf.conf
+%dir %{_sysconfdir}/dnf/libdnf5.conf.d
 %dir %{_sysconfdir}/dnf/vars
 %dir %{_sysconfdir}/dnf/protected.d
 %else

--- a/dnf5/config/etc/dnf/dnf.conf
+++ b/dnf5/config/etc/dnf/dnf.conf
@@ -1,3 +1,0 @@
-# see `man dnf.conf` for defaults and possible options
-
-[main]

--- a/include/libdnf5/conf/config_parser.hpp
+++ b/include/libdnf5/conf/config_parser.hpp
@@ -34,35 +34,35 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
-/// Error accessing config file other than ENOENT; e.g. we don't have read permission
-class InaccessibleConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "InaccessibleConfigError"; }
-};
-
-/// Configuration file is missing
-class MissingConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "MissingConfigError"; }
-};
-
-/// Configuration file is invalid
-class InvalidConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "InvalidConfigError"; }
-};
-
 class ConfigParserError : public Error {
 public:
     using Error::Error;
     const char * get_domain_name() const noexcept override { return "libdnf5"; }
     const char * get_name() const noexcept override { return "ConfigParserError"; }
+};
+
+/// Error accessing config file other than ENOENT; e.g. we don't have read permission
+class InaccessibleConfigError : public ConfigParserError {
+public:
+    using ConfigParserError::ConfigParserError;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "InaccessibleConfigError"; }
+};
+
+/// Configuration file is missing
+class MissingConfigError : public ConfigParserError {
+public:
+    using ConfigParserError::ConfigParserError;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "MissingConfigError"; }
+};
+
+/// Configuration file is invalid
+class InvalidConfigError : public ConfigParserError {
+public:
+    using ConfigParserError::ConfigParserError;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "InvalidConfigError"; }
 };
 
 class ConfigParserSectionNotFoundError : public ConfigParserError {

--- a/include/libdnf5/conf/config_parser.hpp
+++ b/include/libdnf5/conf/config_parser.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/common/preserve_order_map.hpp"
 
+#include <filesystem>
 #include <istream>
 #include <map>
 #include <memory>
@@ -137,7 +138,10 @@ public:
     const Container & get_data() const noexcept;
     Container & get_data() noexcept;
 
+    void set_include_root_path(const std::string & path);
+
 private:
+    std::filesystem::path include_root_path;
     Container data;
     int item_number{0};
     std::string header;
@@ -261,6 +265,10 @@ inline const ConfigParser::Container & ConfigParser::get_data() const noexcept {
 
 inline ConfigParser::Container & ConfigParser::get_data() noexcept {
     return data;
+}
+
+inline void ConfigParser::set_include_root_path(const std::string & path) {
+    include_root_path = path;
 }
 
 }  // namespace libdnf5

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -109,6 +109,13 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc DESTINATION ${CMAKE_INSTALL
 # Makes an empty directory for libdnf5 cache
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/cache/libdnf5")
 
+# Creates "dnf.conf" configuration file
+configure_file("dnf.conf.in" ${CMAKE_CURRENT_BINARY_DIR}/dnf.conf @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/dnf.conf" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/")
+
+# Makes an empty directory for libdnf5 included configuration files
+install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5.conf.d")
+
 # Makes an empty directory for libdnf5-plugins configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")
 

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -85,6 +85,9 @@ void Base::load_defaults() {
 
 void Base::load_config_from_file(const std::string & path) {
     ConfigParser parser;
+    if (!config.get_use_host_config_option().get_value()) {
+        parser.set_include_root_path(config.get_installroot_option().get_value());
+    }
     parser.read(path);
     config.load_from_parser(parser, "main", vars, *get_logger());
 }

--- a/libdnf5/dnf.conf.in
+++ b/libdnf5/dnf.conf.in
@@ -1,0 +1,8 @@
+# see `man dnf.conf` for defaults and possible options
+
+#
+# include all matching files
+#
+#!include_config @CMAKE_INSTALL_FULL_SYSCONFDIR@/dnf/libdnf5.conf.d/*.conf
+
+[main]


### PR DESCRIPTION
The format of the "dnf.conf" configuration file for libdnf5 is compatible with dnf4.
It is based on the INI format. It is a simple text file format that contains "key=value" pairs organized into sections, blank lines, and comments.

This extension adds support for included configuration files. It introduces a special comment format for this - `#!include_config <absolute_path>`.
From the point of view of the INI parser and the original dnf4/yum, this is a comment.

Also adds `#!include "/etc/dnf/libdnf5.conf.d/*.conf"` to the distributed "dnf.conf".
