### PR TITLE
Change librpm log mask value from 0xFF to everything up to RPMLOG_INFO

### DIFF
--- a/libdnf5/rpm/rpm_log_guard.cpp
+++ b/libdnf5/rpm/rpm_log_guard.cpp
@@ -66,7 +66,9 @@ RpmLogGuard::RpmLogGuard(const BaseWeakPtr & base) : RpmLogGuardBase() {
     rpmlogSetCallback(&rpmlog_callback, &*base->get_logger());
 
     // TODO(lukash) once Logger supports log mask, propagate to rpm
-    old_log_mask = rpmlogSetMask(0xff);
+    // logs everything up to RPMLOG_INFO -> everything except RPMLOG_DEBUG, which is fairly low-level
+    // and causes librpm to not remove auxiliary temporary files.
+    old_log_mask = rpmlogSetMask(RPMLOG_UPTO(RPMLOG_PRI(RPMLOG_INFO)));
 }
 
 


### PR DESCRIPTION
RPMLOG_DEBUG is fairly low-level and causes librpm to not remove auxiliary temporary files. Therefore, it is not a good idea to use RPMLOG_DEBUG as the default. Everything except RPMLOG_DEBUG is now logged.

However, we should consider introducing an option to enable RPMLOG_DEBUG for debugging purposes.

It solves the issue https://github.com/rpm-software-management/dnf5/issues/893