### PR TITLE
logger: Possibility to set log file name

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -71,6 +71,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <iostream>
 
+constexpr const char * DNF5_LOGGER_FILENAME = "dnf5.log";
+
 namespace dnf5 {
 
 using namespace libdnf5::cli;
@@ -93,7 +95,6 @@ void register_group_with_args(
 }
 
 }  // namespace
-
 
 class RootCommand : public Command {
 public:
@@ -796,7 +797,7 @@ int main(int argc, char * argv[]) try {
 
         base.setup();
 
-        auto file_logger = libdnf5::create_file_logger(base);
+        auto file_logger = libdnf5::create_file_logger(base, DNF5_LOGGER_FILENAME);
         // Swap to destination stream logger (log to file)
         log_router.swap_logger(file_logger, 0);
         // Write messages from memory buffer logger to stream logger

--- a/include/libdnf5/logger/factory.hpp
+++ b/include/libdnf5/logger/factory.hpp
@@ -35,6 +35,12 @@ constexpr const char * FILE_LOGGER_FILENAME = "dnf5.log";
 /// @return Instance of a new file logger.
 std::unique_ptr<libdnf5::Logger> create_file_logger(libdnf5::Base & base);
 
+/// @brief Helper method for creating a file logger in `logdir` location with given file name.
+/// @param base Reference to Base for loading the configured logger path.
+/// @param filename Name of the log file.
+/// @return Instance of a new file logger.
+std::unique_ptr<libdnf5::Logger> create_file_logger(libdnf5::Base & base, const std::string & filename);
+
 }  // namespace libdnf5
 
 #endif

--- a/include/libdnf5/logger/factory.hpp
+++ b/include/libdnf5/logger/factory.hpp
@@ -28,8 +28,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5 {
 
 // File logger destination filename.
+/// @deprecated The filename should be set by API user.
 constexpr const char * FILE_LOGGER_FILENAME = "dnf5.log";
 
+/// @deprecated It is going to be removed.
 /// @brief Helper method for creating a file logger.
 /// @param base Reference to Base for loading the configured logger path.
 /// @return Instance of a new file logger.

--- a/libdnf5/logger/factory.cpp
+++ b/libdnf5/logger/factory.cpp
@@ -29,11 +29,11 @@ namespace libdnf5 {
 
 using namespace std::filesystem;
 
-std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base) {
+std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base, const std::string & filename) {
     auto & config = base.get_config();
     const std::filesystem::path logdir_path{config.get_logdir_option().get_value()};
     create_directories(logdir_path);
-    auto log_file = logdir_path / FILE_LOGGER_FILENAME;
+    auto log_file = logdir_path / filename;
     auto log_stream = std::make_unique<std::ofstream>(log_file, std::ios::app);
     if (!log_stream->is_open()) {
         throw std::runtime_error(fmt::format("Cannot open log file: {}: {}", log_file.c_str(), strerror(errno)));
@@ -43,6 +43,10 @@ std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base) {
     log_stream->exceptions(std::ios::badbit | std::ios::failbit);
 
     return std::make_unique<libdnf5::StreamLogger>(std::move(log_stream));
+}
+
+std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base) {
+    return create_file_logger(base, FILE_LOGGER_FILENAME);
 }
 
 }  // namespace libdnf5

--- a/test/libdnf5/logger/test_file_logger.cpp
+++ b/test/libdnf5/logger/test_file_logger.cpp
@@ -54,6 +54,13 @@ void FileLoggerTest::test_file_logger_create() {
 }
 
 
+void FileLoggerTest::test_file_logger_create_name() {
+    CPPUNIT_ASSERT(!exists(full_log_path));
+    auto file_logger = libdnf5::create_file_logger(base, libdnf5::FILE_LOGGER_FILENAME);
+    CPPUNIT_ASSERT(exists(full_log_path));
+}
+
+
 void FileLoggerTest::test_file_logger_add() {
     auto log_router = base.get_logger();
     auto loggers_count_before = log_router->get_loggers_count();

--- a/test/libdnf5/logger/test_file_logger.hpp
+++ b/test/libdnf5/logger/test_file_logger.hpp
@@ -37,6 +37,7 @@ public:
     void setUp() override;
     void tearDown() override;
     void test_file_logger_create();
+    void test_file_logger_create_name();
     void test_file_logger_add();
 
 private:

--- a/test/python3/libdnf5/logger/test_file_logger.py
+++ b/test/python3/libdnf5/logger/test_file_logger.py
@@ -41,6 +41,12 @@ class TestFileLogger(base_test_case.BaseTestCase):
         _ = libdnf5.logger.create_file_logger(self.base)
         self.assertTrue(os.path.exists(self.full_log_path))
 
+    def test_file_logger_create_name(self):
+        self.assertFalse(os.path.exists(self.full_log_path))
+        _ = libdnf5.logger.create_file_logger(
+            self.base, libdnf5.logger.FILE_LOGGER_FILENAME)
+        self.assertTrue(os.path.exists(self.full_log_path))
+
     def test_file_logger_add(self):
         log_router = self.base.get_logger()
         loggers_count_before = log_router.get_loggers_count()


### PR DESCRIPTION
I think responsibility for setting the log file name should be on the API
users, and not the library.
This patch enhances `create_file_logger()` method to accept log file name
parameter and also deprecates the variant without the name.

Resolves: https://github.com/rpm-software-management/dnf5/issues/834