### PR TITLE
 Add packit job copr and tests 

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,3 +32,13 @@ jobs:
     dist_git_branches:
       - fedora-39
       - fedora-38 # rawhide updates are created automatically
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-all
+  - job: tests
+    trigger: pull_request
+    targets:
+      - fedora-all
+    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
+    fmf_ref: main


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/ci-dnf-stack/pull/1405
Tests will fail. Once merged test with `/packit test` before merging.

Requirements to onboard:

- [x] wrap our ci so that we don't have to reinvent the wheel
  - [x] use the latest upstream ci-dnf-stack and the same scripts provided by us
  - [x] respect the requirements of running destructive tests in separate containers
- [x] provide copr builds for inspections

Key advantages:
 
- [x] build rpms for all fedoras using copr
- [x] run tests for all fedoras
- [x] reproduce the tests locally (provided by tmt)
- [x] possibility to run tests directly from ci-dnf-stack via `/packit test rpm-software-management/dnf5#973` (provided that the pr has a packit build) https://github.com/rpm-software-management/ci-dnf-stack/pull/1398

Future possible improvements:

- [x] possibility to rerun part of the tests in the future via `/packit test <sometest>` 
- [x] possibility to split the test ci and run separate tiers for different systems

Once this PR gets merged and works, the old actions can be removed: https://github.com/rpm-software-management/dnf5/pull/1008