### PR TITLE
readthedocs: install missing dependency `sphinx_rtd_theme`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 breathe
 sphinx-autoapi
+sphinx_rtd_theme


### PR DESCRIPTION
According to: https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html the dependency should be added to requirements.txt.

It was working previously becuase it was automatically installed by readthedocs, this has been changed: https://blog.readthedocs.com/python-core-requirements-changed/