### PR TITLE
libdnf5 plugin: Implement rhsm (Red Hat Subscription Manager) plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(WITH_LIBDNF5_CLI "Build library for working with a terminal in a command-
 option(WITH_DNF5 "Build dnf5 command-line package manager" ON)
 option(WITH_DNF5_PLUGINS "Build plugins for dnf5 command-line package manager" ON)
 option(WITH_PLUGIN_ACTIONS "Build a dnf5 actions plugin" ON)
+option(WITH_PLUGIN_RHSM "Build a libdnf5 rhsm (Red Hat Subscription Manager) plugin" ON)
 option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python plugins. Requires WITH_PYTHON3=ON." ON)
 
 # build options - features

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -70,6 +70,7 @@ Provides:       dnf5-command(makecache)
 %bcond_without dnf5
 %bcond_without dnf5_plugins
 %bcond_without plugin_actions
+%bcond_without plugin_rhsm
 %bcond_without python_plugins_loader
 
 %bcond_without comps
@@ -179,6 +180,11 @@ BuildRequires:  polkit
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(dbus-python)
 %endif
+%endif
+
+%if %{with plugin_rhsm}
+BuildRequires:  pkgconfig(librhsm) >= 0.0.3
+BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
 %endif
 
 # ========== language bindings section ==========
@@ -517,6 +523,26 @@ Libdnf5 plugin that allows to run actions (external executables) on hooks.
 %config %{_sysconfdir}/dnf/libdnf5-plugins/actions.conf
 %dir %{_sysconfdir}/dnf/libdnf5-plugins/actions.d
 %{_mandir}/man8/libdnf5-actions.8.*
+%endif
+
+
+# ========== libdnf5-plugin-plugin_rhsm ==========
+
+%if %{with plugin_rhsm}
+%package -n libdnf5-plugin-rhsm
+Summary:        Libdnf5 rhsm (Red Hat Subscription Manager) plugin
+License:        LGPL-2.1-or-later
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+
+%description -n libdnf5-plugin-rhsm
+Libdnf5 plugin with basic support for Red Hat subscriptions.
+Synchronizes the the enrollment with the vendor system. This can change
+the contents of the repositories configuration files according
+to the subscription levels.
+
+%files -n libdnf5-plugin-rhsm
+%{_libdir}/libdnf5/plugins/rhsm.*
+%config %{_sysconfdir}/dnf/libdnf5-plugins/rhsm.conf
 %endif
 
 

--- a/libdnf5-plugins/CMakeLists.txt
+++ b/libdnf5-plugins/CMakeLists.txt
@@ -1,2 +1,3 @@
-add_subdirectory("python_plugins_loader")
 add_subdirectory("actions")
+add_subdirectory("python_plugins_loader")
+add_subdirectory("rhsm")

--- a/libdnf5-plugins/rhsm/CMakeLists.txt
+++ b/libdnf5-plugins/rhsm/CMakeLists.txt
@@ -1,0 +1,28 @@
+if(NOT WITH_PLUGIN_RHSM)
+    return()
+endif()
+
+# set gettext domain for translations
+add_definitions(-DGETTEXT_DOMAIN=\"libdnf5\")
+
+pkg_check_modules(RHSM REQUIRED librhsm>=0.0.3)
+include_directories(${RHSM_INCLUDE_DIRS})
+
+pkg_check_modules(GLIB REQUIRED glib-2.0>=2.44.0)
+include_directories(${GLIB_INCLUDE_DIRS})
+
+add_library(rhsm_plugin MODULE rhsm.cpp)
+
+# disable the 'lib' prefix and set output_name in order to create rhsm.so
+set_target_properties(rhsm_plugin PROPERTIES PREFIX "")
+set_target_properties(rhsm_plugin PROPERTIES OUTPUT_NAME "rhsm")
+
+target_link_libraries(rhsm_plugin PRIVATE ${RHSM_LIBRARIES})
+
+target_link_libraries(rhsm_plugin PRIVATE ${GLIB_LIBRARIES})
+
+target_link_libraries(rhsm_plugin PRIVATE libdnf5)
+
+install(TARGETS rhsm_plugin LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")
+
+install(FILES "rhsm.conf" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")

--- a/libdnf5-plugins/rhsm/rhsm.conf
+++ b/libdnf5-plugins/rhsm/rhsm.conf
@@ -1,0 +1,3 @@
+[main]
+name = rhsm
+enabled = host-only

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -1,0 +1,162 @@
+/*
+Copyright Contributors to the dnf5 project.
+
+This file is part of dnf5: https://github.com/rpm-software-management/dnf5/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <fcntl.h>
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/common/exception.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <rhsm/rhsm.h>
+#include <unistd.h>
+
+
+using namespace libdnf5;
+
+namespace {
+
+constexpr const char * PLUGIN_NAME = "rhsm";
+constexpr plugin::Version PLUGIN_VERSION{0, 1, 0};
+
+constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
+constexpr const char * attrs_value[]{
+    "Jaroslav Rohel", "jrohel@redhat.com", "RHSM (Red Hat Subscription Manager) Plugin."};
+
+
+class Rhsm : public plugin::IPlugin {
+public:
+    Rhsm(libdnf5::Base & base, libdnf5::ConfigParser &) : IPlugin(base) {}
+    virtual ~Rhsm() = default;
+
+    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    plugin::Version get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    const char * const * get_attributes() const noexcept override { return attrs; }
+
+    const char * get_attribute(const char * attribute) const noexcept override {
+        for (size_t i = 0; attrs[i]; ++i) {
+            if (std::strcmp(attribute, attrs[i]) == 0) {
+                return attrs_value[i];
+            }
+        }
+        return nullptr;
+    }
+
+    void post_base_setup() override { setup_enrollments(); }
+
+private:
+    void setup_enrollments();
+};
+
+
+class RhsmPluginError : public libdnf5::Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::plugin"; }
+    const char * get_name() const noexcept override { return "RhsmPluginError"; }
+};
+
+
+// Resyncs the enrollment with the vendor system. This can change the contents
+// of the repositories configuration files according to the subscription levels.
+void Rhsm::setup_enrollments() {
+    const auto & config = get_base().get_config();
+
+    // All of the subman stuff only works as root, if we're not
+    // root, assume we're running in the test suite, or we're part of
+    // e.g. rpm-ostree which is trying to run totally as non-root.
+    if (getuid() != 0) {
+        return;
+    }
+
+    // If /var/lib/rhsm exists, then we can assume that
+    // subscription-manager is installed, and thus don't need to
+    // manage redhat.repo via librhsm.
+    if (g_file_test("/var/lib/rhsm", G_FILE_TEST_EXISTS)) {
+        return;
+    }
+
+    const auto & repo_dirs = config.get_reposdir_option().get_value();
+    if (repo_dirs.empty()) {
+        throw RhsmPluginError(M_("Missing path to repository configuration directory"));
+    }
+    g_autofree gchar * repofname = g_build_filename(repo_dirs[0].c_str(), "redhat.repo", NULL);
+    g_autoptr(RHSMContext) rhsm_ctx = rhsm_context_new();
+    g_autoptr(GKeyFile) repofile = rhsm_utils_yum_repo_from_context(rhsm_ctx);
+
+    bool same_content = false;
+    do {
+        int fd;
+        if ((fd = open(repofname, O_RDONLY)) == -1) {
+            break;
+        }
+        gsize length;
+        g_autofree gchar * data = g_key_file_to_data(repofile, &length, NULL);
+        auto file_len = lseek(fd, 0, SEEK_END);
+        if (file_len != static_cast<off_t>(length)) {
+            close(fd);
+            break;
+        }
+        if (length > 0) {
+            g_autofree gchar * buf = g_new(gchar, length);
+            lseek(fd, 0, SEEK_SET);
+            auto readed = read(fd, buf, length);
+            close(fd);
+            if (readed != file_len || memcmp(buf, data, length) != 0) {
+                break;
+            }
+        } else {
+            close(fd);
+        }
+        same_content = true;
+    } while (false);
+
+    if (!same_content) {
+        g_autoptr(GError) err = NULL;
+        if (!g_key_file_save_to_file(repofile, repofname, &err)) {
+            throw RhsmPluginError(
+                M_("Cannot save repository configuration to file \"{}\": {}"), repofname, std::string(err->message));
+        }
+    }
+}
+
+}  // namespace
+
+PluginAPIVersion libdnf_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+const char * libdnf_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+plugin::Version libdnf_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+plugin::IPlugin * libdnf_plugin_new_instance(
+    [[maybe_unused]] LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser) try {
+    return new Rhsm(base, parser);
+} catch (...) {
+    return nullptr;
+}
+
+void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
+    delete plugin_object;
+}


### PR DESCRIPTION
Libdnf5 plugin with basic support for Red Hat subscriptions.
Synchronizes the enrollment with the vendor system. This can change the contents of the repositories configuration files according to the subscription levels.

The plugin uses the `librhsm` library. Just like the context part of the old lbdnf.

Solves https://github.com/rpm-software-management/dnf5/issues/859