### PR TITLE
repoquery: add `--providers-of=PACKAGE_ATTRIBUTE` and `--recursive` options

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -32,8 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/patterns.hpp>
 
-#include <iostream>
-
 namespace dnf5 {
 
 using namespace libdnf5::cli;

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -432,7 +432,7 @@ void RepoqueryCommand::configure() {
             libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_OTHER);
     }
 
-    if ((pkg_attr_option->get_value() == "files") ||
+    if (!file->get_value().empty() || (pkg_attr_option->get_value() == "files") ||
         (libdnf5::cli::output::requires_filelists(query_format_option->get_value()))) {
         context.base.get_config().get_optional_metadata_types_option().add_item(
             libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -75,11 +75,12 @@ private:
     std::unique_ptr<libdnf5::cli::session::BoolOption> installonly{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> srpm{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> disable_modular_filtering{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> changelogs{nullptr};
 
     libdnf5::OptionBool * querytags_option{nullptr};
     libdnf5::OptionString * query_format_option{nullptr};
     libdnf5::OptionEnum<std::string> * pkg_attr_option{nullptr};
-    std::unique_ptr<libdnf5::cli::session::BoolOption> changelogs{nullptr};
+    libdnf5::OptionEnum<std::string> * providers_of_option{nullptr};
 
     std::unique_ptr<AdvisoryOption> advisory_name{nullptr};
     std::unique_ptr<SecurityOption> advisory_security{nullptr};

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -76,6 +76,7 @@ private:
     std::unique_ptr<libdnf5::cli::session::BoolOption> srpm{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> disable_modular_filtering{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> changelogs{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> recursive{nullptr};
 
     libdnf5::OptionBool * querytags_option{nullptr};
     libdnf5::OptionString * query_format_option{nullptr};

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -174,6 +174,9 @@ Repoquery command
  * --queryformat no longer supports ``size`` tag because it was printing install size for installed packages and download
    size for not-installed packages. This could be confusing.
  * Option ``--source`` was renamed to ``--sourcerpm`` and it now matches queryformat's ``sourcerpm`` tag.
+ * Option ``--resolve`` was changed to ``--providers-of=PACKAGE_ATTRIBUTE``. It no longer interacts with the formatting ``--requires``,
+   ``--provides``, ``--suggests``,... options instead it takes the PACKAGE_ATTRIBUTE value directly.
+   E.g., ``dnf rq --resolve --requires glibc`` -> ``dnf rq --providers-of=requires glibc``.
 
 Upgrade command
 ---------------

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -108,6 +108,11 @@ Options
 ``--newpackage``
     | Limit to packages in newpackage advisories.
 
+``--providers-of=PACKAGE_ATTRIBUTE``
+    | After filtering is finished get selected attribute of packages and output packages that provide it.
+    | The outputted packages are limited by ``--available``, ``--installed`` and ``--arch`` options.
+    | Supports: conflicts, depends, enhances, obsoletes, provides, recommends, requires, requires_pre, suggests, supplements.
+
 ``--recent``
     | Limit to only recently changed packages.
 

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -116,6 +116,13 @@ Options
 ``--recent``
     | Limit to only recently changed packages.
 
+``--recursive``
+    | This option is stackable with --whatrequires or --providers-of=requires only.
+    | When used with --whatrequires: it extends the output with packages that require anything provided by outputted packages.
+    | When used with --providers-of=requires: it extends the output with packages that provide anything required by outputted packages.
+    | It repeats the output extension as long as new packages are being added.
+    | The added packages are limited by ``--available``, ``--installed`` and ``--arch`` options.
+
 ``--security``
     | Limit to packages in security advisories.
 

--- a/include/libdnf5-cli/output/repoquery.hpp
+++ b/include/libdnf5-cli/output/repoquery.hpp
@@ -36,6 +36,9 @@ void print_pkg_attr_uniq_sorted(
 
 void print_available_pkg_attrs(std::FILE * target);
 
+libdnf5::rpm::ReldepList get_reldeplist_for_attr(
+    const libdnf5::rpm::PackageSet & pkgs, const std::string & getter_name);
+
 }  // namespace libdnf5::cli::output
 
 #endif  // LIBDNF5_CLI_OUTPUT_REPOQUERY_HPP


### PR DESCRIPTION
I am proposing to change the `repoquery` `--resolve` option to `--providers-of=PACKAGE_ATTRIBUTE`.

The `--resolve` option was using the existing formatting options (`--requires`, `--provides`,...) to determine for which package attribute it should find providers. This is confusing because it completely changes the meaning of those options
and their original functionality is no longer available.

Instead add a new `--providers-of=` option which allows specifying the package attribute directly.
(Another option, perhaps a bit more compatible, would be to call the option `--resolve=PACKAGE_ATTRIBUTE`.)

More context: the `--resolve` option is also used in [download](https://dnf-plugins-core.readthedocs.io/en/latest/download.html#options) and [modulesync](https://dnf-plugins-core.readthedocs.io/en/latest/modulesync.html#options) plugins/commands where it basically: resolves dependencies of specified packages and downloads missing dependencies in the system.

The PR also adds `--recursive` option and fixes a bug with the `--file` option.

For: https://github.com/rpm-software-management/dnf5/issues/122
For: https://github.com/rpm-software-management/dnf5/issues/912
For: https://github.com/rpm-software-management/dnf5/issues/911

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1354