### PR TITLE
Sharing root cache with users

### DIFF
--- a/common/utils/auth.cpp
+++ b/common/utils/auth.cpp
@@ -17,19 +17,14 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DNF5_UTILS_HPP
-#define DNF5_UTILS_HPP
+#include "auth.hpp"
 
-#include <libdnf5/base/goal.hpp>
-#include <sys/types.h>
+#include <unistd.h>
 
-#include <string>
+namespace libdnf5::utils {
 
-namespace dnf5 {
+bool am_i_root() noexcept {
+    return geteuid() == 0;
+}
 
-/// Returns "true" if program runs with effective user ID = 0
-bool am_i_root() noexcept;
-
-}  // namespace dnf5
-
-#endif
+}  // namespace libdnf5::utils

--- a/common/utils/auth.hpp
+++ b/common/utils/auth.hpp
@@ -17,15 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "utils.hpp"
+#ifndef LIBDNF5_UTILS_AUTH_HPP
+#define LIBDNF5_UTILS_AUTH_HPP
 
-#include <libdnf5/common/proc.hpp>
-#include <unistd.h>
 
-namespace dnf5 {
+namespace libdnf5::utils {
 
-bool am_i_root() noexcept {
-    return geteuid() == 0;
-}
+/// Returns "true" if program runs with effective user ID = 0
+bool am_i_root() noexcept;
 
-}  // namespace dnf5
+}  // namespace libdnf5::utils
+
+#endif

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "download_callbacks.hpp"
 #include "plugins.hpp"
-#include "utils.hpp"
 #include "utils/url.hpp"
 
 #include <fmt/format.h>

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -47,7 +47,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "dnf5/context.hpp"
 #include "download_callbacks.hpp"
 #include "plugins.hpp"
-#include "utils.hpp"
 
 #include <fcntl.h>
 #include <fmt/format.h>

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -382,6 +382,11 @@ private:
     /// Depending on the result, the repository may be marked as expired.
     void recompute_expired();
 
+    /// @brief  Clones repodata and solv files from the root cache. The original user repository cache is deleted.
+    ///         The intended use case is for cloning the root cache when the user one is invalid or empty.
+    /// @return Whether at least the repodata cache cloning was successful.
+    bool clone_root_metadata();
+
     libdnf5::BaseWeakPtr base;
     ConfigRepo config;
 

--- a/libdnf5/repo/solv_repo.cpp
+++ b/libdnf5/repo/solv_repo.cpp
@@ -585,6 +585,10 @@ void SolvRepo::write_main(bool load_after_write) {
         }
     }
 
+    std::filesystem::permissions(
+        cache_tmp_file.get_path(),
+        std::filesystem::perms::group_read | std::filesystem::perms::others_read,
+        std::filesystem::perm_options::add);
     std::filesystem::rename(cache_tmp_file.get_path(), solvfile_path);
     cache_tmp_file.release();
 }
@@ -668,6 +672,10 @@ void SolvRepo::write_ext(Id repodata_id, RepodataType type) {
         data->state = REPODATA_AVAILABLE;
     }
 
+    std::filesystem::permissions(
+        cache_tmp_file.get_path(),
+        std::filesystem::perms::group_read | std::filesystem::perms::others_read,
+        std::filesystem::perm_options::add);
     std::filesystem::rename(cache_tmp_file.get_path(), solvfile_path);
     cache_tmp_file.release();
 }


### PR DESCRIPTION
When preparing repositories within `repo_sack`, check for empty or invalid repository metadata. If either condition is met, attempt to clone the root metadata cache, if available.

Solver cache files use the `mkstemp` method and are only readable by the owner. Read attributes have been added to these files.

The packages cache is ignored. It is expected that superuser privileges will be required for any command manipulating packages on the system (see #849 or #337).

Additional notes:

- Copy-on-write functionality is automatically utilized by the filesystem when a copy operation is performed on a filesystem that supports it, such as Btrfs (the default in Fedora).
- For repodata, the default cache location is `/var/cache`, where read permissions are granted to non-owners. However, if a custom directory is specified without read permissions, they are not currently applied to the files. This can be addressed similarly to how it has been implemented for solv files in this PR (see also [#789](https://github.com/rpm-software-management/dnf5/issues/789)).

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1414.
Closes #1000.