### PR TITLE
repoinfo: Implement add-values option

### DIFF
--- a/dnf5/commands/repo/arguments.hpp
+++ b/dnf5/commands/repo/arguments.hpp
@@ -57,6 +57,18 @@ public:
 };
 
 
+class RepoAddValuesOption : public libdnf5::cli::session::AppendStringListOption {
+public:
+    explicit RepoAddValuesOption(libdnf5::cli::session::Command & command)
+        : AppendStringListOption(
+              command,
+              "add-values",
+              '\0',
+              _("Add specified repo values to the output. List option."),
+              _("VALUE_NAME,...")) {}
+};
+
+
 }  // namespace dnf5
 
 

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -117,7 +117,7 @@ void RepoInfoCommand::print(const libdnf5::repo::RepoQuery & query, [[maybe_unus
 
         libdnf5::cli::output::RepoInfo repo_info;
         auto repo_wrapper = RepoInfoWrapper(*repo, repo_size, pkgs.size(), available_pkgs.size());
-        repo_info.add_repo(repo_wrapper);
+        repo_info.add_repo(repo_wrapper, add_values->get_value());
         repo_info.print();
         std::cout << std::endl;
     }

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -59,10 +59,7 @@ public:
     }
     int get_metadata_expire() const { return repo.get_config().get_metadata_expire_option().get_value(); }
     std::vector<std::string> get_excludepkgs() const { return repo.get_config().get_excludepkgs_option().get_value(); }
-    std::vector<std::string> get_includepkgs() const {
-        return repo.get_config().get_includepkgs_option().get_value();
-        ;
-    }
+    std::vector<std::string> get_includepkgs() const { return repo.get_config().get_includepkgs_option().get_value(); }
     bool get_skip_if_unavailable() const { return repo.get_config().get_skip_if_unavailable_option().get_value(); }
     std::vector<std::string> get_gpgkey() const { return repo.get_config().get_gpgkey_option().get_value(); }
     bool get_gpgcheck() const { return repo.get_config().get_gpgcheck_option().get_value(); }
@@ -84,6 +81,14 @@ private:
     uint64_t pkgs;
     uint64_t available_pkgs;
 };
+
+void RepoInfoCommand::set_argument_parser() {
+    RepoListCommand::set_argument_parser();
+
+    add_values = std::make_unique<RepoAddValuesOption>(*this);
+
+    get_argument_parser_command()->set_description("Print details about repositories");
+}
 
 void RepoInfoCommand::configure() {
     auto & context = get_context();

--- a/dnf5/commands/repo/repo_info.hpp
+++ b/dnf5/commands/repo/repo_info.hpp
@@ -31,12 +31,10 @@ class RepoInfoCommand : public RepoListCommand {
 public:
     explicit RepoInfoCommand(Context & context) : RepoListCommand(context, "info") {}
 
-    void set_argument_parser() override {
-        RepoListCommand::set_argument_parser();
-        get_argument_parser_command()->set_description("Print details about repositories");
-    }
-
+    void set_argument_parser() override;
     void configure() override;
+
+    std::unique_ptr<RepoAddValuesOption> add_values{nullptr};
 
 protected:
     void print(const libdnf5::repo::RepoQuery & query, [[maybe_unused]] bool with_status) override;

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -154,7 +154,7 @@ void RepolistCommand::run() {
         for (auto & repo : repositories) {
             auto repo_info = libdnf5::cli::output::RepoInfo();
             auto dbus_repo = DbusRepoWrapper(repo);
-            repo_info.add_repo(dbus_repo);
+            repo_info.add_repo(dbus_repo, {});
             repo_info.print();
             std::cout << std::endl;
         }

--- a/dnf5daemon-client/commands/repolist/repolist.hpp
+++ b/dnf5daemon-client/commands/repolist/repolist.hpp
@@ -43,6 +43,7 @@ public:
 private:
     libdnf5::OptionEnum<std::string> * enable_disable_option{nullptr};
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_options{nullptr};
+    libdnf5::OptionStringList * add_values_option{nullptr};
     const std::string command;
 };
 

--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -58,6 +58,11 @@ Options
 ``--disabled``
     | Show information only about disabled repositories.
 
+``--add-values=VALUE_NAME,...``
+    | Used with ``info`` command to append additional values to the output.
+    | This is a list option.
+    | Accepted values are: `priority`, `cost`, `type`, `skip_if_unavailable`, `gpgkey`, `gpgcheck`, `repo_gpgcheck`.
+
 ``--forcearch=<arch>``
     | Force the use of a specific architecture.
     | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
@@ -71,3 +76,6 @@ Examples
 
 ``dnf5 repo list --disabled *-debuginfo``
     | Print disabled repositories related to debugging.
+
+``dnf5 repo info my_repo --add-values=priority,cost,gpgkey``
+    | Print detailed info for the 'my_repo' repository, including specified additional values in the output.

--- a/include/libdnf5-cli/output/key_value_table.hpp
+++ b/include/libdnf5-cli/output/key_value_table.hpp
@@ -57,6 +57,8 @@ public:
         const char * color = nullptr,
         struct libscols_line * parent = nullptr);
 
+    void drop_line_if_no_children(struct libscols_line * line);
+
     template <typename V>
     struct libscols_line * add_line(
         const char * key, V value, const char * color = nullptr, struct libscols_line * parent = nullptr) {

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -115,23 +115,25 @@ void RepoInfo::add_repo(Repo & repo, const std::vector<std::string> & add_values
     }
 
     // PGP
-    if (std::any_of(add_values.begin(), add_values.end(), [](const std::string & value) {
-            return value.find("gpg") != std::string::npos;
-        })) {
-        auto group_gpg = add_line("PGP", "", nullptr);
+    auto group_gpg = add_line("PGP", "", nullptr);
 
+    if (std::find(add_values.begin(), add_values.end(), "gpgkey") != add_values.end()) {
         auto gpg_keys = repo.get_gpgkey();
-        if (std::find(add_values.begin(), add_values.end(), "gpgkey") != add_values.end() && !gpg_keys.empty()) {
+        if (!gpg_keys.empty()) {
             add_line("Keys", gpg_keys, nullptr, group_gpg);
-        }
-
-        if (std::find(add_values.begin(), add_values.end(), "repo_gpgcheck") != add_values.end()) {
-            add_line("Verify repodata", fmt::format("{}", repo.get_repo_gpgcheck()), nullptr, group_gpg);
-        }
-        if (std::find(add_values.begin(), add_values.end(), "gpgcheck") != add_values.end()) {
-            add_line("Verify packages", fmt::format("{}", repo.get_gpgcheck()), nullptr, group_gpg);
+        } else {
+            add_line("Keys", "N/A", nullptr, group_gpg);
         }
     }
+
+    if (std::find(add_values.begin(), add_values.end(), "repo_gpgcheck") != add_values.end()) {
+        add_line("Verify repodata", fmt::format("{}", repo.get_repo_gpgcheck()), nullptr, group_gpg);
+    }
+    if (std::find(add_values.begin(), add_values.end(), "gpgcheck") != add_values.end()) {
+        add_line("Verify packages", fmt::format("{}", repo.get_gpgcheck()), nullptr, group_gpg);
+    }
+
+    drop_line_if_no_children(group_gpg);
 
     // TODO(jkolarik): Verbose is not implemented and not used yet
     // if (verbose) {

--- a/libdnf5-cli/output/key_value_table.cpp
+++ b/libdnf5-cli/output/key_value_table.cpp
@@ -102,5 +102,11 @@ struct libscols_line * KeyValueTable::add_lines(
     return added_key_line;
 }
 
+void KeyValueTable::drop_line_if_no_children(struct libscols_line * line) {
+    if (scols_line_has_children(line) == 0) {
+        scols_table_remove_line(tb, line);
+    }
+}
+
 
 }  // namespace libdnf5::cli::output


### PR DESCRIPTION
Create `add-values` option for the `repo info` command to allow adding additional repo values to the output. 

Match the default output with the original dnf behavior and allow user to provide more repo values to the output using the `add-values` option.

The related logic was also added to the daemon side.

Added option is now documented in the `repo` command man page.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1383.
Closes: https://github.com/rpm-software-management/dnf5/issues/842.