### PR TITLE
Print error messages in nested errors

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -880,7 +880,7 @@ int main(int argc, char * argv[]) try {
     } catch (libdnf5::cli::SilentCommandExitError & ex) {
         return ex.get_exit_code();
     } catch (std::runtime_error & ex) {
-        std::cerr << ex.what() << std::endl;
+        std::cerr << libdnf5::format(ex, libdnf5::FormatDetailLevel::Plain);
         log_router.error("Command returned error: {}", ex.what());
         return static_cast<int>(libdnf5::cli::ExitCode::ERROR);
     }
@@ -889,6 +889,6 @@ int main(int argc, char * argv[]) try {
 
     return static_cast<int>(libdnf5::cli::ExitCode::SUCCESS);
 } catch (const libdnf5::Error & e) {
-    std::cerr << libdnf5::format(e, false);
+    std::cerr << libdnf5::format(e, libdnf5::FormatDetailLevel::WithName);
     return static_cast<int>(libdnf5::cli::ExitCode::ERROR);
 }

--- a/include/libdnf5/common/exception.hpp
+++ b/include/libdnf5/common/exception.hpp
@@ -204,10 +204,15 @@ public:
     virtual const char * get_description() const noexcept;
 };
 
+enum FormatDetailLevel {
+    Plain,
+    WithName,
+    WithDomainAndName,
+};
 
 /// Formats the error message of an exception.
 /// If the exception is nested, recurses to format the message of the exception it holds.
-std::string format(const std::exception & e, bool with_domain);
+std::string format(const std::exception & e, FormatDetailLevel detail);
 
 }  // namespace libdnf5
 

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -280,11 +280,14 @@ void RepoSack::update_and_load_repos(libdnf5::repo::RepoQuery & repos, bool impo
             except_in_main_thread = true;
             finish_sack_loader();
             throw;
-        } else {
-            base->get_logger()->warning(
-                "Error loading repo \"{}\" (skipping due to \"skip_if_unavailable=true\"): {}",
-                repo->get_id(),
-                e.what());  // TODO(jrohel) we should print nested exceptions
+        }
+        base->get_logger()->warning(
+            "Error loading repo \"{}\" (skipping due to \"skip_if_unavailable=true\"):", repo->get_id());
+        const auto & error_lines = utils::string::split(format(e, FormatDetailLevel::Plain), "\n");
+        for (const auto & line : error_lines) {
+            if (!line.empty()) {
+                base->get_logger()->warning(' ' + line);
+            }
         }
         return false;
     };


### PR DESCRIPTION
Currently, for `libdnf5::Errors`, only the outermost error message is printed, even if the error contains nested errors, which can cause some crucial details to be left out.

Resolves https://github.com/rpm-software-management/dnf5/issues/804.