### PR TITLE
changes.rst: --noautoremove was added back

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -125,11 +125,6 @@ List command
    packages already listed in the `Installed Packages` section to reduce duplicities. But if the `--available` modifier
    is used, dnf5 considers all versions available in the enabled repositories, regardless of which version is installed.
 
-Remove command
---------------
- * Dropped `--noautoremove` option. The behavior for automatic removing of dependencies is now controlled by the
-   `clean_requirements_on_remove` configuration option which is set to `True` by default.
-
 Repoclosure command
 -------------------
  * Dropped `--pkg`` option. Positional arguments can be used to specify packages to check closure for.


### PR DESCRIPTION
The `--noautoremove` option was added back to the `remove` command, so we don't need to mention it in `changes.rst`.

See https://github.com/rpm-software-management/dnf5/pull/755