### PR TITLE
Make `--forcearch` a global argument

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -52,7 +52,6 @@ void DistroSyncCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
-    create_forcearch_option(*this);
 }
 
 void DistroSyncCommand::configure() {

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -79,7 +79,6 @@ void DownloadCommand::set_argument_parser() {
 
     cmd.register_named_arg(alldeps);
     create_destdir_option(*this);
-    create_forcearch_option(*this);
     cmd.register_named_arg(resolve);
     cmd.register_positional_arg(keys);
 }

--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -38,7 +38,6 @@ void GroupCommand::set_parent_command() {
 
 void GroupCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Manage comps groups");
-    create_forcearch_option(*this);
 }
 
 void GroupCommand::register_subcommands() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -54,7 +54,6 @@ void InstallCommand::set_argument_parser() {
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     create_downloadonly_option(*this);
-    create_forcearch_option(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -57,8 +57,6 @@ void ListCommand::set_argument_parser() {
     specs->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, true, false, false); });
     cmd.register_positional_arg(specs);
 
-    create_forcearch_option(*this);
-
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
 

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -36,7 +36,6 @@ void MakeCacheCommand::set_parent_command() {
 
 void MakeCacheCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Generate the metadata cache");
-    create_forcearch_option(*this);
 }
 
 void MakeCacheCommand::run() {

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -35,7 +35,6 @@ void RepoCommand::set_parent_command() {
 
 void RepoCommand::set_argument_parser() {
     get_argument_parser_command()->set_description("Manage repositories");
-    create_forcearch_option(*this);
 }
 
 void RepoCommand::register_subcommands() {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -86,10 +86,6 @@ void RepoqueryCommand::set_argument_parser() {
     });
     cmd.register_positional_arg(keys);
 
-    // OPTIONS:
-
-    create_forcearch_option(*this);
-
     // QUERY SOURCES:
 
     available_option = dynamic_cast<libdnf5::OptionBool *>(

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -48,8 +48,6 @@ void SearchCommand::set_argument_parser() {
 
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
-
-    create_forcearch_option(*this);
 }
 
 void SearchCommand::configure() {

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -68,7 +68,6 @@ void SwapCommand::set_argument_parser() {
     cmd.register_positional_arg(install_spec_arg);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
-    create_forcearch_option(*this);
 }
 
 void SwapCommand::configure() {

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -65,14 +65,13 @@ void create_allow_downgrade_options(dnf5::Command & command);
 /// The values are stored in the `destdir` configuration option
 void create_destdir_option(dnf5::Command & command);
 
-/// Create the `--forcearch` option for a command provided as an argument.
-/// The values are stored in the `forcearch` configuration option
-void create_forcearch_option(dnf5::Command & command);
-
 /// Create the `--downloadonly` option for a command provided as an argument.
 /// The values are stored in the `downloadonly` configuration option
 void create_downloadonly_option(dnf5::Command & command);
 
+/// Create the `--forcearch` option for a command provided as an argument.
+/// The values are stored in the `forcearch` configuration option
+[[deprecated("--forcearch is now a global argument")]] void create_forcearch_option(dnf5::Command & command);
 
 }  // namespace dnf5
 

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -44,10 +44,6 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -47,10 +47,6 @@ Options
 ``--destdir=<path>``
     Set directory used for downloading packages to. Default location is to the current working directory.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -102,10 +102,6 @@ Options
 ``--contains-pkgs``
     | Show only groups containing packages with specified names. List option, supports globs.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -74,10 +74,6 @@ Options
 ``--newpackage``
     | Consider only content contained in newpackage advisories.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/makecache.8.rst
+++ b/doc/commands/makecache.8.rst
@@ -36,11 +36,3 @@ for enabled repositories.
 
 It tries to avoid downloading whenever possible, e.g. when the local metadata hasn't
 expired yet or when the metadata timestamp hasn't changed.
-
-
-Options
-=======
-
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.

--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -58,10 +58,6 @@ Options
 ``--disabled``
     | Show information only about disabled repositories.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -92,10 +92,6 @@ Options
     | Limit to packages that own these files.
     | This is a list option.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 ``--installed``
     | Query installed packages.
     | Can be combined with ``--available`` to query both installed and available packages.

--- a/doc/commands/search.8.rst
+++ b/doc/commands/search.8.rst
@@ -46,10 +46,6 @@ Options
     | Search patterns also inside `Description` and `URL` fields.
     | By applying this option the search lists packages that match at least one of the keys (OR operation).
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 Examples
 ========

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -41,10 +41,6 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
-``--forcearch=<arch>``
-    | Force the use of a specific architecture.
-    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
-
 
 
 Examples

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -196,6 +196,10 @@ Following options are applicable in the general context for any ``dnf5`` command
     | This is a list option which can be specified multiple times.
     | Accepted values are ids, or a glob of ids.
 
+``--forcearch=ARCH``
+    | Force the use of a specific architecture.
+    | :ref:`See <forcearch_misc_ref-label>` :manpage:`dnf5-forcearch(7)` for more info.
+
 ``-h, --help``
     | Show the help.
 


### PR DESCRIPTION
Many commands respect `--forcearch` (distro-sync, download, install, list, makecache, repoquery, search, etc.) so it makes sense to make `--forcearch` a global argument that can be used with any command.

Resolves https://github.com/rpm-software-management/dnf5/issues/872