### PR TITLE
doc: "group install" and "group remove" require an argument

### DIFF
--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -25,7 +25,9 @@
 Synopsis
 ========
 
-``dnf5 group <subcommand> [options] [<group-spec>...]``
+``dnf5 group {list|info} [options] [<group-spec>...]``
+
+``dnf5 group {install|remove} [options] <group-spec>...``
 
 
 Description


### PR DESCRIPTION
dnf5-group(8) synopsis gave an impression that a group specifier is optional:

    SYNOPSIS
           dnf5 group <subcommand> [options] [<group-spec>...]

That's not true for "install" and "remove" commands. This patch fixes the manual.