### PR TITLE
[dnf5] Implement new arguments "--dump-main-config", "--dump-repo-config=REPO_ID,..."

### DIFF
--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -102,6 +102,11 @@ public:
 
     bool get_dump_variables() const { return dump_variables; }
 
+    /// Set to true to print information about main configuration
+    void set_dump_main_config(bool enable) { this->dump_main_config = enable; }
+
+    bool get_dump_main_config() const { return dump_main_config; }
+
     Plugins & get_plugins() { return *plugins; }
 
     libdnf5::Goal * get_goal(bool new_if_not_exist = true);
@@ -131,6 +136,7 @@ private:
 
     bool quiet{false};
     bool dump_variables{false};
+    bool dump_main_config{false};
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -97,15 +97,22 @@ public:
 
     bool get_quiet() const { return quiet; }
 
-    /// Set to true to print information about variables
-    void set_dump_variables(bool enable) { this->dump_variables = enable; }
-
-    bool get_dump_variables() const { return dump_variables; }
-
     /// Set to true to print information about main configuration
     void set_dump_main_config(bool enable) { this->dump_main_config = enable; }
 
     bool get_dump_main_config() const { return dump_main_config; }
+
+    /// Set a list of repository IDs to print information about their configuration
+    void set_dump_repo_config_id_list(const std::vector<std::string> & repo_id_list) {
+        this->dump_repo_config_id_list = repo_id_list;
+    }
+
+    const std::vector<std::string> & get_dump_repo_config_id_list() const { return dump_repo_config_id_list; }
+
+    /// Set to true to print information about variables
+    void set_dump_variables(bool enable) { this->dump_variables = enable; }
+
+    bool get_dump_variables() const { return dump_variables; }
 
     Plugins & get_plugins() { return *plugins; }
 
@@ -135,8 +142,9 @@ private:
     const char * comment{nullptr};
 
     bool quiet{false};
-    bool dump_variables{false};
     bool dump_main_config{false};
+    std::vector<std::string> dump_repo_config_id_list;
+    bool dump_variables{false};
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -175,6 +175,14 @@ Following options are applicable in the general context for any ``dnf5`` command
     | This is a list option which can be specified multiple times.
     | Accepted values are ids, or a glob of ids.
 
+``--dump-main-config``
+    | Print main configuration values to stdout.
+
+``--dump-repo-config=REPO_ID,...``
+    | Print repository configuration values to stdout.
+    | This is a list option which can be specified multiple times.
+    | Accepted values are ids, or a glob of ids.
+
 ``--dump-variables``
     | Print variable values to stdout.
 


### PR DESCRIPTION
The DNF4 `config-manager` plugin supports the `--dump` argument. It prints the main configuration to standard output or, if followed by a list of repository IDs, prints the configuration of the matching repositories.
    
This implements part of the functionality of the dnf4 config-manager plugin, but for general use.

Related to: https://github.com/rpm-software-management/dnf5/issues/405