### PR TITLE
Repoquery reorganize and small improvements

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -371,8 +371,7 @@ void RepoqueryCommand::configure() {
     context.update_repo_metadata_from_specs(pkg_specs);
     system_repo_needed = installed_option->get_value() || userinstalled_option->get_value() ||
                          duplicates->get_value() || leaves_option->get_value() || unneeded->get_value() ||
-                         extras->get_value() || upgrades->get_value() || recent->get_value() ||
-                         installonly->get_value();
+                         extras->get_value() || upgrades->get_value() || installonly->get_value();
     context.set_load_system_repo(system_repo_needed);
     context.update_repo_metadata_from_advisory_options(
         advisory_name->get_value(),
@@ -386,7 +385,7 @@ void RepoqueryCommand::configure() {
     context.set_load_available_repos(
         // available_option is on by default, to check if user specified it we check priority
         available_option->get_priority() >= libdnf5::Option::Priority::COMMANDLINE || !system_repo_needed ||
-                extras->get_value() || upgrades->get_value() || recent->get_value()
+                extras->get_value() || upgrades->get_value()
             ? Context::LoadAvailableRepos::ENABLED
             : Context::LoadAvailableRepos::NONE);
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -363,6 +363,10 @@ void RepoqueryCommand::set_argument_parser() {
 }
 
 void RepoqueryCommand::configure() {
+    if (querytags_option->get_value()) {
+        return;
+    }
+
     auto & context = get_context();
     context.update_repo_metadata_from_specs(pkg_specs);
     system_repo_needed = installed_option->get_value() || userinstalled_option->get_value() ||

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -94,7 +94,7 @@ void RepoqueryCommand::set_argument_parser() {
         parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(true))));
     auto available = parser.add_new_named_arg("available");
     available->set_long_name("available");
-    available->set_description("Limit to available packages (default).");
+    available->set_description("Query available packages (default).");
     available->set_const_value("true");
     available->link_value(available_option);
     cmd.register_named_arg(available);
@@ -103,7 +103,7 @@ void RepoqueryCommand::set_argument_parser() {
         parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));
     auto installed = parser.add_new_named_arg("installed");
     installed->set_long_name("installed");
-    installed->set_description("Limit to installed packages.");
+    installed->set_description("Query installed packages.");
     installed->set_const_value("true");
     installed->link_value(installed_option);
     cmd.register_named_arg(installed);
@@ -158,7 +158,7 @@ void RepoqueryCommand::set_argument_parser() {
         *this,
         "upgrades",
         '\0',
-        "Limit to packages that provide an upgrade for some already installed package.",
+        "Limit to available packages that provide an upgrade for some already installed package.",
         false);
 
     // SIMPLE FILTERS:

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -54,8 +54,9 @@ Options
     | This is a list option.
 
 ``--available``
-    | Limit to available packages.
+    | Query available packages.
     | This is the default behavior.
+    | Can be combined with ``--installed`` to query both installed and available packages.
 
 ``--bugfix``
     | Limit to packages in bugfix advisories.
@@ -96,7 +97,8 @@ Options
     | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
 
 ``--installed``
-    | Limit to installed packages.
+    | Query installed packages.
+    | Can be combined with ``--available`` to query both installed and available packages.
 
 ``--installonly``
     | Limit to installed installonly packages.
@@ -125,7 +127,7 @@ Options
     | This switch lists packages that are going to be removed after executing the `autoremove` command.
 
 ``--upgrades``
-    | Limit to packages that provide an upgrade for some already installed package.
+    | Limit to available packages that provide an upgrade for some already installed package.
 
 ``--userinstalled``
     | Limit to packages that are not installed as dependencies or weak dependencies.

--- a/libdnf5-cli/output/repoqueryformat.cpp
+++ b/libdnf5-cli/output/repoqueryformat.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/output/repoquery.hpp"
 
+#include <libdnf5/common/exception.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
 #include <set>
@@ -286,7 +287,7 @@ void print_pkg_attr_uniq_sorted(
     std::FILE * target, const libdnf5::rpm::PackageSet & pkgs, const std::string & getter_name) {
     auto getter = NAME_TO_GETTER.find(getter_name);
     if (getter == NAME_TO_GETTER.end()) {
-        throw RuntimeError(M_("package getter: %s not available"), getter_name);
+        libdnf_throw_assertion("Package attribute getter: \"{}\" not available", getter_name);
     }
     std::set<std::string> output;
     for (auto package : pkgs) {


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/122

There is quite a bit of code reorganization, I am trying to make the slur of repoquery options more understandable but if you don't consider these changes worth it (they do complicate the history and could be confusing) I can drop them.

There is also a couple of small improvements like: option conflicts, docs improvements, fix for `--recent`, one better exception and faster `--querytags`.