### PR TITLE
Disable the RHSM plugin by default and enable it in the RPM spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(WITH_LIBDNF5_CLI "Build library for working with a terminal in a command-
 option(WITH_DNF5 "Build dnf5 command-line package manager" ON)
 option(WITH_DNF5_PLUGINS "Build plugins for dnf5 command-line package manager" ON)
 option(WITH_PLUGIN_ACTIONS "Build a dnf5 actions plugin" ON)
-option(WITH_PLUGIN_RHSM "Build a libdnf5 rhsm (Red Hat Subscription Manager) plugin" ON)
+option(WITH_PLUGIN_RHSM "Build a libdnf5 rhsm (Red Hat Subscription Manager) plugin" OFF)
 option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python plugins. Requires WITH_PYTHON3=ON." ON)
 
 # build options - features

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -670,6 +670,7 @@ Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclos
     -DWITH_LIBDNF5_CLI=%{?with_libdnf_cli:ON}%{!?with_libdnf_cli:OFF} \
     -DWITH_DNF5=%{?with_dnf5:ON}%{!?with_dnf5:OFF} \
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
+    -DWITH_PLUGIN_RHSM=%{?with_plugin_rhsm:ON}%{!?with_plugin_rhsm:OFF} \
     -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \
     \
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \


### PR DESCRIPTION
Most Linux distributions shipping DNF do not need the RHSM plugin, and it really is only useful for the Red Hat Enterprise Linux family of distributions. Given that the RHSM stuff is often not shipped elsewhere, it's better to have this off by default and only turn it on when needed.

This is done by ensuring that the RPM spec file (which is both the reference spec file and the spec file used for RH/Fedora) turns it on and builds it.