### PR TITLE
dnf5: bash-completion: Use Command substitution instead of Process subst

### DIFF
--- a/dnf5/bash-completion/dnf5
+++ b/dnf5/bash-completion/dnf5
@@ -4,7 +4,7 @@ _do_dnf5_completion()
 {
     local words=() cword
     __reassemble_comp_words_by_ref "><=;|&(:" words cword
-    mapfile -t COMPREPLY < <($1 "--complete=${cword}" "${words[@]}")
+    mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
 }
 
 complete -F _do_dnf5_completion -o nosort -o nospace dnf5


### PR DESCRIPTION
The original version used "Process Substitution". dnf5 was run in another process and the output was referenced by filename (usually /dev/fd/63). That tends to be a problem in the chroot.

The new version uses "Command Substitution". dnf5 is run and its output is passed using "Here Strings".

The patch resolves the issue:
`dnf5 bash: /dev/fd/63: No such file or directory`