### PR TITLE
key_value_table: Method to drop empty group

### DIFF
--- a/include/libdnf5-cli/output/key_value_table.hpp
+++ b/include/libdnf5-cli/output/key_value_table.hpp
@@ -57,6 +57,8 @@ public:
         const char * color = nullptr,
         struct libscols_line * parent = nullptr);
 
+    void drop_line_if_no_children(struct libscols_line * line);
+
     template <typename V>
     struct libscols_line * add_line(
         const char * key, V value, const char * color = nullptr, struct libscols_line * parent = nullptr) {

--- a/libdnf5-cli/output/key_value_table.cpp
+++ b/libdnf5-cli/output/key_value_table.cpp
@@ -102,5 +102,11 @@ struct libscols_line * KeyValueTable::add_lines(
     return added_key_line;
 }
 
+void KeyValueTable::drop_line_if_no_children(struct libscols_line * line) {
+    if (scols_line_has_children(line) == 0) {
+        scols_table_remove_line(tb, line);
+    }
+}
+
 
 }  // namespace libdnf5::cli::output


### PR DESCRIPTION
Allow dropping the table group without any children to `KeyValueTable` API.

Created as a follow-up to the https://github.com/rpm-software-management/dnf5/pull/896 being closed.