### PR TITLE
Add arch to module pool

### DIFF
--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "base_impl.hpp"
 #include "conf/config.h"
+#include "module/module_sack_impl.hpp"
 #include "solv/pool.hpp"
 #include "utils/dnf4convert/dnf4convert.hpp"
 #include "utils/fs/utils.hpp"
@@ -221,7 +222,9 @@ void Base::setup() {
     pool_setdisttype(**pool, DISTTYPE_RPM);
     // TODO(jmracek) - architecture variable is changable therefore architecture in vars must be synchronized with RpmPool
     // (and force to recompute provides) or locked
-    pool_setarch(**pool, vars->get_value("arch").c_str());
+    const char * arch = vars->get_value("arch").c_str();
+    pool_setarch(**pool, arch);
+    module_sack.p_impl->set_arch(arch);
     pool_set_rootdir(**pool, installroot.get_value().c_str());
 
     p_impl->plugins.post_base_setup();

--- a/libdnf5/module/module_sack_impl.hpp
+++ b/libdnf5/module/module_sack_impl.hpp
@@ -32,6 +32,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 extern "C" {
 #include <solv/pool.h>
+#include <solv/poolarch.h>
 }
 
 #include <optional>
@@ -145,6 +146,11 @@ public:
     /// @throw NoModuleError if the module doesn't exist.
     /// @since 5.0.14
     bool reset(const std::string & module_spec, bool count = true);
+    /// Set architecture for module pool
+    /// @param arch architecture.
+    /// @since 5.1.8
+    void set_arch(const char * arch) { pool_setarch(pool, arch); };
+
 
 private:
     friend class libdnf5::base::Transaction;


### PR DESCRIPTION
It is important to provide architecture to libsolv pool, because it might lead to incorrect resolve of active module items.