### PR TITLE
Add support for drop-in configuration directories 

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -300,6 +300,8 @@ Package management library.
 %else
 %exclude %{_sysconfdir}/dnf/dnf.conf
 %endif
+%dir %{_datadir}/dnf5/libdnf.conf.d
+%dir %{_sysconfdir}/dnf/libdnf5.conf.d
 %dir %{_sysconfdir}/dnf/libdnf5-plugins
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so.1*

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -549,7 +549,7 @@ std::vector<std::string> match_specs(
     base.get_config().get_assumeno_option().set(libdnf5::Option::Priority::RUNTIME, true);
     ctx.set_quiet(true);
 
-    base.load_config_from_file();
+    base.load_config();
     base.setup();
 
     // optimization - disable the search for matching installed and available packages for file patterns

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -782,7 +782,7 @@ int main(int argc, char * argv[]) try {
         command->pre_configure();
 
         // Load main configuration
-        base.load_config_from_file();
+        base.load_config();
 
         // Try to open the current directory to see if we have
         // read and execute access. If not, chdir to /

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -72,7 +72,7 @@ Session::Session(
     }
 
     // load configuration
-    base->load_config_from_file();
+    base->load_config();
 
     // set variables
     base->setup();

--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -79,10 +79,16 @@ public:
     /// Returns a pointer to a locked "Base" instance or "nullptr" if no instance is locked.
     static Base * get_locked_base() noexcept;
 
+    /// Loads main configuration.
+    /// The file defined in the current configuration and files in the drop-in directories are used.
+    void load_config();
+
+    /// @deprecated Don't use it! It will be removed in Fedora 40. It was intended for internal use only.
     /// Call a function that loads the config file, catching errors appropriately
     void with_config_file_path(std::function<void(const std::string &)> func);
 
-    /// Loads main configuration from file defined by the current configuration.
+    /// @deprecated It is redundant. It calls `load_config()`.
+    /// Loads main configuration.
     void load_config_from_file();
 
     /// @return a reference to configuration

--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -132,23 +132,6 @@ private:
     friend class libdnf5::repo::RepoSack;
     friend class libdnf5::repo::SolvRepo;
 
-    /// Loads the default configuration. To load distribution-specific configuration.
-    void load_defaults();
-
-    //TODO(jrohel): Make public?
-    /// Loads main configuration from file defined by path.
-    void load_config_from_file(const std::string & path);
-
-    //TODO(jrohel): Make public? Will we support drop-in configuration directories?
-    /// Loads main configuration from files with ".conf" extension from directory defined by dir_path.
-    /// The files in the directory are read in alphabetical order.
-    void load_config_from_dir(const std::string & dir_path);
-
-    //TODO(jrohel): Make public? Will we support drop-in configuration directories?
-    /// Loads main configuration from files with ".conf" extension from directory defined by the current configuration.
-    /// The files in the directory are read in alphabetical order.
-    void load_config_from_dir();
-
     /// Load plugins according to configuration
     void load_plugins();
 

--- a/include/libdnf5/conf/const.hpp
+++ b/include/libdnf5/conf/const.hpp
@@ -32,7 +32,7 @@ constexpr const char * SYSTEM_STATE_DIR = "/usr/lib/sysimage/libdnf5";
 constexpr const char * SYSTEM_CACHEDIR = "/var/cache/libdnf5";
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
-constexpr const char * CONF_DIRECTORY = "/etc/dnf/conf.d";
+constexpr const char * CONF_DIRECTORY = "/etc/dnf/libdnf5.conf.d";
 
 constexpr const char * PLUGINS_CONF_DIR = "/etc/dnf/libdnf5-plugins";
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -109,6 +109,12 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc DESTINATION ${CMAKE_INSTALL
 # Makes an empty directory for libdnf5 cache
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/cache/libdnf5")
 
+# Makes an empty directory for libdnf5 distribution drop-in configuration files
+install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/share/dnf5/libdnf.conf.d")
+
+# Makes an empty directory for libdnf5 user drop-in configuration files
+install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5.conf.d")
+
 # Makes an empty directory for libdnf5-plugins configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")
 

--- a/libdnf5/config.h.in
+++ b/libdnf5/config.h.in
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef _LIBDNF5_CONFIG_H_
 #define _LIBDNF5_CONFIG_H_
 
-#define LIBDNF5_DISTRIBUTION_CONFIG_FILE "@CMAKE_INSTALL_PREFIX@/share/dnf5/libdnf.conf"
+#define LIBDNF5_DISTRIBUTION_CONFIG_DIR "@CMAKE_INSTALL_PREFIX@/share/dnf5/libdnf.conf.d/"
 #define DEFAULT_LIBDNF5_PLUGINS_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/libdnf5/plugins/"
 
 #endif // _LIBDNF5_CONFIG_H_

--- a/test/python3/libdnf5/base/test_base.py
+++ b/test/python3/libdnf5/base/test_base.py
@@ -59,4 +59,4 @@ class TestBase(unittest.TestCase):
         base = libdnf5.base.Base()
         base.get_config().config_file_path = 'this-path-does-not-exist.conf'
 
-        self.assertRaises(RuntimeError, base.load_config_from_file)
+        self.assertRaises(RuntimeError, base.load_config)

--- a/test/python3/libdnf5/tutorial/session/create_base.py
+++ b/test/python3/libdnf5/tutorial/session/create_base.py
@@ -11,13 +11,16 @@ base = libdnf5.base.Base()
 base_config = base.get_config()
 base_config.installroot = installroot
 
-# Optionally load configuration from the config file.
+# Optionally load configuration from the config files.
 #
 # The Base's config is initialized with default values, one of which is
-# `config_file_path()`. This contains the default path to the config file
-# ("/etc/dnf/dnf.conf"). Set a custom value relative to installroot and
-# call the below method to load configuration from a different location.
-base.load_config_from_file()
+# "config_file_path". This contains the default path to the config file
+# ("/etc/dnf/dnf.conf"). If the file does not exist the distribution config file
+# is loaded. Function also loads configuration files from distribution and
+# user ("/etc/dnf/libdnf5.conf.d") drop-in directories.
+# Optionally set a custom value to "config_file_path" before calling this method
+# to load configuration from a anoher configuration file.
+base.load_config()
 
 # Optionally you can set and get vars
 # vars = base.get_vars().get()

--- a/test/tutorial/session/create_base.cpp
+++ b/test/tutorial/session/create_base.cpp
@@ -12,13 +12,16 @@ libdnf5::Base base;
 // installroot directory tree as its root for the rest of its lifetime.
 base.get_config().get_installroot_option().set(installroot);
 
-// Optionally load configuration from the config file.
+// Optionally load configuration from the config files.
 //
 // The Base's config is initialized with default values, one of which is
-// `config_file_path()`. This contains the default path to the config file
-// ("/etc/dnf/dnf.conf"). Set a custom value relative to installroot and
-// call the below method to load configuration from a different location.
-base.load_config_from_file();
+// "config_file_path". This contains the default path to the config file
+// ("/etc/dnf/dnf.conf"). If the file does not exist the distribution config file
+// is loaded. Function also loads configuration files from distribution and
+// user ("/etc/dnf/libdnf5.conf.d") drop-in directories.
+// Optionally set a custom value to "config_file_path" before calling this method
+// to load configuration from a anoher configuration file.
+base.load_config();
 
 // Load vars and do other initialization (of libsolv pool, etc.) based on the
 // configuration.  Locks the installroot and varsdir configuration values so


### PR DESCRIPTION
Introduces a new method `Base::load_config()` to replace `Base::load_config_from_file()`.

In the original implementation, the `Base` class constructor loads the default configuration from the distribution configuration file ("/usr/share/dnf5/libdnf.conf"). And later, the user configuration (by default "/etc/dnf/dnf.conf") was loaded by calling the `Base::load_config_from_file()` method.

**New implementation:**
1. The `Base` class constructor does not load any configuration file.
2. The application calls `Base::load_config()` method instead of `Base::load_config_from_file()`.

**The order of loading the configuration files by the method `Base::load_config()`:**
1. Creates an alphabetically sorted list of names of all configuration files in the distribution configuration drop-in directory ("/usr/share/dnf5/libdnf.conf.d") and the user configuration drop-in directory ("/etc/dnf/libdnf5.conf.d"). If the file with the same name is present in both drop-in directories, only the file from the user configuration drop-in directory is added to the sorted list. So, the distribution configuration drop-in file can be simply masked by creating a file with the same name in the user configuration drop-in directory.
2. Retrieves the configuration from the files in the sorted list. Follows the order. The configuration from the next file overrides the previous one - the last option value wins.
3. Loads the user configuration file (by default "/etc/dnf/dnf.conf"), if exists. If file does not exist and was explicitly requested by the user, the method throws an exeption.

---------------------------------------------
### Example configuration:
**User configuration files:**
/etc/dnf/dnf.conf
/etc/dnf/libdnf5.conf.d/20-user-settings.conf
/etc/dnf/libdnf5.conf.d/60-something.conf
/etc/dnf/libdnf5.conf.d/80-user-settings.conf

**Distribution configuration files:**
/usr/share/dnf5/libdnf.conf.d/50-something.conf
/usr/share/dnf5/libdnf.conf.d/60-something.conf
/usr/share/dnf5/libdnf.conf.d/90-something.conf

**Resulting file loading order by defaul**t
("/usr/share/dnf5/libdnf.conf.d/60-something.conf" is skipped, masked by the user file "/etc/dnf/libdnf5.conf.d/60-something.conf"):

1. /etc/dnf/libdnf5.conf.d/20-user-settings.conf
2. /usr/share/dnf5/libdnf.conf.d/50-something.conf
3. /etc/dnf/libdnf5.conf.d/60-something.conf
4. /etc/dnf/libdnf5.conf.d/80-user-settings.conf
5. /usr/share/dnf5/libdnf.conf.d/90-something.conf
6. /etc/dnf/dnf.conf