### PR TITLE
state: Fix catching fs exception

### DIFF
--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -716,6 +716,8 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
             base->p_impl->get_system_state().save();
         } catch (const FileSystemError & ex) {
             logger->error("Cannot save system state: {}", ex.what());
+        } catch (const std::filesystem::filesystem_error & ex) {
+            logger->error("Cannot save system state: {}", ex.what());
         }
     }
 

--- a/libdnf5/system/state.cpp
+++ b/libdnf5/system/state.cpp
@@ -603,6 +603,7 @@ void State::reset_packages_states(
         save();
     } catch (const FileSystemError & e) {
         // TODO(mblaha) - log this? (will need access to the base)
+    } catch (const std::filesystem::filesystem_error & e) {
     }
 }
 


### PR DESCRIPTION
This is just a quick fix for #1080. But I believe a better way is needed, like wrapping the `create_directories` and throwing our `FileSystemError` exception. Also a CI test should be provided.

Closes #1080.