### PR TITLE
libdnf5 plugins configuration: Support "name" key to define plugin name in cfg file

### DIFF
--- a/libdnf5-plugins/actions/actions.conf
+++ b/libdnf5-plugins/actions/actions.conf
@@ -1,2 +1,3 @@
 [main]
+name = actions
 enabled = host-only

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -104,7 +104,7 @@ public:
     void finish() noexcept;
 
 private:
-    std::string find_plugin_library(const std::string & plugin_conf_path);
+    std::string find_plugin_library(const std::string & plugin_name);
 
     /// Loads the plugin from the library defined by the file path.
     void load_plugin_library(ConfigParser && parser, const std::string & file_path);

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -107,7 +107,7 @@ private:
     std::string find_plugin_library(const std::string & plugin_name);
 
     /// Loads the plugin from the library defined by the file path.
-    void load_plugin_library(ConfigParser && parser, const std::string & file_path);
+    void load_plugin_library(ConfigParser && parser, const std::string & file_path, const std::string & plugin_name);
 
     Base * base;
     std::vector<std::unique_ptr<Plugin>> plugins;


### PR DESCRIPTION
The name of the plugin to load was derived from the name of the plugin configuration file. Plugin configuration files are sorted by name. And then they are loaded in that order. The intention was to prefix the configuration file name with a number to define the order. This breaks the plugin name derivation mechanism.

This modification adds support for the `name` key to the configuration file to define the plugin name. If `name` key is not found, the original approach - deriving the name of the plugin from the name of the configuration file - will be used as a fallback.

Also, a warning is added to the log in case the plugin name from the configuration file differs from the real one.