### PR TITLE
Support skip-broken option for the upgrade command

### DIFF
--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -38,7 +38,6 @@ void GroupUpgradeCommand::set_argument_parser() {
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
 
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
-    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
 }
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -172,6 +172,10 @@ Upgrade command
  * When any argument does not match any package or it is not installed, DNF5 fail. The behavior can be modified by
    the ``--skip-unavailable`` option.
  * Dropped upgrade command aliases ``upgrade-to`` and ``localupdate``.
+ * Dropped ``--skip-broken`` option, as it was already available in DNF4 only for compatibility reasons with YUM,
+   but it has no effect. Instead, the decision about selecting the newer version of a package into the transaction
+   and skipping possible dependency issues is based on the :ref:`best <best_option_ref-label>` or
+   :ref:`no-best <no_best_option_ref-label>` option.
 
 Updateinfo command
 ------------------

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -47,6 +47,9 @@ Options
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
 
 Examples
 ========

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -44,6 +44,9 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
 
 Examples
 ========

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -42,6 +42,9 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
 
 Examples
 ========

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -45,6 +45,9 @@ Options
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
 
 Examples
 ========

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -102,6 +102,9 @@ Options
 ``--contains-pkgs``
     | Show only groups containing packages with specified names. List option, supports globs.
 
+``--skip-broken``
+    | Used with ``install`` command to resolve any dependency problems by removing packages that are causing problems from the transaction.
+
 
 Examples
 ========

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -105,6 +105,9 @@ Options
 ``--skip-broken``
     | Used with ``install`` command to resolve any dependency problems by removing packages that are causing problems from the transaction.
 
+``--skip-unavailable``
+    | Used with ``install`` and ``upgrade`` to allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
 
 Examples
 ========

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -42,6 +42,9 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
 ``--advisories=ADVISORY_NAME,...``
     | Consider only content contained in advisories with specified name.
     | This is a list option.

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -45,6 +45,9 @@ Options
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
 ``--advisories=ADVISORY_NAME,...``
     | Consider only content contained in advisories with specified name.
     | This is a list option.

--- a/doc/commands/mark.8.rst
+++ b/doc/commands/mark.8.rst
@@ -68,6 +68,13 @@ Subcommands
     is desired to be protected and handled as a group member like during ``group remove`` command.
 
 
+Options
+=======
+
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
+
 Examples
 ========
 

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -35,6 +35,13 @@ The ``reinstall`` command in ``DNF5`` is used for reinstalling packages defined 
 ``package-spec`` arguments.
 
 
+Options
+=======
+
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
+
 Examples
 ========
 

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -38,8 +38,14 @@ The ``reinstall`` command in ``DNF5`` is used for reinstalling packages defined 
 Options
 =======
 
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
 
 
 Examples

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -45,6 +45,9 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--skip-unavailable``
+    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+
 ``--advisories=ADVISORY_NAME,...``
     | Consider only content contained in advisories with specified name.
     | This is a list option.

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -263,9 +263,6 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--show-new-leaves``
     | Show newly installed leaf packages and packages that became leaves after a transaction.
 
-``--skip-broken``
-    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
-
 ``-y, --assumeyes``
     | Automatically answer yes for all questions.
 

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -142,6 +142,8 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--assumeno``
     | Automatically answer no for all questions.
 
+.. _best_option_ref-label:
+
 ``--best``
     | Try the best available package versions in transactions.
 
@@ -210,6 +212,8 @@ Following options are applicable in the general context for any ``dnf5`` command
     | Setup installroot path.
     | Absolute path is required.
     | :ref:`See <installroot_misc_ref-label>` :manpage:`dnf5-installroot(7)` for more info.
+
+.. _no_best_option_ref-label:
 
 ``--no-best``
     | Do not limit the transaction to the best candidates only.


### PR DESCRIPTION
- Document dropped support of the `--skip-broken` option from the `upgrade` command
- Exclude the `--skip-broken` option from the global options documentation, restricting only to related commands
- Add missing man pages documentation for options related to resolving missing dependencies

Closes #1033.