### PR TITLE
reldep_parser: Revert reldep regex to match dnf

### DIFF
--- a/libdnf5/solv/reldep_parser.cpp
+++ b/libdnf5/solv/reldep_parser.cpp
@@ -27,7 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::solv {
 
-static const std::regex RELDEP_REGEX("^(\\S*)\\s*(\\S*)?\\s*(\\S*)$");
+static const std::regex RELDEP_REGEX("^(\\S*)\\s*(<=|>=|<|>|=)?\\s*(\\S*)$");
 
 static bool set_cmp_type(libdnf5::rpm::Reldep::CmpType * cmp_type, std::string cmp_type_string, long int length) {
     if (length == 2) {


### PR DESCRIPTION
Fix reldep regex to match the parsing from dnf to work also with expressions without spaces between cmp and evr.

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1365.
Closes #825.