### PR TITLE
libdnf5: add stdexcept header to fix missing exception error

### DIFF
--- a/libdnf5/solv/solv_map.hpp
+++ b/libdnf5/solv/solv_map.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <solv/pooltypes.h>
 
 #include <iterator>
+#include <stdexcept>
 
 
 namespace libdnf5::solv {


### PR DESCRIPTION
Add `#include <stdexcept>` directly to solv_map.hpp so that `std::out_of_range` is guaranteed to exist.

Fixes #768