### PR TITLE
Fix/tune linking targets to dependencies

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,4 +6,4 @@ add_library(common OBJECT ${COMMON_SOURCES})
 set_property(TARGET common PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # required by clang
-target_link_libraries(common stdc++)
+target_link_libraries(common PUBLIC stdc++)

--- a/dnf5-plugins/builddep_plugin/CMakeLists.txt
+++ b/dnf5-plugins/builddep_plugin/CMakeLists.txt
@@ -7,6 +7,9 @@ add_library(builddep_cmd_plugin MODULE builddep.cpp builddep_cmd_plugin.cpp)
 set_target_properties(builddep_cmd_plugin PROPERTIES PREFIX "")
 
 find_library(RPMBUILD NAMES rpmbuild REQUIRED)
-target_link_libraries(builddep_cmd_plugin ${RPMBUILD})
+target_link_libraries(builddep_cmd_plugin PRIVATE ${RPMBUILD})
+
+target_link_libraries(builddep_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
+target_link_libraries(builddep_cmd_plugin PRIVATE dnf5)
 
 install(TARGETS builddep_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)

--- a/dnf5-plugins/changelog_plugin/CMakeLists.txt
+++ b/dnf5-plugins/changelog_plugin/CMakeLists.txt
@@ -2,7 +2,11 @@
 add_definitions(-DGETTEXT_DOMAIN=\"dnf5_cmd_changelog\")
 
 add_library(changelog_cmd_plugin MODULE changelog.cpp changelog_cmd_plugin.cpp)
+
 # disable the 'lib' prefix in order to create changelog_cmd_plugin.so
 set_target_properties(changelog_cmd_plugin PROPERTIES PREFIX "")
+
+target_link_libraries(changelog_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
+target_link_libraries(changelog_cmd_plugin PRIVATE dnf5)
 
 install(TARGETS changelog_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)

--- a/dnf5-plugins/copr_plugin/CMakeLists.txt
+++ b/dnf5-plugins/copr_plugin/CMakeLists.txt
@@ -4,10 +4,14 @@ add_definitions(-DGETTEXT_DOMAIN=\"dnf5_cmd_copr\")
 file(GLOB COPR_SOURCES *.cpp)
 add_library(copr_cmd_plugin MODULE ${COPR_SOURCES})
 
-target_link_libraries(copr_cmd_plugin ${JSONC_LIBRARIES})
-include_directories(${JSONC_INCLUDE_DIRS})
-
 # disable the 'lib' prefix in order to create copr_cmd_plugin.so
 set_target_properties(copr_cmd_plugin PROPERTIES PREFIX "")
+
+pkg_check_modules(JSONC REQUIRED json-c)
+include_directories(${JSONC_INCLUDE_DIRS})
+target_link_libraries(copr_cmd_plugin PRIVATE ${JSONC_LIBRARIES})
+
+target_link_libraries(copr_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
+target_link_libraries(copr_cmd_plugin PRIVATE dnf5)
 
 install(TARGETS copr_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)

--- a/dnf5-plugins/repoclosure_plugin/CMakeLists.txt
+++ b/dnf5-plugins/repoclosure_plugin/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(repoclosure_cmd_plugin MODULE repoclosure.cpp repoclosure_cmd_plugin
 # disable the 'lib' prefix in order to create repoclosure_cmd_plugin.so
 set_target_properties(repoclosure_cmd_plugin PROPERTIES PREFIX "")
 
-target_link_libraries(repoclosure_cmd_plugin ${RPMBUILD})
+target_link_libraries(repoclosure_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
+target_link_libraries(repoclosure_cmd_plugin PRIVATE dnf5)
 
 install(TARGETS repoclosure_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(dnf5 ${DNF5_SOURCES})
 # Enable symbol export. Needed for loadable modules (dnf5 plugins).
 set_property(TARGET dnf5 PROPERTY ENABLE_EXPORTS 1)
 
-target_link_libraries(dnf5 PUBLIC common libdnf5 libdnf5-cli Threads::Threads)
+target_link_libraries(dnf5 PRIVATE common libdnf5 libdnf5-cli Threads::Threads)
 install(TARGETS dnf5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 

--- a/dnf5daemon-client/CMakeLists.txt
+++ b/dnf5daemon-client/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${DNF5DAEMON_CLIENT_BIN} ${DNF5DAEMON_CLIENT_SOURCES})
 
 target_link_libraries(
     ${DNF5DAEMON_CLIENT_BIN}
-    PUBLIC
+    PRIVATE
         common
         libdnf5
         libdnf5-cli

--- a/dnf5daemon-server/CMakeLists.txt
+++ b/dnf5daemon-server/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${DNF5DAEMON_SERVER_BIN} ${DNF5DAEMON_SERVER_SOURCES})
 
 target_link_libraries(
     ${DNF5DAEMON_SERVER_BIN}
-    PUBLIC
+    PRIVATE
         common
         libdnf5
         libdnf5-cli

--- a/libdnf5-cli/CMakeLists.txt
+++ b/libdnf5-cli/CMakeLists.txt
@@ -23,7 +23,7 @@ set(DNF_CLI_SO_VERSION 1)
 set_target_properties(libdnf5-cli PROPERTIES OUTPUT_NAME "dnf5-cli")
 set_target_properties(libdnf5-cli PROPERTIES SOVERSION ${DNF_CLI_SO_VERSION})
 # required by clang
-target_link_libraries(libdnf5-cli stdc++)
+target_link_libraries(libdnf5-cli PUBLIC stdc++)
 
 # install libdnf5-cli.so
 install(TARGETS libdnf5-cli LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
@@ -31,15 +31,15 @@ install(TARGETS libdnf5-cli LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # link libraries and set pkg-config requires
 
-target_link_libraries(libdnf5-cli common libdnf5)
+target_link_libraries(libdnf5-cli PUBLIC libdnf5)
 
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF5_CLI_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
-target_link_libraries(libdnf5-cli ${LIBFMT_LIBRARIES})
+target_link_libraries(libdnf5-cli PUBLIC ${LIBFMT_LIBRARIES})
 
 pkg_check_modules(SMARTCOLS REQUIRED smartcols)
 list(APPEND LIBDNF5_CLI_PC_REQUIRES_PRIVATE "${SMARTCOLS_MODULE_NAME}")
-target_link_libraries(libdnf5-cli ${SMARTCOLS_LIBRARIES})
+target_link_libraries(libdnf5-cli PUBLIC ${SMARTCOLS_LIBRARIES})
 
 
 # sort the pkg-config requires and concatenate them into a string

--- a/libdnf5-plugins/actions/CMakeLists.txt
+++ b/libdnf5-plugins/actions/CMakeLists.txt
@@ -6,8 +6,11 @@ endif()
 add_definitions(-DGETTEXT_DOMAIN=\"libdnf5\")
 
 add_library(actions MODULE actions.cpp)
+
 # disable the 'lib' prefix in order to create actions.so
 set_target_properties(actions PROPERTIES PREFIX "")
+
+target_link_libraries(actions PRIVATE libdnf5)
 
 install(TARGETS actions LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")
 

--- a/libdnf5-plugins/python_plugins_loader/CMakeLists.txt
+++ b/libdnf5-plugins/python_plugins_loader/CMakeLists.txt
@@ -10,11 +10,13 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 include_directories(${Python3_INCLUDE_DIRS})
 
 add_library(python_plugins_loader MODULE python_plugins_loader.cpp)
+
 # disable the 'lib' prefix in order to create python_plugins_loader.so
 set_target_properties(python_plugins_loader PROPERTIES PREFIX "")
 
-target_link_libraries(python_plugins_loader PUBLIC libdnf5 libdnf5-cli)
-target_link_libraries(python_plugins_loader PUBLIC ${Python3_LIBRARIES})
+target_link_libraries(python_plugins_loader PRIVATE ${Python3_LIBRARIES})
+
+target_link_libraries(python_plugins_loader PRIVATE libdnf5)
 
 install(TARGETS python_plugins_loader LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/)
 install(FILES "README" DESTINATION ${Python3_SITELIB}/libdnf_plugins/)

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -30,10 +30,6 @@ target_link_libraries(libdnf5 ${CMAKE_DL_LIBS})
 # required by clang
 target_link_libraries(libdnf5 stdc++)
 
-# link stdc++fs to make experimental std::filesystem available on gcc 8:
-# https://gcc.gnu.org/onlinedocs/libstdc++/manual/using.html
-target_link_libraries(libdnf5 stdc++fs)
-
 # install libdnf5.so
 install(TARGETS libdnf5 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -25,15 +25,15 @@ set(DNF_SO_VERSION 1)
 set_target_properties(libdnf5 PROPERTIES OUTPUT_NAME "dnf5")
 set_target_properties(libdnf5 PROPERTIES SOVERSION ${DNF_SO_VERSION})
 # required to have dlopen symbol
-target_link_libraries(libdnf5 ${CMAKE_DL_LIBS})
+target_link_libraries(libdnf5 PUBLIC ${CMAKE_DL_LIBS})
 
 # required by clang
-target_link_libraries(libdnf5 stdc++)
+target_link_libraries(libdnf5 PUBLIC stdc++)
 
 # install libdnf5.so
 install(TARGETS libdnf5 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
-target_link_libraries(libdnf5 common)
+target_link_libraries(libdnf5 PRIVATE common)
 
 # link libraries and set pkg-config requires
 
@@ -41,33 +41,33 @@ find_package(toml11 REQUIRED)
 
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
-target_link_libraries(libdnf5 ${LIBFMT_LIBRARIES})
+target_link_libraries(libdnf5 PUBLIC ${LIBFMT_LIBRARIES})
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})
-target_link_libraries(libdnf5 ${JSONC_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${JSONC_LIBRARIES})
 
 pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBMODULEMD_MODULE_NAME}")
-target_link_libraries(libdnf5 ${LIBMODULEMD_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${LIBMODULEMD_LIBRARIES})
 
 pkg_check_modules(LIBSOLV REQUIRED libsolv>=0.7.21)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBSOLV_MODULE_NAME}")
-target_link_libraries(libdnf5 ${LIBSOLV_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${LIBSOLV_LIBRARIES})
 
 pkg_check_modules(LIBSOLVEXT REQUIRED libsolvext>=0.7.7)
 list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBSOLVEXT_MODULE_NAME}")
-target_link_libraries(libdnf5 ${LIBSOLVEXT_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${LIBSOLVEXT_LIBRARIES})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${RPM_MODULE_NAME}")
-target_link_libraries(libdnf5 ${RPM_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${RPM_LIBRARIES})
 
 if(WITH_COMPS)
     pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
     list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBXML2_MODULE_NAME}")
     include_directories(${LIBXML2_INCLUDE_DIRS})
-    target_link_libraries(libdnf5 ${LIBXML2_LIBRARIES})
+    target_link_libraries(libdnf5 PRIVATE ${LIBXML2_LIBRARIES})
 endif()
 
 if (WITH_ZCHUNK)
@@ -78,17 +78,17 @@ endif()
 # GLIB librepo and libmodulemd uses glib2 in API :(
 pkg_check_modules (GLIB2 glib-2.0>=2.46.0)
 include_directories(${GLIB2_INCLUDE_DIRS})
-target_link_libraries(libdnf5 ${GLIB2_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${GLIB2_LIBRARIES})
 
 pkg_check_modules(LIBREPO REQUIRED librepo>=1.15.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
-target_include_directories(libdnf5 PRIVATE ${LIBREPO_INCLUDE_DIRS})
-target_link_libraries(libdnf5 ${LIBREPO_LDFLAGS})
+target_include_directories(libdnf5 PUBLIC PRIVATE ${LIBREPO_INCLUDE_DIRS})
+target_link_libraries(libdnf5 PRIVATE ${LIBREPO_LDFLAGS})
 
 # SQLite3
 pkg_check_modules(SQLite3 REQUIRED sqlite3>=3.35.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${SQLite3_MODULE_NAME}")
-target_link_libraries(libdnf5 ${SQLite3_LIBRARIES})
+target_link_libraries(libdnf5 PRIVATE ${SQLite3_LIBRARIES})
 
 
 # sort the pkg-config requires and concatenate them into a string

--- a/test/dnf5-plugins/copr_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/copr_plugin/CMakeLists.txt
@@ -16,7 +16,11 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 include_directories(${JSONC_INCLUDE_DIRS})
 
 add_executable(run_tests_copr ${TEST_COPR_SOURCES})
-target_link_libraries(run_tests_copr stdc++ libdnf5 libdnf5-cli test_shared)
+target_link_libraries(run_tests_copr PRIVATE stdc++ libdnf5 libdnf5-cli test_shared)
+
+pkg_check_modules(JSONC REQUIRED json-c)
+include_directories(${JSONC_INCLUDE_DIRS})
+target_link_libraries(run_tests_copr PRIVATE ${JSONC_LIBRARIES})
 
 add_compile_definitions(TEST_DATADIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 

--- a/test/libdnf5-cli/CMakeLists.txt
+++ b/test/libdnf5-cli/CMakeLists.txt
@@ -15,8 +15,8 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 
 
 add_executable(run_tests_cli ${TEST_LIBDNF5_CLI_SOURCES})
-target_link_directories(run_tests_cli PUBLIC ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(run_tests_cli stdc++ libdnf5 libdnf5-cli cppunit test_shared)
+target_link_directories(run_tests_cli PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
+target_link_libraries(run_tests_cli PRIVATE stdc++ libdnf5 libdnf5-cli cppunit test_shared)
 
 
 add_test(NAME test_libdnf_cli COMMAND run_tests_cli)

--- a/test/libdnf5/CMakeLists.txt
+++ b/test/libdnf5/CMakeLists.txt
@@ -15,12 +15,15 @@ target_compile_options(run_tests PRIVATE "-Wno-unused-value")
 target_compile_options(run_tests PRIVATE "-Wno-self-assign-overloaded")
 target_compile_options(run_tests PRIVATE "-Wno-self-move")
 
-target_link_directories(run_tests PUBLIC ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(run_tests stdc++ libdnf5 cppunit test_shared)
+target_link_directories(run_tests PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
+target_link_libraries(run_tests PRIVATE stdc++ libdnf5 cppunit test_shared)
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})
-target_link_libraries(run_tests ${JSONC_LIBRARIES})
+target_link_libraries(run_tests PRIVATE ${JSONC_LIBRARIES})
+
+pkg_check_modules(LIBSOLV REQUIRED libsolv>=0.7.21)
+target_link_libraries(run_tests PRIVATE ${LIBSOLV_LIBRARIES})
 
 
 if(WITH_PERFORMANCE_TESTS)

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -10,4 +10,4 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 add_library(test_shared OBJECT ${TEST_SHARED_SOURCES})
 
 target_link_directories(test_shared PUBLIC ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(test_shared stdc++ libdnf5 cppunit)
+target_link_libraries(test_shared PUBLIC stdc++ libdnf5 cppunit)

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 
 
 add_executable(run_tests_tutorial ${TEST_TUTORIAL_SOURCES})
-target_link_libraries(run_tests_tutorial stdc++ libdnf5 libdnf5-cli cppunit)
+target_link_libraries(run_tests_tutorial PRIVATE stdc++ libdnf5 libdnf5-cli cppunit)
 
 
 add_test(NAME test_tutorial COMMAND run_tests_tutorial)


### PR DESCRIPTION
- Removes linking to "libstdc++fs"
- Adds missing libraries to link with libdnf5 and dnf5 plugins
- Removes unused direct shared object dependencies

Similar work for swig prepared in this PR https://github.com/rpm-software-management/dnf5/pull/848.
Missing links detected thanks to issue https://github.com/rpm-software-management/dnf5/issues/267.