### PR TITLE
builddep: Escape glob characters in pkg specs

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -217,6 +217,18 @@ bool BuildDepCommand::add_from_pkg(
     }
 }
 
+std::string escape_glob(const std::string & in) {
+    // Escape fnmatch glob characters in a string
+    std::string out;
+    for (const auto ch : in) {
+        if (ch == '*' || ch == '?' || ch == '[' || ch == ']' || ch == '\\') {
+            out += '\\';
+        }
+        out += ch;
+    }
+    return out;
+}
+
 void BuildDepCommand::run() {
     // get build dependencies from various inputs
     std::set<std::string> install_specs{};
@@ -272,7 +284,13 @@ void BuildDepCommand::run() {
             // we do not download filelists and some files could be explicitly mentioned in provide section. The best
             // solution would be to merge result of provide and file search to prevent problems caused by modification
             // during distro lifecycle.
-            goal->add_rpm_install(spec, settings);
+
+            // TODO(egoode) once we have a setting to disable expanding globs
+            // in resolve_pkg_spec, escaping the glob characters will no longer
+            // be needed:
+            // https://github.com/rpm-software-management/dnf5/pull/1085
+            const auto & escaped_spec = escape_glob(spec);
+            goal->add_rpm_install(escaped_spec, settings);
         }
     }
 


### PR DESCRIPTION
Not parsing the pkg specs as globs would require an ABI-breaking change (https://github.com/rpm-software-management/dnf5/pull/1085). A workaround that doesn't involve breaking changes is to escape the glob characters in the pkg specs.

Related: https://github.com/rpm-software-management/mock/issues/1267
Resolves https://github.com/rpm-software-management/dnf5/issues/1084