### PR TITLE
Set installroot in Python unit tests

### DIFF
--- a/test/python3/libdnf5/base/test_goal.py
+++ b/test/python3/libdnf5/base/test_goal.py
@@ -19,8 +19,10 @@ import unittest
 
 import libdnf5.base
 
+import base_test_case
 
-class TestGoal(unittest.TestCase):
+
+class TestGoal(base_test_case.BaseTestCase):
     def test_missing_setup_goal_resolve(self):
         # Create a new Base object
         base = libdnf5.base.Base()
@@ -33,39 +35,31 @@ class TestGoal(unittest.TestCase):
 
     def test_missing_rpm_goal_resolve(self):
         # Try to resolve the goal using unknown RPM package
-        base = libdnf5.base.Base()
-        base.setup()
 
-        goal = libdnf5.base.Goal(base)
+        goal = libdnf5.base.Goal(self.base)
         goal.add_install('unknown_pkg.rpm')
 
         self.assertRaises(RuntimeError, goal.resolve)
 
     def test_invalid_url_goal_resolve(self):
         # Try to resolve the goal using invalid URL
-        base = libdnf5.base.Base()
-        base.setup()
 
-        goal = libdnf5.base.Goal(base)
+        goal = libdnf5.base.Goal(self.base)
         goal.add_install('https://i-dont-exist.com')
 
         self.assertRaises(RuntimeError, goal.resolve)
 
     def test_unsupported_argument_add_remove(self):
         # Try passing unsupported argument to add_remove() method
-        base = libdnf5.base.Base()
-        base.setup()
 
-        goal = libdnf5.base.Goal(base)
+        goal = libdnf5.base.Goal(self.base)
 
         self.assertRaises(RuntimeError, goal.add_remove, 'pkg.rpm')
 
     def test_group_rpm_reason_change_without_id(self):
         # Try changing group reason without group_id
-        base = libdnf5.base.Base()
-        base.setup()
 
-        goal = libdnf5.base.Goal(base)
+        goal = libdnf5.base.Goal(self.base)
 
         self.assertRaises(RuntimeError, goal.add_rpm_reason_change, '@fake-group-spec',
                           libdnf5.base.transaction.TransactionItemReason_GROUP, '')
@@ -74,10 +68,7 @@ class TestGoal(unittest.TestCase):
         # Try accessing transaction.get_resolve_logs()
         spec = 'unknown_spec'
 
-        base = libdnf5.base.Base()
-        base.setup()
-
-        goal = libdnf5.base.Goal(base)
+        goal = libdnf5.base.Goal(self.base)
         goal.add_install(spec)
 
         transaction = goal.resolve()


### PR DESCRIPTION
After we enabled action plugin in action.conf on host system, it blocks builds. The patch does not resolve not informative error.

7/15 Test  #6: test_python3_libdnf .........................................***Failed    0.40 sec
....EEEE.E....................................................
======================================================================
ERROR: test_group_rpm_reason_change_without_id (base.test_goal.TestGoal.test_group_rpm_reason_change_without_id)
----------------------------------------------------------------------
Traceback (most recent call last):
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/test/python3/libdnf5/base/test_goal.py", line 66, in test_group_rpm_reason_change_without_id
   base.setup()
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/redhat-linux-build/bindings/python3/libdnf5/base.py", line 454, in setup
   return _base.Base_setup(self)
          ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot load plugins: actions.conf

====================================================================== ERROR: test_invalid_url_goal_resolve (base.test_goal.TestGoal.test_invalid_url_goal_resolve) ---------------------------------------------------------------------- Traceback (most recent call last):
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/test/python3/libdnf5/base/test_goal.py", line 47, in test_invalid_url_goal_resolve
   base.setup()
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/redhat-linux-build/bindings/python3/libdnf5/base.py", line 454, in setup
   return _base.Base_setup(self)
          ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot load plugins: actions.conf

====================================================================== ERROR: test_log_events_wrapper (base.test_goal.TestGoal.test_log_events_wrapper) ---------------------------------------------------------------------- Traceback (most recent call last):
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/test/python3/libdnf5/base/test_goal.py", line 78, in test_log_events_wrapper
   base.setup()
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/redhat-linux-build/bindings/python3/libdnf5/base.py", line 454, in setup
   return _base.Base_setup(self)
          ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot load plugins: actions.conf

====================================================================== ERROR: test_missing_rpm_goal_resolve (base.test_goal.TestGoal.test_missing_rpm_goal_resolve) ---------------------------------------------------------------------- Traceback (most recent call last):
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/test/python3/libdnf5/base/test_goal.py", line 37, in test_missing_rpm_goal_resolve
   base.setup()
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/redhat-linux-build/bindings/python3/libdnf5/base.py", line 454, in setup
   return _base.Base_setup(self)
          ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot load plugins: actions.conf

====================================================================== ERROR: test_unsupported_argument_add_remove (base.test_goal.TestGoal.test_unsupported_argument_add_remove) ---------------------------------------------------------------------- Traceback (most recent call last):
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/test/python3/libdnf5/base/test_goal.py", line 57, in test_unsupported_argument_add_remove
   base.setup()
 File "/tmp/tito/rpmbuild-dnf5ite8yota/BUILD/dnf5-git-2540.4dd1be3/redhat-linux-build/bindings/python3/libdnf5/base.py", line 454, in setup
   return _base.Base_setup(self)
          ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot load plugins: actions.conf