### PR TITLE
Modify installonly filter

### DIFF
--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -2825,7 +2825,7 @@ void PackageQuery::filter_extras(const bool exact_evr) {
 void PackageQuery::filter_installonly() {
     auto & cfg_main = p_impl->base->get_config();
     const auto & installonly_packages = cfg_main.get_installonlypkgs_option().get_value();
-    filter_provides(installonly_packages, libdnf5::sack::QueryCmp::GLOB);
+    filter_provides(installonly_packages, libdnf5::sack::QueryCmp::EQ);
 }
 
 static const std::unordered_set<std::string> CORE_PACKAGE_NAMES = {


### PR DESCRIPTION
Libsolv is unable to match globs in installonly set `job multiversion provides kernel*` will not mach with anything.

The `Query::filter_installonly() should provide the same behavior therefore query filter must not support globs.