### PR TITLE
transaction: Fix reporting spec matches only source

### DIFF
--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -225,7 +225,7 @@ GoalProblem Transaction::Impl::report_not_found(
         }
         return GoalProblem::NOT_FOUND;
     }
-    query.filter_repo_id({"src", "nosrc"}, sack::QueryCmp::NEQ);
+    query.filter_arch({"src", "nosrc"}, sack::QueryCmp::NEQ);
     if (query.empty()) {
         add_resolve_log(
             action,


### PR DESCRIPTION
Correctly report "Argument matches only source packages." in case user
tries to install a source rpm.
Current code misleadingly reports "Argument matches only excluded
packages."