### PR TITLE
[libdnf, actions plugin] Support for action options, option enabled and "plugin.version" variable

### DIFF
--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -45,7 +45,7 @@ Actions file format
 
 Empty lines and lines that start with a '#' character (comment line) are ignored.
 
-Each non-comment line defines an action and consists of five items separated by colons: ``callback_name:package_filter:direction:reserved:command``.
+Each non-comment line defines an action and consists of five items separated by colons: ``callback_name:package_filter:direction:options:command``.
 
 ``callback_name``
 
@@ -68,6 +68,15 @@ Each non-comment line defines an action and consists of five items separated by 
 
    * ``in`` - packages coming to the system (downgrade, install, reinstall, upgrade)
    * ``out`` - packages going out of the system (upgraded, downgraded, reinstalled, removed, replaced/obsoleted)
+
+``options``
+   Options are separated by spaces. A space within an option can be written using escaping.
+
+   * ``enabled=<value>`` - the value specifies when the action is enabled (added in version 0.3.0)
+
+      * ``1`` - action is always enabled
+      * ``host-only`` - the action is only enabled for operations on the host
+      * ``installroot-only`` - the action is only enabled for operations in the alternative "installroot"
 
 ``command``
    Any executable file with arguments.
@@ -119,9 +128,6 @@ Each non-comment line defines an action and consists of five items separated by 
    of when a particular ``package_filter`` is invoked depends on the position
    of the corresponding package in the transaction.
 
-``reserved``
-   Reserved for future use. Now empty.
-
 
 Action standard output format
 =============================
@@ -146,6 +152,7 @@ An example actions file:
    pre_base_setup::::/usr/bin/sh -c echo\ -------------------------------------\ >>/tmp/actions-trans.log
    pre_base_setup::::/usr/bin/sh -c date\ >>/tmp/actions-trans.log
    pre_base_setup::::/usr/bin/sh -c echo\ libdnf5\ pre_base_setup\ was\ called.\ Process\ ID\ =\ '${pid}'.\ >>/tmp/actions-trans.log
+   pre_base_setup:::enabled=installroot-only:/usr/bin/sh -c echo\ run\ in\ alternative\ "installroot":\ installroot\ =\ '${conf.installroot}'\ >>/tmp/actions-trans.log
 
    # Prints the value of the configuration option "defaultyes".
    pre_base_setup::::/bin/sh -c echo\ 'pre_base_setup:\ conf.defaultyes=${{conf.defaultyes}}'\ >>\ {context.dnf.installroot}/actions.log

--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -79,6 +79,7 @@ Each non-comment line defines an action and consists of five items separated by 
    The following variables in the command will be substituted:
 
    * ``${pid}`` - process ID
+   * ``${plugin.version}`` - version of the actions plugin (added in version 0.3.0)
    * ``${conf.<option_name>}`` - option from base configuration
    * ``${var.<variable_name>}`` - variable
    * ``${tmp.<actions_plugin_variable_name>}`` - variable exists only in actions plugin context

--- a/libdnf5-plugins/actions/actions.conf
+++ b/libdnf5-plugins/actions/actions.conf
@@ -1,3 +1,3 @@
 [main]
 name = actions
-enabled = host-only
+enabled = 1

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -215,6 +215,11 @@ std::pair<std::string, bool> Actions::substitute(
         std::optional<std::string> var_value;
         if (var_name == "pid") {
             var_value = std::to_string(getpid());
+        } else if (var_name.starts_with("plugin.")) {
+            auto plugin_key = var_name.substr(7);
+            if (plugin_key == "version") {
+                var_value = fmt::format("{}.{}.{}", PLUGIN_VERSION.major, PLUGIN_VERSION.minor, PLUGIN_VERSION.micro);
+            }
         } else if (var_name.starts_with("conf.")) {
             auto config_opts = base.get_config().opt_binds();
             auto it = config_opts.find(std::string(var_name.substr(5)));


### PR DESCRIPTION
The fourth item in the action definition has been reserved. It is now used to set additional action options. Options are separated by spaces. A space within an option can be written using escaping.

One option is now supported - `enabled=<value>`.
Supported values of `value`:
 * `1` - action is always enabled
 * `host-only` - the action is only enabled for operations on the host
 * `installroot-only` - the action is only enabled for operations in the alternative "installroot"

Action can allways be disabled by commenting out the action line.

PR also adds a new `${plugin.version}` substitution. The expression is replaced by the actions plugin version.