### PR TITLE
Throw an error on invalid repo input for `setopt` and `*repo` options

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1060,6 +1060,11 @@ int main(int argc, char * argv[]) try {
             repo_sack->create_repos_from_system_configuration();
             any_repos_from_system_configuration = repo_sack->size() > 0;
 
+            auto vars = base.get_vars();
+            for (auto & id_path_pair : context.repos_from_path) {
+                id_path_pair.first = vars->substitute(id_path_pair.first);
+                id_path_pair.second = vars->substitute(id_path_pair.second);
+            }
             repo_sack->create_repos_from_paths(context.repos_from_path, libdnf5::Option::Priority::COMMANDLINE);
             for (const auto & [id, path] : context.repos_from_path) {
                 context.setopts.emplace_back(id + ".enabled", "1");

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -79,6 +79,11 @@ The functionality is now split to two config options - ``skip_broken`` for the u
 corresponding command line options ``--skip-broken`` and ``--skip-unavailable`` for commands where it makes sense.
 
 
+Global options
+--------------
+* Options ``--disable-repo=REPO_ID`` and ``--setopt=[REPO_ID.]OPTION=VALUE`` now always cause an error when provided with invalid ``REPO_ID``.
+  This makes them consistent with ``--repo=REPO_ID`` and ``--enable-repo=REPO_ID``. The ``strict`` configuration option is no longer taken into account.
+
 Alias command
 -------------
 * Dropped. The command is replaced by a different functionality, see

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -601,13 +601,11 @@ void RepoSack::create_repos_from_reposdir() {
 
 void RepoSack::create_repos_from_paths(
     const std::vector<std::pair<std::string, std::string>> & repos_paths, libdnf5::Option::Priority priority) {
-    auto vars = base->get_vars();
     for (const auto & [id, path] : repos_paths) {
-        auto repo_id = vars->substitute(id);
-        auto new_repo = create_repo(repo_id);
+        auto new_repo = create_repo(id);
         auto & new_repo_config = new_repo->get_config();
-        new_repo_config.get_name_option().set(priority, repo_id);
-        new_repo_config.get_baseurl_option().set(priority, {vars->substitute(path)});
+        new_repo_config.get_name_option().set(priority, id);
+        new_repo_config.get_baseurl_option().set(priority, path);
     }
 }
 


### PR DESCRIPTION
Options `--setopt`, `--enable-repo`, `--disable-repo` and `--repo` will not accept repo-id vaule that doesn't match any configured repository.

This is different to dnf4 where only `--repo` and `--enablerepo` throw an error on invalid repo id. `--disablerepo` just shows a warning and `--setopt` doesn't show any problem.

Closes: https://github.com/rpm-software-management/dnf5/issues/1082