### PR TITLE
Implementation of repo info command

### DIFF
--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -76,6 +76,7 @@ public:
     uint64_t get_size() const { return size; }
     uint64_t get_pkgs() const { return pkgs; }
     uint64_t get_available_pkgs() const { return available_pkgs; }
+    std::vector<std::string> get_mirrors() const { return repo.get_mirrors(); }
 
 private:
     libdnf5::repo::Repo & repo;

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -99,7 +99,7 @@ void RepoInfoCommand::print(const libdnf5::repo::RepoQuery & query, [[maybe_unus
         available_pkgs.filter_repo_id({repo->get_id()});
 
         uint64_t repo_size = 0;
-        for (const auto & pkg : available_pkgs) {
+        for (const auto & pkg : pkgs) {
             repo_size += pkg.get_download_size();
         }
 

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -71,6 +71,7 @@ public:
     std::string get_revision() const { return repo.get_revision(); }
     std::vector<std::string> get_content_tags() const { return repo.get_content_tags(); }
     std::vector<std::pair<std::string, std::string>> get_distro_tags() const { return repo.get_distro_tags(); }
+    int64_t get_timestamp() const { return repo.get_timestamp(); }
     int get_max_timestamp() const { return repo.get_max_timestamp(); }
     uint64_t get_size() const { return size; }
     uint64_t get_pkgs() const { return pkgs; }

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -20,10 +20,68 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_info.hpp"
 
 #include <libdnf5-cli/output/repo_info.hpp>
+#include <libdnf5/rpm/package_query.hpp>
 
 #include <iostream>
 
 namespace dnf5 {
+
+struct RepoInfoWrapper {
+public:
+    RepoInfoWrapper(libdnf5::repo::Repo & repo, uint64_t size, uint64_t pkgs, uint64_t available_pkgs)
+        : repo(repo),
+          size(size),
+          pkgs(pkgs),
+          available_pkgs(available_pkgs) {}
+
+    std::string get_id() const { return repo.get_id(); }
+    std::string get_name() const { return repo.get_name(); }
+    std::string get_type() const { return repo.type_to_string(repo.get_type()); }
+    bool is_enabled() const { return repo.is_enabled(); }
+    int get_priority() const { return repo.get_config().get_priority_option().get_value(); }
+    int get_cost() const { return repo.get_config().get_cost_option().get_value(); }
+    std::vector<std::string> get_baseurl() const { return repo.get_config().get_baseurl_option().get_value(); }
+    std::string get_metalink() const {
+        auto & option = repo.get_config().get_metalink_option();
+        if (option.empty()) {
+            return "";
+        } else {
+            return option.get_value();
+        }
+    }
+    std::string get_mirrorlist() const {
+        auto & option = repo.get_config().get_mirrorlist_option();
+        if (option.empty()) {
+            return "";
+        } else {
+            return option.get_value();
+        }
+    }
+    int get_metadata_expire() const { return repo.get_config().get_metadata_expire_option().get_value(); }
+    std::vector<std::string> get_excludepkgs() const { return repo.get_config().get_excludepkgs_option().get_value(); }
+    std::vector<std::string> get_includepkgs() const {
+        return repo.get_config().get_includepkgs_option().get_value();
+        ;
+    }
+    bool get_skip_if_unavailable() const { return repo.get_config().get_skip_if_unavailable_option().get_value(); }
+    std::vector<std::string> get_gpgkey() const { return repo.get_config().get_gpgkey_option().get_value(); }
+    bool get_gpgcheck() const { return repo.get_config().get_gpgcheck_option().get_value(); }
+    bool get_repo_gpgcheck() const { return repo.get_config().get_repo_gpgcheck_option().get_value(); }
+    std::string get_repo_file_path() const { return repo.get_repo_file_path(); }
+    std::string get_revision() const { return repo.get_revision(); }
+    std::vector<std::string> get_content_tags() const { return repo.get_content_tags(); }
+    std::vector<std::pair<std::string, std::string>> get_distro_tags() const { return repo.get_distro_tags(); }
+    int get_max_timestamp() const { return repo.get_max_timestamp(); }
+    uint64_t get_size() const { return size; }
+    uint64_t get_pkgs() const { return pkgs; }
+    uint64_t get_available_pkgs() const { return available_pkgs; }
+
+private:
+    libdnf5::repo::Repo & repo;
+    uint64_t size;
+    uint64_t pkgs;
+    uint64_t available_pkgs;
+};
 
 void RepoInfoCommand::configure() {
     auto & context = get_context();
@@ -31,9 +89,21 @@ void RepoInfoCommand::configure() {
 }
 
 void RepoInfoCommand::print(const libdnf5::repo::RepoQuery & query, [[maybe_unused]] bool with_status) {
-    for (auto & repo : query.get_data()) {
+    for (auto & repo : query) {
+        libdnf5::rpm::PackageQuery pkgs(get_context().base, libdnf5::sack::ExcludeFlags::IGNORE_EXCLUDES);
+        pkgs.filter_repo_id({repo->get_id()});
+
+        libdnf5::rpm::PackageQuery available_pkgs(get_context().base);
+        available_pkgs.filter_repo_id({repo->get_id()});
+
+        uint64_t repo_size = 0;
+        for (const auto & pkg : available_pkgs) {
+            repo_size += pkg.get_download_size();
+        }
+
         libdnf5::cli::output::RepoInfo repo_info;
-        repo_info.add_repo(*repo, false, false);
+        auto repo_wrapper = RepoInfoWrapper(*repo, repo_size, pkgs.size(), available_pkgs.size());
+        repo_info.add_repo(repo_wrapper);
         repo_info.print();
         std::cout << std::endl;
     }

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -25,6 +25,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnf5 {
 
+void RepoInfoCommand::configure() {
+    auto & context = get_context();
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+}
+
 void RepoInfoCommand::print(const libdnf5::repo::RepoQuery & query, [[maybe_unused]] bool with_status) {
     for (auto & repo : query.get_data()) {
         libdnf5::cli::output::RepoInfo repo_info;

--- a/dnf5/commands/repo/repo_info.hpp
+++ b/dnf5/commands/repo/repo_info.hpp
@@ -36,6 +36,8 @@ public:
         get_argument_parser_command()->set_description("Print details about repositories");
     }
 
+    void configure() override;
+
 protected:
     void print(const libdnf5::repo::RepoQuery & query, [[maybe_unused]] bool with_status) override;
 };

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -129,7 +129,8 @@ void RepolistCommand::run() {
             "updated",
             "size",
             "pkgs",
-            "available_pkgs"};
+            "available_pkgs",
+            "mirrors"};
         attrs.insert(attrs.end(), repoinfo_attrs.begin(), repoinfo_attrs.end());
     }
     options["repo_attrs"] = attrs;

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -108,20 +108,11 @@ void RepolistCommand::run() {
     std::vector<std::string> attrs{"id", "name", "enabled"};
     if (command == "repoinfo") {
         std::vector<std::string> repoinfo_attrs{
-            "size",
-            "revision",
-            "content_tags",
-            "distro_tags",
-            "updated",
-            "pkgs",
-            "available_pkgs",
-            "metalink",
-            "mirrorlist",
-            "baseurl",
-            "metadata_expire",
-            "excludepkgs",
-            "includepkgs",
-            "repofile"};
+            "type",          "priority",        "cost",          "baseurl",     "metalink",
+            "mirrorlist",    "metadata_expire", "excludepkgs",   "includepkgs", "skip_if_unavailable",
+            "gpgkey",        "gpgcheck",        "repo_gpgcheck", "repofile",    "revision",
+            "content_tags",  "distro_tags",     "updated",       "size",        "pkgs",
+            "available_pkgs"};
         attrs.insert(attrs.end(), repoinfo_attrs.begin(), repoinfo_attrs.end());
     }
     options["repo_attrs"] = attrs;
@@ -142,10 +133,10 @@ void RepolistCommand::run() {
     } else {
         // repoinfo command
 
-        for (auto & raw_repo : repositories) {
-            DbusRepoWrapper repo(raw_repo);
+        for (auto & repo : repositories) {
             auto repo_info = libdnf5::cli::output::RepoInfo();
-            repo_info.add_repo(repo, ctx.verbose.get_value(), ctx.verbose.get_value());
+            auto dbus_repo = DbusRepoWrapper(repo);
+            repo_info.add_repo(dbus_repo);
             repo_info.print();
             std::cout << std::endl;
         }

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -108,10 +108,27 @@ void RepolistCommand::run() {
     std::vector<std::string> attrs{"id", "name", "enabled"};
     if (command == "repoinfo") {
         std::vector<std::string> repoinfo_attrs{
-            "type",          "priority",        "cost",          "baseurl",     "metalink",
-            "mirrorlist",    "metadata_expire", "excludepkgs",   "includepkgs", "skip_if_unavailable",
-            "gpgkey",        "gpgcheck",        "repo_gpgcheck", "repofile",    "revision",
-            "content_tags",  "distro_tags",     "updated",       "size",        "pkgs",
+            "type",
+            "priority",
+            "cost",
+            "baseurl",
+            "metalink",
+            "mirrorlist",
+            "metadata_expire",
+            "cache_updated",
+            "excludepkgs",
+            "includepkgs",
+            "skip_if_unavailable",
+            "gpgkey",
+            "gpgcheck",
+            "repo_gpgcheck",
+            "repofile",
+            "revision",
+            "content_tags",
+            "distro_tags",
+            "updated",
+            "size",
+            "pkgs",
             "available_pkgs"};
         attrs.insert(attrs.end(), repoinfo_attrs.begin(), repoinfo_attrs.end());
     }

--- a/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
@@ -32,22 +32,28 @@ public:
 
     std::string get_id() const { return rawdata.at("id"); }
     std::string get_name() const { return rawdata.at("name"); }
+    std::string get_type() const { return rawdata.at("type"); }
     bool is_enabled() const { return rawdata.at("enabled"); }
-    uint64_t get_size() const { return rawdata.at("size"); }
-    std::string get_revision() const { return rawdata.at("revision"); }
-    std::vector<std::pair<std::string, std::string>> get_distro_tags() const;
-    int get_max_timestamp() const { return rawdata.at("updated"); }
-    uint64_t get_pkgs() const { return rawdata.at("pkgs"); }
-    uint64_t get_available_pkgs() const { return rawdata.at("available_pkgs"); }
+    int get_priority() const { return rawdata.at("priority"); }
+    int get_cost() const { return rawdata.at("cost"); }
+    std::vector<std::string> get_baseurl() const { return rawdata.at("baseurl"); }
     std::string get_metalink() const { return rawdata.at("metalink"); }
     std::string get_mirrorlist() const { return rawdata.at("mirrorlist"); }
-    std::vector<std::string> get_baseurl() const { return rawdata.at("baseurl"); }
     int get_metadata_expire() const { return rawdata.at("metadata_expire"); }
     std::vector<std::string> get_excludepkgs() const { return rawdata.at("excludepkgs"); }
     std::vector<std::string> get_includepkgs() const { return rawdata.at("includepkgs"); }
-    std::string get_repofile() const { return rawdata.at("repofile"); }
-
+    bool get_skip_if_unavailable() const { return rawdata.at("skip_if_unavailable"); }
+    std::vector<std::string> get_gpgkey() const { return rawdata.at("gpgkey"); }
+    bool get_gpgcheck() const { return rawdata.at("gpgcheck"); }
+    bool get_repo_gpgcheck() const { return rawdata.at("repo_gpgcheck"); }
+    std::string get_repo_file_path() const { return rawdata.at("repofile"); }
+    std::string get_revision() const { return rawdata.at("revision"); }
     std::vector<std::string> get_content_tags() const { return rawdata.at("content_tags"); }
+    std::vector<std::pair<std::string, std::string>> get_distro_tags() const;
+    int get_max_timestamp() const { return rawdata.at("updated"); }
+    uint64_t get_size() const { return rawdata.at("size"); }
+    uint64_t get_pkgs() const { return rawdata.at("pkgs"); }
+    uint64_t get_available_pkgs() const { return rawdata.at("available_pkgs"); }
 
 private:
     dnfdaemon::KeyValueMap rawdata;

--- a/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
@@ -55,6 +55,7 @@ public:
     uint64_t get_size() const { return rawdata.at("size"); }
     uint64_t get_pkgs() const { return rawdata.at("pkgs"); }
     uint64_t get_available_pkgs() const { return rawdata.at("available_pkgs"); }
+    std::vector<std::string> get_mirrors() const { return rawdata.at("mirrors"); }
 
 private:
     dnfdaemon::KeyValueMap rawdata;

--- a/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
@@ -50,6 +50,7 @@ public:
     std::string get_revision() const { return rawdata.at("revision"); }
     std::vector<std::string> get_content_tags() const { return rawdata.at("content_tags"); }
     std::vector<std::pair<std::string, std::string>> get_distro_tags() const;
+    int64_t get_timestamp() const { return rawdata.at("cache_updated"); }
     int get_max_timestamp() const { return rawdata.at("updated"); }
     uint64_t get_size() const { return rawdata.at("size"); }
     uint64_t get_pkgs() const { return rawdata.at("pkgs"); }

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -70,6 +70,7 @@ enum class RepoAttribute {
     size,
     pkgs,
     available_pkgs,  // number of not excluded packages
+    mirrors,
 };
 
 std::vector<RepoAttribute> metadata_required_attributes{
@@ -80,7 +81,8 @@ std::vector<RepoAttribute> metadata_required_attributes{
     RepoAttribute::updated,
     RepoAttribute::size,
     RepoAttribute::pkgs,
-    RepoAttribute::available_pkgs};
+    RepoAttribute::available_pkgs,
+    RepoAttribute::mirrors};
 
 // map string package attribute name to actual attribute
 const static std::map<std::string, RepoAttribute> repo_attributes{
@@ -115,6 +117,7 @@ const static std::map<std::string, RepoAttribute> repo_attributes{
     {"size", RepoAttribute::size},
     {"pkgs", RepoAttribute::pkgs},
     {"available_pkgs", RepoAttribute::available_pkgs},
+    {"mirrors", RepoAttribute::mirrors},
 };
 
 // converts Repo object to dbus map
@@ -237,6 +240,9 @@ dnfdaemon::KeyValueMap repo_to_map(
                 query.filter_repo_id({libdnf_repo->get_id()});
                 dbus_repo.emplace(attr, query.size());
             } break;
+            case RepoAttribute::mirrors:
+                dbus_repo.emplace(attr, libdnf_repo->get_mirrors());
+                break;
         }
     }
     return dbus_repo;

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -222,7 +222,7 @@ dnfdaemon::KeyValueMap repo_to_map(
                 break;
             case RepoAttribute::size: {
                 uint64_t size = 0;
-                libdnf5::rpm::PackageQuery query(base);
+                libdnf5::rpm::PackageQuery query(base, libdnf5::rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.filter_repo_id(reponames);
                 for (auto pkg : query) {

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -48,6 +48,7 @@ enum class RepoAttribute {
     metalink,
     mirrorlist,
     metadata_expire,
+    cache_updated,
     excludepkgs,
     includepkgs,
     skip_if_unavailable,
@@ -93,6 +94,7 @@ const static std::map<std::string, RepoAttribute> repo_attributes{
     {"metalink", RepoAttribute::metalink},
     {"mirrorlist", RepoAttribute::mirrorlist},
     {"metadata_expire", RepoAttribute::metadata_expire},
+    {"cache_updated", RepoAttribute::cache_updated},
     {"excludepkgs", RepoAttribute::excludepkgs},
     {"includepkgs", RepoAttribute::includepkgs},
     {"skip_if_unavailable", RepoAttribute::skip_if_unavailable},
@@ -156,6 +158,9 @@ dnfdaemon::KeyValueMap repo_to_map(
             } break;
             case RepoAttribute::metadata_expire:
                 dbus_repo.emplace(attr, libdnf_repo->get_config().get_metadata_expire_option().get_value());
+                break;
+            case RepoAttribute::cache_updated:
+                dbus_repo.emplace(attr, libdnf_repo->get_timestamp());
                 break;
             case RepoAttribute::excludepkgs:
                 dbus_repo.emplace(attr, libdnf_repo->get_config().get_excludepkgs_option().get_value());

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -22,7 +22,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_CLI_OUTPUT_REPO_INFO_HPP
 
 
+#include "fmt/chrono.h"
 #include "key_value_table.hpp"
+
+#include "libdnf5-cli/utils/units.hpp"
 
 
 namespace libdnf5::cli::output {
@@ -31,95 +34,94 @@ namespace libdnf5::cli::output {
 class RepoInfo : public KeyValueTable {
 public:
     template <typename Repo>
-    void add_repo(Repo & repo, bool verbose = false, bool show_sack_data = false);
+    void add_repo(Repo & repo);
 };
 
 
 template <typename Repo>
-void RepoInfo::add_repo(Repo & repo, bool verbose, bool show_sack_data) {
+void RepoInfo::add_repo(Repo & repo) {
     add_line("Repo ID", repo.get_id(), "bold");
     add_line("Name", repo.get_name());
 
     add_line("Status", repo.is_enabled() ? "enabled" : "disabled", repo.is_enabled() ? "green" : "red");
 
-    // TODO(dmach): implement in libdnf5::repo::Repo
-    /*
-    add_line("Priority", "");
-    add_line("Cost", "");
-    add_line("Type", "");
+    add_line("Priority", repo.get_priority());
+    add_line("Cost", repo.get_cost());
+    add_line("Type", repo.get_type());
     add_line("Exclude packages", repo.get_excludepkgs());
     add_line("Include packages", repo.get_includepkgs());
-    add_line("Metadata expire", "");
-    add_line("Skip if unavailable", "");
-    add_line("Config file", repo.get_repofile());
+    add_line("Metadata expire", fmt::format("{} seconds", repo.get_metadata_expire()));
+    add_line("Skip if unavailable", fmt::format("{}", repo.get_skip_if_unavailable()));
+    add_line("Config file", repo.get_repo_file_path());
 
     // URLs
     auto group_urls = add_line("URLs", "", nullptr);
     add_line("Base URL", repo.get_baseurl(), nullptr, group_urls);
     add_line("Mirrorlist", repo.get_mirrorlist(), nullptr, group_urls);
     add_line("Metalink", repo.get_metalink(), nullptr, group_urls);
-    */
 
-    // GPG
+    // PGP
     auto group_gpg = add_line("PGP", "", nullptr);
-    add_line("Keys", "", nullptr, group_gpg);
-    add_line("Verify repodata", "", nullptr, group_gpg);
-    add_line("Verify packages", "", nullptr, group_gpg);
+    add_line("Keys", repo.get_gpgkey(), nullptr, group_gpg);
+    add_line("Verify repodata", fmt::format("{}", repo.get_repo_gpgcheck()), nullptr, group_gpg);
+    add_line("Verify packages", fmt::format("{}", repo.get_gpgcheck()), nullptr, group_gpg);
 
-    if (verbose) {
-        // Connection settings
-        auto group_conn = add_line("Connection settings", "");
-        add_line("Authentication method", "", nullptr, group_conn);
-        add_line("Username", "", nullptr, group_conn);
-        add_line("Password", "", nullptr, group_conn);
-        add_line("SSL CA certificate", "", nullptr, group_conn);
-        add_line("SSL client certificate", "", nullptr, group_conn);
-        add_line("SSL client key", "", nullptr, group_conn);
-        add_line("Verify SSL certificate", "", nullptr, group_conn);
+    // TODO(jkolarik): Verbose is not implemented and not used yet
+    // if (verbose) {
+    //     // Connection settings
+    //     auto group_conn = add_line("Connection settings", "");
+    //     add_line("Authentication method", "", nullptr, group_conn);
+    //     add_line("Username", "", nullptr, group_conn);
+    //     add_line("Password", "", nullptr, group_conn);
+    //     add_line("SSL CA certificate", "", nullptr, group_conn);
+    //     add_line("SSL client certificate", "", nullptr, group_conn);
+    //     add_line("SSL client key", "", nullptr, group_conn);
+    //     add_line("Verify SSL certificate", "", nullptr, group_conn);
 
-        // Proxy settings
-        auto group_proxy = add_line("Proxy settings", "");
-        add_line("URL", "", nullptr, group_proxy);
-        add_line("Authentication method", "", nullptr, group_proxy);
-        add_line("Username", "", nullptr, group_proxy);
-        add_line("Password", "", nullptr, group_proxy);
-        add_line("SSL CA certificate", "", nullptr, group_proxy);
-        add_line("SSL client certificate", "", nullptr, group_proxy);
-        add_line("SSL client key", "", nullptr, group_proxy);
-        add_line("Verify SSL certificate", "", nullptr, group_proxy);
+    //     // Proxy settings
+    //     auto group_proxy = add_line("Proxy settings", "");
+    //     add_line("URL", "", nullptr, group_proxy);
+    //     add_line("Authentication method", "", nullptr, group_proxy);
+    //     add_line("Username", "", nullptr, group_proxy);
+    //     add_line("Password", "", nullptr, group_proxy);
+    //     add_line("SSL CA certificate", "", nullptr, group_proxy);
+    //     add_line("SSL client certificate", "", nullptr, group_proxy);
+    //     add_line("SSL client key", "", nullptr, group_proxy);
+    //     add_line("Verify SSL certificate", "", nullptr, group_proxy);
 
-        auto group_misc = add_line("Miscelaneous", "");
-        add_line("Load comps groups", "", nullptr, group_misc);
-        add_line("Report \"countme\" statistics", "", nullptr, group_misc);
-        add_line("Enable DeltaRPM", "", nullptr, group_misc);
-        add_line("DeltaRPM percentage", "", nullptr, group_misc);
-        add_line("Use the fastest mirror", "", nullptr, group_misc);
-        add_line("Repository provides module hotfixes", "", nullptr, group_misc);
-        add_line("Use zchunk repodata", "", nullptr, group_misc);
+    //     auto group_misc = add_line("Miscelaneous", "");
+    //     add_line("Load comps groups", "", nullptr, group_misc);
+    //     add_line("Report \"countme\" statistics", "", nullptr, group_misc);
+    //     add_line("Enable DeltaRPM", "", nullptr, group_misc);
+    //     add_line("DeltaRPM percentage", "", nullptr, group_misc);
+    //     add_line("Use the fastest mirror", "", nullptr, group_misc);
+    //     add_line("Repository provides module hotfixes", "", nullptr, group_misc);
+    //     add_line("Use zchunk repodata", "", nullptr, group_misc);
+    // }
+
+    // Repodata
+    auto group_repodata = add_line("Repodata info", "", nullptr);
+    add_line("Available packages", repo.get_available_pkgs(), nullptr, group_repodata);
+    add_line("Total packages", repo.get_pkgs(), nullptr, group_repodata);
+
+    std::string size = libdnf5::cli::utils::units::format_size_aligned(static_cast<int64_t>(repo.get_size()));
+    add_line("Size", size, nullptr, group_repodata);
+
+    add_line("Content tags", repo.get_content_tags(), nullptr, group_repodata);
+
+    std::vector<std::string> distro_tags;
+    for (auto & key_value : repo.get_distro_tags()) {
+        distro_tags.push_back(key_value.second + " (" + key_value.first + ")");
     }
+    add_line("Distro tags", distro_tags, nullptr, group_repodata);
+    add_line("Revision", repo.get_revision(), nullptr, group_repodata);
 
-    if (show_sack_data) {
-        // TODO(dmach): implement in libdnf5::repo::Repo
-        /*
-        // the following lines require downloaded repodata loaded into sack
-        auto group_repodata = add_line("Repodata info", "", nullptr);
-        add_line("Available packages", repo.get_available_pkgs(), nullptr, group_repodata);
-        add_line("Total packages", repo.get_pkgs(), nullptr, group_repodata);
-
-        std::string size = libdnf5::cli::utils::units::format_size(static_cast<int64_t>(repo.get_size()));
-        add_line("Size", size, nullptr, group_repodata);
-
-        add_line("Content tags", repo.get_content_tags(), nullptr, group_repodata);
-
-        std::vector<std::string> distro_tags;
-        for (auto & key_value : repo.get_distro_tags()) {
-            distro_tags.push_back(key_value.second + " (" + key_value.first + ")");
-        }
-        add_line("Distro tags", distro_tags, nullptr, group_repodata);
-        add_line("Revision", repo.get_revision(), nullptr, group_repodata);
-        add_line("Cache updated", repo.get_max_timestamp(), nullptr, group_repodata);
-        */
-    }
+    const auto updated_time = static_cast<time_t>(repo.get_max_timestamp());
+    add_line(
+        "Cache updated",
+        fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(updated_time)),
+        nullptr,
+        group_repodata);
 
     /*
 general connection settings?

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -61,7 +61,22 @@ void RepoInfo::add_repo(Repo & repo) {
         add_line("Include packages", include_packages);
     }
 
-    add_line("Metadata expire", fmt::format("{} seconds", repo.get_metadata_expire()));
+    auto cache_updated = repo.get_timestamp();
+    std::string last_update = "unknown";
+    if (cache_updated > 0) {
+        last_update = fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(cache_updated));
+    }
+
+    auto metadata_expire = repo.get_metadata_expire();
+    std::string expire_value;
+    if (metadata_expire <= -1) {
+        expire_value = "Never";
+    } else if (metadata_expire == 0) {
+        expire_value = "Instant";
+    } else {
+        expire_value = fmt::format("{} seconds", metadata_expire);
+    }
+    add_line("Metadata expire", fmt::format("{} (last: {})", expire_value, last_update));
     add_line("Skip if unavailable", fmt::format("{}", repo.get_skip_if_unavailable()));
 
     auto repo_file_path = repo.get_repo_file_path();
@@ -156,7 +171,7 @@ void RepoInfo::add_repo(Repo & repo) {
 
         const auto updated_time = static_cast<time_t>(repo.get_max_timestamp());
         add_line(
-            "Cache updated",
+            "Updated",
             fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(updated_time)),
             nullptr,
             group_repodata);

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -90,6 +90,11 @@ void RepoInfo::add_repo(Repo & repo) {
     auto base_url = repo.get_baseurl();
     if (!base_url.empty()) {
         add_line("Base URL", base_url, nullptr, group_urls);
+    } else {
+        auto mirrors = repo.get_mirrors();
+        if (!mirrors.empty()) {
+            add_line("Base URL", fmt::format("{} ({} more)", mirrors.front(), mirrors.size()), nullptr, group_urls);
+        }
     }
 
     auto metalink = repo.get_metalink();

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -356,6 +356,9 @@ public:
     /// @since 5.0
     libdnf5::BaseWeakPtr get_base() const;
 
+    /// Return string representation of the Type enum
+    static std::string type_to_string(Type type);
+
 private:
     class Impl;
     friend class RepoSack;

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -535,4 +535,16 @@ void Repo::recompute_expired() {
     }
 }
 
+std::string Repo::type_to_string(Type type) {
+    switch (type) {
+        case Type::AVAILABLE:
+            return "available";
+        case Type::COMMANDLINE:
+            return "commandline";
+        case Type::SYSTEM:
+            return "system";
+    }
+    return "";
+}
+
 }  // namespace libdnf5::repo


### PR DESCRIPTION
Provide `repo info` command with attributes included in original dnf command and several more:
- status: `enabled` / `disabled`
- priority
- cost
- type: `available` / `commandline`
- skip if unavailable: `true` / `false`
- PGP info
  - keys (from the `gpgkey` option)
  - verify repodata: `true` / `false` (from the `repo_gpgcheck` option)
  - verify packages: `true` / `false` (from the `gpgcheck` option) 

Related issue: https://github.com/rpm-software-management/dnf5/issues/150.
CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1363.