### PR TITLE
Hardcode protection of dnf5 package

### DIFF
--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -293,7 +293,7 @@ class ConfigMain::Impl {
     OptionString proxy_username{nullptr};
     OptionString proxy_password{nullptr};
     OptionStringSet proxy_auth_method{"any", "any|none|basic|digest|negotiate|ntlm|digest_ie|ntlm_wb", false};
-    OptionStringList protected_packages{resolve_globs("dnf glob:/etc/dnf/protected.d/*.conf")};
+    OptionStringList protected_packages{resolve_globs("dnf5 glob:/etc/dnf/protected.d/*.conf")};
     OptionString username{""};
     OptionString password{""};
     OptionBool gpgcheck{false};


### PR DESCRIPTION
DNF 5, like DNF 4, should be marked as protected to prevent accidental removal.

Doing it this way, rather than using a file in /etc/dnf/protected.d, means that DNF 4 will still be able to remove DNF 5. I think this is the ideal functionality: DNF 4 will be able to remove DNF 5 and vice-versa, but neither package manager will accidentally remove itself.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2221907 "dnf5 is not marked as protected, removal leaves system more or less bricked ".