### PR TITLE
Workflow for *.pot sync exits if only creation dates were changed

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -47,5 +47,9 @@ jobs:
           done
           popd
           git -C l10n add "*"
+
+          # If only creation dates were changed do nothing
+          if git -C l10n diff --staged --ignore-matching-lines='"POT-Creation-Date:' --exit-code; then exit 0; fi
+
           git -C l10n commit -m "Update source files"
           git -C l10n push


### PR DESCRIPTION
Otherwise the dnf5-l10n repo might contain mostly empty commits.