### PR TITLE
[dnf5] Implement new argument "--dump-variables"

### DIFF
--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -97,6 +97,11 @@ public:
 
     bool get_quiet() const { return quiet; }
 
+    /// Set to true to print information about variables
+    void set_dump_variables(bool enable) { this->dump_variables = enable; }
+
+    bool get_dump_variables() const { return dump_variables; }
+
     Plugins & get_plugins() { return *plugins; }
 
     libdnf5::Goal * get_goal(bool new_if_not_exist = true);
@@ -125,6 +130,7 @@ private:
     const char * comment{nullptr};
 
     bool quiet{false};
+    bool dump_variables{false};
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -101,7 +101,7 @@ public:
     explicit RootCommand(libdnf5::cli::session::Session & context) : Command(context, "dnf5") {}
     void set_parent_command() override { get_session().set_root_command(*this); }
     void set_argument_parser() override;
-    void pre_configure() override { throw_missing_command(); }
+    void pre_configure() override;
 };
 
 void RootCommand::set_argument_parser() {
@@ -553,6 +553,14 @@ void RootCommand::set_argument_parser() {
         subcommands_group->set_header("Subcommands:");
         cmd.register_group(subcommands_group);
     }
+}
+
+void RootCommand::pre_configure() {
+    auto & arg_parser = get_context().get_argument_parser();
+    if (arg_parser.get_named_arg("dump-variables", false).get_parse_count() > 0) {
+        return;
+    }
+    throw_missing_command();
 }
 
 static void add_commands(Context & context) {

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -175,6 +175,9 @@ Following options are applicable in the general context for any ``dnf5`` command
     | This is a list option which can be specified multiple times.
     | Accepted values are ids, or a glob of ids.
 
+``--dump-variables``
+    | Print variable values to stdout.
+
 ``--enable-plugin=PLUGIN_NAME,...``
     | Enable specified plugins for the purpose of the current ``DNF5`` command.
     | This is a list option which can be specified multiple times.


### PR DESCRIPTION
If dnf5 is run with this argument, variable values are added to standard output.

The old DNF4 supports this argument only with the `config-manager` plugin. If the user wants to know the values of the variables with which a certain command will run, he must first use `config-manager` and then run the desired command with the same settings (same environment and configuration files) and hope that nothing changed in between (e.g. thanks to a plugin).

In other words, this PR implements part of the functionality of the dnf4 `config-manager` plugin, but for general use.

Related to: https://github.com/rpm-software-management/dnf5/issues/405