### PR TITLE
repo: Error out on creating repo with duplicate id

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -807,6 +807,9 @@ int main(int argc, char * argv[]) try {
         any_repos_from_system_configuration = repo_sack->size() > 0;
 
         repo_sack->create_repos_from_paths(context.repos_from_path, libdnf5::Option::Priority::COMMANDLINE);
+        for (const auto & [id, path] : context.repos_from_path) {
+            context.setopts.emplace_back(id + ".enabled", "1");
+        }
 
         context.apply_repository_setopts();
 

--- a/include/libdnf5/repo/repo_errors.hpp
+++ b/include/libdnf5/repo/repo_errors.hpp
@@ -58,6 +58,11 @@ class RepoRpmError : public RepoError {
     const char * get_name() const noexcept override { return "RepoRpmError"; }
 };
 
+class RepoIdAlreadyExistsError : public RepoError {
+    using RepoError::RepoError;
+    const char * get_name() const noexcept override { return "RepoIdAlreadyExistsError"; }
+};
+
 }  // namespace libdnf5::repo
 
 #endif

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -71,7 +71,12 @@ RepoSack::RepoSack(libdnf5::Base & base) : RepoSack(base.get_weak_ptr()) {}
 
 
 RepoWeakPtr RepoSack::create_repo(const std::string & id) {
-    // TODO(jrohel): Test repo exists
+    for (const auto & existing_repo : get_data()) {
+        if (existing_repo->get_id() == id) {
+            throw RepoIdAlreadyExistsError(
+                M_("Failed to create repo \"{}\": Id is present more than once in the configuration"), id);
+        }
+    }
     auto repo = std::make_unique<Repo>(base, id, Repo::Type::AVAILABLE);
     return add_item_with_return(std::move(repo));
 }


### PR DESCRIPTION
Exception is thrown in case the configuration contains repository id
multiple times (including repos added by --repofrompath option).

Resolves: https://github.com/rpm-software-management/dnf5/issues/794
Resolves: https://github.com/rpm-software-management/dnf5/issues/793
Resolves: https://github.com/rpm-software-management/dnf5/issues/399