### PR TITLE
modules: Fix transaction table headers for module operations

### DIFF
--- a/include/libdnf5-cli/output/transaction_table.hpp
+++ b/include/libdnf5-cli/output/transaction_table.hpp
@@ -265,10 +265,10 @@ public:
                     text = "Enabling module streams";
                     break;
                 case libdnf5::transaction::TransactionItemAction::DISABLE:
-                    text = "Disabling module streams";
+                    text = "Disabling modules";
                     break;
                 case libdnf5::transaction::TransactionItemAction::RESET:
-                    text = "Resetting module streams";
+                    text = "Resetting modules";
                     break;
                 default:
                     libdnf_throw_assertion(


### PR DESCRIPTION
"Disabling modules" and "Resetting modules" is correct, because the whole module gets disabled or reset, not individual streams. This is also consistent with dnf4.