### PR TITLE
Add TransactionReplay and use it history replay command

### DIFF
--- a/dnf5/commands/history/history.cpp
+++ b/dnf5/commands/history/history.cpp
@@ -54,14 +54,14 @@ void HistoryCommand::register_subcommands() {
     register_subcommand(std::make_unique<HistoryInfoCommand>(get_context()), query_commands_group);
 
     // software management commands
-    // auto * software_management_commands_group = parser.add_new_group("history_software_management_commands");
-    // software_management_commands_group->set_header("Software Management Commands:");
-    // cmd.register_group(software_management_commands_group);
+    auto * software_management_commands_group = parser.add_new_group("history_software_management_commands");
+    software_management_commands_group->set_header("Software Management Commands:");
+    cmd.register_group(software_management_commands_group);
     // register_subcommand(std::make_unique<HistoryUndoCommand>(get_context()), software_management_commands_group);
     // register_subcommand(std::make_unique<HistoryRedoCommand>(get_context()), software_management_commands_group);
     // register_subcommand(std::make_unique<HistoryRollbackCommand>(get_context()), software_management_commands_group);
     // register_subcommand(std::make_unique<HistoryStoreCommand>(get_context()), software_management_commands_group);
-    // register_subcommand(std::make_unique<HistoryReplayCommand>(get_context()), software_management_commands_group);
+    register_subcommand(std::make_unique<HistoryReplayCommand>(get_context()), software_management_commands_group);
 }
 
 void HistoryCommand::pre_configure() {

--- a/dnf5/commands/history/history_replay.cpp
+++ b/dnf5/commands/history/history_replay.cpp
@@ -19,12 +19,56 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_replay.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 void HistoryReplayCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Replay a transaction that was previously stored to a file");
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_description("Replay a transaction that was previously stored to a file");
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+
+    auto * transaction_path_arg = parser.add_new_positional_arg("transaction-path", 1, nullptr, nullptr);
+    transaction_path_arg->set_description("Path to a stored stransaction to replay.");
+    transaction_path_arg->set_parse_hook_func([this](
+                                                  [[maybe_unused]] libdnf5::cli::ArgumentParser::PositionalArg * arg,
+                                                  [[maybe_unused]] int argc,
+                                                  const char * const argv[]) {
+        transaction_path = argv[0];
+        return true;
+    });
+    cmd.register_positional_arg(transaction_path_arg);
+
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
+
+    resolve = std::make_unique<libdnf5::cli::session::BoolOption>(
+        *this, "resolve", '\0', "Resolve the transaction again. TODO(amatej): enhance description", false);
+    ignore_installed = std::make_unique<libdnf5::cli::session::BoolOption>(
+        *this, "ignore-installed", '\0', "TODO(amatej): add", false);
 }
 
-void HistoryReplayCommand::run() {}
+void HistoryReplayCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+}
+
+void HistoryReplayCommand::run() {
+    auto & context = get_context();
+    replay = std::make_unique<libdnf5::transaction::TransactionReplay>(
+        context.base.get_weak_ptr(), std::filesystem::path(transaction_path), ignore_installed->get_value());
+
+    if (resolve->get_value()) {
+        replay->fill_goal(*context.get_goal());
+    } else {
+        context.set_transaction(replay->create_transaction());
+    }
+}
+
+void HistoryReplayCommand::goal_resolved() {
+    replay->fix_reasons(get_context().get_transaction());
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_replay.hpp
+++ b/dnf5/commands/history/history_replay.hpp
@@ -21,8 +21,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_REPLAY_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_REPLAY_HPP
 
-#include <dnf5/context.hpp>
+#include "arguments.hpp"
 
+#include <dnf5/context.hpp>
+#include <libdnf5/conf/option_bool.hpp>
+#include <libdnf5/transaction/transaction_replay.hpp>
 
 namespace dnf5 {
 
@@ -30,8 +33,18 @@ namespace dnf5 {
 class HistoryReplayCommand : public Command {
 public:
     explicit HistoryReplayCommand(Context & context) : Command(context, "replay") {}
+    void configure() override;
     void set_argument_parser() override;
     void run() override;
+    void goal_resolved() override;
+
+private:
+    std::string transaction_path;
+
+    std::unique_ptr<libdnf5::cli::session::BoolOption> resolve{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> ignore_installed{nullptr};
+
+    std::unique_ptr<libdnf5::transaction::TransactionReplay> replay{nullptr};
 };
 
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1036,11 +1036,12 @@ int main(int argc, char * argv[]) try {
             command->load_additional_packages();
 
             command->run();
-            if (auto goal = context.get_goal(false)) {
+            if (auto * goal = context.get_goal(false)) {
                 context.set_transaction(goal->resolve());
-
                 command->goal_resolved();
+            }
 
+            if (context.get_transaction()) {
                 download_callbacks->reset_progress_bar();
                 download_callbacks->set_number_widget_visible(true);
                 download_callbacks->set_show_total_bar_limit(0);

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -169,6 +169,9 @@ public:
     /// If set to true, group operations (install / remove) will only work
     /// with the group itself, but will not add to the transaction any packages.
     bool group_no_packages{false};
+    /// If set to true, environment operations (install / remove) will only work
+    /// with the environment itself, but will not add to the transaction any groups.
+    bool environment_no_groups{false};
 
     /// Set whether hints should be reported
     bool report_hint{true};

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -35,6 +35,9 @@ namespace libdnf5::rpm {
 class KeyInfo;
 }  // namespace libdnf5::rpm
 
+namespace libdnf5::transaction {
+class TransactionReplay;
+}
 
 namespace libdnf5::base {
 
@@ -168,6 +171,7 @@ private:
     friend class TransactionModule;
     friend class TransactionPackage;
     friend class libdnf5::Goal;
+    friend class libdnf5::transaction::TransactionReplay;
 
     Transaction(const libdnf5::BaseWeakPtr & base);
 

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -84,8 +84,7 @@ public:
     std::vector<std::string> get_resolve_logs_as_strings() const;
 
     /// @return the transaction packages.
-    // TODO(jrohel): Return reference instead of copy?
-    std::vector<libdnf5::base::TransactionPackage> get_transaction_packages() const;
+    std::vector<libdnf5::base::TransactionPackage> & get_transaction_packages() const;
 
     /// @return the number of transaction packages.
     std::size_t get_transaction_packages_count() const;

--- a/include/libdnf5/base/transaction_package.hpp
+++ b/include/libdnf5/base/transaction_package.hpp
@@ -75,6 +75,7 @@ public:
 
 private:
     friend class Transaction::Impl;
+    friend class libdnf5::transaction::TransactionReplay;
     friend class ::BaseGoalTest;
     friend class ::RpmTransactionTest;
 

--- a/include/libdnf5/transaction/transaction_replay.hpp
+++ b/include/libdnf5/transaction/transaction_replay.hpp
@@ -39,6 +39,9 @@ public:
     void fill_goal(libdnf5::Goal & goal);
     void fix_reasons(libdnf5::base::Transaction * transaction);
 
+    // Use create_transaction to directly create transaction without resolving
+    libdnf5::base::Transaction create_transaction();
+
 private:
     friend libdnf5::base::Transaction::Impl;
 

--- a/include/libdnf5/transaction/transaction_replay.hpp
+++ b/include/libdnf5/transaction/transaction_replay.hpp
@@ -1,0 +1,74 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TRANSACTION_TRANSACTION_REPLAY_HPP
+#define LIBDNF5_TRANSACTION_TRANSACTION_REPLAY_HPP
+
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/comps/environment/environment.hpp>
+#include <libdnf5/comps/group/group.hpp>
+
+#include <filesystem>
+
+
+namespace libdnf5::transaction {
+
+class TransactionReplay {
+public:
+    //TODO(amatej): document API
+    TransactionReplay(const libdnf5::BaseWeakPtr & base, std::filesystem::path filename, bool ignore_installed);
+
+    // Use fill_goal and fix_reason to resolve the transaction again
+    void fill_goal(libdnf5::Goal & goal);
+    void fix_reasons(libdnf5::base::Transaction * transaction);
+
+private:
+    friend libdnf5::base::Transaction::Impl;
+
+    struct GroupAction {
+        std::string action;
+        libdnf5::transaction::TransactionItemReason reason;
+        libdnf5::comps::Group group;
+        libdnf5::comps::PackageType pkg_types;
+    };
+    struct EnvironmentAction {
+        std::string action;
+        libdnf5::transaction::TransactionItemReason reason;
+        libdnf5::comps::Environment environment;
+        libdnf5::comps::PackageType pkg_types;
+    };
+    struct PackageAction {
+        std::string action;
+        libdnf5::transaction::TransactionItemReason reason;
+        libdnf5::rpm::Package package;
+    };
+
+    //TODO(amatej): ModuleActions
+
+    std::vector<GroupAction> group_actions;
+    std::vector<EnvironmentAction> environment_actions;
+    std::vector<PackageAction> package_actions;
+    libdnf5::BaseWeakPtr base;
+    std::unordered_map<std::string, TransactionItemReason> cached_reasons;
+};
+
+}  // namespace libdnf5::transaction
+
+#endif  // LIBDNF5_TRANSACTION_TRANSACTION_REPLAY_HPP

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1580,7 +1580,8 @@ void Goal::Impl::remove_group_packages(const rpm::PackageSet & remove_candidates
         // removed together with removal candidates
         Goal goal_tmp(base);
         goal_tmp.add_rpm_remove(remove_candidates);
-        for (const auto & tspkg : goal_tmp.resolve().get_transaction_packages()) {
+        auto trans = goal_tmp.resolve();
+        for (const auto & tspkg : trans.get_transaction_packages()) {
             if (transaction_item_action_is_outbound(tspkg.get_action())) {
                 dependent_base.remove(tspkg.get_package());
             }

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1786,6 +1786,9 @@ void Goal::Impl::add_environment_install_to_goal(
     std::vector<GroupSpec> env_group_specs;
     for (auto environment : environment_query) {
         rpm_goal.add_environment(environment, transaction::TransactionItemAction::INSTALL, with_optional);
+        if (settings.environment_no_groups) {
+            continue;
+        }
         for (const auto & grp_id : environment.get_groups()) {
             env_group_specs.emplace_back(
                 GoalAction::INSTALL_BY_COMPS, transaction::TransactionItemReason::DEPENDENCY, grp_id, group_settings);
@@ -1828,6 +1831,9 @@ void Goal::Impl::add_environment_remove_to_goal(
     for (auto & [spec, environment_query, settings] : environments_to_remove) {
         for (const auto & environment : environment_query) {
             rpm_goal.add_environment(environment, transaction::TransactionItemAction::REMOVE, {});
+            if (settings.environment_no_groups) {
+                continue;
+            }
             // get all groups installed by the environment
             comps::GroupQuery environment_groups(query_installed);
             environment_groups.filter_groupid(

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -193,8 +193,7 @@ private:
     using EnvironmentItem = std::tuple<std::string, comps::EnvironmentQuery, GoalJobSettings>;
     std::map<GoalAction, std::vector<EnvironmentItem>> resolved_environment_specs;
 
-    /// group_specs contain both comps groups and environments. These are resolved
-    /// according to settings.group_search_type flags value.
+    /// group_specs contain both comps groups and environments.
     /// <libdnf5::GoalAction, TransactionItemReason reason, std::string group_spec, GoalJobSettings settings>
     std::vector<GroupSpec> group_specs;
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -140,7 +140,7 @@ GoalProblem Transaction::get_problems() {
     return p_impl->problems;
 }
 
-std::vector<TransactionPackage> Transaction::get_transaction_packages() const {
+std::vector<TransactionPackage> & Transaction::get_transaction_packages() const {
     return p_impl->packages;
 }
 

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -31,6 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/base/transaction_package.hpp"
 #include "libdnf5/module/module_sack.hpp"
 #include "libdnf5/rpm/rpm_signature.hpp"
+#include "libdnf5/transaction/transaction_replay.hpp"
 
 #include <solv/transaction.h>
 
@@ -49,6 +50,7 @@ public:
 
     /// Set transaction according resolved goal and problems to EventLog
     void set_transaction(rpm::solv::GoalPrivate & solved_goal, module::ModuleSack & module_sack, GoalProblem problems);
+    void set_transaction(const libdnf5::transaction::TransactionReplay & trans_replay);
 
     TransactionPackage make_transaction_package(
         Id id,

--- a/libdnf5/transaction/transaction_replay.cpp
+++ b/libdnf5/transaction/transaction_replay.cpp
@@ -347,6 +347,13 @@ TransactionReplay::TransactionReplay(
     }
 };
 
+libdnf5::base::Transaction TransactionReplay::create_transaction() {
+    base::Transaction transaction(this->base);
+    transaction.p_impl->set_transaction(*this);
+
+    return transaction;
+}
+
 void TransactionReplay::fill_goal(libdnf5::Goal & goal) {
     bool skip_unavailable = base->get_config().get_skip_unavailable_option().get_value();
 

--- a/libdnf5/transaction/transaction_replay.cpp
+++ b/libdnf5/transaction/transaction_replay.cpp
@@ -1,0 +1,425 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "../base/transaction_impl.hpp"
+#include "utils/string.hpp"
+
+#include "libdnf5/comps/group/query.hpp"
+#include "libdnf5/rpm/package_query.hpp"
+
+#include <json.h>
+#include <libdnf5/comps/environment/query.hpp>
+#include <libdnf5/comps/group/package.hpp>
+#include <libdnf5/transaction/transaction_replay.hpp>
+
+#include <utility>
+
+namespace {
+
+void raise_or_warn(bool warn_only, const std::string & msg) {
+    if (warn_only) {
+        //TODO(amatej): logger
+        printf("problem: %s\n", msg.c_str());
+    } else {
+        //TODO(amatej): throw custom TransactionReplay exception
+        throw std::runtime_error(msg);
+    }
+}
+
+}  // namespace
+
+namespace libdnf5::transaction {
+
+TransactionReplay::TransactionReplay(
+    const libdnf5::BaseWeakPtr & base, std::filesystem::path filename, bool ignore_installed)
+    : base(base) {
+    auto * data = json_object_from_file(filename.c_str());
+    if (data == nullptr) {
+        //TODO(amatej): throw custom TransactionReplay exception
+        throw std::runtime_error("Can't find: " + std::string(filename));
+    }
+    bool skip_unavailable = base->get_config().get_skip_unavailable_option().get_value();
+
+    //TODO(amatej): Verify RPMDB cookie?
+
+    // parse json
+    struct json_object * value = nullptr;
+
+    // PARSE AND FIND ENVIRONMENTS
+
+    struct json_object * json_environments = nullptr;
+    if (json_object_object_get_ex(data, "environments", &json_environments) != 0) {
+        std::string action;
+        std::string environment_id;
+        std::string reason;
+        libdnf5::comps::PackageType group_package_types = libdnf5::comps::PackageType::DEFAULT;
+        auto len = json_object_array_length(json_environments);
+
+        for (std::size_t i = 0; i < len; ++i) {
+            struct json_object * environment = json_object_array_get_idx(json_environments, i);
+            if (json_object_object_get_ex(environment, "action", &value) != 0) {
+                action = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(environment, "reason", &value) != 0) {
+                reason = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(environment, "id", &value) != 0) {
+                environment_id = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(environment, "package_types", &value) != 0) {
+                auto split = libdnf5::utils::string::split(json_object_get_string(value), ",");
+                std::for_each(split.begin(), split.end(), libdnf5::utils::string::trim);
+                group_package_types = libdnf5::comps::package_type_from_string(split);
+            }
+
+            struct json_object * json_environment_groups = nullptr;
+            std::vector<libdnf5::comps::Group> groups;
+            if (json_object_object_get_ex(environment, "groups", &json_environment_groups) != 0) {
+                bool installed = false;
+                std::string id;
+                std::string group_type;
+                auto len_j = json_object_array_length(json_environment_groups);
+                for (std::size_t j = 0; j < len_j; ++j) {
+                    struct json_object * group = json_object_array_get_idx(json_environment_groups, j);
+                    if (json_object_object_get_ex(group, "installed", &value) != 0) {
+                        installed = (json_object_get_boolean(value) != 0);
+                    }
+                    if (json_object_object_get_ex(group, "id", &value) != 0) {
+                        id = json_object_get_string(value);
+                    }
+                    if (json_object_object_get_ex(group, "group_type", &value) != 0) {
+                        group_type = json_object_get_string(value);
+                    }
+                    //TODO(amatej): set what groups to install
+                    //group_actions.emplace_back(action, id, libdnf5::comps::package_type_from_string(group_type));
+                    (void)installed;
+                }
+            }
+
+            //TODO(amatej): I just hard-coded this in to fix a test -- it is likely wrong..
+            if (reason.empty()) {
+                reason = "None";
+            }
+            comps::EnvironmentQuery env_query(base);
+            if (action == "Removed") {
+                env_query.filter_installed(true);
+            } else if (action == "Install" || action == "Upgrade") {
+                env_query.filter_installed(false);
+            } else {
+                //TODO(amatej): throw transaction replay exception
+                throw std::runtime_error("Unknown action: " + action);
+            }
+
+            env_query.filter_environmentid(environment_id);
+            if (env_query.empty()) {
+                raise_or_warn(skip_unavailable, fmt::format("Cannot find environment with id: {:s}", environment_id));
+                continue;
+            }
+            if (env_query.size() > 1) {
+                raise_or_warn(skip_unavailable, fmt::format("Multiple environments matching id: {:s}", environment_id));
+                continue;
+            }
+            environment_actions.push_back(
+                {action, transaction_item_reason_from_string(reason), env_query.get(), group_package_types});
+        }
+    }
+
+    // PARSE AND FIND GROUPS
+
+    struct json_object * json_groups = nullptr;
+    if (json_object_object_get_ex(data, "groups", &json_groups) != 0) {
+        std::string action;
+        std::string group_id;
+        std::string reason;
+        libdnf5::comps::PackageType group_package_types = libdnf5::comps::PackageType::DEFAULT;
+        auto len = json_object_array_length(json_groups);
+
+        for (std::size_t i = 0; i < len; ++i) {
+            libdnf5::GoalJobSettings settings;
+            settings.group_no_packages = true;
+            settings.clean_requirements_on_remove = libdnf5::GoalSetting::SET_FALSE;
+            struct json_object * group = json_object_array_get_idx(json_groups, i);
+            if (json_object_object_get_ex(group, "action", &value) != 0) {
+                action = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(group, "reason", &value) != 0) {
+                reason = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(group, "id", &value) != 0) {
+                group_id = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(group, "package_types", &value) != 0) {
+                auto split = libdnf5::utils::string::split(json_object_get_string(value), ",");
+                std::for_each(split.begin(), split.end(), libdnf5::utils::string::trim);
+                group_package_types = libdnf5::comps::package_type_from_string(split);
+            }
+
+            struct json_object * json_group_packages = nullptr;
+            if (json_object_object_get_ex(group, "packages", &json_group_packages) != 0) {
+                bool installed = false;
+                std::string name;
+                std::string package_type;
+                auto len_j = json_object_array_length(json_group_packages);
+                for (std::size_t j = 0; j < len_j; ++j) {
+                    struct json_object * pkg = json_object_array_get_idx(json_group_packages, j);
+                    if (json_object_object_get_ex(pkg, "installed", &value) != 0) {
+                        installed = (json_object_get_boolean(value) != 0);
+                    }
+                    if (json_object_object_get_ex(pkg, "name", &value) != 0) {
+                        name = json_object_get_string(value);
+                    }
+                    if (json_object_object_get_ex(pkg, "package_type", &value) != 0) {
+                        package_type = json_object_get_string(value);
+                    }
+                    //TODO(amatej): I have to set the packages I want to install.. in case its not all of them -> install pkgs with reason group
+                    //package_actions.emplace_back(name, libdnf5::comps::package_type_from_string(package_type), "");
+                    (void)installed;
+                }
+            }
+
+            //TODO(amatej): I just hard-coded this in to fix a test
+            if (reason.empty()) {
+                reason = "None";
+            }
+            comps::GroupQuery group_query(base);
+
+            if (action == "Removed") {
+                group_query.filter_installed(true);
+            } else if (action == "Install" || action == "Upgrade") {
+                group_query.filter_installed(false);
+            } else {
+                //todo(amatej): throw transaction replay exception
+                throw std::runtime_error("unknown action: " + action);
+            }
+
+            group_query.filter_groupid(group_id);
+            if (group_query.empty()) {
+                raise_or_warn(skip_unavailable, fmt::format("Cannot find group with id: {:s}", group_id));
+                continue;
+            }
+            if (group_query.size() > 1) {
+                raise_or_warn(skip_unavailable, fmt::format("Multiple environments matching id: {:s}", group_id));
+                continue;
+            }
+            group_actions.push_back(
+                {action, transaction_item_reason_from_string(reason), group_query.get(), group_package_types});
+        }
+    }
+
+    // PARSE AND FIND PACKAGES
+
+    struct json_object * json_rpms = nullptr;
+    if (json_object_object_get_ex(data, "rpms", &json_rpms) != 0) {
+        std::string action;
+        std::string nevra;
+        TransactionItemReason reason = TransactionItemReason::NONE;
+        std::string group;
+        std::string repo_id;
+        auto len = json_object_array_length(json_rpms);
+
+        libdnf5::rpm::PackageQuery installed(base);
+        installed.filter_installed();
+
+        for (std::size_t i = 0; i < len; ++i) {
+            struct json_object * rpm = json_object_array_get_idx(json_rpms, i);
+            if (json_object_object_get_ex(rpm, "action", &value) != 0) {
+                action = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(rpm, "nevra", &value) != 0) {
+                nevra = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(rpm, "reason", &value) != 0) {
+                reason = transaction_item_reason_from_string(json_object_get_string(value));
+            }
+            if (json_object_object_get_ex(rpm, "group", &value) != 0) {
+                group = json_object_get_string(value);
+            }
+            if (json_object_object_get_ex(rpm, "repo_id", &value) != 0) {
+                repo_id = json_object_get_string(value);
+            }
+
+
+            // Find the required package
+            libdnf5::rpm::PackageQuery pkg_query(base);
+
+            // In case the package is found in the same repo as in the original transaction, limit the query to that
+            // plus installed packages. IOW remove packages with the same NEVRA in case they are found in multiple
+            // repos and the repo the package came from originally is one of them.
+            // This can e.g. make a difference in the system-upgrade plugin, in case the same NEVRA is in two repos,
+            // this makes sure the same repo is used for both download and upgrade steps of the plugin.
+            if (!repo_id.empty()) {
+                if (repo_id == "@System") {
+                    pkg_query = installed;
+                } else {
+                    libdnf5::rpm::PackageQuery query_repo(base);
+                    query_repo.filter_repo_id({repo_id});
+                    if (!query_repo.empty()) {
+                        pkg_query = query_repo;
+                        pkg_query |= installed;
+                    }
+                }
+            }
+
+            auto nevra_pair = pkg_query.resolve_pkg_spec(
+                nevra,
+                libdnf5::ResolveSpecSettings{.with_provides = false, .with_filenames = false, .with_binaries = false},
+                false);
+            if (!nevra_pair.first) {
+                raise_or_warn(skip_unavailable, fmt::format("Cannot find rpm nevra {:s}", nevra));
+                continue;
+            }
+            //TODO(amatej): verify package checksums
+
+            if (action == "Install" || action == "Upgrade" || action == "Downgrade" || action == "Reinstall") {
+                libdnf5::rpm::PackageQuery pkg_query_na(installed);
+                pkg_query_na.filter_name({nevra_pair.second.get_name()});
+                pkg_query_na.filter_arch({nevra_pair.second.get_arch()});
+                libdnf5::rpm::PackageQuery pkg_query_installonly(pkg_query_na);
+                pkg_query_installonly.filter_installonly();
+
+                if (action == "Install" && !pkg_query_na.empty() && pkg_query_installonly.empty()) {
+                    raise_or_warn(
+                        ignore_installed,
+                        fmt::format(
+                            "Package {:s}.{:s} is already installed, it cannot be installed again.",
+                            nevra_pair.second.get_name(),
+                            nevra_pair.second.get_arch()));
+                }
+
+                pkg_query.filter_available();
+                if (pkg_query.empty()) {
+                    raise_or_warn(
+                        skip_unavailable,
+                        fmt::format("Package nevra {:s} not available for action {:s}", nevra, action));
+                    continue;
+                }
+                package_actions.push_back({action, reason, *pkg_query.begin()});
+            } else if (action == "Reason Change") {
+                pkg_query.filter_installed();
+                if (pkg_query.empty()) {
+                    //TODO(amatej): Unavailable reason changes are just ignored because the reason is fixed in post transaction action anyway (when we resolve goal)
+                    //raise_or_warn(skip_unavailable, fmt::format("Package nevra {:s} not installed for action {:s}.", nevra, action));
+                    continue;
+                }
+                package_actions.push_back({action, reason, *pkg_query.begin()});
+            } else if (
+                action == "Upgraded" || action == "Downgraded" || action == "Reinstalled" || action == "Removed" ||
+                action == "Obsoleted") {
+                pkg_query.filter_installed();
+                if (pkg_query.empty()) {
+                    raise_or_warn(
+                        ignore_installed,
+                        fmt::format("Package nevra {:s} not installed for action {:s}.", nevra, action));
+                    continue;
+                }
+
+                // Erasing the original version (the reverse part of an action like e.g. upgrade) is more robust,
+                // but we can't do it if skip_unavailable is True, because if the forward part of the action
+                // is skipped, we would simply remove the package here.
+                // TODO(amatej): But it is required when resolving is skipped?
+                if (!skip_unavailable || action == "Removed") {
+                    package_actions.push_back({action, reason, *pkg_query.begin()});
+                }
+            } else {
+                //TODO(amatej): throw transaction replay exception
+                throw std::runtime_error("Unknown action: " + action);
+            }
+
+            cached_reasons[nevra] = reason;
+        }
+    }
+};
+
+void TransactionReplay::fill_goal(libdnf5::Goal & goal) {
+    bool skip_unavailable = base->get_config().get_skip_unavailable_option().get_value();
+
+    for (const auto & environment_elem : environment_actions) {
+        libdnf5::GoalJobSettings settings;
+        settings.clean_requirements_on_remove = libdnf5::GoalSetting::SET_FALSE;
+        settings.environment_no_groups = true;
+        settings.set_group_package_types(environment_elem.pkg_types);
+
+        if (environment_elem.action == "Install") {
+            goal.add_group_install(environment_elem.environment.get_environmentid(), environment_elem.reason, settings);
+        } else if (environment_elem.action == "Removed") {
+            goal.add_group_remove(environment_elem.environment.get_environmentid(), environment_elem.reason, settings);
+        } else if (environment_elem.action == "Upgrade") {
+            goal.add_group_upgrade(environment_elem.environment.get_environmentid(), settings);
+        }
+    }
+    for (const auto & group_elem : group_actions) {
+        libdnf5::GoalJobSettings settings;
+        settings.clean_requirements_on_remove = libdnf5::GoalSetting::SET_FALSE;
+        settings.environment_no_groups = true;
+        settings.set_group_package_types(group_elem.pkg_types);
+
+        if (group_elem.action == "Install") {
+            goal.add_group_install(group_elem.group.get_groupid(), group_elem.reason, settings);
+        } else if (group_elem.action == "Removed") {
+            goal.add_group_remove(group_elem.group.get_groupid(), group_elem.reason, settings);
+        } else if (group_elem.action == "Upgrade") {
+            goal.add_group_upgrade(group_elem.group.get_groupid(), settings);
+        }
+    }
+
+    for (const auto & package_action : package_actions) {
+        libdnf5::GoalJobSettings settings;
+        settings.clean_requirements_on_remove = libdnf5::GoalSetting::SET_FALSE;
+
+        if (package_action.action == "Upgrade" || package_action.action == "Install" ||
+            package_action.action == "Downgrade") {
+            goal.add_rpm_install(package_action.package, settings);
+        } else if (package_action.action == "Upgraded") {
+            goal.add_rpm_upgrade(package_action.package, settings);
+        } else if (package_action.action == "Reinstall") {
+            goal.add_rpm_reinstall(package_action.package, settings);
+        } else if (
+            package_action.action == "Downgraded" || package_action.action == "Reinstalled" ||
+            package_action.action == "Removed" || package_action.action == "Obsoleted") {
+            if (!skip_unavailable || package_action.action == "Removed") {
+                goal.add_rpm_remove(package_action.package, settings);
+            }
+        } else if (package_action.action == "Reason Change") {
+            goal.add_rpm_reason_change(package_action.package.get_nevra(), package_action.reason);
+        } else {
+            //TODO(amatej): throw transaction replay exception
+            throw std::runtime_error("Unknown action: " + package_action.action);
+        }
+    }
+}
+
+//TODO(amatej): better name? copy from dnf4?
+//TODO(amatej): This is needed only when resolving though goal
+void TransactionReplay::fix_reasons(libdnf5::base::Transaction * transaction) {
+    // we need the whole transaction beacuse we are goinh to change reasons for envs, groups, packages
+
+    // check if there are additional pkgs in transaction
+    for (auto & tspkg : transaction->get_transaction_packages()) {
+        const auto & pkg = tspkg.get_package();
+        try {
+            const auto reason = cached_reasons[pkg.get_nevra()];
+            tspkg.set_reason(reason);
+        } catch (const std::out_of_range & e) {
+            continue;
+        }
+    }
+}
+
+}  // namespace libdnf5::transaction


### PR DESCRIPTION
There are two approaches (APIs):
 - load the stored transaction and use it to fill `Goal` that is then resolved which creates the transaction
 - load the stored transaction and create `base::Transaction` directly, no resolving is done

If we want to use `TransactionReplay` for history undo operation we will need to be able to resolve the loaded transaction.
On the other hand `SystemUpgrade` plugin doesn't require the second resolving.

To make both available I have added a `--resolve` switch to `history replay` command.

For: https://github.com/rpm-software-management/dnf5/issues/999