### PR TITLE
Add support for $releasever_major, $releasever_minor, and limited shell expansion

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -106,6 +106,7 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %ignore ConfigParserOptionNotFoundError;
 %include "libdnf5/conf/config_parser.hpp"
 
+%ignore libdnf5::ReadOnlyVariableError;
 %include "libdnf5/conf/vars.hpp"
 
 %include "libdnf5/conf/config.hpp"

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -257,7 +257,12 @@ void RootCommand::set_argument_parser() {
                 throw libdnf5::cli::ArgumentParserError(M_("setvar: Badly formatted argument value \"{}\""), value);
             }
             auto name = std::string(value, val);
-            ctx.base.get_vars()->set(name, val + 1, libdnf5::Vars::Priority::COMMANDLINE);
+            try {
+                ctx.base.get_vars()->set(name, val + 1, libdnf5::Vars::Priority::COMMANDLINE);
+            } catch (libdnf5::Error & ex) {
+                std::string message{ex.what()};
+                throw libdnf5::cli::ArgumentParserError(M_("setvar: {}"), message);
+            }
             return true;
         });
     global_options_group->register_argument(setvar);

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -137,6 +137,13 @@ private:
         const std::function<const std::unique_ptr<const std::string>()> & get_value,
         Priority prio);
 
+    /// @brief Expand variables in a subexpression
+    ///
+    /// @param text String with variable expressions
+    /// @param depth The recursive depth
+    /// @return Pair of the resulting string and the number of characters scanned in `text`
+    std::pair<std::string, size_t> substitute_expression(std::string_view text, unsigned int depth) const;
+
     BaseWeakPtr base;
     std::map<std::string, Variable> variables;
 };

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -88,6 +88,12 @@ public:
 
     static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
+    /// @brief Split releasever on the first "." into its "major" and "minor" components
+    ///
+    /// @param releasever A releasever string, possibly containing a "."
+    /// @return releasever_major, releasever_minor
+    static std::tuple<std::string, std::string> split_releasever(const std::string & releasever);
+
 private:
     friend class Base;
 
@@ -120,6 +126,16 @@ private:
     /// Reads environment variables that match "DNF[0-9]" and
     /// "DNF_VAR_[A-Za-z0-9_]+" patterns. The "DNF_VAR_" prefix is cut off.
     void load_from_env();
+
+    /// @brief Set a variable to a value, only obtaining the value if needed using `get_value`
+    ///
+    /// @param name Name of the variable
+    /// @param get_value Function that returns the (optional) value for the variable
+    /// @param prio Source/Priority of the value
+    void set_lazy(
+        const std::string & name,
+        const std::function<const std::unique_ptr<const std::string>()> & get_value,
+        Priority prio);
 
     BaseWeakPtr base;
     std::map<std::string, Variable> variables;

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -94,12 +94,6 @@ public:
 
     static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
-    /// @brief Split releasever on the first "." into its "major" and "minor" components
-    ///
-    /// @param releasever A releasever string, possibly containing a "."
-    /// @return releasever_major, releasever_minor
-    static std::tuple<std::string, std::string> split_releasever(const std::string & releasever);
-
 private:
     friend class Base;
 
@@ -149,6 +143,12 @@ private:
     /// @param depth The recursive depth
     /// @return Pair of the resulting string and the number of characters scanned in `text`
     std::pair<std::string, size_t> substitute_expression(std::string_view text, unsigned int depth) const;
+
+    /// @brief Split releasever on the first "." into its "major" and "minor" components
+    ///
+    /// @param releasever A releasever string, possibly containing a "."
+    /// @return releasever_major, releasever_minor
+    static std::tuple<std::string, std::string> split_releasever(const std::string & releasever);
 
     BaseWeakPtr base;
     std::map<std::string, Variable> variables;

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -23,9 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/base/base_weak.hpp"
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
-
 
 namespace libdnf5 {
 
@@ -69,6 +69,12 @@ public:
     /// @param value Value to be stored in variable
     /// @param prio Source/Priority of the value
     void set(const std::string & name, const std::string & value, Priority prio = Priority::RUNTIME);
+
+    /// @brief Checks whether a variable is read-only
+    ///
+    /// @param name Name of the variable
+    /// @return true if the variable is read-only, false if it is writable
+    bool is_read_only(const std::string & name) const;
 
     /// @brief Checks if there is an variable with name equivalent to name in the container.
     ///

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -29,6 +29,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
+// Thrown when attempting to set a read-only variable
+class ReadOnlyVariableError : public Error {
+    using Error::Error;
+
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "ReadOnlyVariableError"; }
+};
+
 /// @class Vars
 ///
 /// @brief Class for reading and substituting DNF vars (arch, releasever, etc.).
@@ -68,6 +76,7 @@ public:
     /// @param name Name of the variable
     /// @param value Value to be stored in variable
     /// @param prio Source/Priority of the value
+    /// @throw ReadOnlyVariableError if the variable is read-only
     void set(const std::string & name, const std::string & value, Priority prio = Priority::RUNTIME);
 
     /// @brief Checks whether a variable is read-only
@@ -132,6 +141,7 @@ private:
     /// @param name Name of the variable
     /// @param get_value Function that returns the (optional) value for the variable
     /// @param prio Source/Priority of the value
+    /// @throw ReadOnlyVariableError if the variable is read-only
     void set_lazy(
         const std::string & name,
         const std::function<const std::unique_ptr<const std::string>()> & get_value,

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -374,7 +374,7 @@ bool Vars::is_read_only(const std::string & name) const {
 
 void Vars::set(const std::string & name, const std::string & value, Priority prio) {
     if (is_read_only(name)) {
-        throw RuntimeError(M_("Variable \"{}\" is read-only"), name);
+        throw ReadOnlyVariableError(M_("Variable \"{}\" is read-only"), name);
     }
 
     // set_unsafe sets the variable without checking whether it's read-only

--- a/test/libdnf5/conf/test_vars.cpp
+++ b/test/libdnf5/conf/test_vars.cpp
@@ -39,6 +39,10 @@ void VarsTest::test_vars() {
     CPPUNIT_ASSERT_EQUAL(std::string("foovalue123-bar"), base->get_vars()->substitute("foo$var1-bar"));
     CPPUNIT_ASSERT_EQUAL(
         std::string("$$$value123456-$nn-${nnn}"), base->get_vars()->substitute("$$$${var1}$var2-$nn-${nnn}"));
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("alternate-default-${nn:+n${nn:-${nnn:}"),
+        base->get_vars()->substitute("${var1:+alternate}-${unset:-default}-${nn:+n${nn:-${nnn:}"));
+    CPPUNIT_ASSERT_EQUAL(std::string("456"), base->get_vars()->substitute("${unset:-${var1:+${var2:+$var2}}}"));
 }
 
 void VarsTest::test_vars_multiple_dirs() {


### PR DESCRIPTION
Resolves https://github.com/rpm-software-management/dnf5/issues/710.

Add `$releasever_major` and `$releasever_minor`: whenever the `releasever` var is set, automatically derive and set the `releasever_major` and `releasever_minor` vars by splitting `releasever` on the first dot. In the future (or now, possibly), we may also want to add `releasever_patch`.

Compatible with this implementation in libzypp:
https://github.com/openSUSE/libzypp/blob/d03a02d986f43266af81c73cced1b310e8615971/zypp/repo/RepoVariables.cc#L478-L495



Also adds support for `${variable:-word}` and `${variable:+word}` expansions of vars, similar to the functionality in POSIX shell.

`${variable:-word}` means if `variable` is unset or empty, the expansion of `word` is substituted. Otherwise, the value of `variable` is substituted.

`${variable:+word}` means if `variable` is unset or empty, nothing is substituted. Otherwise, the expansion of `word` is substituted.

Both support nested variable expressions; you could do `${var0:-${var1:+${var2:+$var3}}}`

Zypper also supports these expansions, see here: https://doc.opensuse.org/projects/libzypp/HEAD/structzypp_1_1repo_1_1RepoVarExpand.html