### PR TITLE
vars: Change detecting arch mechanism

### DIFF
--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <dirent.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
 #include <rpm/rpmts.h>
 #include <sys/types.h>
 
@@ -125,9 +126,7 @@ static constexpr const char * DISTROVERPKGS[] = {
 
 static const char * detect_arch() {
     init_lib_rpm();
-    const char * value{nullptr};
-    // Can it return nullptr?
-    rpmGetArchInfo(&value, nullptr);
+    const char * value = rpmExpand("%{_host_cpu}", NULL);
     return value;
 }
 


### PR DESCRIPTION
Currently used `rpmGetArchInfo()` API corresponds to basearch and not the
actual architecture, causing problems with incompatible architectures
during transaction resolving.
To really get the actual architecture, we need to use
`rpmExpand("%_host_cpu", NULL)`, which is also what RPM uses to detect
the architecture.

Resolves: https://github.com/rpm-software-management/dnf5/issues/795
(also see the discussion there for details)