### PR TITLE
cachedir: Use system dir when cacheonly enabled

### DIFF
--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -183,6 +183,11 @@ void Base::setup() {
         config.get_logdir_option().set(Option::Priority::INSTALLROOT, full_path);
     }
 
+    // If cachedir is not explicitly specified and cacheonly is activated, use the system cachedir location.
+    if (config.get_cacheonly_option().get_value() == "all") {
+        config.get_cachedir_option().set(Option::Priority::DEFAULT, config.get_system_cachedir_option().get_value());
+    }
+
     load_plugins();
     p_impl->plugins.init();
 

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -188,6 +188,11 @@ void Base::setup() {
         config.get_cachedir_option().set(Option::Priority::DEFAULT, config.get_system_cachedir_option().get_value());
     }
 
+    // If only cached metadata are used, disable rebuilding solv cache files.
+    if (config.get_cacheonly_option().get_value() != "none") {
+        config.get_build_cache_option().set(Option::Priority::RUNTIME, false);
+    }
+
     load_plugins();
     p_impl->plugins.init();
 


### PR DESCRIPTION
If `cacheonly` is enabled for all data and `cachedir` is not explicitly configured, use the system cachedir location, so unprivileged users can read system cached data.

`build_cache` is turned off when loading metadata only from cache as there is no need to rebuild solv cache files. And also based on the root mask we might not be able to create those files when running with system cache as unprivileged user.