### PR TITLE
modules: Change module dependency string to be the same as in dnf4

### DIFF
--- a/libdnf5/module/module_dependency.cpp
+++ b/libdnf5/module/module_dependency.cpp
@@ -43,9 +43,6 @@ namespace libdnf5::module {
 
 
 std::string ModuleDependency::to_string() {
-    if (streams.empty()) {
-        return module_name;
-    }
     std::sort(streams.begin(), streams.end());
     return fmt::format("{}:[{}]", module_name, utils::string::join(streams, ","));
 }

--- a/test/libdnf5/module/test_module.cpp
+++ b/test/libdnf5/module/test_module.cpp
@@ -78,7 +78,7 @@ void ModuleTest::test_load() {
                     "spends writing or debugging build definitions is a second wasted. So is every second spent "
                     "waiting for the build system to actually start compiling code."),
         meson.get_description());
-    CPPUNIT_ASSERT_EQUAL(std::string("ninja;platform:[f29,f30,f31]"), meson.get_module_dependencies_string());
+    CPPUNIT_ASSERT_EQUAL(std::string("ninja:[];platform:[f29,f30,f31]"), meson.get_module_dependencies_string());
     CPPUNIT_ASSERT_EQUAL((size_t)1, meson.get_profiles().size());
     CPPUNIT_ASSERT_EQUAL(std::string("default"), meson.get_profiles()[0].get_name());
     CPPUNIT_ASSERT_EQUAL(false, meson.get_profiles()[0].is_default());


### PR DESCRIPTION
Add ":[]" when any stream is required instead of keeping only the module name. This makes it consistent with `modulemd_stream` yaml and with dnf4 output of the module info command.