### PR TITLE
build: Restore compatiblity with libxml2-2.12.0

### DIFF
--- a/libdnf5/comps/group/group.cpp
+++ b/libdnf5/comps/group/group.cpp
@@ -36,6 +36,7 @@ extern "C" {
 }
 
 #include <libxml/tree.h>
+#include <libxml/xmlerror.h>
 
 #include <set>
 #include <string>


### PR DESCRIPTION
libxml2-2.12.0 shuffled header files and as a result a build failed:

    cd /tmp/b/libdnf5 && /usr/bin/c++ -DGETTEXT_DOMAIN=\"libdnf5\" -DLIBSOLV_SOLVABLE_PREPEND_DEP -DPROJECT_BINARY_DIR=\"/tmp/b\" -DPROJECT_SOURCE_DIR=\"/home/test/dnf5\" -DPROJECT_VERSION_MAJOR=5 -DPROJECT_VERSION_MINOR=1 -DPROJECT_VERSION_PATCH=7 -DWITH_ZCHUNK -Dlibdnf5_EXPORTS -I/home/test/dnf5/include -I/home/test/dnf5/common -I/home/test/dnf5/libdnf5/. -I/usr/include/json-c -I/usr/include/libxml2 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -std=gnu++20 -fPIC -fmacro-prefix-map=/home/test/dnf5/= -Wall -Wextra -Werror -Wcast-align -Wformat-nonliteral -Wmissing-format-attribute -Wredundant-decls -Wsign-compare -Wtype-limits -Wuninitialized -Wwrite-strings -Werror=unused-result -Wodr -Wconversion -Wl,--as-needed -MD -MT libdnf5/CMakeFiles/libdnf5.dir/comps/group/group.cpp.o -MF CMakeFiles/libdnf5.dir/comps/group/group.cpp.o.d -o CMakeFiles/libdnf5.dir/comps/group/group.cpp.o -c /home/test/dnf5/libdnf5/comps/group/group.cpp
    /home/test/dnf5/libdnf5/comps/group/group.cpp: In member function ‘void libdnf5::comps::Group::serialize(const std::string&)’:
    /home/test/dnf5/libdnf5/comps/group/group.cpp:199:5: error: ‘xmlSetGenericErrorFunc’ was not declared in this scope
      199 |     xmlSetGenericErrorFunc(&xml_errors, &error_to_strings);
	  |     ^~~~~~~~~~~~~~~~~~~~~~

The cause was that libdnf5/comps/group/group.cpp calls xmlSetGenericErrorFunc() without including <libxml/xmlerror.h>. This patch fixes it.

An example of the build failure in our  testing-farm:fedora-rawhide-x86_64 CI <https://download.copr.fedorainfracloud.org/results/packit/rpm-software-management-dnf5-1022/fedora-rawhide-x86_64/06669784-dnf5/builder-live.log.gz>