### PR TITLE
Add/remove group aliases

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -96,20 +96,6 @@ descr = "Alias for 'downgrade'"
 group_id = 'commands-compatibility-aliases'
 complete = false
 
-['groupinfo']
-type = 'command'
-attached_command = 'group.info'
-descr = "Alias for 'group info'"
-group_id = 'commands-compatibility-aliases'
-complete = true
-
-['grouplist']
-type = 'command'
-attached_command = 'group.list'
-descr = "Alias for 'group list'"
-group_id = 'commands-compatibility-aliases'
-complete = true
-
 ['grp']
 type = 'command'
 attached_command = 'group'

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -82,6 +82,13 @@ header = "Compatibility Aliases:"
 #  { id_path = 'remove.unneeded' }
 # ]
 
+['check-update']
+type = 'command'
+attached_command = 'check-upgrade'
+descr = "Alias for 'check-upgrade'"
+group_id = 'commands-compatibility-aliases'
+complete = true
+
 ['dg']
 type = 'command'
 attached_command = 'downgrade'
@@ -100,6 +107,13 @@ complete = true
 type = 'command'
 attached_command = 'group.list'
 descr = "Alias for 'group list'"
+group_id = 'commands-compatibility-aliases'
+complete = true
+
+['grp']
+type = 'command'
+attached_command = 'group'
+descr = "Alias for 'group'"
 group_id = 'commands-compatibility-aliases'
 complete = true
 
@@ -182,13 +196,6 @@ complete = true
 attached_named_args = [
  { id_path = 'upgrade.minimal' }
 ]
-
-['check-update']
-type = 'command'
-attached_command = 'check-upgrade'
-descr = "Alias for 'check-upgrade'"
-group_id = 'commands-compatibility-aliases'
-complete = true
 
 
 ########################################

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -501,6 +501,11 @@ public:
         /// Returns the pointer to the parent Command (as set by register_command()).
         Command * get_parent() const noexcept { return parent; }
 
+        /// Gets the list of command-line arguments needed to invoke the command.
+        /// Command aliases are resolved; so `get_invocation` for a
+        /// RepoListCommand would return `{"dnf5", "repo", "list"}`
+        virtual std::vector<std::string> get_invocation() const noexcept;
+
     private:
         friend class ArgumentParser;
 
@@ -598,6 +603,8 @@ public:
         void register_positional_arg(PositionalArg * arg) override { attached_command.register_positional_arg(arg); }
 
         void register_group(Group * grp) override { attached_command.register_group(grp); }
+
+        std::vector<std::string> get_invocation() const noexcept override { return attached_command.get_invocation(); }
 
         /// Gets a list of registered commands.
         const std::vector<Command *> & get_commands() const noexcept override {

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -754,6 +754,15 @@ static std::string get_named_arg_names(const ArgumentParser::NamedArg * arg) {
     return arg_names;
 }
 
+std::vector<std::string> ArgumentParser::Command::get_invocation() const noexcept {
+    std::vector<std::string> invocation = {get_id()};
+    if (parent) {
+        auto parent_invocation = parent->get_invocation();
+        invocation.insert(invocation.begin(), parent_invocation.begin(), parent_invocation.end());
+    }
+    return invocation;
+}
+
 void ArgumentParser::Command::help() const noexcept {
     auto & cmds = get_commands();
     auto & named_args = get_named_args();
@@ -763,8 +772,8 @@ void ArgumentParser::Command::help() const noexcept {
     libdnf5::cli::output::Usage usage_output;
 
     // generate usage
-    // start with the current command name
-    std::string usage = get_id();
+    // start with the invocation of the current command
+    std::string usage = utils::string::join(get_invocation(), " ");
 
     if (cmds.empty()) {
         // leaf command
@@ -772,13 +781,6 @@ void ArgumentParser::Command::help() const noexcept {
     } else {
         // command that has subcommands
         usage += " <COMMAND> [--help] ...";
-    }
-
-    // prepend parent commands to usage
-    Command * cmd = parent;
-    while (cmd) {
-        usage = cmd->get_id() + " " + usage;
-        cmd = cmd->parent;
     }
 
     // print usage


### PR DESCRIPTION
- Per https://github.com/rpm-software-management/dnf5/issues/138:
  - Add `grp` alias for group command
  - Remove `grouplist` and `groupinfo` aliases

Also adds `ArgumentParser::Command::get_invocation` to resolve aliases when printing the usage of a command, so:
```
dnf5 repolist --help
```
will print
```
Usage:
  dnf5 repo list ...
```
which is similar to what DNF 4 did, and we can enable those command alias tests.