### PR TITLE
Treat logdir relative to host when specified on command-line

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -794,13 +794,13 @@ int main(int argc, char * argv[]) try {
             close(fd);
         }
 
+        base.setup();
+
         auto file_logger = libdnf5::create_file_logger(base);
         // Swap to destination stream logger (log to file)
         log_router.swap_logger(file_logger, 0);
         // Write messages from memory buffer logger to stream logger
         dynamic_cast<libdnf5::MemoryBufferLogger &>(*file_logger).write_to_logger(log_router);
-
-        base.setup();
 
         auto repo_sack = base.get_repo_sack();
         repo_sack->create_repos_from_system_configuration();

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -42,10 +42,11 @@ will be used.
 
 Note: When a path is specified within a command line argument
 (``--config=CONFIG_FILE_PATH`` in case of `configuration` file,
-``--setopt=reposdir=/path/to/repodir`` for `reposdir` or
+``--setopt=reposdir=/path/to/repodir`` for `reposdir`,
+``--setopt=logdir=/path/to/logdir`` for `logdir`, or
 ``--setopt=varsdir=/paths/to/varsdir`` for `vars`), then this path is always
-relative to the host with no exceptions.
-`pluginpath` and `pluginconfpath` are relative to the host.
+relative to the host with no exceptions. `pluginpath` and `pluginconfpath` are
+relative to the host.
 
 Note: You may also want to use the command-line option ``--releasever=RELEASEVER`` when creating
 the installroot, otherwise the $releasever value is taken from the rpmdb within the installroot

--- a/libdnf5/logger/factory.cpp
+++ b/libdnf5/logger/factory.cpp
@@ -31,12 +31,9 @@ using namespace std::filesystem;
 
 std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base) {
     auto & config = base.get_config();
-    auto & installroot = config.get_installroot_option().get_value();
-    auto & logdir = config.get_logdir_option().get_value();
-    auto logdir_full_path = path(installroot) / path(logdir).relative_path();
-
-    create_directories(logdir_full_path);
-    auto log_file = logdir_full_path / FILE_LOGGER_FILENAME;
+    const std::filesystem::path logdir_path{config.get_logdir_option().get_value()};
+    create_directories(logdir_path);
+    auto log_file = logdir_path / FILE_LOGGER_FILENAME;
     auto log_stream = std::make_unique<std::ofstream>(log_file, std::ios::app);
     if (!log_stream->is_open()) {
         throw std::runtime_error(fmt::format("Cannot open log file: {}: {}", log_file.c_str(), strerror(errno)));

--- a/test/libdnf5/logger/test_file_logger.cpp
+++ b/test/libdnf5/logger/test_file_logger.cpp
@@ -33,11 +33,11 @@ void FileLoggerTest::setUp() {
     BaseTestCase::setUp();
 
     auto & config = base.get_config();
-    auto & installroot = config.get_installroot_option().get_value();
-    auto & temp_logdir = "/var/log/FileLoggerTestLogDir";
-    config.get_logdir_option().set(temp_logdir);
+    auto installroot = path(config.get_installroot_option().get_value());
+    auto temp_logdir = path("/var/log/FileLoggerTestLogDir");
+    config.get_logdir_option().set(installroot / temp_logdir.relative_path());
 
-    full_log_path = path(installroot) / path(temp_logdir).relative_path() / libdnf5::FILE_LOGGER_FILENAME;
+    full_log_path = installroot / temp_logdir.relative_path() / libdnf5::FILE_LOGGER_FILENAME;
 }
 
 

--- a/test/python3/libdnf5/logger/test_file_logger.py
+++ b/test/python3/libdnf5/logger/test_file_logger.py
@@ -27,9 +27,10 @@ class TestFileLogger(base_test_case.BaseTestCase):
     def setUp(self):
         super().setUp()
         config = self.base.get_config()
-        config.logdir = "FileLoggerTestLogDir"
+        config.logdir = os.path.join(
+            config.installroot, "FileLoggerTestLogDir")
         self.full_log_path = os.path.join(
-            config.installroot, config.logdir, libdnf5.logger.FILE_LOGGER_FILENAME)
+            config.logdir, libdnf5.logger.FILE_LOGGER_FILENAME)
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
There should be a way to set a logdir outside the installroot [1].

Currently, when `--setopt=varsdir` and `--setopt=reposdir` are specified on the command line rather than in a config file, they are treated as relative to the host, not the installroot. This patch changes `logdir` to behave the same way.

[1] https://github.com/rpm-software-management/dnf5/issues/721