### PR TITLE
Limit exclude search for only  NEVRA

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -183,7 +183,9 @@ bool BuildDepCommand::add_from_pkg(
 
     libdnf5::rpm::PackageQuery pkg_query(ctx.base);
     pkg_query.resolve_pkg_spec(
-        pkg_spec, libdnf5::ResolveSpecSettings{.with_provides = false, .with_filenames = false}, false);
+        pkg_spec,
+        libdnf5::ResolveSpecSettings{.with_provides = false, .with_filenames = false, .with_binaries = false},
+        false);
 
     std::vector<std::string> source_names{pkg_spec};
     for (const auto & pkg : pkg_query) {

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -142,7 +142,11 @@ void ChangelogCommand::run() {
     //query
     libdnf5::rpm::PackageQuery query(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
     libdnf5::ResolveSpecSettings settings{
-        .ignore_case = true, .with_nevra = true, .with_provides = false, .with_filenames = false};
+        .ignore_case = true,
+        .with_nevra = true,
+        .with_provides = false,
+        .with_filenames = false,
+        .with_binaries = false};
     if (pkgs_spec_to_show_options->size() > 0) {
         for (auto & pattern : *pkgs_spec_to_show_options) {
             libdnf5::rpm::PackageQuery package_query(full_package_query);

--- a/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
@@ -139,7 +139,8 @@ void RepoclosureCommand::run() {
 
     if (!pkg_specs.empty()) {
         libdnf5::rpm::PackageQuery to_check_pkgs(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
-        libdnf5::ResolveSpecSettings settings{.with_nevra = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .with_nevra = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         bool specs_resolved = true;
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery package_query(to_check_query);

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -113,7 +113,8 @@ void CheckUpgradeCommand::run() {
     // filter by provided specs, for `check-upgrade <pkg1> <pkg2> ...`
     if (!pkg_specs.empty()) {
         upgrades_query = libdnf5::rpm::PackageQuery(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
-        libdnf5::ResolveSpecSettings settings{.with_nevra = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .with_nevra = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery package_query(ctx.base);
             package_query.resolve_pkg_spec(spec, settings, true);

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -153,7 +153,8 @@ void ListCommand::run() {
     // pre-select by patterns
     if (!pkg_specs.empty()) {
         base_query = libdnf5::rpm::PackageQuery(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
-        libdnf5::ResolveSpecSettings settings{.with_nevra = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .with_nevra = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery pkg_query(full_package_query);
             pkg_query.resolve_pkg_spec(spec, settings, true);

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -438,6 +438,7 @@ static libdnf5::rpm::PackageSet resolve_nevras_to_packges(
     auto settings = libdnf5::ResolveSpecSettings();
     settings.with_provides = false;
     settings.with_filenames = false;
+    settings.with_binaries = false;
     for (const auto & nevra : nevra_globs) {
         auto tmp_query = base_query;
         tmp_query.resolve_pkg_spec(nevra, settings, true);
@@ -471,7 +472,8 @@ void RepoqueryCommand::run() {
             }
         }
 
-        const libdnf5::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false};
+        const libdnf5::ResolveSpecSettings settings{
+            .ignore_case = true, .with_provides = false, .with_binaries = false};
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery package_query(base_query);
             package_query.resolve_pkg_spec(spec, settings, true);

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -593,7 +593,9 @@ std::vector<std::string> match_specs(
     {
         libdnf5::rpm::PackageQuery matched_pkgs_query(base);
         matched_pkgs_query.resolve_pkg_spec(
-            pattern + '*', {.ignore_case = false, .with_provides = false, .with_filenames = false}, true);
+            pattern + '*',
+            {.ignore_case = false, .with_provides = false, .with_filenames = false, .with_binaries = false},
+            true);
 
         for (const auto & package : matched_pkgs_query) {
             auto [it, inserted] = result_set.insert(package.get_name());

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -42,6 +42,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
                 match patterns against available packages provides
             - with_filenames: bool (default true)
                 match patterns against names of the files in available packages
+            - with_binaries: bool (default true)
+                match patterns against names of the binaries in `/usr/(s)bin` in available packages
             - with_src: bool (default true)
                 include source rpms into the results
             - icase: bool (default true)

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -73,7 +73,7 @@ std::vector<std::string> get_filter_patterns(dnfdaemon::KeyValueMap options, con
 
 libdnf5::rpm::PackageQuery resolve_nevras(libdnf5::rpm::PackageQuery base_query, std::vector<std::string> nevras) {
     libdnf5::rpm::PackageQuery result(base_query.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
-    libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
+    libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false, .with_binaries = false};
     for (const auto & nevra : nevras) {
         libdnf5::rpm::PackageQuery nevra_query(base_query);
         nevra_query.resolve_pkg_spec(nevra, settings, false);
@@ -124,7 +124,8 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall & call) {
             .ignore_case = key_value_map_get<bool>(options, "icase", true),
             .with_nevra = key_value_map_get<bool>(options, "with_nevra", true),
             .with_provides = key_value_map_get<bool>(options, "with_provides", true),
-            .with_filenames = key_value_map_get<bool>(options, "with_filenames", true)};
+            .with_filenames = key_value_map_get<bool>(options, "with_filenames", true),
+            .with_binaries = key_value_map_get<bool>(options, "with_binaries", true)};
         for (auto & pattern : patterns) {
             libdnf5::rpm::PackageQuery package_query(query);
             package_query.resolve_pkg_spec(pattern, settings, with_src);

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -677,7 +677,11 @@ void Actions::on_transaction(
     std::set<CommandToRun> unique_commands_to_run;  // std::set is used to detect duplicate commands
 
     libdnf5::ResolveSpecSettings spec_settings{
-        .ignore_case = false, .with_nevra = true, .with_provides = false, .with_filenames = true};
+        .ignore_case = false,
+        .with_nevra = true,
+        .with_provides = false,
+        .with_filenames = true,
+        .with_binaries = false};
     for (const auto & action : trans_actions) {
         if (action.pkg_filter.empty()) {
             // action without packages - the action is called regardless of the of number of packages in the transaction

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1486,6 +1486,7 @@ void Goal::Impl::install_group_package(base::Transaction & transaction, libdnf5:
     auto pkg_settings = GoalJobSettings();
     pkg_settings.with_provides = false;
     pkg_settings.with_filenames = false;
+    pkg_settings.with_binaries = false;
     pkg_settings.nevra_forms.push_back(rpm::Nevra::Form::NAME);
 
     // TODO(mblaha): apply pkg.basearchonly when available in comps
@@ -1685,6 +1686,7 @@ void Goal::Impl::add_group_upgrade_to_goal(
         auto pkg_settings = GoalJobSettings();
         pkg_settings.with_provides = false;
         pkg_settings.with_filenames = false;
+        pkg_settings.with_binaries = false;
         for (const auto & pkg_name : state_group.packages) {
             if (new_set.contains(pkg_name)) {
                 // upgrade all packages installed with the group

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -192,6 +192,7 @@ GoalProblem Transaction::Impl::report_not_found(
                 settings_copy.ignore_case = true;
                 settings_copy.with_provides = false;
                 settings_copy.with_filenames = false;
+                settings_copy.with_binaries = false;
                 auto nevra_pair_icase = icase.resolve_pkg_spec(pkg_spec, settings_copy, false);
                 if (nevra_pair_icase.first) {
                     add_resolve_log(

--- a/libdnf5/rpm/package_sack.cpp
+++ b/libdnf5/rpm/package_sack.cpp
@@ -107,7 +107,11 @@ void PackageSack::Impl::load_config_excludes_includes(bool only_main) {
     bool includes_exist = false;  // found packages for include
 
     ResolveSpecSettings resolve_settings{
-        .ignore_case = false, .with_nevra = true, .with_provides = false, .with_filenames = false};
+        .ignore_case = false,
+        .with_nevra = true,
+        .with_provides = false,
+        .with_filenames = false,
+        .with_binaries = false};
 
     // first evaluate repo specific includes/excludes
     if (!only_main) {

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -671,7 +671,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // test Name.Arch
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -681,7 +681,8 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test NA icase
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .ignore_case = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("Pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -691,7 +692,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test a provide
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{.with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("pkg >= 1", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -701,7 +702,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test NEVRA glob
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -711,7 +712,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test NEVRA glob - icase == false, nothing found
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, false);
         std::vector<Package> expected = {};
@@ -721,7 +722,8 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test NEVRA glob - icase == true
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .ignore_case = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -731,7 +733,8 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // Test NEVRA icase
         PackageQuery query(base);
-        libdnf5::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
+        libdnf5::ResolveSpecSettings settings{
+            .ignore_case = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
         auto return_value = query.resolve_pkg_spec("Pkg-0:1.2-3.X86_64", settings, true);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));


### PR DESCRIPTION
The issue was created by adding binary search that is enabled by default.

Closes: https://github.com/rpm-software-management/dnf5/issues/763

CI-Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1353