### PR TITLE
Use focusbest: prefer latest deps versions over smaller transactions

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -103,7 +103,7 @@ Provides:       dnf5-command(makecache)
 
 %global libmodulemd_version 2.5.0
 %global librepo_version 1.15.0
-%global libsolv_version 0.7.21
+%global libsolv_version 0.7.25
 %global sqlite_version 3.35.0
 %global swig_version 4
 %global zchunk_version 0.9.11

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -51,7 +51,7 @@ pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBMODULEMD_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBMODULEMD_LIBRARIES})
 
-pkg_check_modules(LIBSOLV REQUIRED libsolv>=0.7.21)
+pkg_check_modules(LIBSOLV REQUIRED libsolv>=0.7.25)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBSOLV_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLV_LIBRARIES})
 

--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -376,6 +376,9 @@ libdnf5::GoalProblem GoalPrivate::resolve() {
     libsolv_solver.set_flag(SOLVER_FLAG_ALLOW_VENDORCHANGE, vendor_change);
     libsolv_solver.set_flag(SOLVER_FLAG_DUP_ALLOW_VENDORCHANGE, vendor_change);
 
+    // Ensure the solver tries to use the latest versions of dependencies, even if it results in a bigger transaction
+    libsolv_solver.set_flag(SOLVER_FLAG_FOCUS_BEST, 1);
+
     if (libsolv_solver.solve(job)) {
         return libdnf5::GoalProblem::SOLVER_ERROR;
     }


### PR DESCRIPTION
I chose the name `--prefer-latest` but I would be happy to change it if there is a better name.
I think `--prefer-latest` is better than `focus-best` (used by libsolv) because it is more descriptive and doesn't confuse the behavior with the `--best` option.

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1350