### PR TITLE
base: Call rpmReadConfigFiles() earlier

### DIFF
--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -20,6 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dnf5/shared_options.hpp"
 
+#include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+
+#include <libdnf5/rpm/arch.hpp>
 
 namespace dnf5 {
 
@@ -72,6 +75,21 @@ void create_forcearch_option(dnf5::Command & command) {
                                        [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
                                        [[maybe_unused]] const char * option,
                                        const char * value) {
+        auto supported_arches = libdnf5::rpm::get_supported_arches();
+        if (std::find(supported_arches.begin(), supported_arches.end(), value) == supported_arches.end()) {
+            std::string available_arches{};
+            auto it = supported_arches.begin();
+            if (it != supported_arches.end()) {
+                available_arches.append("\"" + *it + "\"");
+                ++it;
+                for (; it != supported_arches.end(); ++it) {
+                    available_arches.append(", ");
+                    available_arches.append("\"" + *it + "\"");
+                }
+            }
+            throw libdnf5::cli::ArgumentParserInvalidValueError(
+                M_("Unsupported architecture \"{0}\". Please choose one from {1}"), value, available_arches);
+        }
         ctx.base.get_config().get_ignorearch_option().set(libdnf5::Option::Priority::COMMANDLINE, true);
         ctx.base.get_vars()->set("arch", value, libdnf5::Vars::Priority::COMMANDLINE);
         return true;

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -143,6 +143,13 @@ public:
     const char * get_name() const noexcept override { return "ArgumentParserMissingDependentArgumentError"; }
 };
 
+/// Exception is thrown when the given argument value is not valid.
+class ArgumentParserInvalidValueError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserInvalidValueError"; }
+};
+
 /// Base class for user data used in ArgumentParser::Argument
 class ArgumentParserUserData {};
 

--- a/include/libdnf5/rpm/arch.hpp
+++ b/include/libdnf5/rpm/arch.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF5_RPM_ARCH_HPP
+#define LIBDNF5_RPM_ARCH_HPP
+
+#include <string>
+#include <vector>
+
+
+namespace libdnf5::rpm {
+
+std::vector<std::string> get_supported_arches();
+
+}  // namespace libdnf5::rpm
+
+#endif  // LIBDNF5_RPM_ARCH_HPP

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -182,8 +182,9 @@ void Base::setup() {
     auto & config = get_config();
     auto & installroot = config.get_installroot_option();
     installroot.lock("Locked by Base::setup()");
+    auto vars = get_vars();
 
-    get_vars()->load(vars_installroot, config.get_varsdir_option().get_value());
+    vars->load(vars_installroot, config.get_varsdir_option().get_value());
 
     // TODO(mblaha) - move system state load closer to the system repo loading
     std::filesystem::path system_state_dir{config.get_system_state_dir_option().get_value()};
@@ -220,7 +221,7 @@ void Base::setup() {
     pool_setdisttype(**pool, DISTTYPE_RPM);
     // TODO(jmracek) - architecture variable is changable therefore architecture in vars must be synchronized with RpmPool
     // (and force to recompute provides) or locked
-    pool_setarch(**pool, get_vars()->get_value("arch").c_str());
+    pool_setarch(**pool, vars->get_value("arch").c_str());
     pool_set_rootdir(**pool, installroot.get_value().c_str());
 
     p_impl->plugins.post_base_setup();

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -442,7 +442,10 @@ void Vars::detect_vars(const std::string & installroot) {
 
     set_lazy(
         "basearch",
-        [this]() -> auto { return std::make_unique<std::string>(get_base_arch(variables["arch"].value.c_str())); },
+        [this]() -> auto {
+            auto base_arch = get_base_arch(variables["arch"].value.c_str());
+            return base_arch ? std::make_unique<std::string>(base_arch) : nullptr;
+        },
         Priority::AUTO);
 
     set_lazy(

--- a/libdnf5/rpm/arch.cpp
+++ b/libdnf5/rpm/arch.cpp
@@ -1,0 +1,52 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "libdnf5/rpm/arch.hpp"
+
+#include "arch_private.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+namespace libdnf5::rpm {
+
+std::vector<std::string> get_supported_arches() {
+    std::vector<std::string> arches;
+    for (int i = 0; ARCH_MAP[i].base; ++i) {
+        for (int j = 0; ARCH_MAP[i].native[j]; ++j) {
+            arches.emplace_back(ARCH_MAP[i].native[j]);
+        }
+    }
+    std::sort(arches.begin(), arches.end());
+    return arches;
+}
+
+const char * get_base_arch(const char * arch) {
+    for (int i = 0; libdnf5::rpm::ARCH_MAP[i].base; ++i) {
+        for (int j = 0; libdnf5::rpm::ARCH_MAP[i].native[j]; ++j) {
+            if (std::strcmp(libdnf5::rpm::ARCH_MAP[i].native[j], arch) == 0) {
+                return libdnf5::rpm::ARCH_MAP[i].base;
+            }
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace libdnf5::rpm

--- a/libdnf5/rpm/arch_private.hpp
+++ b/libdnf5/rpm/arch_private.hpp
@@ -1,0 +1,74 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_RPM_ARCH_PRIVATE_HPP
+#define LIBDNF5_RPM_ARCH_PRIVATE_HPP
+
+namespace libdnf5::rpm {
+
+#define MAX_NATIVE_ARCHES 12
+
+// data taken from DNF
+// TODO(mblaha): think about using a C++ structure for this e.g. std::map<std::string_view>
+static const struct {
+    const char * base;
+    const char * native[MAX_NATIVE_ARCHES];
+} ARCH_MAP[] = {
+    {"aarch64", {"aarch64", nullptr}},
+    {"alpha",
+     {"alpha",
+      "alphaev4",
+      "alphaev45",
+      "alphaev5",
+      "alphaev56",
+      "alphaev6",
+      "alphaev67",
+      "alphaev68",
+      "alphaev7",
+      "alphapca56",
+      nullptr}},
+    {"arm", {"armv5tejl", "armv5tel", "armv5tl", "armv6l", "armv7l", "armv8l", nullptr}},
+    {"armhfp", {"armv6hl", "armv7hl", "armv7hnl", "armv8hl", "armv8hnl", "armv8hcnl", nullptr}},
+    {"i386", {"i386", "athlon", "geode", "i486", "i586", "i686", nullptr}},
+    {"ia64", {"ia64", nullptr}},
+    {"mips", {"mips", nullptr}},
+    {"mipsel", {"mipsel", nullptr}},
+    {"mips64", {"mips64", nullptr}},
+    {"mips64el", {"mips64el", nullptr}},
+    {"noarch", {"noarch", nullptr}},
+    {"ppc", {"ppc", nullptr}},
+    {"ppc64", {"ppc64", "ppc64iseries", "ppc64p7", "ppc64pseries", nullptr}},
+    {"ppc64le", {"ppc64le", nullptr}},
+    {"riscv32", {"riscv32", nullptr}},
+    {"riscv64", {"riscv64", nullptr}},
+    {"riscv128", {"riscv128", nullptr}},
+    {"s390", {"s390", nullptr}},
+    {"s390x", {"s390x", nullptr}},
+    {"sh3", {"sh3", nullptr}},
+    {"sh4", {"sh4", "sh4a", nullptr}},
+    {"sparc", {"sparc", "sparc64", "sparc64v", "sparcv8", "sparcv9", "sparcv9v", nullptr}},
+    {"x86_64", {"x86_64", "amd64", "ia32e", nullptr}},
+    {"loongarch64", {"loongarch64", nullptr}},
+    {nullptr, {nullptr}}};
+
+const char * get_base_arch(const char * arch);
+
+}  // namespace libdnf5::rpm
+
+#endif  // LIBDNF5_RPM_ARCH_PRIVATE_HPP


### PR DESCRIPTION
Currently, libdnf5 initializes librpm only when detecting `arch` or
`releasever` variables. In case both these values are provided using
command line options (--releasever, --forcearch), `rpmReadConfigFiles()`
is not called at all, resulting in uninitialized librpm.

This patch moves `init_lib_rpm()` call to the `Base` class constructor,
ensuring that `rpmReadConfigFiles()` is always called.

Resolves: https://github.com/rpm-software-management/dnf5/issues/855