### PR TITLE
Advisory binding for AdvisoryModule and tests and docs for advisory Python API

### DIFF
--- a/bindings/libdnf5/advisory.i
+++ b/bindings/libdnf5/advisory.i
@@ -25,11 +25,10 @@
     }
 }
 
-// TODO(jkolarik): advisory modules skipped for now
-
 %{
     #include "libdnf5/advisory/advisory.hpp"
     #include "libdnf5/advisory/advisory_package.hpp"
+    #include "libdnf5/advisory/advisory_module.hpp"
     #include "libdnf5/advisory/advisory_set.hpp"
     #include "libdnf5/advisory/advisory_set_iterator.hpp"
     #include "libdnf5/advisory/advisory_collection.hpp"
@@ -47,11 +46,12 @@
 %rename(value) libdnf5::advisory::AdvisorySetIterator::operator*();
 %include "libdnf5/advisory/advisory_set_iterator.hpp"
 
-%ignore libdnf5::advisory::AdvisoryCollection::get_modules();
+%include "libdnf5/advisory/advisory_module.hpp"
 %include "libdnf5/advisory/advisory_collection.hpp"
 %include "libdnf5/advisory/advisory_query.hpp"
 %include "libdnf5/advisory/advisory_reference.hpp"
 
+%template(VectorAdvisoryModule) std::vector<libdnf5::advisory::AdvisoryModule>;
 %template(VectorAdvisoryCollection) std::vector<libdnf5::advisory::AdvisoryCollection>;
 %template(VectorAdvisoryPackage) std::vector<libdnf5::advisory::AdvisoryPackage>;
 %template(VectorAdvisoryReference) std::vector<libdnf5::advisory::AdvisoryReference>;

--- a/bindings/libdnf5/shared.i
+++ b/bindings/libdnf5/shared.i
@@ -12,4 +12,12 @@
 
     // From perl5 - utf8.h: conflicts with fmt/format.h header
     #undef utf8_to_utf16
+
+    // Recent versions of Perl (5.8.0) have namespace conflict problems.
+    // Perl defines a bunch of short macros to make the Perl API function names shorter.
+    // For example, in /usr/lib64/perl5/CORE/embed.h there is:
+    // #define get_context Perl_get_context
+    // We have to undefine that since we don't want our AdvisoryModule::get_context to
+    // be renamed to Perl_get_context
+    #undef get_context
 %}

--- a/doc/api/python/libdnf5_advisory.rst
+++ b/doc/api/python/libdnf5_advisory.rst
@@ -1,0 +1,12 @@
+libdnf5.advisory
+================
+
+
+.. toctree::
+    libdnf5_advisory_advisory
+    libdnf5_advisory_advisory_collection
+    libdnf5_advisory_advisory_module
+    libdnf5_advisory_advisory_package
+    libdnf5_advisory_advisory_query
+    libdnf5_advisory_advisory_reference
+    libdnf5_advisory_advisory_set

--- a/doc/api/python/libdnf5_advisory_advisory.rst
+++ b/doc/api/python/libdnf5_advisory_advisory.rst
@@ -1,0 +1,6 @@
+Advisory
+========
+
+
+.. autoclass:: libdnf5.advisory.Advisory
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_collection.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_collection.rst
@@ -1,0 +1,6 @@
+AdvisoryCollection
+==================
+
+
+.. autoclass:: libdnf5.advisory.AdvisoryCollection
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_module.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_module.rst
@@ -1,0 +1,6 @@
+AdvisoryModule
+==============
+
+
+.. autoclass:: libdnf5.advisory.AdvisoryModule
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_package.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_package.rst
@@ -1,0 +1,6 @@
+AdvisoryPackage
+===============
+
+
+.. autoclass:: libdnf5.advisory.AdvisoryPackage
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_query.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_query.rst
@@ -1,0 +1,6 @@
+AdvisoryQuery
+=============
+
+
+.. autoclass:: libdnf5.advisory.AdvisoryQuery
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_reference.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_reference.rst
@@ -1,0 +1,6 @@
+AdvisoryReference
+=================
+
+
+.. autoclass:: libdnf5.advisory.AdvisoryReference
+    :members:

--- a/doc/api/python/libdnf5_advisory_advisory_set.rst
+++ b/doc/api/python/libdnf5_advisory_advisory_set.rst
@@ -1,0 +1,6 @@
+AdvisorySet
+===========
+
+
+.. autoclass:: libdnf5.advisory.AdvisorySet
+    :members:

--- a/doc/api/python/python.rst
+++ b/doc/api/python/python.rst
@@ -4,6 +4,7 @@ Python
 
 
 .. toctree::
+    libdnf5_advisory
     libdnf5_base
     libdnf5_repo
     libdnf5_rpm

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -54,6 +54,12 @@ extensions = [
 breathe_projects = {'dnf5': '@CMAKE_CURRENT_BINARY_DIR@/xml/'}
 breathe_default_project = 'dnf5'
 
+# Show undocumented members for both C++ and Python API docs
+breathe_default_members = ('members', 'undoc-members')
+autodoc_default_options = {
+    'undoc-members': True,
+}
+
 # The autoapi config is only used doc/setup.py in readthedocs workflow (not by cmake)
 autoapi_type = 'python'
 autoapi_dirs = ['@CMAKE_CURRENT_BINARY_DIR@/../bindings/python3/libdnf5', '@CMAKE_CURRENT_BINARY_DIR@/../bindings/python3/libdnf5_cli']

--- a/test/python3/libdnf5/advisory/test_advisory.py
+++ b/test/python3/libdnf5/advisory/test_advisory.py
@@ -24,9 +24,122 @@ class TestAdvisory(base_test_case.BaseTestCase):
     def setUp(self):
         super().setUp()
         self.add_repo_repomd("repomd-repo1")
-
-    def test_get_name(self):
         query = libdnf5.advisory.AdvisoryQuery(self.base)
         query.filter_type("security")
-        pkg = next(iter(query))
-        self.assertEqual(pkg.get_name(), "DNF-2019-1")
+        self.advisory = next(iter(query))
+
+    def test_advisory_query(self):
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        query.filter_name("DNF-2019-1")
+        self.assertEqual(query.size(), 1)
+        advisory = next(iter(query))
+        self.assertEqual(advisory.get_name(), "DNF-2019-1")
+
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        query.filter_type("bugfix")
+        self.assertEqual(query.size(), 2)
+        advisory = next(iter(query))
+        self.assertEqual(advisory.get_type(), "bugfix")
+
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        query.filter_reference("1111")
+        self.assertEqual(query.size(), 1)
+        advisory = next(iter(query))
+        refs = advisory.get_references()
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].get_id(), "1111")
+
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        query.filter_severity("moderate")
+        self.assertEqual(query.size(), 1)
+        advisory = next(iter(query))
+        self.assertEqual(advisory.get_severity(), "moderate")
+
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        pkgquery = libdnf5.rpm.PackageQuery(self.base)
+        query.filter_packages(pkgquery)
+        self.assertEqual(query.size(), 1)
+        advisory = next(iter(query))
+        self.assertEqual(advisory.get_name(), "DNF-2019-1")
+
+        query = libdnf5.advisory.AdvisoryQuery(self.base)
+        pkgquery = libdnf5.rpm.PackageQuery(self.base)
+        pkgs = query.get_advisory_packages_sorted(pkgquery)
+        self.assertEqual(pkgs.size(), 1)
+        self.assertEqual(pkgs[0].get_nevra(), "pkg-1.2-3.x86_64")
+
+    def test_advisory(self):
+        self.assertEqual(self.advisory.get_name(), "DNF-2019-1")
+        self.assertEqual(self.advisory.get_severity(), "moderate")
+        self.assertEqual(self.advisory.get_type(), "security")
+        self.assertEqual(self.advisory.get_buildtime(), 1550849401)
+        self.assertEqual(self.advisory.get_vendor(), "dnf-testing@redhat.com")
+        self.assertEqual(self.advisory.get_description(),
+                         "testing advisory 2019")
+        self.assertEqual(self.advisory.get_title(), "bugfix_A-1.0-1")
+        self.assertEqual(self.advisory.get_status(), "stable")
+        self.assertEqual(self.advisory.get_rights(), "")
+        self.assertEqual(self.advisory.get_message(), "")
+        self.assertEqual(self.advisory.is_applicable(), True)
+
+    def test_references(self):
+        refs = self.advisory.get_references()
+        self.assertEqual(len(refs), 1)
+        reference = refs[0]
+        self.assertEqual(reference.get_id(), "1111")
+        self.assertEqual(reference.get_type(), "cve")
+        self.assertEqual(reference.get_title(), "CVE-2999")
+        self.assertEqual(reference.get_url(), "https://foobar/foobarupdate_2")
+
+    def test_collections(self):
+        cols = self.advisory.get_collections()
+        self.assertEqual(len(cols), 1)
+        collection = cols[0]
+        self.assertEqual(collection.get_advisory_id(), self.advisory.get_id())
+        self.assertEqual(collection.get_advisory(), self.advisory)
+        self.assertEqual(collection.is_applicable(), True)
+
+    def test_advisory_packages(self):
+        collection = self.advisory.get_collections()[0]
+        adv_packages = collection.get_packages()
+        self.assertEqual(len(adv_packages), 2)
+        adv_package = adv_packages[0]
+
+        self.assertEqual(adv_package.get_advisory_id(), self.advisory.get_id())
+        self.assertEqual(adv_package.get_advisory(), self.advisory)
+        # We can't compare the collections directly because adv_package constructs
+        # a new instance of the same collection
+        self.assertEqual(adv_package.get_advisory_collection(
+        ).get_advisory_id(), self.advisory.get_id())
+
+        self.assertEqual(adv_package.get_name(), "pkg")
+        self.assertEqual(adv_package.get_epoch(), "0")
+        self.assertEqual(adv_package.get_version(), "1.2")
+        self.assertEqual(adv_package.get_release(), "3")
+        self.assertEqual(adv_package.get_evr(), "1.2-3")
+        self.assertEqual(adv_package.get_arch(), "x86_64")
+        self.assertEqual(adv_package.get_nevra(), "pkg-1.2-3.x86_64")
+
+        self.assertEqual(adv_package.get_reboot_suggested(), True)
+        self.assertEqual(adv_package.get_restart_suggested(), False)
+        self.assertEqual(adv_package.get_relogin_suggested(), False)
+
+    def test_advisory_modules(self):
+        collection = self.advisory.get_collections()[0]
+        adv_modules = collection.get_modules()
+        self.assertEqual(len(adv_modules), 2)
+        adv_module = adv_modules[0]
+
+        self.assertEqual(adv_module.get_advisory_id(), self.advisory.get_id())
+        self.assertEqual(adv_module.get_advisory(), self.advisory)
+        # We can't compare the collections directly because adv_module constructs
+        # a new instance of the same collection
+        self.assertEqual(adv_module.get_advisory_collection(
+        ).get_advisory_id(), self.advisory.get_id())
+
+        self.assertEqual(adv_module.get_name(), "perl-DBI")
+        self.assertEqual(adv_module.get_stream(), "master")
+        self.assertEqual(adv_module.get_version(), "2")
+        self.assertEqual(adv_module.get_context(), "2a")
+        self.assertEqual(adv_module.get_arch(), "x86_64")
+        self.assertEqual(adv_module.get_nsvca(), "perl-DBI:master:2:2a:x86_64")


### PR DESCRIPTION
- Enable bindings for `AdvisoryModule`
- Add Advisory API Python tests - for https://github.com/rpm-software-management/dnf5/issues/213
- Add Advisory API Python docs
- Enables generating docs for undocumented methods for both C++ and Python bindings.