### PR TITLE
Set substitution for librepo handle from Base Vars

### DIFF
--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -327,6 +327,7 @@ public:
     // @replaces libdnf:repo/Repo.hpp:method:Repo.getMirrors()
     std::vector<std::string> get_mirrors() const;
 
+    /// @deprecated It is redundant because repo class has direct access to Base and Vars
     /// Sets substitutions. Substitutions are used to substitute variables in repository configuration.
     // @replaces libdnf:repo/Repo.hpp:method:Repo.setSubstitutions(const std::map<std::string, std::string> & substitutions)
     void set_substitutions(const std::map<std::string, std::string> & substitutions);

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -511,8 +511,12 @@ void RepoDownloader::common_handle_setup(LibrepoHandle & h) {
     h.set_opt(LRO_YUMSLIST, repomd_substs);
 
     LrUrlVars * substs = nullptr;
+    // Deprecated, we have direct access to base, therefore we don't need to set explicitly substitutions
     for (const auto & item : substitutions) {
         substs = lr_urlvars_set(substs, item.first.c_str(), item.second.c_str());
+    }
+    for (const auto & item : base->get_vars()->get_variables()) {
+        substs = lr_urlvars_set(substs, item.first.c_str(), item.second.value.c_str());
     }
     h.set_opt(LRO_VARSUB, substs);
 


### PR DESCRIPTION
It allows substitutions in mirrorlist.

Additionally it marks method of Repo class as deprecated, because it is not required anymore.

Closes: https://github.com/rpm-software-management/dnf5/issues/761

CI-test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1347