### PR TITLE
bindings: Fix and enable builds with Go bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ option(WITH_DNF5DAEMON_TESTS "Build dnf5daemon tests (requires configured dbus)"
 option(WITH_SANITIZERS "Build with address, leak and undefined sanitizers (DEBUG ONLY)" OFF)
 
 # build options - bindings
-option(WITH_GO "Build Go bindings" OFF)
+option(WITH_GO "Build Go bindings" ON)
 option(WITH_PERL5 "Build Perl 5 bindings" ON)
 option(WITH_PYTHON3 "Build Python 3 bindings" ON)
 option(WITH_RUBY "Build Ruby bindings" ON)

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -19,6 +19,7 @@
 
 %include <shared.i>
 
+#ifndef SWIGGO
 %typemap(out) std::string * {
     if ($1 == nullptr) {
         $result = SWIG_FromCharPtrAndSize("", 0);
@@ -26,6 +27,7 @@
         $result = SWIG_FromCharPtrAndSize($1->c_str(), $1->size());
     }
 }
+#endif
 
 %{
     #include "libdnf5/common/weak_ptr.hpp"
@@ -87,6 +89,7 @@ namespace std {
   };
 }
 
+#ifndef SWIGGO
 %define wrap_unique_ptr(Name, Type)
   %newobject std::unique_ptr<Type>::release;
   %apply SWIGTYPE *DISOWN {Type * ptr};
@@ -98,6 +101,7 @@ namespace std {
   %}
 
 %enddef
+#endif
 
 #if defined(SWIGPYTHON)
 %pythoncode %{

--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -42,10 +42,7 @@
 #define CV __perl_CV
 #define final
 
-wrap_unique_ptr(StringUniquePtr, std::string);
-
 %include "libdnf5/version.hpp"
-
 %include "libdnf5/conf/const.hpp"
 
 %ignore libdnf5::OptionError;

--- a/bindings/libdnf5/logger.i
+++ b/bindings/libdnf5/logger.i
@@ -38,8 +38,10 @@ typedef int32_t pid_t;
 
 #define CV __perl_CV
 
+#ifndef SWIGGO
 wrap_unique_ptr(LoggerUniquePtr, libdnf5::Logger);
 wrap_unique_ptr(MemoryBufferLoggerUniquePtr, libdnf5::MemoryBufferLogger);
+#endif
 
 %template(LogRouterWeakPtr) libdnf5::WeakPtr<libdnf5::LogRouter, false>;
 

--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -47,9 +47,11 @@
 
 %include "libdnf5/repo/config_repo.hpp"
 
+#ifndef SWIGGO
 %feature("director") DownloadCallbacks;
 %include "libdnf5/repo/download_callbacks.hpp"
 wrap_unique_ptr(DownloadCallbacksUniquePtr, libdnf5::repo::DownloadCallbacks);
+#endif
 
 %ignore FileDownloadError;
 %include "libdnf5/repo/file_downloader.hpp"
@@ -68,9 +70,11 @@ wrap_unique_ptr(DownloadCallbacksUniquePtr, libdnf5::repo::DownloadCallbacks);
 %template(SetRepoWeakPtr) libdnf5::Set<libdnf5::repo::RepoWeakPtr>;
 %template(SackQueryRepoWeakPtr) libdnf5::sack::Query<libdnf5::repo::RepoWeakPtr>;
 
+#ifndef SWIGGO
 %feature("director") RepoCallbacks;
 %include "libdnf5/repo/repo_callbacks.hpp"
 wrap_unique_ptr(RepoCallbacksUniquePtr, libdnf5::repo::RepoCallbacks);
+#endif
 
 %include "libdnf5/repo/repo_query.hpp"
 %template(SackRepoRepoQuery) libdnf5::sack::Sack<libdnf5::repo::Repo>;

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -85,9 +85,11 @@
 add_iterator(PackageSet)
 add_iterator(ReldepList)
 
+#ifndef SWIGGO
 %feature("director") TransactionCallbacks;
 %include "libdnf5/rpm/transaction_callbacks.hpp"
 wrap_unique_ptr(TransactionCallbacksUniquePtr, libdnf5::rpm::TransactionCallbacks);
+#endif
 
 %ignore KeyImportError;
 %ignore SignatureCheckError;

--- a/include/libdnf5/conf/config.hpp
+++ b/include/libdnf5/conf/config.hpp
@@ -33,8 +33,9 @@ namespace libdnf5 {
 /// Base class for configurations objects
 class Config {
 public:
+#ifndef SWIGGO
     OptionBinds & opt_binds() noexcept { return binds; }
-
+#endif
     virtual ~Config() = default;
 
     virtual void load_from_parser(

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -101,7 +101,7 @@ public:
     /// @param name Name of the variable
     const Variable & get(const std::string & name) const { return variables.at(name); }
 
-    static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
+    static std::string detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
 private:
     friend class Base;

--- a/include/libdnf5/repo/repo_cache.hpp
+++ b/include/libdnf5/repo/repo_cache.hpp
@@ -53,8 +53,13 @@ class RepoCache {
 public:
     using RemoveStatistics = RepoCacheRemoveStatistics;
 
-    /// The name of the attribute used to mark the cache as expired.
+/// The name of the attribute used to mark the cache as expired.
+#ifndef SWIGGO
     static constexpr const char * ATTRIBUTE_EXPIRED = "expired";
+#else
+    // https://github.com/swig/swig/issues/2724
+    const char * ATTRIBUTE_EXPIRED = "expired";
+#endif
 
     /// Construct a new repository cache management instance.
     ///

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -121,8 +121,8 @@ static std::string detect_arch() {
 // ==================================================================
 
 
-std::unique_ptr<std::string> Vars::detect_release(const BaseWeakPtr & base, const std::string & install_root_path) {
-    std::unique_ptr<std::string> release_ver;
+std::string Vars::detect_release(const BaseWeakPtr & base, const std::string & install_root_path) {
+    std::string release_ver;
 
     libdnf5::rpm::RpmLogGuard rpm_log_guard(base);
 
@@ -144,12 +144,12 @@ std::unique_ptr<std::string> Vars::detect_release(const BaseWeakPtr & base, cons
             }
             if (version) {
                 // Is the result of rpmdsEVR(ds) valid after rpmdsFree(ds)? Make a copy to be sure.
-                release_ver = std::make_unique<std::string>(version);
+                release_ver = version;
             }
             rpmdsFree(ds);
         }
         rpmdbFreeIterator(mi);
-        if (release_ver) {
+        if (release_ver.empty()) {
             break;
         }
     }
@@ -425,7 +425,9 @@ void Vars::detect_vars(const std::string & installroot) {
         Priority::AUTO);
 
     set_lazy(
-        "releasever", [this, &installroot]() -> auto { return detect_release(base, installroot); }, Priority::AUTO);
+        "releasever",
+        [this, &installroot]() -> auto { return std::make_unique<std::string>(detect_release(base, installroot)); },
+        Priority::AUTO);
 }
 
 static void dir_close(DIR * d) {


### PR DESCRIPTION
Fixes #719 

Ok, disclaimer, I am neither a SWIG expert nor a dnf one but I was just poking around the codebase.

With that being clear, its a rough take on exposing the API. 
 - Disables a lot of the callbacks relying on `std::unique_ptr`, which I don't know if important or not. 
 - Changed the API a bit on the libdnf/conf/vars, there is one more copy down the line but we avoid exposing unique_ptr to the API
 - SWIG/Go doesn't like `constexpr const char*` which is a bit annoying but can be worked around
 - the only thing I couldn't figure out was the Config::opt_bind, SWIG thinks it returns a pointer and not a reference

Definitely need some help.