### PR TITLE
Document dropped "if" alias of info command

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -113,6 +113,10 @@ Help command
 ------------
  * Dropped. The functionality is replaced by `--help` option
 
+Info command
+------------
+ * Dropped `if` alias.
+
 List command
 ------------
  * Dropped `--all` option since this behavior is now the default one.


### PR DESCRIPTION
It's confusing and does not save that many keystrokes.

With this the https://github.com/rpm-software-management/dnf5/issues/141 is resolved.