### PR TITLE
Modify dnf and microdnf obsoletes for RHEL

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -12,18 +12,18 @@ Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
 
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
-%if ! (0%{?fedora} > 38 || 0%{?rhel} > 9)
+%if ! (0%{?fedora} > 38 || 0%{?rhel} > 10)
 Requires:       dnf-data
 %endif
 Recommends:     bash-completion
 
 # Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 9
+%if 0%{?fedora} > 37 || 0%{?rhel} > 10
 Provides:       microdnf = %{version}-%{release}
 Obsoletes:      microdnf < 4
 %endif
 
-%if 0%{?fedora} > 38 || 0%{?rhel} > 9
+%if 0%{?fedora} > 38 || 0%{?rhel} > 10
 Provides:       dnf = %{version}-%{release}
 Obsoletes:      dnf < 5
 
@@ -217,13 +217,13 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 
 %files
 %{_bindir}/dnf5
-%if 0%{?fedora} > 38 || 0%{?rhel} > 9
+%if 0%{?fedora} > 38 || 0%{?rhel} > 10
 %{_bindir}/dnf
 %{_bindir}/yum
 %endif
 
 # Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 9
+%if 0%{?fedora} > 37 || 0%{?rhel} > 10
 %{_bindir}/microdnf
 %endif
 
@@ -283,7 +283,7 @@ License:        LGPL-2.1-or-later
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
 Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
-%if 0%{?fedora} > 38 || 0%{?rhel} > 9
+%if 0%{?fedora} > 38 || 0%{?rhel} > 10
 Conflicts:      dnf-data < 4.16.0
 %endif
 
@@ -291,7 +291,7 @@ Conflicts:      dnf-data < 4.16.0
 Package management library.
 
 %files -n libdnf5
-%if 0%{?fedora} > 38 || 0%{?rhel} > 9
+%if 0%{?fedora} > 38 || 0%{?rhel} > 10
 %config(noreplace) %{_sysconfdir}/dnf/dnf.conf
 %dir %{_sysconfdir}/dnf/vars
 %dir %{_sysconfdir}/dnf/protected.d
@@ -566,7 +566,7 @@ Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Requires:       dbus
 Requires:       polkit
-%if ! (0%{?fedora} > 38 || 0%{?rhel} > 9)
+%if ! (0%{?fedora} > 38 || 0%{?rhel} > 10)
 Requires:       dnf-data
 %endif
 
@@ -672,7 +672,7 @@ Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclos
 %install
 %cmake_install
 
-%if 0%{?fedora} > 38 || 0%{?rhel} > 9
+%if 0%{?fedora} > 38 || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/dnf
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/yum
 %endif
@@ -691,7 +691,7 @@ done
 #find_lang {name}
 
 # Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 9
+%if 0%{?fedora} > 37 || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/microdnf
 %endif
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -12,7 +12,7 @@ Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
 
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
-%if ! (0%{?fedora} > 38 || 0%{?rhel} > 10)
+%if ! (0%{?fedora} > 40 || 0%{?rhel} > 10)
 Requires:       dnf-data
 %endif
 Recommends:     bash-completion
@@ -23,7 +23,7 @@ Provides:       microdnf = %{version}-%{release}
 Obsoletes:      microdnf < 4
 %endif
 
-%if 0%{?fedora} > 38 || 0%{?rhel} > 10
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
 Provides:       dnf = %{version}-%{release}
 Obsoletes:      dnf < 5
 
@@ -217,7 +217,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 
 %files
 %{_bindir}/dnf5
-%if 0%{?fedora} > 38 || 0%{?rhel} > 10
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
 %{_bindir}/dnf
 %{_bindir}/yum
 %endif
@@ -283,7 +283,7 @@ License:        LGPL-2.1-or-later
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
 Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
-%if 0%{?fedora} > 38 || 0%{?rhel} > 10
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
 Conflicts:      dnf-data < 4.16.0
 %endif
 
@@ -291,7 +291,7 @@ Conflicts:      dnf-data < 4.16.0
 Package management library.
 
 %files -n libdnf5
-%if 0%{?fedora} > 38 || 0%{?rhel} > 10
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
 %config(noreplace) %{_sysconfdir}/dnf/dnf.conf
 %dir %{_sysconfdir}/dnf/vars
 %dir %{_sysconfdir}/dnf/protected.d
@@ -566,7 +566,7 @@ Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Requires:       dbus
 Requires:       polkit
-%if ! (0%{?fedora} > 38 || 0%{?rhel} > 10)
+%if ! (0%{?fedora} > 40 || 0%{?rhel} > 10)
 Requires:       dnf-data
 %endif
 
@@ -672,7 +672,7 @@ Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclos
 %install
 %cmake_install
 
-%if 0%{?fedora} > 38 || 0%{?rhel} > 10
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/dnf
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/yum
 %endif


### PR DESCRIPTION
The patch prevents replacement of microdnf and dnf by dnf5 in RHEL10 and previous versions.