### PR TITLE
Add debug solver data for comps

### DIFF
--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -102,10 +102,14 @@ public:
     /// @return `true` if the command line repository has been initialized (via `get_cmdline_repo()`).
     bool has_cmdline_repo() const noexcept { return cmdline_repo; }
 
-    /// Dumps libsolv's debugdata of all loaded repositories.
+    /// Dumps libsolv's rpm debugdata of all loaded repositories.
     /// @param dir The directory into which to dump the debugdata.
     // TODO (lukash): There's an overlap with dumping the debugdata on the Goal class
     void dump_debugdata(const std::string & dir);
+
+    /// Dumps libsolv's comps debugdata of all loaded repositories.
+    /// @param dir The directory into which to dump the debugdata.
+    void dump_comps_debugdata(const std::string & dir);
 
     /// Downloads (if necessary) all enabled repository metadata and loads them in parallel.
     ///

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2220,11 +2220,14 @@ base::Transaction Goal::resolve() {
     if (cfg_main.get_debug_solver_option().get_value()) {
         auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value());
         auto pkgs_debug_dir = std::filesystem::absolute(debug_dir / "packages");
+        auto comps_debug_dir = std::filesystem::absolute(debug_dir / "comps");
 
-        // Ensures the presence of the directory.
+        // Ensures the presence of the directories.
         std::filesystem::create_directories(pkgs_debug_dir);
+        std::filesystem::create_directories(comps_debug_dir);
 
         p_impl->rpm_goal.write_debugdata(pkgs_debug_dir);
+        p_impl->base->get_repo_sack()->dump_comps_debugdata(comps_debug_dir);
 
         transaction.p_impl->add_resolve_log(
             GoalAction::RESOLVE,

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2217,6 +2217,7 @@ base::Transaction Goal::resolve() {
     ret |= p_impl->rpm_goal.resolve();
 
     // Write debug solver data
+    // Note: Modules debug data are handled separately when resolving module goal in ModuleSack::Impl::module_solve()
     if (cfg_main.get_debug_solver_option().get_value()) {
         auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value());
         auto pkgs_debug_dir = std::filesystem::absolute(debug_dir / "packages");

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -510,6 +510,12 @@ void RepoSack::dump_debugdata(const std::string & dir) {
 }
 
 
+void RepoSack::dump_comps_debugdata(const std::string & dir) {
+    libdnf5::solv::Solver solver{get_comps_pool(base)};
+    solver.write_debugdata(dir, false);
+}
+
+
 void RepoSack::create_repos_from_file(const std::string & path) {
     auto & logger = *base->get_logger();
     ConfigParser parser;


### PR DESCRIPTION
Save debug solver data into the debugdir / "comps" subdirectory.

The `dump_comps_debugdata()` method is being exposed on the `libdnf5::repo::RepoSack` public API where there is already an existing `dump_debugdata()` for dumping the rpm solver data.

Related issue: https://github.com/rpm-software-management/dnf5/issues/172.