### PR TITLE
ArgumentParser::Command::help: Improve "usage" text

### DIFF
--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -772,15 +772,19 @@ void ArgumentParser::Command::help() const noexcept {
     libdnf5::cli::output::Usage usage_output;
 
     // generate usage
-    // start with the invocation of the current command
-    std::string usage = utils::string::join(get_invocation(), " ");
-
-    if (cmds.empty()) {
-        // leaf command
-        usage += " [GLOBAL OPTIONS] [OPTIONS] [ARGUMENTS]";
-    } else {
-        // command that has subcommands
-        usage += " <COMMAND> [--help] ...";
+    std::string usage;
+    for (const auto * cmd = this; cmd; cmd = cmd->parent) {
+        std::string tmp = cmd->get_id();
+        if (!cmd->get_named_args().empty()) {
+            tmp += cmd->parent ? " [OPTIONS]" : " [GLOBAL OPTIONS]";
+        }
+        if (!cmd->get_positional_args().empty()) {
+            tmp += " [ARGUMENTS]";
+        }
+        usage = tmp + ' ' + usage;
+    }
+    if (!cmds.empty()) {
+        usage += "<COMMAND> ...";
     }
 
     // print usage


### PR DESCRIPTION
Prints the options in the correct place. It also takes into account whether the parent command has options and arguments.

**Examples:**

**`dnf5 --help`:**
old: `dnf5 <COMMAND> [--help] ...`
new: `dnf5 [GLOBAL OPTIONS] <COMMAND> ...`

**dnf5 history --help:**
old: `dnf5 history <COMMAND> [--help] ...`
new: `dnf5 [GLOBAL OPTIONS] history <COMMAND> ...`

**`dnf5 history list --help`:**
old: `dnf5 history list [GLOBAL OPTIONS] [OPTIONS] [ARGUMENTS]`
new: `dnf5 [GLOBAL OPTIONS] history list [OPTIONS] [ARGUMENTS]`

**`dnf5 repo --help`:**
old: `dnf5 repo <COMMAND> [--help] ...`
new: `dnf5 [GLOBAL OPTIONS] repo [OPTIONS] <COMMAND> ...`

**`dnf5 repo list --help`:**
old: `dnf5 repo list [GLOBAL OPTIONS] [OPTIONS] [ARGUMENTS]`
new: `dnf5 [GLOBAL OPTIONS] repo [OPTIONS] list [OPTIONS] [ARGUMENTS]`