### PR TITLE
builddep: Don't try to expand globs in pkg specs

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -219,18 +219,6 @@ bool BuildDepCommand::add_from_pkg(
     }
 }
 
-std::string escape_glob(const std::string & in) {
-    // Escape fnmatch glob characters in a string
-    std::string out;
-    for (const auto ch : in) {
-        if (ch == '*' || ch == '?' || ch == '[' || ch == ']' || ch == '\\') {
-            out += '\\';
-        }
-        out += ch;
-    }
-    return out;
-}
-
 void BuildDepCommand::run() {
     // get build dependencies from various inputs
     std::set<std::string> install_specs{};
@@ -281,7 +269,7 @@ void BuildDepCommand::run() {
     // Don't expand globs in pkg specs. The special characters in a pkg spec
     // such as the brackets in `python3dist(build[virtualenv])`, should be
     // treated as literal.
-    settings.expand_globs = false;
+    settings.set_expand_globs(false);
 
     for (const auto & spec : install_specs) {
         if (libdnf5::rpm::Reldep::is_rich_dependency(spec)) {
@@ -291,13 +279,7 @@ void BuildDepCommand::run() {
             // we do not download filelists and some files could be explicitly mentioned in provide section. The best
             // solution would be to merge result of provide and file search to prevent problems caused by modification
             // during distro lifecycle.
-
-            // TODO(egoode) once we have a setting to disable expanding globs
-            // in resolve_pkg_spec, escaping the glob characters will no longer
-            // be needed:
-            // https://github.com/rpm-software-management/dnf5/pull/1085
-            const auto & escaped_spec = escape_glob(spec);
-            goal->add_rpm_install(escaped_spec, settings);
+            goal->add_rpm_install(spec, settings);
         }
     }
 

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -192,6 +192,7 @@ bool BuildDepCommand::add_from_pkg(
     settings.set_with_provides(false);
     settings.set_with_filenames(false);
     settings.set_with_binaries(false);
+    settings.set_expand_globs(false);
     pkg_query.resolve_pkg_spec(pkg_spec, settings, false);
 
     std::vector<std::string> source_names{pkg_spec};
@@ -276,6 +277,11 @@ void BuildDepCommand::run() {
     libdnf5::GoalJobSettings settings;
     settings.set_with_nevra(false);
     settings.set_with_binaries(false);
+
+    // Don't expand globs in pkg specs. The special characters in a pkg spec
+    // such as the brackets in `python3dist(build[virtualenv])`, should be
+    // treated as literal.
+    settings.expand_globs = false;
 
     for (const auto & spec : install_specs) {
         if (libdnf5::rpm::Reldep::is_rich_dependency(spec)) {

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -193,6 +193,13 @@ public:
     void set_with_binaries(bool with_binaries);
     bool get_with_binaries() const;
 
+    /// Set whether to expand globs in package specs using fnmatch
+    ///
+    /// Default: true
+    void set_expand_globs(bool expand_globs);
+    bool get_expand_globs() const;
+
+
     /// When matching packages' nevras is enabled specify allowed nevra forms.
     ///
     /// The default can be obtained from libdnf5::rpm::Nevra::get_default_pkg_spec_forms().

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -199,7 +199,6 @@ public:
     void set_expand_globs(bool expand_globs);
     bool get_expand_globs() const;
 
-
     /// When matching packages' nevras is enabled specify allowed nevra forms.
     ///
     /// The default can be obtained from libdnf5::rpm::Nevra::get_default_pkg_spec_forms().

--- a/libdnf5/base/goal_elements.cpp
+++ b/libdnf5/base/goal_elements.cpp
@@ -31,6 +31,7 @@ class ResolveSpecSettings::Impl {
     bool with_provides{true};
     bool with_filenames{true};
     bool with_binaries{true};
+    bool expand_globs{true};
     bool group_with_id{true};
     bool group_with_name{false};
     bool group_search_groups{true};

--- a/libdnf5/base/goal_elements.cpp
+++ b/libdnf5/base/goal_elements.cpp
@@ -93,6 +93,13 @@ bool ResolveSpecSettings::get_with_binaries() const {
     return p_impl->with_binaries;
 }
 
+void ResolveSpecSettings::set_expand_globs(bool expand_globs) {
+    p_impl->expand_globs = expand_globs;
+}
+bool ResolveSpecSettings::get_expand_globs() const {
+    return p_impl->expand_globs;
+}
+
 void ResolveSpecSettings::set_nevra_forms(std::vector<libdnf5::rpm::Nevra::Form> nevra_forms) {
     p_impl->nevra_forms = std::move(nevra_forms);
 }

--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -2588,7 +2588,7 @@ std::pair<bool, libdnf5::rpm::Nevra> PackageQuery::resolve_pkg_spec(
 
     libdnf5::solv::SolvMap filter_result(pool.get_nsolvables());
 
-    bool glob = settings.expand_globs && libdnf5::utils::is_glob_pattern(pkg_spec.c_str());
+    bool glob = settings.get_expand_globs() && libdnf5::utils::is_glob_pattern(pkg_spec.c_str());
     libdnf5::sack::QueryCmp cmp = glob ? libdnf5::sack::QueryCmp::GLOB : libdnf5::sack::QueryCmp::EQ;
     if (settings.get_with_nevra()) {
         const std::vector<Nevra::Form> & test_forms =

--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -2588,7 +2588,7 @@ std::pair<bool, libdnf5::rpm::Nevra> PackageQuery::resolve_pkg_spec(
 
     libdnf5::solv::SolvMap filter_result(pool.get_nsolvables());
 
-    bool glob = libdnf5::utils::is_glob_pattern(pkg_spec.c_str());
+    bool glob = settings.expand_globs && libdnf5::utils::is_glob_pattern(pkg_spec.c_str());
     libdnf5::sack::QueryCmp cmp = glob ? libdnf5::sack::QueryCmp::GLOB : libdnf5::sack::QueryCmp::EQ;
     if (settings.get_with_nevra()) {
         const std::vector<Nevra::Form> & test_forms =


### PR DESCRIPTION
This commit makes a breaking change adding `expand_globs` setting to the `ResolveSpecSetting`.

Related: https://github.com/rpm-software-management/mock/issues/1267
Resolves https://github.com/rpm-software-management/dnf5/issues/1084

Are there any other places where the `expand_globs` setting should be `false`? Or maybe `false` should be the default and the commands that accept pkg specs on the command line should set it to `true` themselves?

WIP since a ci-dnf-stack PR is still on the way.