### PR TITLE
Don't drop cached packages when only removing packages (RhBug:2237883)

### DIFF
--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -124,6 +124,10 @@ public:
     /// To watch progress or trigger actions during specific transactions events,
     /// setup the `callbacks` object.
     ///
+    /// After a successful transaction, any temporarily downloaded packages are removed
+    /// if the 'keepcache' option is set to 'false' and the transaction involved an inbound action.
+    /// Otherwise, the packages are preserved on the disk.
+    ///
     /// @return An enum describing the result of running the transaction.
     TransactionRunResult run();
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -524,6 +524,15 @@ static void process_scriptlets_output(int fd, Logger * logger) {
     close(fd);
 }
 
+static bool contains_any_inbound_package(std::vector<TransactionPackage> & packages) {
+    for (const auto & package : packages) {
+        if (transaction_item_action_is_inbound(package.get_action())) {
+            return true;
+        }
+    }
+    return false;
+}
+
 Transaction::TransactionRunResult Transaction::Impl::test() {
     return this->_run(std::make_unique<libdnf5::rpm::TransactionCallbacks>(), "", std::nullopt, "", true);
 }
@@ -869,7 +878,10 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
 
     if (ret == 0) {
         // removes any temporarily stored packages from the system
-        if (!config.get_keepcache_option().get_value()) {
+        // only if any inbound action takes place
+        auto keepcache = config.get_keepcache_option().get_value();
+        auto any_inbound_action_present = contains_any_inbound_package(packages);
+        if (!keepcache && any_inbound_action_present) {
             libdnf5::repo::TempFilesMemory temp_files_memory(config.get_cachedir_option().get_value());
             auto temp_files = temp_files_memory.get_files();
             for (auto & file : temp_files) {


### PR DESCRIPTION
In order to have a easier workflow for making package caching exceptions for some commands and also to match the `keepcache` behavior with the original dnf in this matter, the cached files are now removed only when `keepcache` option is turned off at the moment.

We don't want to remove the stored packages cache after running the `remove` command transaction, therefore we override the `keepcache` option to true. This is useful for use cases when the previous transaction downloaded a large amount of data, but didn't finished correctly. Then we'd like to fix the system state by removing some problematic package. We don't want to lose our cached data in this case.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1381
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2237883