### PR TITLE
Add missing cast to fix build on i386

### DIFF
--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -20,9 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_UTILS_STRING_HPP
 #define LIBDNF5_UTILS_STRING_HPP
 
+#include "fmt/chrono.h"
+
 #include <algorithm>
 #include <ctime>
 #include <string>
+#include <utility>
 #include <vector>
 
 
@@ -107,12 +110,13 @@ inline std::string tolower(const std::string & s) {
     return result;
 }
 
-inline std::string format_epoch(unsigned long long epoch_num) {
-    const time_t epoch = static_cast<time_t>(epoch_num);
-    struct tm * ptm = gmtime(&epoch);
-    char buffer[20];
-    strftime(buffer, 20, "%F %T", ptm);
-    return std::string(buffer);
+template <typename T>
+inline std::string format_epoch(T epoch_num) {
+    if (std::in_range<time_t>(epoch_num)) {
+        const auto epoch = static_cast<time_t>(epoch_num);
+        return fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(epoch));
+    }
+    return "unrepresentable";
 }
 
 }  // namespace libdnf5::utils::string

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -61,7 +61,7 @@ void RepoInfo::add_repo(Repo & repo) {
         add_line("Include packages", include_packages);
     }
 
-    auto cache_updated = repo.get_timestamp();
+    auto cache_updated = static_cast<time_t>(repo.get_timestamp());
     std::string last_update = "unknown";
     if (cache_updated > 0) {
         last_update = fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(cache_updated));

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_CLI_OUTPUT_REPO_INFO_HPP
 
 
-#include "fmt/chrono.h"
 #include "key_value_table.hpp"
+#include "utils/string.hpp"
 
 #include "libdnf5-cli/utils/units.hpp"
 
@@ -61,10 +61,10 @@ void RepoInfo::add_repo(Repo & repo) {
         add_line("Include packages", include_packages);
     }
 
-    auto cache_updated = static_cast<time_t>(repo.get_timestamp());
+    auto cache_updated = repo.get_timestamp();
     std::string last_update = "unknown";
     if (cache_updated > 0) {
-        last_update = fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(cache_updated));
+        last_update = libdnf5::utils::string::format_epoch(cache_updated);
     }
 
     auto metadata_expire = repo.get_metadata_expire();
@@ -174,12 +174,7 @@ void RepoInfo::add_repo(Repo & repo) {
 
         add_line("Revision", repo.get_revision(), nullptr, group_repodata);
 
-        const auto updated_time = static_cast<time_t>(repo.get_max_timestamp());
-        add_line(
-            "Updated",
-            fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(updated_time)),
-            nullptr,
-            group_repodata);
+        add_line("Updated", libdnf5::utils::string::format_epoch(repo.get_max_timestamp()), nullptr, group_repodata);
     }
 
     /*

--- a/libdnf5-cli/output/transactioninfo.cpp
+++ b/libdnf5-cli/output/transactioninfo.cpp
@@ -20,20 +20,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/output/transactioninfo.hpp"
 
-#include "fmt/chrono.h"
+#include "utils/string.hpp"
 
 
 namespace libdnf5::cli::output {
 
 void print_transaction_info(libdnf5::transaction::Transaction & transaction) {
-    const auto dt_start_time = static_cast<time_t>(transaction.get_dt_start());
-    const auto dt_end_time = static_cast<time_t>(transaction.get_dt_end());
-
     KeyValueTable info;
     info.add_line("Transaction ID", transaction.get_id(), "bold");
-    info.add_line("Begin time", fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(dt_start_time)));
+    info.add_line("Begin time", libdnf5::utils::string::format_epoch(transaction.get_dt_start()));
     info.add_line("Begin rpmdb", transaction.get_rpmdb_version_begin());
-    info.add_line("End time", fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(dt_end_time)));
+    info.add_line("End time", libdnf5::utils::string::format_epoch(transaction.get_dt_end()));
     info.add_line("End rpmdb", transaction.get_rpmdb_version_end());
 
     info.add_line("User", transaction.get_user_id());

--- a/libdnf5-cli/output/transactionlist.cpp
+++ b/libdnf5-cli/output/transactionlist.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5-cli/output/transactionlist.hpp"
 
-#include "fmt/chrono.h"
+#include "utils/string.hpp"
 
 #include "libdnf5-cli/tty.hpp"
 
@@ -43,12 +43,10 @@ void print_transaction_list(std::vector<libdnf5::transaction::Transaction> & ts_
     }
 
     for (auto & ts : ts_list) {
-        const auto dt_start_time = static_cast<time_t>(ts.get_dt_start());
         struct libscols_line * ln = scols_table_new_line(table.get(), NULL);
         scols_line_set_data(ln, 0, std::to_string(ts.get_id()).c_str());
         scols_line_set_data(ln, 1, ts.get_description().c_str());
-        scols_line_set_data(
-            ln, 2, fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(dt_start_time)).c_str());
+        scols_line_set_data(ln, 2, libdnf5::utils::string::format_epoch(ts.get_dt_start()).c_str());
         // TODO(lukash) fill the Actions(s), if we even want them?
         scols_line_set_data(ln, 3, "");
         scols_line_set_data(ln, 4, std::to_string(ts.get_packages().size()).c_str());


### PR DESCRIPTION
From: https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf5-unstable/fedora-37-i386/06330258-dnf5/builder-live.log.gz
```
/builddir/build/BUILD/dnf5-5.1.2-20230822004434.9.g54ab9891/include/libdnf5-cli/output/repo_info.hpp:67:86: error: conversion from 'long long int' to 'time_t' {aka 'long int'} may change value [-Werror=conversion]
   67 |         last_update = fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(cache_updated));
      |                                                                                      ^~~~~~~~~~~~~
```

It is failing in nightly: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf5-unstable/build/6350897/