### PR TITLE
Fix Clang compilation error

### DIFF
--- a/include/libdnf5-cli/output/provides.hpp
+++ b/include/libdnf5-cli/output/provides.hpp
@@ -31,7 +31,7 @@ namespace libdnf5::cli::output {
 
 enum ProvidesMatchedBy : int { NO_MATCH = 0, PROVIDES = 1, FILENAME = 2, BINARY = 3 };
 
-static void add_line_into_provides_table(struct libscols_table * table, const char * key, const char * value) {
+static inline void add_line_into_provides_table(struct libscols_table * table, const char * key, const char * value) {
     struct libscols_line * ln = scols_table_new_line(table, nullptr);
     scols_line_set_data(ln, 0, key);
     scols_line_set_data(ln, 1, value);


### PR DESCRIPTION
fixes the error:
```
dnf5/include/libdnf5-cli/output/provides.hpp:34:13: error: 'static' function 'add_line_into_provides_tab le' declared in header file should be declared 'static inline' [-Werror,-Wunneeded-internal-declaration]
   34 | static void add_line_into_provides_table(struct libscols_table * table, const char * key, const char * value)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
