### PR TITLE
dnf5: Configure secondary logger for dnf5

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -60,6 +60,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/logger/factory.hpp>
 #include <libdnf5/logger/global_logger.hpp>
 #include <libdnf5/logger/memory_buffer_logger.hpp>
+#include <libdnf5/logger/stream_logger.hpp>
 #include <libdnf5/repo/repo_cache.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/version.hpp>
@@ -698,6 +699,10 @@ int main(int argc, char * argv[]) try {
     const std::size_t max_log_items_to_keep = 10000;
     const std::size_t prealloc_log_items = 256;
     loggers.emplace_back(std::make_unique<libdnf5::MemoryBufferLogger>(max_log_items_to_keep, prealloc_log_items));
+
+    auto stderr_logger = std::make_unique<libdnf5::StdCStreamPlainLogger>(std::cerr);
+    stderr_logger->set_level(libdnf5::Logger::Level::ERROR);
+    loggers.emplace_back(std::move(stderr_logger));
 
     loggers.front()->info("DNF5 start");
 

--- a/include/libdnf5/logger/logger.hpp
+++ b/include/libdnf5/logger/logger.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <array>
 #include <chrono>
+#include <optional>
 #include <string>
 
 
@@ -48,6 +49,19 @@ public:
         auto ilevel = static_cast<unsigned int>(level);
         return ilevel >= LEVEL_C_STR.size() ? "UNDEFINED" : LEVEL_C_STR[ilevel];
     }
+
+    /// Set logging level for the logger. If set, all messages with the level higher then this value are skipped.
+    /// @param level    Maximal level of log messages the logger will write.
+    void set_level(Level level) { this->level = level; }
+
+    /// Get logging level of the logger. LoggerErrorLevelNotSet is thrown in case the level is not set.
+    Level get_level();
+
+    /// Check whether logging level is set for the level.
+    bool is_level_set() { return level.has_value(); }
+
+    /// Check whether the message of given level will be logged.
+    bool is_enabled_for(Level msg_level);
 
     template <typename... Ss>
     void critical(std::string_view format, Ss &&... args) {
@@ -102,6 +116,8 @@ private:
     static constexpr std::array<const char *, static_cast<unsigned int>(Level::TRACE) + 1> LEVEL_C_STR = {
         "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG", "TRACE"};
 #endif
+
+    std::optional<Level> level;
 };
 
 class StringLogger : public Logger {

--- a/include/libdnf5/logger/stream_logger.hpp
+++ b/include/libdnf5/logger/stream_logger.hpp
@@ -51,6 +51,18 @@ private:
     std::ostream & log_stream;
 };
 
+/// Logger that logs only messages without timestamp and pid.
+class StdCStreamPlainLogger : public StdCStreamLogger {
+public:
+    using StdCStreamLogger::StdCStreamLogger;
+    using StdCStreamLogger::write;
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept override;
+};
+
 }  // namespace libdnf5
 
 #endif

--- a/libdnf5/logger/logger.cpp
+++ b/libdnf5/logger/logger.cpp
@@ -30,9 +30,28 @@ void Logger::log_line(Level level, const std::string & message) noexcept {
     write(system_clock::now(), getpid(), level, message);
 }
 
+Logger::Level Logger::get_level() {
+    if (level) {
+        return level.value();
+    } else {
+        // XXX throw proper exception
+        throw "XXX";
+    }
+}
+
+bool Logger::is_enabled_for(Level msg_level) {
+    if (this->level) {
+        return msg_level <= this->level;
+    } else {
+        return true;
+    }
+}
 
 void StringLogger::write(
     const time_point<system_clock> & time, pid_t pid, Level level, const std::string & message) noexcept {
+    if (!is_enabled_for(level)) {
+        return;
+    }
     try {
         write(fmt::format("{:%FT%T%z} [{}] {} {}\n", time_point_cast<seconds>(time), pid, level_to_cstr(level), message)
                   .c_str());

--- a/libdnf5/logger/memory_buffer_logger.cpp
+++ b/libdnf5/logger/memory_buffer_logger.cpp
@@ -35,6 +35,9 @@ void MemoryBufferLogger::write(
     pid_t pid,
     Level level,
     const std::string & message) noexcept {
+    if (!is_enabled_for(level)) {
+        return;
+    }
     try {
         std::lock_guard<std::mutex> guard(items_mutex);
         if (max_items == 0 || items.size() < max_items) {

--- a/libdnf5/logger/stream_logger.cpp
+++ b/libdnf5/logger/stream_logger.cpp
@@ -39,4 +39,23 @@ void StdCStreamLogger::write(const char * line) noexcept {
     }
 }
 
+void StdCStreamPlainLogger::write(
+    [[maybe_unused]] const std::chrono::time_point<std::chrono::system_clock> & time,
+    [[maybe_unused]] pid_t pid,
+    Level level,
+    const std::string & message) noexcept {
+    if (!is_enabled_for(level)) {
+        return;
+    }
+    try {
+        write(fmt::format("{} {}\n", level_to_cstr(level), message).c_str());
+    } catch (const std::exception & e) {
+        write("Failed to format: ");
+        write(message.c_str());
+        write(" (");
+        write(e.what());
+        write(")\n");
+    }
+}
+
 }  // namespace libdnf5


### PR DESCRIPTION
The logger writes messages with level ERROR and higher directly to the 
stderr so that user can see them.
Currently some libdnf5 errors are buried in the log file and user is not aware
of the problem until they read the log. This change should increase the
visibility of such problems.