### PR TITLE
PackageQuery: add `filter_installonly`

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -492,13 +492,6 @@ static libdnf5::rpm::PackageSet resolve_nevras_to_packges(
     return resolved_nevras_set;
 }
 
-static libdnf5::rpm::PackageQuery get_installonly_query(libdnf5::Base & base) {
-    auto & cfg_main = base.get_config();
-    const auto & installonly_packages = cfg_main.get_installonlypkgs_option().get_value();
-    libdnf5::rpm::PackageQuery installonly_query(base);
-    installonly_query.filter_provides(installonly_packages, libdnf5::sack::QueryCmp::GLOB);
-    return installonly_query;
-}
 
 void RepoqueryCommand::run() {
     auto & ctx = get_context();
@@ -539,7 +532,9 @@ void RepoqueryCommand::run() {
     }
 
     if (duplicates->get_value()) {
-        result_query -= get_installonly_query(ctx.base);
+        libdnf5::rpm::PackageQuery installonly_query(ctx.base, flags, false);
+        installonly_query.filter_installonly();
+        result_query -= installonly_query;
         result_query.filter_duplicates();
     }
 
@@ -548,7 +543,9 @@ void RepoqueryCommand::run() {
     }
 
     if (installonly->get_value()) {
-        result_query &= get_installonly_query(ctx.base);
+        libdnf5::rpm::PackageQuery installonly_query(ctx.base, flags, false);
+        installonly_query.filter_installonly();
+        result_query &= installonly_query;
     }
 
     // APPLY FILTERS THAT REQUIRE BOTH INSTALLED AND AVAILABLE PACKAGES TO BE LOADED

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -690,6 +690,11 @@ public:
     /// @return  Groups of one or more interdependent leaf packages.
     std::vector<std::vector<Package>> filter_leaves_groups();
 
+    /// Filter installonly packages.
+    ///
+    /// Filter packages that provide a capability that matches with any value in installonlypkgs configuration option.
+    void filter_installonly();
+
 private:
     std::vector<std::vector<Package>> filter_leaves(bool return_grouped_leaves);
 

--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -2822,5 +2822,10 @@ void PackageQuery::filter_extras(const bool exact_evr) {
     }
 }
 
+void PackageQuery::filter_installonly() {
+    auto & cfg_main = p_impl->base->get_config();
+    const auto & installonly_packages = cfg_main.get_installonlypkgs_option().get_value();
+    filter_provides(installonly_packages, libdnf5::sack::QueryCmp::GLOB);
+}
 
 }  // namespace libdnf5::rpm

--- a/libdnf5/rpm/solv/goal_private.hpp
+++ b/libdnf5/rpm/solv/goal_private.hpp
@@ -127,8 +127,6 @@ public:
     /// PackageId.id == 0 => not set
     /// PackageId.id == -1 => cannot be detected
     PackageId get_protect_running_kernel() { return protected_running_kernel; };
-    /// Set running kernel that mus be not removed
-    void set_protect_running_kernel(PackageId value) { protected_running_kernel = value; };
 
     // Get protected_packages. Running kernel is not included
     const libdnf5::solv::SolvMap * get_protected_packages() { return protected_packages.get(); };
@@ -138,6 +136,7 @@ public:
     void set_protected_packages(const libdnf5::solv::SolvMap & map);
     /// Reset all protected packages
     void reset_protected_packages();
+    /// Set running kernel that mus be not removed
     void set_protected_running_kernel(PackageId kernel) { protected_running_kernel = kernel; };
     /// Set Ids of user-installed packages
     void set_user_installed_packages(const libdnf5::solv::IdQueue & queue);

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -147,11 +147,10 @@ void Transaction::fill(const base::Transaction & transaction) {
     // Used to detect installation of a installonly package with lower version
     // that is currently installed.
     std::map<std::string, libdnf5::rpm::Package> installonly_versions;
-    const auto & installonlypkgs = base->get_config().get_installonlypkgs_option().get_value();
     rpm::PackageQuery installonly_query(base);
     installonly_query.filter_installed();
     installonly_query.filter_latest_evr();
-    installonly_query.filter_provides(installonlypkgs, libdnf5::sack::QueryCmp::GLOB);
+    installonly_query.filter_installonly();
     for (const auto & pkg : installonly_query) {
         installonly_versions.insert(std::make_pair(pkg.get_name(), pkg));
     }


### PR DESCRIPTION
I also plan to reuse the installonly filter in transaction replay.