### PR TITLE
Implement `get_reason()` for groups and environments

### DIFF
--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -126,6 +126,8 @@ private:
     friend class libdnf5::base::Transaction;
     friend class libdnf5::Goal;
     friend class libdnf5::rpm::Package;
+    friend class libdnf5::comps::Group;
+    friend class libdnf5::comps::Environment;
     friend class libdnf5::advisory::AdvisoryQuery;
     friend class libdnf5::module::ModuleDB;
     friend class libdnf5::module::ModuleSack;

--- a/include/libdnf5/comps/environment/environment.hpp
+++ b/include/libdnf5/comps/environment/environment.hpp
@@ -106,12 +106,7 @@ public:
     /// @return Resolved reason why the Environment was installed.
     ///         Environments can be installed due to multiple reasons, only the most significant is returned.
     /// @since 5.0
-    //
-    // TODO(dmach): return actual value from data in EnvironmentSack
-    // TODO(dmach): throw an exception when getting a reason for an available package (it should work only for installed)
-    libdnf5::transaction::TransactionItemReason get_reason() const {
-        return libdnf5::transaction::TransactionItemReason::NONE;
-    }
+    libdnf5::transaction::TransactionItemReason get_reason() const;
 
     /// Merge the Environment with another one.
     /// @since 5.0

--- a/include/libdnf5/comps/group/group.hpp
+++ b/include/libdnf5/comps/group/group.hpp
@@ -125,12 +125,7 @@ public:
     /// @return Resolved reason why the Group was installed.
     ///         Groups can be installed due to multiple reasons, only the most significant is returned.
     /// @since 5.0
-    //
-    // TODO(dmach): return actual value from data in GroupSack
-    // TODO(dmach): throw an exception when getting a reason for an available package (it should work only for installed)
-    libdnf5::transaction::TransactionItemReason get_reason() const {
-        return libdnf5::transaction::TransactionItemReason::NONE;
-    }
+    libdnf5::transaction::TransactionItemReason get_reason() const;
 
     /// Merge the Group with another one.
     /// @since 5.0

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -193,8 +193,7 @@ private:
     using EnvironmentItem = std::tuple<std::string, comps::EnvironmentQuery, GoalJobSettings>;
     std::map<GoalAction, std::vector<EnvironmentItem>> resolved_environment_specs;
 
-    /// group_specs contain both comps groups and environments. These are resolved
-    /// according to settings.group_search_type flags value.
+    /// group_specs contain both comps groups and environments.
     /// <libdnf5::GoalAction, TransactionItemReason reason, std::string group_spec, GoalJobSettings settings>
     std::vector<GroupSpec> group_specs;
 

--- a/libdnf5/comps/environment/environment.cpp
+++ b/libdnf5/comps/environment/environment.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/xml.hpp"
 
 #include "libdnf5/base/base.hpp"
+#include "libdnf5/comps/environment/query.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
 extern "C" {
@@ -135,6 +136,23 @@ std::vector<std::string> Environment::get_optional_groups() {
         optional_groups = load_groups_from_pool(get_comps_pool(base), environment_ids[0].id, false);
     }
     return optional_groups;
+}
+
+libdnf5::transaction::TransactionItemReason Environment::get_reason() const {
+    comps::EnvironmentQuery installed_query(base);
+    installed_query.filter_installed(true);
+    installed_query.filter_environmentid(get_environmentid());
+    if (!installed_query.empty()) {
+        auto reason = base->p_impl->get_system_state().get_environment_reason(get_environmentid());
+
+        if (reason == libdnf5::transaction::TransactionItemReason::NONE) {
+            return libdnf5::transaction::TransactionItemReason::EXTERNAL_USER;
+        }
+
+        return reason;
+    }
+
+    return libdnf5::transaction::TransactionItemReason::NONE;
 }
 
 

--- a/libdnf5/system/state.cpp
+++ b/libdnf5/system/state.cpp
@@ -276,6 +276,30 @@ transaction::TransactionItemReason State::get_package_reason(const std::string &
     return packages_reason;
 }
 
+transaction::TransactionItemReason State::get_group_reason(const std::string & id) {
+    transaction::TransactionItemReason group_reason = transaction::TransactionItemReason::NONE;
+    auto it = group_states.find(id);
+    if (it != group_states.end()) {
+        if (it->second.userinstalled) {
+            group_reason = transaction::TransactionItemReason::USER;
+        } else {
+            group_reason = transaction::TransactionItemReason::DEPENDENCY;
+        }
+    }
+
+    return group_reason;
+}
+
+transaction::TransactionItemReason State::get_environment_reason(const std::string & id) {
+    transaction::TransactionItemReason environment_reason = transaction::TransactionItemReason::NONE;
+    auto it = environment_states.find(id);
+    if (it != environment_states.end()) {
+        environment_reason = transaction::TransactionItemReason::USER;
+    }
+
+    return environment_reason;
+}
+
 
 void State::set_package_reason(const std::string & na, transaction::TransactionItemReason reason) {
     auto reason_str = transaction::transaction_item_reason_to_string(reason);

--- a/libdnf5/system/state.hpp
+++ b/libdnf5/system/state.hpp
@@ -116,6 +116,14 @@ public:
     /// @since 5.0
     transaction::TransactionItemReason get_package_reason(const std::string & na);
 
+    /// @return The reason for a group id.
+    /// @param id The group id to get the reason for.
+    transaction::TransactionItemReason get_group_reason(const std::string & id);
+
+    /// @return The reason for a environment id.
+    /// @param id The environment id to get the reason for.
+    transaction::TransactionItemReason get_environment_reason(const std::string & id);
+
     /// Sets the reason for a package NA (Name.Arch).
     /// @param na The NA to set the reason for.
     /// @param reason The reason to set.


### PR DESCRIPTION
This is currently always returning hard-coded `libdnf5::transaction::TransactionItemReason::NONE` breaking my transaction replay tests.

Part of https://github.com/rpm-software-management/dnf5/issues/999 work.