### PR TITLE
repo: Don't error out on duplicate repo id

### DIFF
--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -512,7 +512,13 @@ void RepoSack::create_repos_from_file(const std::string & path) {
 
         logger.debug("Creating repo \"{}\" from config file \"{}\" section \"{}\"", repo_id, path, section);
 
-        auto repo = create_repo(repo_id);
+        RepoWeakPtr repo;
+        try {
+            repo = create_repo(repo_id);
+        } catch (const RepoIdAlreadyExistsError & ex) {
+            logger.error(ex.what());
+            continue;
+        }
         repo->set_repo_file_path(path);
         auto & repo_cfg = repo->get_config();
         repo_cfg.load_from_parser(parser, section, *base->get_vars(), *base->get_logger());


### PR DESCRIPTION
It turned out that with copr inter-project dependency it's possible to
have a repo id present in configuration files multiple times.
With this patch dnf5 will not error out, but only log an error and
ignore duplicate repo.
For repositories defined by --repofrompath option the previous behaviour
is preserved, and dnf5 still errors out.
Now the behaviour is consistent with dnf4.

Fixes: https://github.com/rpm-software-management/dnf5/issues/399