### PR TITLE
Print more useful form for large epochs that don't fit into `time_t`

### DIFF
--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -116,7 +116,7 @@ inline std::string format_epoch(T epoch_num) {
         const auto epoch = static_cast<time_t>(epoch_num);
         return fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(epoch));
     }
-    return "unrepresentable";
+    return fmt::format("{} seconds since Unix epoch", epoch_num);
 }
 
 }  // namespace libdnf5::utils::string


### PR DESCRIPTION
Follow up to: https://github.com/rpm-software-management/dnf5/pull/844
Closes: https://github.com/rpm-software-management/dnf5/issues/889