### PR TITLE
Avoid using GNU extensions in the dependency splitter regex

### DIFF
--- a/libdnf5/solv/reldep_parser.cpp
+++ b/libdnf5/solv/reldep_parser.cpp
@@ -27,7 +27,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::solv {
 
-static const std::regex RELDEP_REGEX("^(\\S*)\\s*(<=|>=|<|>|=)?\\s*(\\S*)$");
+// Avoid using the \s and \S patterns here as they are GNU extensions and aren't portable.
+static const std::regex RELDEP_REGEX("^([^[:space:]]*)[[:space:]]*(<=|>=|<|>|=)?[[:space:]]*([^[:space:]]*)$");
 
 static bool set_cmp_type(libdnf5::rpm::Reldep::CmpType * cmp_type, std::string cmp_type_string, long int length) {
     if (length == 2) {


### PR DESCRIPTION
Sticking to POSIX-compatible extended regular expressions makes the code more portable.  In particular, this change is required to avoid an abort at load time on FreeBSD.

No functional change intended.