### PR TITLE
Argument parser: support repeated positional args, use p_impl, no inline methods

### DIFF
--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -159,26 +159,34 @@ public:
 
     class Group {
     public:
+        Group() = delete;
+        Group(const Group &) = delete;
+        Group(Group &&) = delete;
+        Group & operator=(const Group &) = delete;
+        Group & operator=(Group &&) = delete;
+
+        ~Group();
+
         /// Sets group header.
-        void set_header(std::string header) noexcept { this->header = std::move(header); }
+        void set_header(std::string header) noexcept;
 
         /// Gets group id.
-        const std::string & get_id() const noexcept { return id; }
+        const std::string & get_id() const noexcept;
 
         /// Gets group header.
-        const std::string & get_header() const noexcept { return header; }
+        const std::string & get_header() const noexcept;
 
         /// Registers an argument to the group.
         /// An exception is thrown when an argument with the same ID is already registered.
         void register_argument(Argument * arg);
 
         /// Gets a list of registered arguments.
-        const std::vector<Argument *> & get_arguments() const noexcept { return arguments; }
+        const std::vector<Argument *> & get_arguments() const noexcept;
 
     private:
         friend class ArgumentParser;
 
-        Group(const std::string & id) : id(id) {}
+        Group(const std::string & id);
 
         std::string id;
         std::string header;
@@ -187,21 +195,23 @@ public:
 
     class Argument {
     public:
+        Argument() = delete;
         Argument(const Argument &) = delete;
         Argument(Argument &&) = delete;
         Argument & operator=(const Argument &) = delete;
         Argument & operator=(Argument &&) = delete;
-        virtual ~Argument() = default;
+
+        virtual ~Argument();
 
         /// Sets a long description of the argument.
-        void set_long_description(std::string descr) noexcept { long_description = std::move(descr); }
+        void set_long_description(std::string descr) noexcept;
 
         /// Sets a brief description of the argument.
-        void set_description(std::string descr) noexcept { description = std::move(descr); }
+        void set_description(std::string descr) noexcept;
 
         /// Passes a list of arguments that cannot be used with this argument.
         /// Can contain this argument. Groups of conflicting argument can be used.
-        void set_conflict_arguments(std::vector<Argument *> * args) noexcept { conflict_args = args; }
+        void set_conflict_arguments(std::vector<Argument *> * args) noexcept;
 
         /// Adds a conflicting argument. Also adds reverse conflict.
         void add_conflict_argument(Argument & conflict_arg);
@@ -210,44 +220,44 @@ public:
         void add_conflict_arguments_from_another(Argument & src_arg);
 
         /// Gets argument id.
-        const std::string & get_id() const noexcept { return id; }
+        const std::string & get_id() const noexcept;
 
         /// Gets a long description of the argument.
-        const std::string & get_long_description() const { return long_description; }
+        const std::string & get_long_description() const;
 
         /// Gets a brief description of the argument.
-        const std::string & get_description() const { return description; }
+        const std::string & get_description() const;
 
         /// Returns a list of arguments that cannot be used with this argument or nullptr.
-        std::vector<Argument *> * get_conflict_arguments() noexcept { return conflict_args; }
+        std::vector<Argument *> * get_conflict_arguments() noexcept;
 
         /// Gets the number of times the argument was used during analysis.
         /// Can be used to determine how many times the argument has been used on the command line.
-        int get_parse_count() const noexcept { return parse_count; }
+        int get_parse_count() const noexcept;
 
         /// Set the number of times the argument was used during analysis count to 0.
-        void reset_parse_count() noexcept { parse_count = 0; }
+        void reset_parse_count() noexcept;
 
         /// Tests input for arguments that cannot be used with this argument.
         /// Returns the first conflicting argument or nullptr.
         Argument * get_conflict_argument() const noexcept;
 
         /// Sets whether the argument participates in completion.
-        void set_complete(bool complete) noexcept { this->complete = complete; }
+        void set_complete(bool complete) noexcept;
 
         /// Returns whether the argument participates in completion.
-        bool get_complete() const noexcept { return complete; }
+        bool get_complete() const noexcept;
 
-        virtual void help() const noexcept {}
+        virtual void help() const noexcept;
 
         // Returns the ArgumentParser instance to which the argument belongs.
-        ArgumentParser & get_argument_parser() const noexcept { return owner; }
+        ArgumentParser & get_argument_parser() const noexcept;
 
         /// Sets a pointer to user data in the argument.
-        void set_user_data(ArgumentParserUserData * user_data) noexcept { this->user_data = user_data; }
+        void set_user_data(ArgumentParserUserData * user_data) noexcept;
 
         /// Gets a pointer to the user data attached to the argument.
-        ArgumentParserUserData * get_user_data() const noexcept { return user_data; }
+        ArgumentParserUserData * get_user_data() const noexcept;
 
     private:
         friend class ArgumentParser;
@@ -273,9 +283,17 @@ public:
         using ParseHookFunc = std::function<bool(PositionalArg * arg, int argc, const char * const argv[])>;
         using CompleteHookFunc = std::function<std::vector<std::string>(const char * arg_to_complete)>;
 
+        PositionalArg() = delete;
+        PositionalArg(const PositionalArg &) = delete;
+        PositionalArg(PositionalArg &&) = delete;
+        PositionalArg & operator=(const PositionalArg &) = delete;
+        PositionalArg & operator=(PositionalArg &&) = delete;
+
+        ~PositionalArg() override;
+
         /// Gets the number of values required by this argument on the command line.
         /// May return special values: OPTIONAL, UNLIMITED, AT_LEAST_ONE
-        int get_nvals() const noexcept { return nvals; }
+        int get_nvals() const noexcept;
 
         /// Enables/disables storing parsed values.
         /// Values can be processed / stored in the user parse hook function.
@@ -283,31 +301,31 @@ public:
         void set_store_value(bool enable);
 
         /// Returns true if storing the parsed values is enabled.
-        bool get_store_value() const noexcept { return store_value; }
+        bool get_store_value() const noexcept;
 
         /// Gets list of values.
         /// Parsed values are stored there if if get_store_value() == true.
-        std::vector<std::unique_ptr<libdnf5::Option>> * get_linked_values() noexcept { return values; }
+        std::vector<std::unique_ptr<libdnf5::Option>> * get_linked_values() noexcept;
 
         /// Sets the user function for parsing the argument.
-        void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
+        void set_parse_hook_func(ParseHookFunc && func);
 
         /// Gets the user function for parsing the argument.
-        const ParseHookFunc & get_parse_hook_func() const noexcept { return parse_hook; }
+        const ParseHookFunc & get_parse_hook_func() const noexcept;
 
         /// Sets the user function to complete the argument.
-        void set_complete_hook_func(CompleteHookFunc && func) { complete_hook = std::move(func); }
+        void set_complete_hook_func(CompleteHookFunc && func);
 
         /// Gets the user function to complete the argument.
-        const CompleteHookFunc & get_complete_hook_func() const noexcept { return complete_hook; }
+        const CompleteHookFunc & get_complete_hook_func() const noexcept;
 
         /// Sets the required number of repetitions of this argument on the command line.
         /// The special values OPTIONAL, UNLIMITED, AT_LEAST_ONE can be used.
-        void set_nrepeats(int nrepeats) { this->nrepeats = nrepeats; }
+        void set_nrepeats(int nrepeats);
 
         /// Gets the required number of repetitions of this argument on the command line.
         /// May return special values: OPTIONAL, UNLIMITED, AT_LEAST_ONE
-        int get_nrepeats() const noexcept { return nrepeats; }
+        int get_nrepeats() const noexcept;
 
     private:
         friend class ArgumentParser;
@@ -338,62 +356,70 @@ public:
     public:
         using ParseHookFunc = std::function<bool(NamedArg * arg, const char * option, const char * value)>;
 
+        NamedArg() = delete;
+        NamedArg(const NamedArg &) = delete;
+        NamedArg(NamedArg &&) = delete;
+        NamedArg & operator=(const NamedArg &) = delete;
+        NamedArg & operator=(NamedArg &&) = delete;
+
+        ~NamedArg() override;
+
         /// Sets long name of argument. Long name is prefixed with two dashes on the command line (e.g. "--help").
-        void set_long_name(std::string long_name) noexcept { this->long_name = std::move(long_name); }
+        void set_long_name(std::string long_name) noexcept;
 
         /// Sets short name of argument. Short name is prefixed with one dash on the command line (e.g. "-h").
-        void set_short_name(char short_name) { this->short_name = short_name; }
+        void set_short_name(char short_name);
 
         /// Does the argument need a value on the command line?
-        void set_has_value(bool has_value) { this->has_value = has_value; }
+        void set_has_value(bool has_value);
 
         /// Links the value to the argument.
         /// Parsed value is stored there if if get_store_value() == true.
-        void link_value(libdnf5::Option * value) { this->value = value; }
+        void link_value(libdnf5::Option * value);
 
         /// Sets constant argument value.
         /// It is used for argument without value on command line (get_has_value() == false).
-        void set_const_value(std::string const_value) noexcept { const_val = std::move(const_value); }
+        void set_const_value(std::string const_value) noexcept;
 
         /// Gets long name of argument. Long name is prefixed with two dashes on the command line (e.g. "--help").
-        const std::string & get_long_name() const noexcept { return long_name; }
+        const std::string & get_long_name() const noexcept;
 
         /// Gets short name of argument. Short name is prefixed with one dash on the command line (e.g. "-h").
-        char get_short_name() const noexcept { return short_name; }
+        char get_short_name() const noexcept;
 
         /// Returns true if the argument need a value on the command line.
-        bool get_has_value() const noexcept { return has_value; }
+        bool get_has_value() const noexcept;
 
         /// Gets constant argument value.
         /// It is used for argument without value on command line (get_has_value() == false).
-        const std::string & get_const_value() const noexcept { return const_val; }
+        const std::string & get_const_value() const noexcept;
 
         /// Gets the value.
         /// Parsed value is stored there if if get_store_value() == true.
-        libdnf5::Option * get_linked_value() noexcept { return value; }
+        libdnf5::Option * get_linked_value() noexcept;
 
         /// Gets value.
         /// Parsed value is stored there if if get_store_value() == true.
-        const libdnf5::Option * get_linked_value() const noexcept { return value; }
+        const libdnf5::Option * get_linked_value() const noexcept;
 
         /// Enables/disables storing parsed values.
         /// Values can be processed / stored in the user parse hook function.
-        void set_store_value(bool enable) noexcept { store_value = enable; }
+        void set_store_value(bool enable) noexcept;
 
         /// Returns true if storing the parsed values is enabled.
-        bool get_store_value() const noexcept { return store_value; }
+        bool get_store_value() const noexcept;
 
         /// Sets the user function for parsing the argument.
-        void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
+        void set_parse_hook_func(ParseHookFunc && func);
 
         /// Gets the user function for parsing the argument.
-        const ParseHookFunc & get_parse_hook_func() const noexcept { return parse_hook; }
+        const ParseHookFunc & get_parse_hook_func() const noexcept;
 
         /// Sets help text for argument value.
-        void set_arg_value_help(std::string text) { arg_value_help = std::move(text); }
+        void set_arg_value_help(std::string text);
 
         /// Gets help text for argument value.
-        const std::string & get_arg_value_help() const noexcept { return arg_value_help; }
+        const std::string & get_arg_value_help() const noexcept;
 
         /// Create alias for this named arg. The alias is not shown in completion.
         /// The conflicting args of the alias are copied to match the current conflicting args of this named arg.
@@ -408,7 +434,7 @@ public:
     private:
         friend class ArgumentParser;
 
-        NamedArg(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
+        NamedArg(ArgumentParser & owner, const std::string & id);
 
         /// Parses long argument.
         /// Returns number of consumed arguments from the input.
@@ -440,8 +466,13 @@ public:
     public:
         using ParseHookFunc = std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])>;
 
-        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
-        virtual void parse(const char * option, int argc, const char * const argv[]) = 0;
+        Command() = delete;
+        Command(const Command &) = delete;
+        Command(Command &&) = delete;
+        Command & operator=(const Command &) = delete;
+        Command & operator=(Command &&) = delete;
+
+        ~Command() override;
 
         /// Registers (sub)command to the command.
         /// An exception is thrown when a command with the same ID is already registered.
@@ -491,31 +522,32 @@ public:
         /// Gets the user function for parsing the argument.
         virtual const ParseHookFunc & get_parse_hook_func() const noexcept = 0;
 
+        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
+        virtual void parse(const char * option, int argc, const char * const argv[]) = 0;
+
         /// Prints command help text.
         void help() const noexcept override;
 
         /// Sets the header of the subcommand table. Used to generate help.
-        void set_commands_help_header(std::string text) noexcept { commands_help_header = std::move(text); }
+        void set_commands_help_header(std::string text) noexcept;
 
         /// Sets the header of the named arguments table. Used to generate help.
-        void set_named_args_help_header(std::string text) noexcept { named_args_help_header = std::move(text); }
+        void set_named_args_help_header(std::string text) noexcept;
 
         /// Sets the header of the positional arguments table. Used to generate help.
-        void set_positional_args_help_header(std::string text) noexcept {
-            positional_args_help_header = std::move(text);
-        }
+        void set_positional_args_help_header(std::string text) noexcept;
 
         /// Gets the header of the subcommand table. Used to generate help.
-        const std::string & get_commands_help_header() const noexcept { return commands_help_header; }
+        const std::string & get_commands_help_header() const noexcept;
 
         /// Gets the header of the named arguments table. Used to generate help.
-        const std::string & get_named_args_help_header() const noexcept { return named_args_help_header; }
+        const std::string & get_named_args_help_header() const noexcept;
 
         /// Gets the header of the positional arguments table. Used to generate help.
-        const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header; }
+        const std::string & get_positional_args_help_header() const noexcept;
 
         /// Returns the pointer to the parent Command (as set by register_command()).
-        Command * get_parent() const noexcept { return parent; }
+        Command * get_parent() const noexcept;
 
         /// Gets the list of command-line arguments needed to invoke the command.
         /// Command aliases are resolved; so `get_invocation` for a
@@ -525,8 +557,10 @@ public:
     private:
         friend class ArgumentParser;
 
-        Command(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
+        Command(ArgumentParser & owner, const std::string & id);
 
+        // Prints a completed argument `arg` or a table with suggestions and help to complete
+        // if there is more than one solution.
         void print_complete(
             const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments);
 
@@ -538,8 +572,13 @@ public:
 
     class CommandOrdinary : public Command {
     public:
-        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
-        void parse(const char * option, int argc, const char * const argv[]) override;
+        CommandOrdinary() = delete;
+        CommandOrdinary(const CommandOrdinary &) = delete;
+        CommandOrdinary(CommandOrdinary &&) = delete;
+        CommandOrdinary & operator=(const CommandOrdinary &) = delete;
+        CommandOrdinary & operator=(CommandOrdinary &&) = delete;
+
+        ~CommandOrdinary() override;
 
         /// Registers (sub)command to the command.
         /// An exception is thrown when a command with the same ID is already registered.
@@ -556,16 +595,16 @@ public:
         void register_group(Group * grp) override;
 
         /// Gets a list of registered commands.
-        const std::vector<Command *> & get_commands() const noexcept override { return cmds; }
+        const std::vector<Command *> & get_commands() const noexcept override;
 
         /// Gets a list of registered named arguments.
-        const std::vector<NamedArg *> & get_named_args() const noexcept override { return named_args; }
+        const std::vector<NamedArg *> & get_named_args() const noexcept override;
 
         /// Gets a list of registered positional arguments.
-        const std::vector<PositionalArg *> & get_positional_args() const noexcept override { return pos_args; }
+        const std::vector<PositionalArg *> & get_positional_args() const noexcept override;
 
         /// Gets a list of registered groups.
-        const std::vector<Group *> & get_groups() const noexcept override { return groups; }
+        const std::vector<Group *> & get_groups() const noexcept override;
 
         /// Returns (sub)command with given ID.
         /// Exception CommandNotFound is thrown if command is not found.
@@ -584,15 +623,18 @@ public:
         Group & get_group(const std::string & id) const override;
 
         /// Sets the user function for parsing the argument.
-        void set_parse_hook_func(ParseHookFunc && func) override { parse_hook = std::move(func); }
+        void set_parse_hook_func(ParseHookFunc && func) override;
 
         /// Gets the user function for parsing the argument.
-        const ParseHookFunc & get_parse_hook_func() const noexcept override { return parse_hook; }
+        const ParseHookFunc & get_parse_hook_func() const noexcept override;
+
+        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
+        void parse(const char * option, int argc, const char * const argv[]) override;
 
     private:
         friend class ArgumentParser;
 
-        CommandOrdinary(ArgumentParser & owner, const std::string & id) : Command(owner, id) {}
+        CommandOrdinary(ArgumentParser & owner, const std::string & id);
 
         std::vector<Command *> cmds;
         std::vector<NamedArg *> named_args;
@@ -603,82 +645,76 @@ public:
 
     class CommandAlias : public Command {
     public:
-        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
-        void parse(const char * option, int argc, const char * const argv[]) override;
+        CommandAlias() = delete;
+        CommandAlias(const CommandAlias &) = delete;
+        CommandAlias(CommandAlias &&) = delete;
+        CommandAlias & operator=(const CommandAlias &) = delete;
+        CommandAlias & operator=(CommandAlias &&) = delete;
+
+        ~CommandAlias() override;
 
         /// Registers (sub)command to the command.
         /// An exception is thrown when a command with the same ID is already registered.
-        void register_command(Command * cmd) override { attached_command.register_command(cmd); }
+        void register_command(Command * cmd) override;
 
         /// Registers named argument to the command.
         /// An exception is thrown when a named argument with the same ID is already registered.
-        void register_named_arg(NamedArg * arg) override { attached_command.register_named_arg(arg); }
+        void register_named_arg(NamedArg * arg) override;
 
         /// Registers positional argument to the command.
         /// An exception is thrown when a positional argument with the same ID is already registered.
-        void register_positional_arg(PositionalArg * arg) override { attached_command.register_positional_arg(arg); }
+        void register_positional_arg(PositionalArg * arg) override;
 
-        void register_group(Group * grp) override { attached_command.register_group(grp); }
+        void register_group(Group * grp) override;
 
-        std::vector<std::string> get_invocation() const noexcept override { return attached_command.get_invocation(); }
+        std::vector<std::string> get_invocation() const noexcept override;
 
         /// Gets a list of registered commands.
-        const std::vector<Command *> & get_commands() const noexcept override {
-            return attached_command.get_commands();
-        }
+        const std::vector<Command *> & get_commands() const noexcept override;
 
         /// Gets a list of registered named arguments.
-        const std::vector<NamedArg *> & get_named_args() const noexcept override {
-            return attached_command.get_named_args();
-        }
+        const std::vector<NamedArg *> & get_named_args() const noexcept override;
 
         /// Gets a list of registered positional arguments.
-        const std::vector<PositionalArg *> & get_positional_args() const noexcept override {
-            return attached_command.get_positional_args();
-        }
+        const std::vector<PositionalArg *> & get_positional_args() const noexcept override;
 
         /// Gets a list of registered groups.
-        const std::vector<Group *> & get_groups() const noexcept override { return attached_command.get_groups(); }
+        const std::vector<Group *> & get_groups() const noexcept override;
 
         /// Returns (sub)command with given ID.
         /// Exception CommandNotFound is thrown if command is not found.
-        Command & get_command(const std::string & id) const override { return attached_command.get_command(id); }
+        Command & get_command(const std::string & id) const override;
 
         /// Returns named argument with given ID.
         /// Exception NamedArgNotFound is thrown if argument is not found.
-        NamedArg & get_named_arg(const std::string & id) const override { return attached_command.get_named_arg(id); }
+        NamedArg & get_named_arg(const std::string & id) const override;
 
         /// Returns positional argument with given ID.
         /// Exception PositionalArgNotFound is thrown if argument is not found.
-        PositionalArg & get_positional_arg(const std::string & id) const override {
-            return attached_command.get_positional_arg(id);
-        }
+        PositionalArg & get_positional_arg(const std::string & id) const override;
 
         /// Returns registered group with given ID.
         /// Exception ArgumentParserNotFoundError is thrown if group is not found.
-        Group & get_group(const std::string & id) const override { return attached_command.get_group(id); }
+        Group & get_group(const std::string & id) const override;
 
         /// Sets the user function for parsing the argument.
-        void set_parse_hook_func(ParseHookFunc && func) override {
-            attached_command.set_parse_hook_func(std::move(func));
-        }
+        void set_parse_hook_func(ParseHookFunc && func) override;
 
         /// Gets the user function for parsing the argument.
-        const ParseHookFunc & get_parse_hook_func() const noexcept override {
-            return attached_command.get_parse_hook_func();
-        }
+        const ParseHookFunc & get_parse_hook_func() const noexcept override;
+
+        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
+        void parse(const char * option, int argc, const char * const argv[]) override;
 
         /// Returns the Command to which the CommandAlias is attached.
-        Command & get_attached_command() noexcept { return attached_command; }
+        Command & get_attached_command() noexcept;
 
         void attach_named_arg(const std::string & id_path, const std::string & value);
 
     private:
         friend class ArgumentParser;
 
-        CommandAlias(ArgumentParser & owner, const std::string & id, Command & attached_command)
-            : Command(owner, id),
-              attached_command(attached_command) {}
+        CommandAlias(ArgumentParser & owner, const std::string & id, Command & attached_command);
 
         Command & attached_command;
 
@@ -689,6 +725,14 @@ public:
         };
         std::vector<AttachedNamedArg> attached_named_args;
     };
+
+    ArgumentParser(const ArgumentParser &) = delete;
+    ArgumentParser(ArgumentParser &&) = delete;
+    ArgumentParser & operator=(const ArgumentParser &) = delete;
+    ArgumentParser & operator=(ArgumentParser &&) = delete;
+
+    ArgumentParser();
+    ~ArgumentParser();
 
     /// Constructs a new command and stores it to the argument parser.
     /// Returns a pointer to the newly created command.
@@ -738,15 +782,15 @@ public:
 
     /// Sets the "root" command.
     /// This is the top-level command in the command hierarchy. It can contain named and positional arguments and subcommands.
-    void set_root_command(Command * command) noexcept { root_command = command; }
+    void set_root_command(Command * command) noexcept;
 
     /// Gets the "root" command.
     /// This is the top-level command in the command hierarchy. It can contain named and positional arguments and subcommands.
-    Command * get_root_command() noexcept { return root_command; }
+    Command * get_root_command() noexcept;
 
     /// Get the selected command.
     /// Needed for printing help, bash completion etc.
-    Command * get_selected_command() noexcept { return selected_command; }
+    Command * get_selected_command() noexcept;
 
     /// Parses input. The parser from the "root" command is called.
     /// The "AssertionError" exception is thrown when the "root" command is not set.
@@ -759,10 +803,10 @@ public:
     /// If the parser does not find a named argument definition during subcommand processing and
     /// named arguments inheritance is enabled, parser searches the named arguments of the parent commands.
     /// @param enable  true - enable parent argument inheritance, false - disable
-    void set_inherit_named_args(bool enable) noexcept { inherit_named_args = enable; }
+    void set_inherit_named_args(bool enable) noexcept;
 
     /// Returns true if the inheritance of named arguments is enabled for the parser.
-    bool get_inherit_named_args() const noexcept { return inherit_named_args; }
+    bool get_inherit_named_args() const noexcept;
 
     /// Returns (sub)command with given ID path.
     /// The root command ID must be omitted. It is added automatically.
@@ -796,32 +840,21 @@ public:
     PositionalArg & get_positional_arg(const std::string & id_path, bool search_in_parent);
 
     /// Gets a list of all commands stored in the argument parser.
-    const std::vector<std::unique_ptr<Command>> & get_commands() const noexcept { return cmds; }
+    const std::vector<std::unique_ptr<Command>> & get_commands() const noexcept;
 
     /// Gets a list of all named arguments stored in the argument parser.
-    const std::vector<std::unique_ptr<NamedArg>> & get_named_args() const noexcept { return named_args; }
+    const std::vector<std::unique_ptr<NamedArg>> & get_named_args() const noexcept;
 
     /// Gets a list of all positional argument stored in the argument parser.
-    const std::vector<std::unique_ptr<PositionalArg>> & get_positional_args() const noexcept { return pos_args; }
+    const std::vector<std::unique_ptr<PositionalArg>> & get_positional_args() const noexcept;
 
     /// Prints the completed argument from the `complete_arg_idx` position in the argv array. In case of more than one
     /// potential completion matches, prints a table with the potential matches along with their short help descriptions.
     void complete(int argc, const char * const argv[], int complete_arg_idx);
 
 private:
-    void assert_root_command();
-
-    std::vector<std::unique_ptr<Command>> cmds;
-    std::vector<std::unique_ptr<NamedArg>> named_args;
-    std::vector<std::unique_ptr<PositionalArg>> pos_args;
-    std::vector<std::unique_ptr<Group>> groups;
-    std::vector<std::unique_ptr<std::vector<Argument *>>> conflict_args_groups;
-    std::vector<std::unique_ptr<libdnf5::Option>> values_init;
-    std::vector<std::unique_ptr<std::vector<std::unique_ptr<libdnf5::Option>>>> values;
-    Command * root_command{nullptr};
-    Command * selected_command{nullptr};
-    bool inherit_named_args{false};
-    const char * const * complete_arg_ptr{nullptr};
+    class ArgumentParserImpl;
+    const std::unique_ptr<ArgumentParserImpl> p_impl;
 };
 
 }  // namespace libdnf5::cli

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -301,6 +301,14 @@ public:
         /// Gets the user function to complete the argument.
         const CompleteHookFunc & get_complete_hook_func() const noexcept { return complete_hook; }
 
+        /// Sets the required number of repetitions of this argument on the command line.
+        /// The special values OPTIONAL, UNLIMITED, AT_LEAST_ONE can be used.
+        void set_nrepeats(int nrepeats) { this->nrepeats = nrepeats; }
+
+        /// Gets the required number of repetitions of this argument on the command line.
+        /// May return special values: OPTIONAL, UNLIMITED, AT_LEAST_ONE
+        int get_nrepeats() const noexcept { return nrepeats; }
+
     private:
         friend class ArgumentParser;
 
@@ -317,12 +325,13 @@ public:
         /// Returns number of consumed arguments from the input.
         int parse(const char * option, int argc, const char * const argv[]);
 
-        int nvals;
+        int nvals;  // Number of values required by this positional argument on the command line
         libdnf5::Option * init_value;
         std::vector<std::unique_ptr<libdnf5::Option>> * values;
         bool store_value{true};
         ParseHookFunc parse_hook;
         CompleteHookFunc complete_hook;
+        int nrepeats{1};  // The required number of repetitions of this positional argument on the command line
     };
 
     class NamedArg : public Argument {

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -579,8 +579,12 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
             }
         }
         if (!used && *argv[i] != '-' && used_positional_arguments < pos_args.size()) {
-            i += pos_args[used_positional_arguments]->parse(argv[i], argc - i, &argv[i]);
-            ++used_positional_arguments;
+            auto * pos_arg = pos_args[used_positional_arguments];
+            i += pos_arg->parse(argv[i], argc - i, &argv[i]);
+            auto nrepeats = pos_arg->get_nrepeats();
+            if ((nrepeats > 0 && pos_arg->parse_count >= nrepeats) || nrepeats == PositionalArg::OPTIONAL) {
+                ++used_positional_arguments;
+            }
             used = true;
         }
         if (!used) {
@@ -596,10 +600,14 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
 
     // Test that all required positional arguments are present.
     for (const auto * pos_arg : pos_args) {
-        const auto nvals = pos_arg->get_nvals();
-        if (pos_arg->get_parse_count() == 0 && nvals != PositionalArg::UNLIMITED && nvals != PositionalArg::OPTIONAL) {
-            throw ArgumentParserMissingPositionalArgumentError(
-                M_("Missing positional argument \"{}\" for command \"{}\""), pos_arg->get_id(), id);
+        const auto nrepeats = pos_arg->get_nrepeats();
+        if (nrepeats > 0 || nrepeats == PositionalArg::AT_LEAST_ONE) {
+            const auto nvals = pos_arg->get_nvals();
+            if (pos_arg->get_parse_count() == 0 && nvals != PositionalArg::UNLIMITED &&
+                nvals != PositionalArg::OPTIONAL) {
+                throw ArgumentParserMissingPositionalArgumentError(
+                    M_("Missing positional argument \"{}\" for command \"{}\""), pos_arg->get_id(), id);
+            }
         }
     }
 
@@ -707,8 +715,12 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
             }
         }
         if (!used && *argv[i] != '-' && used_positional_arguments < pos_args.size()) {
-            i += pos_args[used_positional_arguments]->parse(argv[i], argc - i, &argv[i]);
-            ++used_positional_arguments;
+            auto * pos_arg = pos_args[used_positional_arguments];
+            i += pos_arg->parse(argv[i], argc - i, &argv[i]);
+            auto nrepeats = pos_arg->get_nrepeats();
+            if ((nrepeats > 0 && pos_arg->parse_count >= nrepeats) || nrepeats == PositionalArg::OPTIONAL) {
+                ++used_positional_arguments;
+            }
             used = true;
         }
         if (!used) {
@@ -724,10 +736,14 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
 
     // Test that all required positional arguments are present.
     for (const auto * pos_arg : pos_args) {
-        const auto nvals = pos_arg->get_nvals();
-        if (pos_arg->get_parse_count() == 0 && nvals != PositionalArg::UNLIMITED && nvals != PositionalArg::OPTIONAL) {
-            throw ArgumentParserMissingPositionalArgumentError(
-                M_("Missing positional argument \"{}\" for command \"{}\""), pos_arg->get_id(), id);
+        const auto nrepeats = pos_arg->get_nrepeats();
+        if (nrepeats > 0 || nrepeats == PositionalArg::AT_LEAST_ONE) {
+            const auto nvals = pos_arg->get_nvals();
+            if (pos_arg->get_parse_count() == 0 && nvals != PositionalArg::UNLIMITED &&
+                nvals != PositionalArg::OPTIONAL) {
+                throw ArgumentParserMissingPositionalArgumentError(
+                    M_("Missing positional argument \"{}\" for command \"{}\""), pos_arg->get_id(), id);
+            }
         }
     }
 


### PR DESCRIPTION
Breaks the `AgumentParser` ABI. But it simplifies its maintainability for the future.
Related to https://github.com/rpm-software-management/dnf5/issues/1025