### PR TITLE
swig: Fix linking targets to dependencies

### DIFF
--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_go_module LIBRARY_NAME MODULE_NAME)
     target_compile_options(${TARGET_NAME} PUBLIC ${SWIG_COMPILE_OPTIONS})
 
     string(REPLACE "_" "-" C_LIBRARY_NAME ${LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${C_LIBRARY_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${C_LIBRARY_NAME})
 endfunction()
 
 

--- a/bindings/perl5/CMakeLists.txt
+++ b/bindings/perl5/CMakeLists.txt
@@ -74,7 +74,8 @@ function(add_perl5_module LIBRARY_NAME MODULE_NAME)
     target_compile_options(${TARGET_NAME} PUBLIC ${SWIG_COMPILE_OPTIONS})
 
     string(REPLACE "_" "-" C_LIBRARY_NAME ${LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${C_LIBRARY_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${C_LIBRARY_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${PERL_LIBRARY})
 
     install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION "${PERL_INSTALL_PATH}/auto/${LIBRARY_NAME}/${MODULE_NAME}")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}.pm" DESTINATION "${PERL_INSTALL_PATH}/${LIBRARY_NAME}")

--- a/bindings/python3/CMakeLists.txt
+++ b/bindings/python3/CMakeLists.txt
@@ -41,8 +41,8 @@ function(add_python3_module LIBRARY_NAME MODULE_NAME)
     target_compile_options(${TARGET_NAME} PUBLIC ${SWIG_COMPILE_OPTIONS})
 
     string(REPLACE "_" "-" C_LIBRARY_NAME ${LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${C_LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${Python3_LIBRARIES})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${C_LIBRARY_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${Python3_LIBRARIES})
 
     # generate a dist-info for the library (redundantly created for multi-module packages, oh well...)
     set(DISTINFO_PATH "${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_NAME}-${CMAKE_PROJECT_VERSION}.dist-info")

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -22,8 +22,8 @@ function(add_ruby_module LIBRARY_NAME MODULE_NAME)
     target_compile_options(${TARGET_NAME} PUBLIC ${SWIG_COMPILE_OPTIONS})
 
     string(REPLACE "_" "-" C_LIBRARY_NAME ${LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${C_LIBRARY_NAME})
-    swig_link_libraries(${TARGET_NAME} ${RUBY_LIBRARIES})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${C_LIBRARY_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${RUBY_LIBRARY})
 
     install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION "${RUBY_VENDORARCH_DIR}/${LIBRARY_NAME}")
 endfunction()


### PR DESCRIPTION
- perl5: add missing linking against `${PERL_LIBRARY}`

- ruby: fix linking, replace `${RUBY_LIBRARIES}` with `${RUBY_LIBRARY}`
  `${RUBY_LIBRARY}` or `${Ruby_LIBRARIES}` can be used - same meaning.

- use `target_link_libraries` instead of deprecated `swig_link_libraries`
  `swig_link_libraries` has been deprecated since cmake 3.13

Missing links detected thanks to issue https://github.com/rpm-software-management/dnf5/issues/267.