### PR TITLE
doc: Add a tutorial how to write plugins

### DIFF
--- a/dnf5/include/dnf5/iplugin.hpp
+++ b/dnf5/include/dnf5/iplugin.hpp
@@ -34,6 +34,7 @@ struct PluginVersion {
     std::uint16_t micro;
 };
 
+/// @brief A base class for implementing DNF5 plugins that provide one or more commands to users.
 class IPlugin {
 public:
     IPlugin(Context & context) : context(&context) {}
@@ -64,10 +65,6 @@ public:
     virtual void init() {}
 
     virtual std::vector<std::unique_ptr<Command>> create_commands() = 0;
-
-    /// It is called when a hook is reached. The argument describes what happened.
-    // TODO(jrohel): Design an API for a different plugin type than command. For example, to modify or log output.
-    //virtual bool hook(HookId hook_id) = 0;
 
     /// Finish the plugin and release all resources obtained by the init method and in hooks.
     virtual void finish() noexcept = 0;

--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -158,17 +158,6 @@ bool Plugins::init() {
     return true;
 }
 
-/*bool Plugins::hook(HookId id) {
-    for (auto & plugin : plugins) {
-        if (plugin->get_enabled()) {
-            if (!plugin->hook(id)) {
-                return false;
-            }
-        }
-    }
-    return true;
-}*/
-
 void Plugins::finish() noexcept {
     for (auto plugin = plugins.rbegin(), stop = plugins.rend(); plugin != stop; ++plugin) {
         if ((*plugin)->get_enabled()) {

--- a/doc/dnf5_plugins/index.rst
+++ b/doc/dnf5_plugins/index.rst
@@ -1,3 +1,5 @@
+.. _dnf5 plugins:
+
 ============
 DNF5 Plugins
 ============

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,7 @@ Welcome to DNF5's documentation!
     about
     tutorial/index
     tutorial/bindings/index
+    tutorial/plugins/index
     api/index
     libdnf5_plugins/index
     commands/index

--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -18,9 +18,9 @@
 
 .. _actions_plugin_ref-label:
 
-======================
-libdnf5 Actions Plugin
-======================
+==============
+Actions Plugin
+==============
 
 Description
 ===========

--- a/doc/libdnf5_plugins/index.rst
+++ b/doc/libdnf5_plugins/index.rst
@@ -1,5 +1,7 @@
+.. _libdnf5 plugins:
+
 ===============
-libdnf5 Plugins
+LIBDNF5 Plugins
 ===============
 
 

--- a/doc/templates/dnf5-plugin/CMakeLists.txt
+++ b/doc/templates/dnf5-plugin/CMakeLists.txt
@@ -1,0 +1,18 @@
+# set gettext domain for translations
+add_definitions(-DGETTEXT_DOMAIN=\"dnf5_cmd_template\")
+
+# add your source files
+add_library(template_cmd_plugin MODULE template.cpp template_cmd_plugin.cpp)
+
+# disable the 'lib' prefix in order to create template_cmd_plugin.so
+set_target_properties(template_cmd_plugin PROPERTIES PREFIX "")
+
+# optionally, add your dependencies and link them to the plugin
+# pkg_check_modules(RPM REQUIRED rpm)
+# target_link_libraries(template_cmd_plugin PRIVATE ${RPM_LIBRARIES})
+
+# link the default dnf libraries
+target_link_libraries(template_cmd_plugin PRIVATE dnf5 libdnf5 libdnf5-cli)
+
+# install the plugin into the common dnf5-plugins location
+install(TARGETS template_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)

--- a/doc/templates/dnf5-plugin/template.cpp
+++ b/doc/templates/dnf5-plugin/template.cpp
@@ -1,0 +1,1 @@
+../command/template.cpp

--- a/doc/templates/dnf5-plugin/template.hpp
+++ b/doc/templates/dnf5-plugin/template.hpp
@@ -1,0 +1,1 @@
+../command/template.hpp

--- a/doc/templates/dnf5-plugin/template_cmd_plugin.cpp
+++ b/doc/templates/dnf5-plugin/template_cmd_plugin.cpp
@@ -1,0 +1,98 @@
+#include "template.hpp"
+
+#include <dnf5/iplugin.hpp>
+
+using namespace dnf5;
+
+namespace {
+
+constexpr const char * PLUGIN_NAME{"template"};
+
+constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+
+constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
+constexpr const char * attrs_value[]{"Fred Fedora", "dummy@email.com", "Plugin description."};
+
+class TemplateCmdPlugin : public IPlugin {
+public:
+    using IPlugin::IPlugin;
+
+    /// Fill in the API version of your plugin.
+    /// This is used to check if the provided plugin API version is compatible with the application's plugin API version.
+    /// MANDATORY to override.
+    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    /// Enter the name of your new plugin.
+    /// This is used in log messages when an action or error related to the plugin occurs.
+    /// MANDATORY to override.
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    /// Fill in the version of your plugin.
+    /// This is utilized in informative and debugging log messages.
+    /// MANDATORY to override.
+    PluginVersion get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    /// Add custom attributes, such as information about yourself and a description of the plugin.
+    /// These can be used to query plugin-specific data through the API.
+    /// Optional to override.
+    const char * const * get_attributes() const noexcept override { return attrs; }
+    const char * get_attribute(const char * attribute) const noexcept override {
+        for (size_t i = 0; attrs[i]; ++i) {
+            if (std::strcmp(attribute, attrs[i]) == 0) {
+                return attrs_value[i];
+            }
+        }
+        return nullptr;
+    }
+
+    /// Export all the commands that plugin is implementing.
+    /// MANDATORY to override.
+    std::vector<std::unique_ptr<Command>> create_commands() override;
+
+    /// Initialization method called after the Base object is created and before command-line arguments are parsed.
+    /// Optional to override.
+    void init() override {}
+
+    /// Cleanup method called when plugin objects are garbage collected.
+    /// Optional to override.
+    void finish() noexcept override {}
+};
+
+std::vector<std::unique_ptr<Command>> TemplateCmdPlugin::create_commands() {
+    std::vector<std::unique_ptr<Command>> commands;
+    commands.push_back(std::make_unique<TemplateCommand>(get_context()));
+    return commands;
+}
+
+
+}  // namespace
+
+/// Below is a block of functions with C linkage used for loading the plugin binaries from disk.
+/// All of these are MANDATORY to implement.
+
+/// Return plugin's API version.
+PluginAPIVersion dnf5_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+/// Return plugin's name.
+const char * dnf5_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+/// Return plugin's version.
+PluginVersion dnf5_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+/// Return the instance of the implemented plugin.
+IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
+    return new TemplateCmdPlugin(context);
+} catch (...) {
+    return nullptr;
+}
+
+/// Delete the plugin instance.
+void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
+    delete plugin_object;
+}

--- a/doc/templates/index.rst
+++ b/doc/templates/index.rst
@@ -7,3 +7,5 @@ Templates
     :numbered:
 
     template-command
+    template-dnf5-plugin
+    template-libdnf5-plugin

--- a/doc/templates/libdnf5-plugin/CMakeLists.txt
+++ b/doc/templates/libdnf5-plugin/CMakeLists.txt
@@ -1,0 +1,19 @@
+# setup conditional build
+if(NOT WITH_PLUGIN_TEMPLATE)
+    return()
+endif()
+
+# set gettext domain for translations
+add_definitions(-DGETTEXT_DOMAIN=\"libdnf5\")
+
+# add your source files
+add_library(template MODULE template.cpp)
+
+# disable the 'lib' prefix in order to create template.so
+set_target_properties(template PROPERTIES PREFIX "")
+
+# link the libdnf5 library
+target_link_libraries(template PRIVATE libdnf5)
+
+# install the plugin into the common libdnf5-plugins location
+install(TARGETS template LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")

--- a/doc/templates/libdnf5-plugin/template.conf
+++ b/doc/templates/libdnf5-plugin/template.conf
@@ -1,0 +1,9 @@
+[main]
+name = template
+enabled = yes
+
+# We can provide optional custom keys and sections.
+custom_key = some_value
+
+[custom]
+website = https://my-hosting/template-plugin.org

--- a/doc/templates/libdnf5-plugin/template.cpp
+++ b/doc/templates/libdnf5-plugin/template.cpp
@@ -1,0 +1,115 @@
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/common/exception.hpp>
+
+#include <algorithm>
+
+using namespace libdnf5;
+
+namespace {
+
+constexpr const char * PLUGIN_NAME{"template"};
+
+constexpr plugin::Version PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+
+constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
+constexpr const char * attrs_value[]{"Fatima Freedom", "dummy@email.com", "Plugin description."};
+
+class TemplatePlugin : public plugin::IPlugin {
+public:
+    /// Implement custom constructor for the new plugin.
+    /// This is not necessary when you only need Base object for your implementation.
+    /// Optional to override.
+    TemplatePlugin(libdnf5::Base & base, libdnf5::ConfigParser &) : IPlugin(base) {}
+
+    /// Fill in the API version of your plugin.
+    /// This is used to check if the provided plugin API version is compatible with the library's plugin API version.
+    /// MANDATORY to override.
+    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    /// Enter the name of your new plugin.
+    /// This is used in log messages when an action or error related to the plugin occurs.
+    /// MANDATORY to override.
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    /// Fill in the version of your plugin.
+    /// This is utilized in informative and debugging log messages.
+    /// MANDATORY to override.
+    plugin::Version get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    /// Add custom attributes, such as information about yourself and a description of the plugin.
+    /// These can be used to query plugin-specific data through the API.
+    /// Optional to override.
+    const char * const * get_attributes() const noexcept override { return attrs; }
+    const char * get_attribute(const char * attribute) const noexcept override {
+        for (size_t i = 0; attrs[i]; ++i) {
+            if (std::strcmp(attribute, attrs[i]) == 0) {
+                return attrs_value[i];
+            }
+        }
+        return nullptr;
+    }
+
+    /// Initialization method called after the Base object is created and before command-line arguments are parsed.
+    /// Optional to override.
+    void init() override {}
+
+    /// Cleanup method called when plugin objects are garbage collected.
+    /// Optional to override.
+    void finish() noexcept override {}
+
+    /// Override the hooks you want to implement.
+    void post_base_setup() override { post_base_magic(); }
+    void pre_transaction(const libdnf5::base::Transaction & transaction) override {
+        pre_transaction_magic(transaction);
+    };
+
+private:
+    void post_base_magic();
+    void pre_transaction_magic(const libdnf5::base::Transaction &);
+};
+
+/// Example how to implement additional logic after the Base is set up.
+void TemplatePlugin::post_base_magic() {
+    const auto & tsflags = get_base().get_config().get_tsflags_option().get_value();
+    if (std::find(tsflags.begin(), tsflags.end(), "noscripts") != tsflags.end()) {
+        libdnf_throw_assertion("Hey, we don't want a transaction without scriptlets!");
+    }
+}
+
+/// Example how to implement additional logic before starting the transaction.
+void TemplatePlugin::pre_transaction_magic(const libdnf5::base::Transaction & transaction) {
+    transaction.set_description("This is our important transaction.");
+}
+
+}  // namespace
+
+/// Below is a block of functions with C linkage used for loading the plugin binaries from disk.
+/// All of these are MANDATORY to implement.
+
+/// Return plugin's API version.
+PluginAPIVersion libdnf_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+/// Return plugin's name.
+const char * libdnf_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+/// Return plugin's version.
+plugin::Version libdnf_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+/// Return the instance of the implemented plugin.
+plugin::IPlugin * libdnf_plugin_new_instance(
+    [[maybe_unused]] LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser) try {
+    return new TemplatePlugin(base, parser);
+} catch (...) {
+    return nullptr;
+}
+
+/// Delete the plugin instance.
+void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
+    delete plugin_object;
+}

--- a/doc/templates/template-command.rst
+++ b/doc/templates/template-command.rst
@@ -1,3 +1,5 @@
+.. _command template:
+
 DNF5 Command Template
 =====================
 

--- a/doc/templates/template-dnf5-plugin.rst
+++ b/doc/templates/template-dnf5-plugin.rst
@@ -1,0 +1,17 @@
+DNF5 Plugin Template
+====================
+
+Below is a template code for a DNF5 plugin. For the complete tutorial on writing
+DNF5 plugins, refer to :ref:`dnf5 plugins tutorial`.
+
+``dnf5-plugins/template_plugin/template_cmd_plugin.cpp``
+
+.. literalinclude:: dnf5-plugin/template_cmd_plugin.cpp
+    :language: c++
+    :linenos:
+
+``dnf5-plugins/template_plugin/CMakeLists.txt``
+
+.. literalinclude:: dnf5-plugin/CMakeLists.txt
+    :language: cmake
+    :linenos:

--- a/doc/templates/template-libdnf5-plugin.rst
+++ b/doc/templates/template-libdnf5-plugin.rst
@@ -1,0 +1,23 @@
+LIBDNF5 Plugin Template
+=======================
+
+Below is a template code for a LIBDNF5 plugin. For the complete tutorial
+on writing LIBDNF5 plugins, refer to :ref:`libdnf5 plugins tutorial`.
+
+``libdnf5-plugins/template/template.cpp``
+
+.. literalinclude:: libdnf5-plugin/template.cpp
+    :language: c++
+    :linenos:
+
+``libdnf5-plugins/template/CMakeLists.txt``
+
+.. literalinclude:: libdnf5-plugin/CMakeLists.txt
+    :language: cmake
+    :linenos:
+
+``libdnf5-plugins/template/template.conf``
+
+.. literalinclude:: libdnf5-plugin/template.conf
+    :language: cfg
+    :linenos:

--- a/doc/tutorial/plugins/dnf5-plugins.rst
+++ b/doc/tutorial/plugins/dnf5-plugins.rst
@@ -1,0 +1,87 @@
+.. _dnf5 plugins tutorial:
+
+DNF5 Plugins
+============
+
+This is the way for adding a new command to DNF5, allowing users to simply type
+``dnf5 new-command`` and access the implemented functionality.
+
+Command vs Plugin
+-----------------
+
+The reason why you can't directly implement a new DNF5 command is the following.
+
+The core commands in ``dnf5/commands`` implement essential package manager
+functionality, primarily focused on installing and managing packages. They are
+integral to the DNF5 package.
+
+Plugin commands implement additional features that extend the capabilities
+of DNF5. They are packaged separately for optional installation by users who
+need these additional features.
+
+Thus, core commands and plugins differ by logic and implementation.
+
+Writing an Active Plugin
+------------------------
+
+A DNF5 plugin comprises one or more commands. Visit the :ref:`command template`
+to see how to implement a command.
+
+Note that for plugin purposes, we don't want to register new commands
+in the ``dnf5/main.cpp`` file. Instead, we will implement the ``dnf5::IPlugin``
+interface by reusing the existing boilerplate code, as shown below (refer to the
+comments in the provided code for the expected input locations):
+
+.. literalinclude:: ../../templates/dnf5-plugin/template_cmd_plugin.cpp
+    :language: c++
+    :linenos:
+
+.. note::
+    During the startup of the DNF5 application, the plugin library scans
+    the files in the configured plugins directory to check for the presence
+    of any plugins implementing the common ``dnf5::IPlugin`` interface.
+    If such plugins are found, they are loaded into memory along with all
+    the commands they implement.
+
+Each plugin source is structured in its own directory within the
+``dnf5-plugins`` folder. See other plugins, such as ``builddep_plugin``:
+
+.. code-block:: bash
+
+    $ tree dnf5-plugins/builddep_plugin/
+    dnf5-plugins/builddep_plugin/
+    ├── builddep_cmd_plugin.cpp
+    ├── builddep.cpp
+    ├── builddep.hpp
+    └── CMakeLists.txt
+
+Building the Binary
+-------------------
+
+To create the plugin binary, add a CMake build script:
+
+.. literalinclude:: ../../templates/dnf5-plugin/CMakeLists.txt
+    :language: cmake
+    :linenos:
+
+Include the newly created plugin in the ``CMakeLists.txt`` parent file inside
+``dnf5-plugins`` like this: ``add_subdirectory("template_plugin")``.
+
+Delivering to the User
+----------------------
+
+We still need to set up the deployment process so that users can install
+the new plugin into DNF5 through the package manager.
+
+Add a new provide in the ``dnf5-plugins`` section of the ``dnf5.spec`` file:
+``Provides: dnf5-command(template)``.
+
+You should also include a documentation man page describing the usage of your
+plugin in detail. There are several places which need to be interconnected,
+make sure to complete all the following steps:
+
+* ``doc/dnf5_plugins/template.8.rst``: Add a new man page for your plugin with the respective name.
+* ``doc/dnf5_plugins/index.rst``: Reference the new plugin in the DNF5 plugins page.
+* ``doc/dnf5.8.rst``: Reference the new plugin in the main DNF5 man page.
+* ``doc/CMakeLists.txt`` and ``doc/conf.py.in``: Integrate with Sphinx documentation.
+* ``dnf5.spec``: Include the new man page in the ``dnf5-plugins`` package.

--- a/doc/tutorial/plugins/index.rst
+++ b/doc/tutorial/plugins/index.rst
@@ -1,0 +1,40 @@
+Tutorial: Writing Plugins
+=========================
+
+Plugins are the means to extend the existing functionality of DNF5. They are
+written in the native language of DNF5, which is C++. Two types of plugins are
+supported:
+
+* :ref:`dnf5 plugins`:
+    * **Active:** Used to implement one or more commands.
+* :ref:`libdnf5 plugins`:
+    * **Passive:** Used to implement additional logic into the library using hooks.
+
+.. note::
+    Existing plugins from the preceding DNF project are not compatible
+    with the new DNF5. A different API is now used, and they were
+    written in Python, which is not a mandatory component in DNF5.
+
+For detailed information on both types of plugins, refer to their respective pages:
+
+.. toctree::
+    :maxdepth: 2
+
+    dnf5-plugins
+    libdnf5-plugins
+
+Debugging Tips
+--------------
+
+To test your freshly built DNF5 Plugin, redirect DNF5 to load it by setting
+the ``DNF5_PLUGINS_DIR`` environmental variable to your build directory (e.g.,
+``DNF5_PLUGINS_DIR=/home/user/dnf5/build/dnf5-plugins/template_plugin``).
+
+Speaking about LIBDNF5 Plugins, utilize the ``LIBDNF_PLUGINS_CONFIG_DIR``
+environmental variable to configure the directory with the plugin's configuration.
+This can also be overridden by the ``pluginconfpath`` configuration option.
+Additionally, set the directory for the plugin binaries with the ``pluginpath``
+configuration option.
+
+Ensure effective debugging by building the project with debugging symbols
+(``-DCMAKE_BUILD_TYPE=Debug``).

--- a/doc/tutorial/plugins/libdnf5-plugins.rst
+++ b/doc/tutorial/plugins/libdnf5-plugins.rst
@@ -1,0 +1,121 @@
+.. _libdnf5 plugins tutorial:
+
+LIBDNF5 Plugins
+===============
+
+These plugins enable changes to the existing DNF5 workflow.
+Possible uses of DNF5 passive plugins are modifying the LIBDNF5's
+behavior at specific breakpoints, changing or implementing the logic,
+or triggering the loading of additional plugins via prepared callbacks.
+
+Writing a Passive Plugin
+------------------------
+
+Similarly to the :ref:`dnf5 plugins tutorial`, we have to implement
+the ``libdnf5::plugin::IPlugin`` interface and override the hooks
+to alter DNF5's logic.
+
+In the following code block, a simple example plugin introduces logic in two
+different steps. The first is after preparing the ``libdnf5::Base`` object.
+The second is before the start of the transaction.
+
+.. literalinclude:: ../../templates/libdnf5-plugin/template.cpp
+    :language: c++
+    :linenos:
+
+Each plugin is structured in its own directory within the ``libdnf5-plugins``
+folder. Review other plugins, such as ``actions``, to understand the expected
+structure:
+
+.. code-block:: bash
+
+    $ tree libdnf5-plugins/actions/
+    libdnf5-plugins/actions/
+    ├── actions.conf
+    ├── actions.cpp
+    └── CMakeLists.txt
+
+Building the Binary
+-------------------
+
+To create the plugin binary, include a CMake build script:
+
+.. literalinclude:: ../../templates/libdnf5-plugin/CMakeLists.txt
+    :language: cmake
+    :linenos:
+
+Unlike the :ref:`dnf5 plugins tutorial`, plugins are part of the same domain
+as the core DNF5 functionality. Individual plugins are optionally included
+in the binary using created macro expressions in the spec file:
+
+.. code-block:: spec
+
+    # ========== build options ==========
+    ...
+    %bcond_without plugin_template
+    ...
+    # ========== unpack, build, check & install ==========
+    ...
+    %build
+    %cmake \
+        ...
+        -DWITH_PLUGIN_TEMPLATE=%{?with_plugin_template:ON}%{!?with_plugin_template:OFF} \
+        ...
+
+Define the connected CMake option in the ``dnf5/CMakeLists.txt`` file:
+
+.. code-block:: cmake
+
+    option(WITH_PLUGIN_TEMPLATE "Build a DNF5 template plugin" ON)
+
+This sets up the default behavior to include the plugin in the build.
+
+Include the newly created plugin in the ``CMakeLists.txt`` parent file inside
+``libdnf5-plugins``: ``add_subdirectory("template")``.
+
+Delivering to the User
+----------------------
+
+Each plugin requires a mandatory configuration file where we need to define the plugin's name
+and specify when to enable it during runtime. Options include:
+
+* ``NO``: Plugin is disabled.
+* ``YES``: Plugin is enabled.
+* ``HOST_ONLY``: Plugin is enabled only in configurations without installroot.
+* ``INSTALLROOT_ONLY``: Plugin is enabled only in configurations with installroot.
+
+Additional optional configuration options and sections can be defined and then accessed from
+the plugin implementation. Here's an example configuration file:
+
+.. literalinclude:: ../../templates/libdnf5-plugin/template.conf
+    :language: cfg
+    :linenos:
+
+In the :ref:`libdnf5 plugins tutorial`, each plugin is delivered in a separate
+package. Include a new section in the spec file for this purpose:
+
+.. code-block:: spec
+
+    # ========== libdnf5-plugin-template ==========
+
+    %if %{with plugin_template}
+    %package -n libdnf5-plugin-template
+    Summary:        Libdnf5 template plugin
+    License:        LGPL-2.1-or-later
+    Requires:       libdnf5%{?_isa} = %{version}-%{release}
+
+    %description -n libdnf5-plugin-template
+    Include a more descriptive message about your plugin here.
+
+    %files -n libdnf5-plugin-template
+    %{_libdir}/libdnf5/plugins/template.*
+    %config %{_sysconfdir}/dnf/libdnf5-plugins/template.conf
+    %endif
+
+Consider including a documentation man page describing your plugin's functionality.
+Ensure that you complete all the following steps:
+
+* ``doc/libdnf5_plugins/template.8.rst``: Add a new man page for your plugin with the respective name.
+* ``doc/libdnf5_plugins/index.rst``: Add a reference to the new plugin to the LIBDNF5 plugins page.
+* ``doc/CMakeLists.txt`` and ``doc/conf.py.in``: Integrate with Sphinx documentation.
+* ``dnf5.spec``: Include the new man page in your newly created package.

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -44,6 +44,7 @@ struct Version {
     std::uint16_t micro;
 };
 
+/// @brief A base class for implementing LIBDNF5 plugins that introduce additional logic into the library using hooks.
 class IPlugin {
 public:
     IPlugin(Base & base) : base(&base) {}


### PR DESCRIPTION
Documentation updates cover the following aspects:

- DNF5 and LIBDNF5 plugins
- Example template codes
- Purpose of plugins
- Deployment description

Closes #287.