### PR TITLE
Fix building with -z defs

### DIFF
--- a/dnf5-plugins/CMakeLists.txt
+++ b/dnf5-plugins/CMakeLists.txt
@@ -3,6 +3,9 @@ if(NOT WITH_DNF5_PLUGINS)
 endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/dnf5/include/")
+# These plugins use symbols from dnf5 program, hence the symbold are undefined
+# at link time and cannot pass "-z defs" linker check. Disable the check.
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,undefs")
 
 add_subdirectory("builddep_plugin")
 add_subdirectory("changelog_plugin")

--- a/dnf5-plugins/builddep_plugin/CMakeLists.txt
+++ b/dnf5-plugins/builddep_plugin/CMakeLists.txt
@@ -9,6 +9,9 @@ set_target_properties(builddep_cmd_plugin PROPERTIES PREFIX "")
 find_library(RPMBUILD NAMES rpmbuild REQUIRED)
 target_link_libraries(builddep_cmd_plugin PRIVATE ${RPMBUILD})
 
+pkg_check_modules(RPM REQUIRED rpm)
+target_link_libraries(builddep_cmd_plugin PRIVATE ${RPM_LIBRARIES})
+
 target_link_libraries(builddep_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(builddep_cmd_plugin PRIVATE dnf5)
 

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -26,6 +26,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <rpm/rpmbuild.h>
+#include <rpm/rpmds.h>
+#include <rpm/rpmio.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
+#include <rpm/rpmts.h>
 
 #include <iostream>
 


### PR DESCRIPTION
This patchset fixes issue #267. First commit fixes a transitive reliance on directly used librpm fucntions in builddep_plugin dnf plugin. The second commit disables -z defs for program plugins. As a result, it is possible to build DNF5 with "-z defs" among system-wide linker flags.