### PR TITLE
Add support for repos configuration overrides

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -302,6 +302,8 @@ Package management library.
 %endif
 %dir %{_datadir}/dnf5/libdnf.conf.d
 %dir %{_sysconfdir}/dnf/libdnf5.conf.d
+%dir %{_datadir}/dnf5/repos.override.d
+%dir %{_sysconfdir}/dnf/repos.override.d
 %dir %{_sysconfdir}/dnf/libdnf5-plugins
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so.1*

--- a/include/libdnf5/conf/const.hpp
+++ b/include/libdnf5/conf/const.hpp
@@ -37,6 +37,7 @@ constexpr const char * CONF_DIRECTORY = "/etc/dnf/libdnf5.conf.d";
 constexpr const char * PLUGINS_CONF_DIR = "/etc/dnf/libdnf5-plugins";
 
 const std::vector<std::string> REPOSITORY_CONF_DIRS{"/etc/yum.repos.d", "/etc/distro.repos.d"};
+constexpr const char * REPOS_OVERRIDE_DIR = "/etc/dnf/repos.override.d";
 
 // More important varsdirs must be on the end of vector
 const std::vector<std::string> VARS_DIRS{"/etc/dnf/vars"};

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -74,9 +74,10 @@ public:
 
     /// Creates new repositories from the Base's configuration file (the /
     /// "config_file_path" configuration option) and from directories defined by
-    /// the "reposdir" configuration option.
+    /// the "reposdir" configuration option. Repository overrides are then applied.
     ///
-    /// Calls `create_repos_from_config_file()` and `create_repos_from_reposdir()`.
+    /// Calls `create_repos_from_config_file()`, `create_repos_from_reposdir()`,
+    /// and loads repository configuration overrides.
     void create_repos_from_system_configuration();
 
     /// Creates a new repository from a libsolv testcase file.
@@ -154,6 +155,10 @@ private:
 
     explicit RepoSack(const libdnf5::BaseWeakPtr & base) : base(base) {}
     explicit RepoSack(libdnf5::Base & base);
+
+    /// Loads repositories configuration overrides from drop-in directories. No new repositories are created.
+    /// Only the configuration of the coresponding existing repositories is modified.
+    void load_repos_configuration_overrides();
 
     WeakPtrGuard<RepoSack, false> sack_guard;
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -111,6 +111,12 @@ install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/share/dnf5/libdnf.conf.d"
 # Makes an empty directory for libdnf5 user drop-in configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5.conf.d")
 
+# Creates an empty directory for distribution-supplied repositories configuration overrides
+install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/share/dnf5/repos.override.d")
+
+# Creates an empty directory for user-defined repositories configuration overrides
+install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/repos.override.d")
+
 # Makes an empty directory for libdnf5-plugins configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")
 

--- a/libdnf5/config.h.in
+++ b/libdnf5/config.h.in
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define _LIBDNF5_CONFIG_H_
 
 #define LIBDNF5_DISTRIBUTION_CONFIG_DIR "@CMAKE_INSTALL_PREFIX@/share/dnf5/libdnf.conf.d/"
+#define LIBDNF5_REPOS_DISTRIBUTION_OVERRIDE_DIR "@CMAKE_INSTALL_PREFIX@/share/dnf5/repos.override.d"
 #define DEFAULT_LIBDNF5_PLUGINS_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/libdnf5/plugins/"
 
 #endif // _LIBDNF5_CONFIG_H_

--- a/libdnf5/utils/fs/utils.hpp
+++ b/libdnf5/utils/fs/utils.hpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <filesystem>
 #include <string>
+#include <string_view>
+#include <vector>
 
 
 namespace libdnf5::utils::fs {
@@ -29,11 +31,17 @@ namespace libdnf5::utils::fs {
 /// Compares content of two files.
 /// Returns "true" if files have the same content.
 /// If content differs or error occurred (file doesn't exist, not readable, ...) returns "false".
-bool have_files_same_content_noexcept(const char * file_path1, const char * file_path2) noexcept;
+[[nodiscard]] bool have_files_same_content_noexcept(const char * file_path1, const char * file_path2) noexcept;
 
 /// Recursive renames/moves file/directory.
 /// Implements copy and remove fallback.
 void move_recursive(const std::filesystem::path & src, const std::filesystem::path & dest);
+
+// Creates an alphabetically sorted list of all files with `file_extension` from `directories`.
+// If a file with the same name is in multiple directories, only the first file found is added to the list.
+// Directories are traversed in the same order as they are in the input vector.
+[[nodiscard]] std::vector<std::filesystem::path> create_sorted_file_list(
+    const std::vector<std::filesystem::path> & directories, std::string_view file_extension);
 
 }  // namespace libdnf5::utils::fs
 

--- a/libdnf5/utils/iniparser.cpp
+++ b/libdnf5/utils/iniparser.cpp
@@ -148,8 +148,6 @@ IniParser::ItemType IniParser::next() {
             line_ready = false;
         }
     }
-    trim_value();
-    return previous_line_with_key_val ? ItemType::KEY_VAL : ItemType::END_OF_INPUT;
 }
 
 }  // namespace libdnf5

--- a/test/libdnf5/iniparser/test_iniparser.cpp
+++ b/test/libdnf5/iniparser/test_iniparser.cpp
@@ -73,26 +73,25 @@ void parse_and_check_results(std::string_view ini_file_content, const std::vecto
 void IniparserTest::test_iniparser() {
     // Source data
     constexpr std::string_view ini_file_content =
-        R"**([section1]
-key1 = value1
-key2 =value2
-
-key3= value3
-# Comment1
-key4=value4
-;Comment2
-key5    = value5
-key6 = two line
- value1
-
-key7 = two line
- value2
-key8 = value8
-
-[section2]  # Test section2
-
-key1 = value1
-)**";
+        "[section1]\n"
+        "key1 = value1\n"
+        "key2 =value2\n"
+        "\n"
+        "key3= value3\n"
+        "# Comment1\n"
+        "key4=value4\n"
+        ";Comment2\n"
+        "key5    = value5\n"
+        "key6 = two line\n"
+        " value1\n"
+        "\n"
+        "key7 = two line\n"
+        " value2\n"
+        "key8 = value8\n"
+        "\n"
+        "[section2]  # Test section2\n"
+        "\n"
+        "key1 = value1\n";
 
     // Expected results from parser
     const std::vector<Item> expected_items = {
@@ -127,21 +126,21 @@ key1 = value1
 void IniparserTest::test_iniparser2() {
     // Source data
     constexpr std::string_view ini_file_content =
-        R"**(
-# Test comment1
-# Test comment2
-[section1]
-key1 = value1
-key2 = two line  
-    value2
-key3 = multi line
-    with
-    
-    value3
-key4 = value4
-[sect[i]on2]; Test section2
-  
-key1 = value1)**";
+        "\n"
+        "# Test comment1\n"
+        "# Test comment2\n"
+        "[section1]\n"
+        "key1 = value1\n"
+        "key2 = two line  \n"
+        "    value2\n"
+        "key3 = multi line\n"
+        "    with\n"
+        "    \n"
+        "    value3\n"
+        "key4 = value4\n"
+        "[sect[i]on2]; Test section2\n"
+        "  \n"
+        "key1 = value1";
 
     // Expected results from parser
     const std::vector<Item> expected_items = {

--- a/test/libdnf5/iniparser/test_iniparser.cpp
+++ b/test/libdnf5/iniparser/test_iniparser.cpp
@@ -19,23 +19,20 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_iniparser.hpp"
 
+#include "utils/fs/file.hpp"
+#include "utils/fs/temp.hpp"
 #include "utils/iniparser.hpp"
 
-#include <memory>
+#include <string_view>
+#include <vector>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(IniparserTest);
 
 
-void IniparserTest::setUp() {
-    CppUnit::TestCase::setUp();
-    temp_dir = std::make_unique<libdnf5::utils::fs::TempDir>("libdnf_test_iniparser");
-}
+void IniparserTest::setUp() {}
 
 
-void IniparserTest::tearDown() {
-    temp_dir.reset();
-    CppUnit::TestCase::tearDown();
-}
+void IniparserTest::tearDown() {}
 
 
 using ItemType = libdnf5::IniParser::ItemType;
@@ -50,11 +47,32 @@ struct Item {
     const char * raw;
 };
 
+void parse_and_check_results(std::string_view ini_file_content, const std::vector<Item> & expected_items) {
+    // write the content to a temporary ini file
+    libdnf5::utils::fs::TempDir temp_dir("libdnf_test_iniparser");
+    std::filesystem::path ini_path = temp_dir.get_path() / "test.ini";
+    libdnf5::utils::fs::File(ini_path, "w").write(ini_file_content);
+
+    // parse the ini file and check the results
+    libdnf5::IniParser parser(ini_path);
+    for (std::size_t idx = 0; idx < expected_items.size(); ++idx) {
+        auto readedType = parser.next();
+        CPPUNIT_ASSERT_EQUAL(expected_items[idx].type, readedType);
+        CPPUNIT_ASSERT_EQUAL(std::string(expected_items[idx].section), parser.get_section());
+        if (readedType == ItemType::KEY_VAL) {
+            CPPUNIT_ASSERT_EQUAL(std::string(expected_items[idx].key), parser.get_key());
+            CPPUNIT_ASSERT_EQUAL(std::string(expected_items[idx].value), parser.get_value());
+        }
+        CPPUNIT_ASSERT_EQUAL(std::string(expected_items[idx].raw), parser.get_raw_item());
+    }
+}
+
 }  // namespace
+
 
 void IniparserTest::test_iniparser() {
     // Source data
-    const std::string ini_file_content =
+    constexpr std::string_view ini_file_content =
         R"**([section1]
 key1 = value1
 key2 =value2
@@ -76,11 +94,8 @@ key8 = value8
 key1 = value1
 )**";
 
-    std::filesystem::path ini_path = temp_dir->get_path() / "test.ini";
-    libdnf5::utils::fs::File(ini_path, "w").write(ini_file_content);
-
     // Expected results from parser
-    const Item expected_items[] = {
+    const std::vector<Item> expected_items = {
         {ItemType::SECTION, "section1", "", "", "[section1]\n"},
         {ItemType::KEY_VAL, "section1", "key1", "value1", "key1 = value1\n"},
         {ItemType::KEY_VAL, "section1", "key2", "value2", "key2 =value2\n"},
@@ -105,23 +120,13 @@ key1 = value1
         {ItemType::KEY_VAL, "section2", "key1", "value1", "key1 = value1\n"},
         {ItemType::END_OF_INPUT, "section2", "", "", ""}};
 
-    // Parse input
-    libdnf5::IniParser parser(ini_path);
-    for (std::size_t idx = 0; idx < sizeof(expected_items) / sizeof(expected_items[0]); ++idx) {
-        auto readedType = parser.next();
-        CPPUNIT_ASSERT_EQUAL(readedType, expected_items[idx].type);
-        CPPUNIT_ASSERT_EQUAL(parser.get_section(), std::string(expected_items[idx].section));
-        if (readedType == ItemType::KEY_VAL) {
-            CPPUNIT_ASSERT_EQUAL(parser.get_key(), std::string(expected_items[idx].key));
-            CPPUNIT_ASSERT_EQUAL(parser.get_value(), std::string(expected_items[idx].value));
-        }
-        CPPUNIT_ASSERT_EQUAL(parser.get_raw_item(), std::string(expected_items[idx].raw));
-    }
+    parse_and_check_results(ini_file_content, expected_items);
 }
+
 
 void IniparserTest::test_iniparser2() {
     // Source data
-    const std::string ini_file_content =
+    constexpr std::string_view ini_file_content =
         R"**(
 # Test comment1
 # Test comment2
@@ -138,11 +143,8 @@ key4 = value4
   
 key1 = value1)**";
 
-    std::filesystem::path ini_path = temp_dir->get_path() / "test.ini";
-    libdnf5::utils::fs::File(ini_path, "w").write(ini_file_content);
-
     // Expected results from parser
-    const Item expected_items[] = {
+    const std::vector<Item> expected_items = {
         {ItemType::EMPTY_LINE, "", "", "", "\n"},
         {ItemType::COMMENT_LINE, "", "", "", "# Test comment1\n"},
         {ItemType::COMMENT_LINE, "", "", "", "# Test comment2\n"},
@@ -160,16 +162,5 @@ key1 = value1)**";
         {ItemType::KEY_VAL, "section2", "key1", "value1", "key1 = value1\n"},
         {ItemType::END_OF_INPUT, "section2", "", "", ""}};
 
-    // Parse input
-    libdnf5::IniParser parser(ini_path);
-    for (std::size_t idx = 0; idx < sizeof(expected_items) / sizeof(expected_items[0]); ++idx) {
-        auto readedType = parser.next();
-        CPPUNIT_ASSERT_EQUAL(readedType, expected_items[idx].type);
-        CPPUNIT_ASSERT_EQUAL(parser.get_section(), std::string(expected_items[idx].section));
-        if (readedType == ItemType::KEY_VAL) {
-            CPPUNIT_ASSERT_EQUAL(parser.get_key(), std::string(expected_items[idx].key));
-            CPPUNIT_ASSERT_EQUAL(parser.get_value(), std::string(expected_items[idx].value));
-        }
-        CPPUNIT_ASSERT_EQUAL(parser.get_raw_item(), std::string(expected_items[idx].raw));
-    }
+    parse_and_check_results(ini_file_content, expected_items);
 }

--- a/test/libdnf5/iniparser/test_iniparser.cpp
+++ b/test/libdnf5/iniparser/test_iniparser.cpp
@@ -139,7 +139,7 @@ key3 = multi line
     
     value3
 key4 = value4
-[section2]; Test section2
+[sect[i]on2]; Test section2
   
 key1 = value1)**";
 
@@ -157,10 +157,10 @@ key1 = value1)**";
          "multi line\nwith\n\nvalue3",
          "key3 = multi line\n    with\n    \n    value3\n"},
         {ItemType::KEY_VAL, "section1", "key4", "value4", "key4 = value4\n"},
-        {ItemType::SECTION, "section2", "", "", "[section2]; Test section2\n"},
-        {ItemType::EMPTY_LINE, "section2", "", "", "  \n"},
-        {ItemType::KEY_VAL, "section2", "key1", "value1", "key1 = value1\n"},
-        {ItemType::END_OF_INPUT, "section2", "", "", ""}};
+        {ItemType::SECTION, "sect[i]on2", "", "", "[sect[i]on2]; Test section2\n"},
+        {ItemType::EMPTY_LINE, "sect[i]on2", "", "", "  \n"},
+        {ItemType::KEY_VAL, "sect[i]on2", "key1", "value1", "key1 = value1\n"},
+        {ItemType::END_OF_INPUT, "sect[i]on2", "", "", ""}};
 
     parse_and_check_results(ini_file_content, expected_items);
 }

--- a/test/libdnf5/iniparser/test_iniparser.hpp
+++ b/test/libdnf5/iniparser/test_iniparser.hpp
@@ -30,6 +30,14 @@ class IniparserTest : public CppUnit::TestCase {
 #ifndef WITH_PERFORMANCE_TESTS
     CPPUNIT_TEST(test_iniparser);
     CPPUNIT_TEST(test_iniparser2);
+    CPPUNIT_TEST(test_iniparser_missing_section_header);
+    CPPUNIT_TEST(test_iniparser_missing_bracket);
+    CPPUNIT_TEST(test_iniparser_missing_bracket2);
+    CPPUNIT_TEST(test_iniparser_empty_section_name);
+    CPPUNIT_TEST(test_iniparser_text_after_section);
+    CPPUNIT_TEST(test_iniparser_illegal_continuation_line);
+    CPPUNIT_TEST(test_iniparser_missing_key);
+    CPPUNIT_TEST(test_iniparser_missing_equal);
 #endif
 
     CPPUNIT_TEST_SUITE_END();
@@ -40,6 +48,14 @@ public:
 
     void test_iniparser();
     void test_iniparser2();
+    void test_iniparser_missing_section_header();
+    void test_iniparser_missing_bracket();
+    void test_iniparser_missing_bracket2();
+    void test_iniparser_empty_section_name();
+    void test_iniparser_text_after_section();
+    void test_iniparser_illegal_continuation_line();
+    void test_iniparser_missing_key();
+    void test_iniparser_missing_equal();
 };
 
 #endif

--- a/test/libdnf5/iniparser/test_iniparser.hpp
+++ b/test/libdnf5/iniparser/test_iniparser.hpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_TEST_INIPARSER_HPP
 #define LIBDNF5_TEST_INIPARSER_HPP
 
-#include "utils/fs/temp.hpp"
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -42,8 +40,6 @@ public:
 
     void test_iniparser();
     void test_iniparser2();
-
-    std::unique_ptr<libdnf5::utils::fs::TempDir> temp_dir;
 };
 
 #endif


### PR DESCRIPTION
After the repositories configuration is loaded, new code is run that loads the override files from the `/usr/share/dnf5/repos.override.d` and `/etc/dnf/repos.overide.d` directories.
  
The format of override files is the same as regular ".repo" files. However, override files can modify the settings of already existing repositories. They cannot create new repositories.
Overide files support glob in the repository ID (in the configuration file section name) to support bulk modification of repositories parameters.

**The order of processing the files with overrides:**
1. Creates an alphabetically sorted list of all filenames with overrides in the distribution override directory ("/usr/share/dnf5/repos.override.d") and the user override directory ("/etc/dnf/repos.overide.d"). If a file with the same name is present in both override directories, only the file from the user override directory is added to the sorted list. So, the distribution override file can be simply masked by creating a file with the same name in the user override directory.
2. Retrieves the overrides from the files in the sorted list. Follows the order. The override from the next file overrides the previous one - the last override value wins.

The PR also includes a commit that adds support for the ']' character in the section header name in `IniParser`. Allows to use more complex glob patterns for repository IDs.

-------------------------------------------------
### Example of the repos configuration override file:
```
# Enable `skip_if_unavailable` for all repositories
[*]
skip_if_unavailable = true

# And then disable `skip_if_unavailable` for repositories with id prefix "fedora"
[fedora*]
skip_if_unavailable = false
```

-------------------------------------------------------------------
### An example showing the order in which override files are processed:
**Files with user repos overrides:**
/etc/dnf/repos.overide.d/20-user-overrides.repo
/etc/dnf/repos.overide.d/60-something2.repo
/etc/dnf/repos.overide.d/80-user-overrides.repo
/etc/dnf/repos.overide.d/99-config-manager.repo

**Files with distribution repos overrides:**
/usr/share/dnf5/repos.overide.d/50-something2.repo
/usr/share/dnf5/repos.overide.d/60-something2.repo
/usr/share/dnf5/repos.overide.d/90-something2.repo

**Resulting file processing order:**
1. /etc/dnf/repos.overide.d/20-user-overrides.repo
2. /usr/share/dnf5/repos.overide.d/50-something2.repo
3. /etc/dnf/repos.overide.d/60-something2.repo
4. /etc/dnf/repos.overide.d/80-user-overrides.repo
5. /usr/share/dnf5/repos.overide.d/90-something2.repo
6. /etc/dnf/repos.overide.d/99-config-manager.repo

