### PR TITLE
Add debug solver data for modules

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2218,13 +2218,13 @@ base::Transaction Goal::resolve() {
 
     // Write debug solver data
     if (cfg_main.get_debug_solver_option().get_value()) {
-        auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value()) / "packages";
-        auto abs_debug_dir = std::filesystem::absolute(debug_dir);
+        auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value());
+        auto pkgs_debug_dir = std::filesystem::absolute(debug_dir / "packages");
 
         // Ensures the presence of the directory.
-        std::filesystem::create_directories(abs_debug_dir);
+        std::filesystem::create_directories(pkgs_debug_dir);
 
-        p_impl->rpm_goal.write_debugdata(abs_debug_dir);
+        p_impl->rpm_goal.write_debugdata(pkgs_debug_dir);
 
         transaction.p_impl->add_resolve_log(
             GoalAction::RESOLVE,
@@ -2232,7 +2232,7 @@ base::Transaction Goal::resolve() {
             {},
             libdnf5::transaction::TransactionItemType::PACKAGE,
             "",
-            {abs_debug_dir},
+            {std::filesystem::canonical(debug_dir)},
             libdnf5::Logger::Level::WARNING);
     }
 

--- a/libdnf5/module/module_goal_private.cpp
+++ b/libdnf5/module/module_goal_private.cpp
@@ -251,4 +251,10 @@ libdnf5::solv::IdQueue ModuleGoalPrivate::list_conflicting() {
 }
 
 
+void ModuleGoalPrivate::write_debugdata(const std::filesystem::path & abs_dest_dir) {
+    libdnf_assert_goal_resolved();
+    libsolv_solver.write_debugdata(abs_dest_dir);
+}
+
+
 }  // namespace libdnf5::module

--- a/libdnf5/module/module_goal_private.hpp
+++ b/libdnf5/module/module_goal_private.hpp
@@ -82,6 +82,10 @@ public:
     /// @since 5.0
     ::Transaction * get_transaction() { return libsolv_transaction; }
 
+    /// Write solver debug data to the given directory.
+    /// @param abs_dest_dir Destination directory. Requires a full existing path.
+    void write_debugdata(const std::filesystem::path & abs_dest_dir);
+
 private:
     libdnf5::solv::IdQueue list_results(Id type_filter1, Id type_filter2);
 

--- a/libdnf5/module/module_sack.cpp
+++ b/libdnf5/module/module_sack.cpp
@@ -497,7 +497,14 @@ std::pair<std::vector<std::vector<std::string>>, ModuleSack::ModuleErrorType> Mo
 
     auto ret = goal_strict.resolve();
 
-    // TODO(pkratoch): Write debugdata if debug_solver config option is set to true.
+    // Store modules debug solver data
+    if (base->get_config().get_debug_solver_option().get_value()) {
+        auto debug_dir = std::filesystem::path(base->get_config().get_debugdir_option().get_value());
+        auto modules_debug_dir = std::filesystem::absolute(debug_dir / "modules");
+        std::filesystem::create_directories(modules_debug_dir);
+
+        goal_strict.write_debugdata(modules_debug_dir);
+    }
 
     if (ret == libdnf5::GoalProblem::NO_PROBLEM) {
         set_active_modules(goal_strict);


### PR DESCRIPTION
Save debug solver data into the `debugdir` / "modules" subdirectory after module goal is resolved.
Also, use canonical format when displaying debug data file path to the user and show just the path to the parent directory as there could be more debug data subdirectories (e.g. like "modules") inside.

Related issue: https://github.com/rpm-software-management/dnf5/issues/172.