### PR TITLE
Revert default of allow_vendor_change to true

### DIFF
--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -210,7 +210,7 @@ class ConfigMain::Impl {
     OptionBool gpgkey_dns_verification{false};
     OptionBool obsoletes{true};
     OptionBool exit_on_lock{false};
-    OptionBool allow_vendor_change{false};
+    OptionBool allow_vendor_change{true};
     OptionSeconds metadata_timer_sync{60 * 60 * 3};  // 3 hours
     OptionStringList disable_excludes{std::vector<std::string>{}};
     OptionEnum<std::string> multilib_policy{"best", {"best", "all"}};  // :api


### PR DESCRIPTION
We discovered several issues related to the feature.

Command line packages are refused to get installed when they have a different vendor.

Disabling copr repository results in refusing installation of packages and upgrades from original repositories - skipping all upgrades.

Cryptic solver message
 - it is impossible to guess that the real issue is related to a different vendor of both packages
 - cannot install both dnf5-5.0.13-2.fc38.x86_64 and dnf5-5.1.0-20230719020203.0.gc17c4f61.fc38.x86_64 repoquery info does not show vendor

Closes: #738
Closes: #701  
Closes: #722  

Requires revert of https://github.com/rpm-software-management/dnf5/pull/621