### PR TITLE
Fix algorithm in package NEVRA filter

### DIFF
--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -1942,14 +1942,26 @@ void PackageQuery::PQImpl::filter_nevra(
         case libdnf5::sack::QueryCmp::LTE:
             filter_nevra_internal_str<cmp_lte>(pool, c_pattern, sorted_solvables, filter_result);
             break;
-        case libdnf5::sack::QueryCmp::GLOB:
-            filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra>(
-                pool, c_pattern, *pkg_set.p_impl, filter_result, 0);
-            break;
-        case libdnf5::sack::QueryCmp::IGLOB:
-            filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra>(
-                pool, c_pattern, *pkg_set.p_impl, filter_result, FNM_CASEFOLD);
-            break;
+        case libdnf5::sack::QueryCmp::GLOB: {
+            auto found = pattern.find(':');
+            if (found == std::string::npos) {
+                filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra_without_epoch>(
+                    pool, c_pattern, *pkg_set.p_impl, filter_result, 0);
+            } else {
+                filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra_with_epoch>(
+                    pool, c_pattern, *pkg_set.p_impl, filter_result, 0);
+            }
+        } break;
+        case libdnf5::sack::QueryCmp::IGLOB: {
+            auto found = pattern.find(':');
+            if (found == std::string::npos) {
+                filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra_without_epoch>(
+                    pool, c_pattern, *pkg_set.p_impl, filter_result, FNM_CASEFOLD);
+            } else {
+                filter_glob_internal<&libdnf5::solv::RpmPool::get_nevra_with_epoch>(
+                    pool, c_pattern, *pkg_set.p_impl, filter_result, FNM_CASEFOLD);
+            }
+        } break;
         case libdnf5::sack::QueryCmp::IEXACT: {
             for (Id candidate_id : *pkg_set.p_impl) {
                 const char * nevra = pool.get_nevra(candidate_id);

--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -181,9 +181,20 @@ public:
 
     const char * get_arch(Id id) const noexcept { return id2str(id2solvable(id)->arch); }
 
+    /// Construct package string ID without epoch when epoch is 0
+    /// Returns a temporary object allocated by pool_alloctmpspace
     const char * get_nevra(Id id) const noexcept { return solvable2str(id2solvable(id)); }
 
+    /// Construct package string ID containing always epoch
     std::string get_full_nevra(Id id) const;
+
+    /// Construct package string ID without epoch
+    /// Returns a temporary object allocated by pool_alloctmpspace
+    const char * get_nevra_without_epoch(Id id) const noexcept;
+
+    /// Construct package string ID containing always epoch
+    /// Returns a temporary object allocated by pool_alloctmpspace
+    const char * get_nevra_with_epoch(Id id) const noexcept;
 
     bool is_installed(Solvable * solvable) const { return solvable->repo == pool->installed; }
 


### PR DESCRIPTION
DNF5 detects first, whether provided argument contains epoch (find ':') then it construct package strings IDs accordingly.

CI-tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1372

Closes: https://github.com/rpm-software-management/dnf5/issues/614