### PR TITLE
Improve Python binding of Reldep and PAckage Classes

### DIFF
--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -154,6 +154,16 @@ del ClassName##__iter__
 #endif
 %enddef
 
+%define add_hash(ClassName)
+#if defined(SWIGPYTHON)
+%extend ClassName {
+    int __hash__() const {
+        return $self->get_hash();
+    }
+}
+#endif
+%enddef
+
 %{
     #include "libdnf5/common/sack/query.hpp"
     #include "libdnf5/common/sack/query_cmp.hpp"

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -144,6 +144,16 @@ del ClassName##__iter__
 #endif
 %enddef
 
+%define add_repr(ClassName)
+#if defined(SWIGPYTHON)
+%extend ClassName {
+    std::string __repr__() const {
+        return $self->to_string_description();
+    }
+}
+#endif
+%enddef
+
 %{
     #include "libdnf5/common/sack/query.hpp"
     #include "libdnf5/common/sack/query_cmp.hpp"

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -134,6 +134,15 @@ del ClassName##__iter__
 #endif
 %enddef
 
+%define add_str(ClassName)
+#if defined(SWIGPYTHON)
+%extend ClassName {
+    std::string __str__() const {
+        return $self->to_string();
+    }
+}
+#endif
+%enddef
 
 %{
     #include "libdnf5/common/sack/query.hpp"

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -64,6 +64,7 @@
 
 add_str(libdnf5::rpm::Reldep)
 add_repr(libdnf5::rpm::Reldep)
+add_hash(libdnf5::rpm::Reldep)
 %include "libdnf5/rpm/reldep.hpp"
 
 %rename(next) libdnf5::rpm::ReldepListIterator::operator++();

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -71,6 +71,10 @@ add_hash(libdnf5::rpm::Reldep)
 %rename(value) libdnf5::rpm::ReldepListIterator::operator*();
 %include "libdnf5/rpm/reldep_list_iterator.hpp"
 %include "libdnf5/rpm/reldep_list.hpp"
+
+add_str(libdnf5::rpm::Package)
+add_repr(libdnf5::rpm::Package)
+add_hash(libdnf5::rpm::Package)
 %include "libdnf5/rpm/package.hpp"
 
 %template(VectorPackage) std::vector<libdnf5::rpm::Package>;

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -29,6 +29,7 @@
     }
 }
 
+
 %{
     #include "libdnf5/rpm/arch.hpp"
     #include "libdnf5/rpm/checksum.hpp"
@@ -61,6 +62,7 @@
 %include "libdnf5/rpm/package_sack.hpp"
 %template(PackageSackWeakPtr) libdnf5::WeakPtr<libdnf5::rpm::PackageSack, false>;
 
+add_str(libdnf5::rpm::Reldep)
 %include "libdnf5/rpm/reldep.hpp"
 
 %rename(next) libdnf5::rpm::ReldepListIterator::operator++();

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -63,6 +63,7 @@
 %template(PackageSackWeakPtr) libdnf5::WeakPtr<libdnf5::rpm::PackageSack, false>;
 
 add_str(libdnf5::rpm::Reldep)
+add_repr(libdnf5::rpm::Reldep)
 %include "libdnf5/rpm/reldep.hpp"
 
 %rename(next) libdnf5::rpm::ReldepListIterator::operator++();

--- a/include/libdnf5/rpm/package.hpp
+++ b/include/libdnf5/rpm/package.hpp
@@ -515,6 +515,15 @@ public:
     /// @since 5.0.5
     libdnf5::BaseWeakPtr get_base() const;
 
+    /// Return NEVRA -> 0 epoch is not shown in string
+    std::string to_string() const { return get_nevra(); };
+
+    /// Provide descriptive information about instance including NEVRA and ID
+    std::string to_string_description() const;
+
+    /// Return unique ID representing Package
+    int get_hash() const { return get_id().id; };
+
 protected:
     // @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_new(DnfSack *sack, Id id)
     Package(const BaseWeakPtr & base, PackageId id);

--- a/include/libdnf5/rpm/reldep.hpp
+++ b/include/libdnf5/rpm/reldep.hpp
@@ -95,7 +95,10 @@ public:
 
     /// @brief Test if pattern is rich dependency
     /// Return true if pattern start with "("
-    static bool is_rich_dependency(const std::string & pattern) { return pattern[0] == '('; }
+    static bool is_rich_dependency(const std::string & pattern) { return pattern[0] == '('; };
+
+    /// Return unique ID representing Reldep
+    int get_hash() const { return get_id().id; };
 
 protected:
     /// @brief Creates a reldep from Id

--- a/include/libdnf5/rpm/reldep.hpp
+++ b/include/libdnf5/rpm/reldep.hpp
@@ -83,6 +83,9 @@ public:
     // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
     std::string to_string() const;
 
+    /// Provide descriptive information about instance including string value and ID
+    std::string to_string_description() const;
+
     // @replaces libdnf/repo/solvable/Dependency.hpp:method:getId()
     // @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
     ReldepId get_id() const noexcept { return id; };

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -511,4 +511,8 @@ BaseWeakPtr Package::get_base() const {
     return base;
 }
 
+std::string Package::to_string_description() const {
+    return fmt::format("<libdnf5.rpm.Package object, {}, id: {}>", to_string(), get_id().id);
+}
+
 }  // namespace libdnf5::rpm

--- a/libdnf5/rpm/reldep.cpp
+++ b/libdnf5/rpm/reldep.cpp
@@ -64,6 +64,10 @@ std::string Reldep::to_string() const {
     return cstring ? std::string(cstring) : std::string();
 }
 
+std::string Reldep::to_string_description() const {
+    return fmt::format("<libdnf5.rpm.Reldep object, {}, id: {}>", to_string(), get_id().id);
+}
+
 ReldepId Reldep::get_reldep_id(
     const BaseWeakPtr & base, const char * name, const char * version, CmpType cmp_type, int create) {
     static_assert(


### PR DESCRIPTION
I believe we should directly set Python slot using SWIG feature (see bellow), but I was unable to make it working.

`%feature("python:slot", "tp_str", functype="reprfunc") libdnf5::rpm::Reldep::to_string;`

`set_property(SOURCE rpm.i PROPERTY SWIG_FLAGS "-builtin"`