### PR TITLE
Check serialized temporary files memory is non-empty

### DIFF
--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -882,7 +882,7 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
         auto keepcache = config.get_keepcache_option().get_value();
         auto any_inbound_action_present = contains_any_inbound_package(packages);
         if (!keepcache && any_inbound_action_present) {
-            libdnf5::repo::TempFilesMemory temp_files_memory(config.get_cachedir_option().get_value());
+            libdnf5::repo::TempFilesMemory temp_files_memory(base, config.get_cachedir_option().get_value());
             auto temp_files = temp_files_memory.get_files();
             for (auto & file : temp_files) {
                 try {

--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -209,7 +209,7 @@ void PackageDownloader::download() try {
             });
 
         auto & cachedir = config.get_cachedir_option().get_value();
-        TempFilesMemory temp_files_memory(cachedir);
+        TempFilesMemory temp_files_memory(p_impl->base, cachedir);
         temp_files_memory.add_files(package_paths);
     }
 

--- a/libdnf5/repo/temp_files_memory.hpp
+++ b/libdnf5/repo/temp_files_memory.hpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_TEMP_FILES_MEMORY_HPP
 #define LIBDNF5_REPO_TEMP_FILES_MEMORY_HPP
 
+#include "libdnf5/base/base_weak.hpp"
+
 #include <filesystem>
 #include <vector>
 
@@ -38,10 +40,11 @@ public:
     static constexpr const char * FILE_PATHS_TOML_KEY = "files";
 
     /// @brief Create the object for managing temporary files' paths.
+    /// @param base       A weak pointer to Base object.
     /// @param parent_dir Path to a directory where the memory file is or will be stored.
     ///                   If the directory doesn't exist yet, it will be created.
     /// @exception std::filesystem::filesystem_error When an error occurs during creating the parent directory.
-    TempFilesMemory(const std::string & parent_dir);
+    TempFilesMemory(const BaseWeakPtr & base, const std::string & parent_dir);
     ~TempFilesMemory();
 
     /// @brief Retrieve stored paths of temporary files.
@@ -64,6 +67,7 @@ public:
     void clear();
 
 private:
+    BaseWeakPtr base;
     std::filesystem::path full_memory_path;
 };
 

--- a/test/libdnf5/repo/test_package_downloader.cpp
+++ b/test/libdnf5/repo/test_package_downloader.cpp
@@ -107,7 +107,7 @@ void PackageDownloaderTest::test_package_downloader_temp_files_memory() {
     config.get_keepcache_option().set(false);
 
     auto & cachedir = config.get_cachedir_option().get_value();
-    libdnf5::repo::TempFilesMemory memory(cachedir);
+    libdnf5::repo::TempFilesMemory memory(base.get_weak_ptr(), cachedir);
 
     // check memory is empty before downloading
     CPPUNIT_ASSERT_EQUAL((size_t)0, memory.get_files().size());

--- a/test/libdnf5/repo/test_temp_files_memory.cpp
+++ b/test/libdnf5/repo/test_temp_files_memory.cpp
@@ -79,6 +79,17 @@ void TempFilesMemoryTest::test_add_files_when_empty_storage() {
     CPPUNIT_ASSERT_EQUAL(new_paths, memory.get_files());
 }
 
+void TempFilesMemoryTest::test_add_no_files_when_empty_storage() {
+    // make sure that adding an empty vector will not cause crashing
+
+    TempFilesMemory memory(base.get_weak_ptr(), parent_dir_path);
+    CPPUNIT_ASSERT(memory.get_files().empty());
+
+    std::vector<std::string> empty_paths = {};
+    memory.add_files(empty_paths);
+    CPPUNIT_ASSERT(memory.get_files().empty());
+}
+
 void TempFilesMemoryTest::test_add_files_when_existing_storage() {
     std::vector<std::string> new_paths = {"path3", "path4"};
     libdnf5::utils::fs::File(full_path, "w")

--- a/test/libdnf5/repo/test_temp_files_memory.hpp
+++ b/test/libdnf5/repo/test_temp_files_memory.hpp
@@ -34,6 +34,7 @@ class TempFilesMemoryTest : public BaseTestCase {
     CPPUNIT_TEST(test_get_files_throws_exception_when_invalid_format);
     CPPUNIT_TEST(test_get_files_returns_stored_values);
     CPPUNIT_TEST(test_add_files_when_empty_storage);
+    CPPUNIT_TEST(test_add_no_files_when_empty_storage);
     CPPUNIT_TEST(test_add_files_when_existing_storage);
     CPPUNIT_TEST(test_add_files_deduplicates_and_sorts_data);
     CPPUNIT_TEST(test_clear_deletes_storage_content);
@@ -48,6 +49,7 @@ public:
     void test_get_files_throws_exception_when_invalid_format();
     void test_get_files_returns_stored_values();
     void test_add_files_when_empty_storage();
+    void test_add_no_files_when_empty_storage();
     void test_add_files_when_existing_storage();
     void test_add_files_deduplicates_and_sorts_data();
     void test_clear_deletes_storage_content();

--- a/test/libdnf5/repo/test_temp_files_memory.hpp
+++ b/test/libdnf5/repo/test_temp_files_memory.hpp
@@ -20,15 +20,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_TEST_REPO_TEMP_FILES_MEMORY_HPP
 #define LIBDNF5_TEST_REPO_TEMP_FILES_MEMORY_HPP
 
-#include "utils/fs/temp.hpp"
+#include "../shared/base_test_case.hpp"
 
-#include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 
 #include <filesystem>
 
 
-class TempFilesMemoryTest : public CppUnit::TestCase {
+class TempFilesMemoryTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(TempFilesMemoryTest);
     CPPUNIT_TEST(test_directory_is_created_when_not_exists);
     CPPUNIT_TEST(test_get_files_when_empty_storage);
@@ -43,7 +42,6 @@ class TempFilesMemoryTest : public CppUnit::TestCase {
 
 public:
     void setUp() override;
-    void tearDown() override;
 
     void test_directory_is_created_when_not_exists();
     void test_get_files_when_empty_storage();
@@ -56,7 +54,6 @@ public:
     void test_clear_when_empty_storage();
 
 private:
-    std::unique_ptr<libdnf5::utils::fs::TempDir> temp_dir;
     std::filesystem::path parent_dir_path;
     std::filesystem::path full_path;
 };


### PR DESCRIPTION
Based on the https://github.com/rpm-software-management/dnf5/issues/1001, adding a check after the toml serialization of temporary files memory to make sure the result is not an empty file. Such a file would not be parsable when loading from the disk afterwards.

Closes #1001.