### PR TITLE
needs-restarting: Add microcode_ctl to a reboot list

### DIFF
--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -2839,6 +2839,7 @@ static const std::unordered_set<std::string> CORE_PACKAGE_NAMES = {
     "kernel-smp",
     "kernel-xen",
     "linux-firmware",
+    "microcode_ctl",
     "dbus",
     "glibc",
     "hal",


### PR DESCRIPTION
To fully update CPU microcode, a reboot is needed because the microcode update should be applied before starting a kernel and other process.

Therefore recommend a reboot after installing or updating microcode_ctl package.

https://issues.redhat.com/browse/RHEL-4600