### PR TITLE
Make get_base_arch() public

### DIFF
--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -30,6 +30,7 @@
 }
 
 %{
+    #include "libdnf5/rpm/arch.hpp"
     #include "libdnf5/rpm/checksum.hpp"
     #include "libdnf5/rpm/nevra.hpp"
     #include "libdnf5/rpm/package.hpp"
@@ -45,6 +46,8 @@
 %}
 
 #define CV __perl_CV
+
+%include "libdnf5/rpm/arch.hpp"
 
 %include "libdnf5/rpm/checksum.hpp"
 

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -83,8 +83,7 @@ void create_forcearch_option(dnf5::Command & command) {
                 available_arches.append("\"" + *it + "\"");
                 ++it;
                 for (; it != supported_arches.end(); ++it) {
-                    available_arches.append(", ");
-                    available_arches.append("\"" + *it + "\"");
+                    available_arches.append(", \"" + *it + "\"");
                 }
             }
             throw libdnf5::cli::ArgumentParserInvalidValueError(

--- a/include/libdnf5/rpm/arch.hpp
+++ b/include/libdnf5/rpm/arch.hpp
@@ -27,7 +27,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::rpm {
 
+/// Returns a list of architectures supported by libdnf5.
 std::vector<std::string> get_supported_arches();
+
+/// Returns base architecture of the given `arch`. In case the base arch is not
+/// found the function returns empty string.
+/// @param arch Architecture.
+std::string get_base_arch(const std::string & arch);
 
 }  // namespace libdnf5::rpm
 

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -19,12 +19,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/conf/vars.hpp"
 
-#include "rpm/arch_private.hpp"
 #include "rpm/rpm_log_guard.hpp"
 #include "utils/fs/file.hpp"
 
 #include "libdnf5/base/base.hpp"
 #include "libdnf5/common/exception.hpp"
+#include "libdnf5/rpm/arch.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
 #include <dirent.h>
@@ -389,8 +389,8 @@ void Vars::detect_vars(const std::string & installroot) {
     set_lazy(
         "basearch",
         [this]() -> auto {
-            auto base_arch = libdnf5::rpm::get_base_arch(variables["arch"].value.c_str());
-            return base_arch ? std::make_unique<std::string>(base_arch) : nullptr;
+            auto base_arch = libdnf5::rpm::get_base_arch(variables["arch"].value);
+            return base_arch.empty() ? nullptr : std::make_unique<std::string>(std::move(base_arch));
         },
         Priority::AUTO);
 

--- a/libdnf5/rpm/arch.cpp
+++ b/libdnf5/rpm/arch.cpp
@@ -38,15 +38,16 @@ std::vector<std::string> get_supported_arches() {
     return arches;
 }
 
-const char * get_base_arch(const char * arch) {
+std::string get_base_arch(const std::string & arch) {
+    auto arch_c = arch.c_str();
     for (int i = 0; libdnf5::rpm::ARCH_MAP[i].base; ++i) {
         for (int j = 0; libdnf5::rpm::ARCH_MAP[i].native[j]; ++j) {
-            if (std::strcmp(libdnf5::rpm::ARCH_MAP[i].native[j], arch) == 0) {
+            if (std::strcmp(libdnf5::rpm::ARCH_MAP[i].native[j], arch_c) == 0) {
                 return libdnf5::rpm::ARCH_MAP[i].base;
             }
         }
     }
-    return nullptr;
+    return {};
 }
 
 }  // namespace libdnf5::rpm

--- a/libdnf5/rpm/arch_private.hpp
+++ b/libdnf5/rpm/arch_private.hpp
@@ -67,8 +67,6 @@ static const struct {
     {"loongarch64", {"loongarch64", nullptr}},
     {nullptr, {nullptr}}};
 
-const char * get_base_arch(const char * arch);
-
 }  // namespace libdnf5::rpm
 
 #endif  // LIBDNF5_RPM_ARCH_PRIVATE_HPP

--- a/test/libdnf5/rpm/test_arch.cpp
+++ b/test/libdnf5/rpm/test_arch.cpp
@@ -1,0 +1,41 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_arch.hpp"
+
+#include <libdnf5/rpm/arch.hpp>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ArchTest);
+
+
+void ArchTest::test_get_supported_arches() {
+    std::vector<std::string> arches = libdnf5::rpm::get_supported_arches();
+    // at least one architecture was found
+    CPPUNIT_ASSERT(arches.size() > 0);
+    // the arches vector is sorted and contains unique elements
+    for (size_t i = 0; i < arches.size() - 1; ++i) {
+        CPPUNIT_ASSERT(arches[i] < arches[i + 1]);
+    }
+}
+
+void ArchTest::test_get_base_arch() {
+    CPPUNIT_ASSERT_EQUAL(libdnf5::rpm::get_base_arch("x86_64"), std::string("x86_64"));
+    CPPUNIT_ASSERT_EQUAL(libdnf5::rpm::get_base_arch("amd64"), std::string("x86_64"));
+    CPPUNIT_ASSERT_EQUAL(libdnf5::rpm::get_base_arch("UNKNOWN_ARCH"), std::string(""));
+}

--- a/test/libdnf5/rpm/test_arch.hpp
+++ b/test/libdnf5/rpm/test_arch.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TEST_ARCH_HPP
+#define LIBDNF5_TEST_ARCH_HPP
+
+#include "../shared/base_test_case.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class ArchTest : public BaseTestCase {
+    CPPUNIT_TEST_SUITE(ArchTest);
+    CPPUNIT_TEST(test_get_base_arch);
+    CPPUNIT_TEST(test_get_supported_arches);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_get_base_arch();
+    void test_get_supported_arches();
+};
+
+#endif  // TEST_LIBDNF5_RPM_ARCH_HPP

--- a/test/python3/libdnf5/rpm/test_arch.py
+++ b/test/python3/libdnf5/rpm/test_arch.py
@@ -1,0 +1,38 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import libdnf5
+
+import base_test_case
+
+
+class TestRpmArch(unittest.TestCase):
+    def test_get_supported_arches(self):
+        arches = libdnf5.rpm.get_supported_arches()
+        # at least one architecture was found
+        self.assertTrue(len(arches) > 0)
+        # the arches list is sorted and contains unique elements
+        for i in range(len(arches) - 1):
+            self.assertTrue(arches[i] < arches[i+1])
+
+    def test_get_base_arch(self):
+        self.assertEqual(libdnf5.rpm.get_base_arch("x86_64"), "x86_64")
+        self.assertEqual(libdnf5.rpm.get_base_arch("amd64"), "x86_64")
+        self.assertEqual(libdnf5.rpm.get_base_arch("UNKNOWN_ARCH"), "")


### PR DESCRIPTION
Let's also standardize the rpm.arch interface by consistently using the std::string type for both arguments and return values. While this might not be the most optimal choice (as the underlying structure is char *), I prioritize consistency over performance in this case. I did consider using std::string_view, but it's not supported by SWIG.

Unit tests included.

Resolves: https://github.com/rpm-software-management/dnf5/issues/600