### PR TITLE
Epoch formatting: set whole seconds precision

### DIFF
--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -114,7 +114,8 @@ template <typename T>
 inline std::string format_epoch(T epoch_num) {
     if (std::in_range<time_t>(epoch_num)) {
         const auto epoch = static_cast<time_t>(epoch_num);
-        return fmt::format("{:%F %X}", std::chrono::system_clock::from_time_t(epoch));
+        return fmt::format(
+            "{:%F %X}", std::chrono::round<std::chrono::seconds>(std::chrono::system_clock::from_time_t(epoch)));
     }
     return fmt::format("{} seconds since Unix epoch", epoch_num);
 }


### PR DESCRIPTION
There was a change in fmt-10.0.0 which adds support for sub-second precision printing.
Given that we want only whole seconds on the output round the time point to `std::chrono::seconds`.

Closes: https://github.com/rpm-software-management/dnf5/issues/1020