### PR TITLE
Add a method accepting std::string for filter_provides()

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -199,7 +199,7 @@ bool BuildDepCommand::add_from_pkg(
     }
 
     libdnf5::rpm::PackageQuery source_pkgs(ctx.base);
-    source_pkgs.filter_arch({"src"});
+    source_pkgs.filter_arch(std::vector<std::string>{"src", "nosrc"});
     source_pkgs.filter_name(source_names);
     if (source_pkgs.empty()) {
         std::cerr << "No package matched \"" << pkg_spec << "\"." << std::endl;

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -282,7 +282,7 @@ void BuildDepCommand::run() {
         auto system_repo = ctx.base.get_repo_sack()->get_system_repo();
         auto rpm_package_sack = ctx.base.get_rpm_package_sack();
         libdnf5::rpm::PackageQuery conflicts_query_available(ctx.base);
-        conflicts_query_available.filter_name({conflicts_specs.begin(), conflicts_specs.end()});
+        conflicts_query_available.filter_name(std::vector<std::string>{conflicts_specs.begin(), conflicts_specs.end()});
         libdnf5::rpm::PackageQuery conflicts_query_installed(conflicts_query_available);
         conflicts_query_available.filter_repo_id({system_repo->get_id()}, libdnf5::sack::QueryCmp::NEQ);
         rpm_package_sack->add_user_excludes(conflicts_query_available);

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -132,7 +132,7 @@ void CheckUpgradeCommand::run() {
     // Source RPMs should not be reported as upgrades, e.g. when the binary
     // package is marked exclude and only the source package is left in the
     // repo
-    upgrades_query.filter_arch({"src", "nosrc"}, libdnf5::sack::QueryCmp::NOT_EXACT);
+    upgrades_query.filter_arch(std::vector<std::string>{"src", "nosrc"}, libdnf5::sack::QueryCmp::NOT_EXACT);
 
     libdnf5::rpm::PackageQuery installed_query(ctx.base);
     installed_query.filter_installed();

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -210,7 +210,7 @@ void ListCommand::run() {
         case PkgNarrow::UPGRADES:
             base_query.filter_priority();
             base_query.filter_upgrades();
-            base_query.filter_arch({"src", "nosrc"}, libdnf5::sack::QueryCmp::NEQ);
+            base_query.filter_arch(std::vector<std::string>{"src", "nosrc"}, libdnf5::sack::QueryCmp::NEQ);
             base_query.filter_latest_evr();
             package_matched |= sections->add_section("Available upgrades", base_query, colorizer);
             break;

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -717,7 +717,7 @@ void RepoqueryCommand::run() {
     if (srpm->get_value()) {
         libdnf5::rpm::PackageQuery srpms(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
         auto only_src_query = result_query;
-        only_src_query.filter_arch({"src"});
+        only_src_query.filter_arch(std::vector<std::string>{"src", "nosrc"});
         for (const auto & pkg : result_query) {
             if (!pkg.get_sourcerpm().empty()) {
                 auto tmp_q = only_src_query;

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -776,13 +776,24 @@ public:
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
 
     /// Filter packages by their `location`.
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`.
+    /// @since 5.2
+    //
+    // TODO(dmach): enable glob match to enable filename matching: {nevra.rpm, */nevra.rpm}
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_LOCATION
+    void filter_location(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_location(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `location`.
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
     //
     // TODO(dmach): enable glob match to enable filename matching: {nevra.rpm, */nevra.rpm}
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_LOCATION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_LOCATION
     void filter_location(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -339,12 +339,23 @@ public:
 
     /// Filter packages by their `summary`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUMMARY
+    void filter_summary(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_summary(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `summary`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUMMARY
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUMMARY
     void filter_summary(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -105,15 +105,36 @@ public:
 
     /// Filter packages by their `epoch`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EPOCH
+    void filter_epoch(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_epoch(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `epoch`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EPOCH
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EPOCH
     void filter_epoch(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
+
+    /// Filter packages by their `epoch`.
+    ///
+    /// @param pattern          A number the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
+    /// @since 5.2
+    void filter_epoch(unsigned long pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_epoch(std::vector<unsigned long>{pattern}, cmp_type);
+    };
 
     /// Filter packages by their `epoch`.
     ///

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -194,6 +194,16 @@ public:
 
     /// Filter packages by their `arch`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    void filter_arch(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_arch(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `arch`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -719,12 +719,24 @@ public:
 
     /// Filter packages by their `supplements`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUPPLEMENTS
+    void filter_supplements(
+        const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_supplements(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `supplements`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUPPLEMENTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUPPLEMENTS
     void filter_supplements(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -800,12 +800,23 @@ public:
 
     /// Filter packages by `id` of the Repo they belong to.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REPONAME
+    void filter_repo_id(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_repo_id(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by `id` of the Repo they belong to.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REPONAME
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REPONAME
     void filter_repo_id(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -626,6 +626,18 @@ public:
 
     /// Filter packages by their `suggests`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUGGESTS
+    void filter_suggests(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_suggests(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `suggests`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -316,12 +316,23 @@ public:
 
     /// Filter packages by their `url`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_URL
+    void filter_url(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_url(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `url`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_URL
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_URL
     void filter_url(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -754,12 +754,23 @@ public:
 
     /// Filter packages by `files` they contain.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_FILE
+    void filter_file(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_file(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by `files` they contain.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_FILE
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_FILE
     void filter_file(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -362,12 +362,24 @@ public:
 
     /// Filter packages by their `summary`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_DESCRIPTION
+    void filter_description(
+        const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_description(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `summary`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_DESCRIPTION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_DESCRIPTION
     void filter_description(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -245,14 +245,25 @@ public:
 
     /// Filter packages by their `name-[epoch:]version-release.arch`. The following matches are tolerant to omitted 0 epoch: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`, `IGLOB`, `NOT_IGLOB`, `IEXACT`, `NOT_IEXACT`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA_STRICT
+    void filter_nevra(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_nevra(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `name-[epoch:]version-release.arch`. The following matches are tolerant to omitted 0 epoch: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`, `IGLOB`, `NOT_IGLOB`, `IEXACT`, `NOT_IEXACT`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA_STRICT
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA_STRICT
     void filter_nevra(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -487,12 +487,23 @@ public:
 
     /// Filter packages by their `conflicts`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_CONFLICTS
+    void filter_conflicts(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_conflicts(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `conflicts`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_CONFLICTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_CONFLICTS
     void filter_conflicts(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -147,12 +147,23 @@ public:
 
     /// Filter packages by their `version`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_VERSION
+    void filter_version(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_version(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `version`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_VERSION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_VERSION
     void filter_version(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -673,12 +673,23 @@ public:
 
     /// Filter packages by their `enhances`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_ENHANCES
+    void filter_enhances(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_enhances(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `enhances`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_ENHANCES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_ENHANCES
     void filter_enhances(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -275,12 +275,23 @@ public:
 
     /// Filter packages by their `provides`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_PROVIDES
+    void filter_provides(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_provides(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `provides`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_PROVIDES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_PROVIDES
     void filter_provides(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -441,12 +441,23 @@ public:
 
     /// Filter packages by their `requires`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REQUIRES
+    void filter_requires(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_requires(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `requires`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REQUIRES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REQUIRES
     void filter_requires(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -579,12 +579,24 @@ public:
 
     /// Filter packages by their `recommends`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RECOMMENDS
+    void filter_recommends(
+        const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_recommends(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `recommends`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RECOMMENDS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_RECOMMENDS
     void filter_recommends(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -533,12 +533,23 @@ public:
 
     /// Filter packages by their `obsoletes`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_OBSOLETES
+    void filter_obsoletes(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_obsoletes(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `obsoletes`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_OBSOLETES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_OBSOLETES
     void filter_obsoletes(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -170,6 +170,18 @@ public:
 
     /// Filter packages by their `release`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RELEASE
+    void filter_release(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_release(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `release`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `GLOB`, `NOT_GLOB`.

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -295,11 +295,21 @@ public:
 
     /// Filter packages by their `sourcerpm`.
     ///
-    /// @param patterns         A vector of strings the filter is matched against.
+    /// @param pattern          A string the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SOURCERPM
+    void filter_sourcerpm(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_sourcerpm(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `sourcerpm`.
+    ///
+    /// @param patterns         A vector of strings the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SOURCERPM
     void filter_sourcerpm(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -222,12 +222,23 @@ public:
 
     /// Filter packages by their `epoch:version-release`.
     ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `GT`, `LT`, `GTE`, `LTE`, `EQ`.
+    /// @since 5.2
+    //
+    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EVR
+    void filter_evr(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_evr(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `epoch:version-release`.
+    ///
     /// @param patterns         A vector of strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `GT`, `LT`, `GTE`, `LTE`, `EQ`.
     /// @since 5.0
     //
-    // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EVR
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EVR
     void filter_evr(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -74,12 +74,23 @@ public:
 
     /// Filter packages by their `name`.
     ///
-    /// @param patterns         A vector of strings the filter is matched against.
+    /// @param pattern          A strings the filter is matched against.
     /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NAME
+    void filter_name(const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_name(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filter packages by their `name`.
+    ///
+    /// @param patterns         A vector of strings the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `ICONTAINS`, `NOT_ICONTAINS`, `IGLOB`, `NOT_IGLOB`, `CONTAINS`, `NOT_CONTAINS`.
+    /// @since 5.0
+    //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NAME
     void filter_name(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1407,7 +1407,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             log_level);
                         continue;
                     }
-                    query.filter_arch({pool.get_arch(id)});
+                    query.filter_arch(pool.get_arch(id));
                     if (query.empty()) {
                         // Report when package with the same name is installed for a different architecture
                         transaction.p_impl->add_resolve_log(

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1336,7 +1336,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                         }
                     }
                     rpm::PackageQuery query(installed);
-                    query.filter_name({pool.get_name(id)});
+                    query.filter_name(pool.get_name(id));
                     if (query.empty()) {
                         // Report when package with the same name is not installed
                         transaction.p_impl->add_resolve_log(
@@ -1394,7 +1394,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                 solv::IdQueue ids_downgrades;
                 for (auto id : ids) {
                     rpm::PackageQuery query(installed);
-                    query.filter_name({pool.get_name(id)});
+                    query.filter_name(pool.get_name(id));
                     if (query.empty()) {
                         // Report when package with the same name is not installed
                         transaction.p_impl->add_resolve_log(

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1366,7 +1366,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             continue;
                         }
                     }
-                    query.filter_evr({pool.get_evr(id)}, sack::QueryCmp::GTE);
+                    query.filter_evr(pool.get_evr(id), sack::QueryCmp::GTE);
                     if (!query.empty()) {
                         // Report when package with higher or equal version is installed
                         transaction.p_impl->add_resolve_log(
@@ -1420,7 +1420,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             log_level);
                         continue;
                     }
-                    query.filter_evr({pool.get_evr(id)}, sack::QueryCmp::LTE);
+                    query.filter_evr(pool.get_evr(id), sack::QueryCmp::LTE);
                     if (!query.empty()) {
                         // Report when package with lower or equal version is installed
                         std::string name_arch(pool.get_name(id));

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1304,7 +1304,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                 solv::IdQueue ids_nevra_installed;
                 for (auto id : ids) {
                     rpm::PackageQuery query(installed);
-                    query.filter_nevra({pool.get_nevra(id)});
+                    query.filter_nevra(pool.get_nevra(id));
                     if (query.empty()) {
                         // Report when package with the same NEVRA is not installed
                         transaction.p_impl->add_resolve_log(

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -226,7 +226,7 @@ GoalProblem Transaction::Impl::report_not_found(
         }
         return GoalProblem::NOT_FOUND;
     }
-    query.filter_arch({"src", "nosrc"}, sack::QueryCmp::NEQ);
+    query.filter_arch(std::vector<std::string>{"src", "nosrc"}, sack::QueryCmp::NEQ);
     if (query.empty()) {
         add_resolve_log(
             action,

--- a/libdnf5/module/module_sack.cpp
+++ b/libdnf5/module/module_sack.cpp
@@ -659,7 +659,7 @@ std::optional<std::pair<std::string, std::string>> ModuleSack::Impl::detect_plat
     }
 
     libdnf5::rpm::PackageQuery base_query(base);
-    base_query.filter_provides({"system-release"});
+    base_query.filter_provides("system-release");
     base_query.filter_latest_evr();
 
     // try to detect platform id from available packages

--- a/libdnf5/module/module_sack.cpp
+++ b/libdnf5/module/module_sack.cpp
@@ -323,7 +323,7 @@ void ModuleSack::Impl::module_filtering() {
     // prevent filtering out of binary packages that has the same name as source package but binary package is not
     // in module (it prevents creation of broken dependenciers in the distribution)
     exclude_src_names_query.filter_name(src_names);
-    exclude_src_names_query.filter_arch({"src", "nosrc"});
+    exclude_src_names_query.filter_arch(std::vector<std::string>{"src", "nosrc"});
 
     // Required to filtrate out source packages and packages with incompatible architectures.
     exclude_names_query.filter_name(names);

--- a/test/libdnf5/base/test_goal.cpp
+++ b/test/libdnf5/base/test_goal.cpp
@@ -230,7 +230,7 @@ void BaseGoalTest::test_install_installed_pkg() {
 
     libdnf5::rpm::PackageQuery query(base);
     query.filter_available();
-    query.filter_nevra({"one-0:1-1.noarch"});
+    query.filter_nevra("one-0:1-1.noarch");
 
     std::vector<libdnf5::rpm::Package> expected = {get_pkg("one-0:1-1.noarch")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
@@ -534,7 +534,7 @@ void BaseGoalTest::test_install_or_reinstall() {
     libdnf5::Goal goal(base);
     libdnf5::rpm::PackageQuery query(base);
     query.filter_available();
-    query.filter_nevra({"one-0:1-1.noarch"});
+    query.filter_nevra("one-0:1-1.noarch");
     CPPUNIT_ASSERT_EQUAL((size_t)1, query.size());
     goal.add_rpm_install_or_reinstall(query);
     auto transaction = goal.resolve();

--- a/test/libdnf5/repo/test_package_downloader.cpp
+++ b/test/libdnf5/repo/test_package_downloader.cpp
@@ -72,7 +72,7 @@ void PackageDownloaderTest::test_package_downloader() {
     auto repo = add_repo_rpm("rpm-repo1");
 
     libdnf5::rpm::PackageQuery query(base);
-    query.filter_name({"one"});
+    query.filter_name("one");
     query.filter_version({"2"});
     query.filter_arch({"noarch"});
     CPPUNIT_ASSERT_EQUAL((size_t)1, query.size());
@@ -99,7 +99,7 @@ void PackageDownloaderTest::test_package_downloader_temp_files_memory() {
     auto repo = add_repo_rpm("rpm-repo1");
 
     libdnf5::rpm::PackageQuery query(base);
-    query.filter_name({"one"});
+    query.filter_name("one");
     CPPUNIT_ASSERT_EQUAL((size_t)4, query.size());
 
     auto & config = base.get_config();

--- a/test/libdnf5/repo/test_package_downloader.cpp
+++ b/test/libdnf5/repo/test_package_downloader.cpp
@@ -73,7 +73,7 @@ void PackageDownloaderTest::test_package_downloader() {
 
     libdnf5::rpm::PackageQuery query(base);
     query.filter_name("one");
-    query.filter_version({"2"});
+    query.filter_version("2");
     query.filter_arch({"noarch"});
     CPPUNIT_ASSERT_EQUAL((size_t)1, query.size());
 

--- a/test/libdnf5/repo/test_package_downloader.cpp
+++ b/test/libdnf5/repo/test_package_downloader.cpp
@@ -74,7 +74,7 @@ void PackageDownloaderTest::test_package_downloader() {
     libdnf5::rpm::PackageQuery query(base);
     query.filter_name("one");
     query.filter_version("2");
-    query.filter_arch({"noarch"});
+    query.filter_arch("noarch");
     CPPUNIT_ASSERT_EQUAL((size_t)1, query.size());
 
     auto downloader = libdnf5::repo::PackageDownloader(base);

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -322,7 +322,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset_cmp() {
 
     // prepare query to compare packages with
     PackageQuery patterns(base);
-    patterns.filter_nevra({"pkg-libs-1:1.2-4.x86_64"});
+    patterns.filter_nevra("pkg-libs-1:1.2-4.x86_64");
     std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Pattern preparation failed", expected, to_vector(patterns));
 
@@ -423,7 +423,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
         PackageQuery query(base);
-        query.filter_nevra({"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
+        query.filter_nevra(std::vector<std::string>{"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
@@ -431,7 +431,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
         PackageQuery query(base);
-        query.filter_nevra({"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
+        query.filter_nevra(std::vector<std::string>{"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
@@ -439,7 +439,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - single argument
         PackageQuery query(base);
-        query.filter_nevra({"pkg-1.2-3.src"});
+        query.filter_nevra("pkg-1.2-3.src");
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
@@ -447,7 +447,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument with 0 epoch - single argument
         PackageQuery query(base);
-        query.filter_nevra({"pkg-0:1.2-3.src"});
+        query.filter_nevra("pkg-0:1.2-3.src");
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
@@ -455,7 +455,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument with unknown release - two elements
         PackageQuery query(base);
-        query.filter_nevra({"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
+        query.filter_nevra(std::vector<std::string>{"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
         std::vector<Package> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
@@ -463,7 +463,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument with unknown version - single argument
         PackageQuery query(base);
-        query.filter_nevra({"pkg-0:1.2-unknown2.x86_64"});
+        query.filter_nevra("pkg-0:1.2-unknown2.x86_64");
         CPPUNIT_ASSERT_EQUAL((size_t)0, query.size());
         std::vector<Package> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
@@ -472,7 +472,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without epoch, but package with epoch - single argument
         PackageQuery query(base);
-        query.filter_nevra({"pkg-libs-1.2-4.x86_64"});
+        query.filter_nevra("pkg-libs-1.2-4.x86_64");
         std::vector<Package> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -539,7 +539,7 @@ void RpmPackageQueryTest::test_filter_provides() {
 
     // packages with Provides == "libpkg.so.0()(64bit)"
     PackageQuery query1(base);
-    query1.filter_provides({"libpkg.so.0()(64bit)"});
+    query1.filter_provides("libpkg.so.0()(64bit)");
 
     std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
@@ -548,7 +548,7 @@ void RpmPackageQueryTest::test_filter_provides() {
 
     // packages without Provides == "libpkg.so.0()(64bit)"
     PackageQuery query2(base);
-    query2.filter_provides({"libpkg.so.0()(64bit)"}, libdnf5::sack::QueryCmp::NEQ);
+    query2.filter_provides("libpkg.so.0()(64bit)", libdnf5::sack::QueryCmp::NEQ);
 
     expected = {
         get_pkg("pkg-0:1.2-3.src"),
@@ -657,7 +657,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     query.filter_version({"1.2"});
     query.filter_release({"3"});
     query.filter_arch({"x86_64"});
-    query.filter_provides({"foo"}, libdnf5::sack::QueryCmp::NEQ);
+    query.filter_provides("foo", libdnf5::sack::QueryCmp::NEQ);
     query.filter_requires({"foo"}, libdnf5::sack::QueryCmp::NEQ);
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -827,6 +827,6 @@ void RpmPackageQueryTest::test_filter_provides_performance() {
 
     for (int i = 0; i < 100000; ++i) {
         PackageQuery query(base);
-        query.filter_provides({"prv-all"});
+        query.filter_provides("prv-all");
     }
 }

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -509,7 +509,7 @@ void RpmPackageQueryTest::test_filter_release() {
 
     // packages with release == "3"
     PackageQuery query1(base);
-    query1.filter_release({"3"});
+    query1.filter_release("3");
 
     std::vector<Package> expected = {
         get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64"), get_pkg("pkg-libs-0:1.2-3.x86_64")};
@@ -519,7 +519,7 @@ void RpmPackageQueryTest::test_filter_release() {
 
     // packages with Release != "3"
     PackageQuery query2(base);
-    query2.filter_release({"3"}, libdnf5::sack::QueryCmp::NEQ);
+    query2.filter_release("3", libdnf5::sack::QueryCmp::NEQ);
 
     expected = {get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
@@ -655,7 +655,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     query.filter_name("pkg");
     query.filter_epoch("0");
     query.filter_version("1.2");
-    query.filter_release({"3"});
+    query.filter_release("3");
     query.filter_arch({"x86_64"});
     query.filter_provides("foo", libdnf5::sack::QueryCmp::NEQ);
     query.filter_requires({"foo"}, libdnf5::sack::QueryCmp::NEQ);
@@ -747,7 +747,7 @@ void RpmPackageQueryTest::test_update() {
 
     // packages with Release == "3"
     PackageQuery query1(base);
-    query1.filter_release({"3"});
+    query1.filter_release("3");
 
     PackageQuery query2(base);
     query2.filter_name("pkg-libs");
@@ -772,7 +772,7 @@ void RpmPackageQueryTest::test_intersection() {
 
     // packages with Release == "3"
     PackageQuery query1(base);
-    query1.filter_release({"3"});
+    query1.filter_release("3");
     CPPUNIT_ASSERT_EQUAL((size_t)3, query1.size());
 
     // packages with Name == "pkg-libs"
@@ -794,12 +794,12 @@ void RpmPackageQueryTest::test_difference() {
 
     // packages with Release == "3"
     PackageQuery query1(base);
-    query1.filter_release({"3"});
+    query1.filter_release("3");
     CPPUNIT_ASSERT_EQUAL((size_t)3, query1.size());
 
     // packages with Release == "3" and name == "pkg-libs"
     PackageQuery query2(base);
-    query2.filter_release({"3"});
+    query2.filter_release("3");
     query2.filter_name("pkg-libs");
     CPPUNIT_ASSERT_EQUAL((size_t)1, query2.size());
 

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -653,7 +653,7 @@ void RpmPackageQueryTest::test_filter_chain() {
 
     PackageQuery query(base);
     query.filter_name("pkg");
-    query.filter_epoch({"0"});
+    query.filter_epoch("0");
     query.filter_version({"1.2"});
     query.filter_release({"3"});
     query.filter_arch({"x86_64"});

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -484,7 +484,7 @@ void RpmPackageQueryTest::test_filter_version() {
 
     // packages with version == "1.2"
     PackageQuery query1(base);
-    query1.filter_version({"1.2"});
+    query1.filter_version("1.2");
 
     std::vector<Package> expected = {
         get_pkg("pkg-0:1.2-3.src"),
@@ -497,7 +497,7 @@ void RpmPackageQueryTest::test_filter_version() {
 
     // packages with version != "1.2"
     PackageQuery query2(base);
-    query2.filter_version({"1.2"}, libdnf5::sack::QueryCmp::NEQ);
+    query2.filter_version("1.2", libdnf5::sack::QueryCmp::NEQ);
 
     expected = {get_pkg("pkg-libs-1:1.3-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
@@ -654,7 +654,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     PackageQuery query(base);
     query.filter_name("pkg");
     query.filter_epoch("0");
-    query.filter_version({"1.2"});
+    query.filter_version("1.2");
     query.filter_release({"3"});
     query.filter_arch({"x86_64"});
     query.filter_provides("foo", libdnf5::sack::QueryCmp::NEQ);

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -564,7 +564,7 @@ void RpmPackageQueryTest::test_filter_requires() {
 
     // packages with Requires == "pkg-libs"
     PackageQuery query1(base);
-    query1.filter_requires({"pkg-libs"});
+    query1.filter_requires("pkg-libs");
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
@@ -573,7 +573,7 @@ void RpmPackageQueryTest::test_filter_requires() {
 
     // packages without Requires == "pkg-libs"
     PackageQuery query2(base);
-    query2.filter_requires({"pkg-libs"}, libdnf5::sack::QueryCmp::NEQ);
+    query2.filter_requires("pkg-libs", libdnf5::sack::QueryCmp::NEQ);
 
     expected = {
         get_pkg("pkg-0:1.2-3.src"),
@@ -658,7 +658,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     query.filter_release("3");
     query.filter_arch("x86_64");
     query.filter_provides("foo", libdnf5::sack::QueryCmp::NEQ);
-    query.filter_requires({"foo"}, libdnf5::sack::QueryCmp::NEQ);
+    query.filter_requires("foo", libdnf5::sack::QueryCmp::NEQ);
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -178,7 +178,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name == "pkg"
     PackageQuery query1(base);
-    query1.filter_name({"pkg"});
+    query1.filter_name("pkg");
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
@@ -187,7 +187,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name matching "pkg*" glob
     PackageQuery query2(base);
-    query2.filter_name({"pkg*"}, libdnf5::sack::QueryCmp::GLOB);
+    query2.filter_name("pkg*", libdnf5::sack::QueryCmp::GLOB);
 
     expected = {
         get_pkg("pkg-0:1.2-3.src"),
@@ -201,7 +201,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name matching "p?g" glob
     PackageQuery query3(base);
-    query3.filter_name({"p?g"}, libdnf5::sack::QueryCmp::GLOB);
+    query3.filter_name("p?g", libdnf5::sack::QueryCmp::GLOB);
 
     expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query3));
@@ -210,7 +210,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name != "pkg"
     PackageQuery query4(base);
-    query4.filter_name({"pkg"}, libdnf5::sack::QueryCmp::NEQ);
+    query4.filter_name("pkg", libdnf5::sack::QueryCmp::NEQ);
 
     expected = {
         get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
@@ -220,7 +220,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name == "Pkg" - case insensitive match
     PackageQuery query5(base);
-    query5.filter_name({"Pkg"}, libdnf5::sack::QueryCmp::IEXACT);
+    query5.filter_name("Pkg", libdnf5::sack::QueryCmp::IEXACT);
 
     expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query5));
@@ -230,7 +230,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // packages with Name matching "P?g" glob - case insensitive match
     PackageQuery query6(base);
     std::vector<std::string> names_glob_icase{"cq?lib"};
-    query6.filter_name({"P?g"}, libdnf5::sack::QueryCmp::IGLOB);
+    query6.filter_name("P?g", libdnf5::sack::QueryCmp::IGLOB);
 
     expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query6));
@@ -239,7 +239,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name that contain "kg-l"
     PackageQuery query7(base);
-    query7.filter_name({"kg-l"}, libdnf5::sack::QueryCmp::CONTAINS);
+    query7.filter_name("kg-l", libdnf5::sack::QueryCmp::CONTAINS);
 
     expected = {
         get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
@@ -249,7 +249,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // packages with Name that contain "kG-l" - case insensitive match
     PackageQuery query8(base);
-    query8.filter_name({"kG-l"}, libdnf5::sack::QueryCmp::ICONTAINS);
+    query8.filter_name("kG-l", libdnf5::sack::QueryCmp::ICONTAINS);
 
     expected = {
         get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
@@ -258,13 +258,13 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // unsupported comparison type (operator)
-    CPPUNIT_ASSERT_THROW(query8.filter_name({"pkg"}, libdnf5::sack::QueryCmp::GT), libdnf5::AssertionError);
+    CPPUNIT_ASSERT_THROW(query8.filter_name("pkg", libdnf5::sack::QueryCmp::GT), libdnf5::AssertionError);
 
     // ---
 
     // packages with Name "pkg" or "pkg-libs" - two patterns matched in one expression
     PackageQuery query9(base);
-    query9.filter_name({"pkg", "pkg-libs"});
+    query9.filter_name(std::vector<std::string>{"pkg", "pkg-libs"});
 
     expected = {
         get_pkg("pkg-0:1.2-3.src"),
@@ -280,7 +280,7 @@ void RpmPackageQueryTest::test_filter_name_packgset() {
 
     // packages with Name == "pkg"
     PackageQuery query1(base);
-    query1.filter_name({"pkg"});
+    query1.filter_name("pkg");
     query1.filter_arch({"src"});
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
@@ -301,7 +301,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);
-    query1.filter_name({"cmdline"});
+    query1.filter_name("cmdline");
     std::vector<Package> expected1 = {get_pkg("cmdline-0:1.2-3.noarch", true), get_pkg("cmdline-0:1.2-3.noarch")};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query1));
     query1.filter_installed();
@@ -337,7 +337,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset_cmp() {
     {
         // comparator NEQ
         PackageQuery query(base);
-        query.filter_name({"pkg-libs"});
+        query.filter_name("pkg-libs");
         query.filter_nevra(patterns, libdnf5::sack::QueryCmp::NEQ);
         std::vector<Package> expected = {get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
         CPPUNIT_ASSERT_EQUAL_MESSAGE("NEQ comparator failed", expected, to_vector(query));
@@ -381,7 +381,7 @@ void RpmPackageQueryTest::test_filter_name_arch() {
 
     // packages with Name == "pkg"
     PackageQuery query1(base);
-    query1.filter_name({"pkg"});
+    query1.filter_name("pkg");
     query1.filter_arch({"src"});
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
@@ -401,7 +401,7 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
     add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);
-    query1.filter_name({"cmdline"});
+    query1.filter_name("cmdline");
     std::vector<Package> expected1 = {get_pkg("cmdline-0:1.2-3.noarch", true), get_pkg("cmdline-0:1.2-3.noarch")};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query1));
 
@@ -652,7 +652,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     add_repo_solv("solv-repo1");
 
     PackageQuery query(base);
-    query.filter_name({"pkg"});
+    query.filter_name("pkg");
     query.filter_epoch({"0"});
     query.filter_version({"1.2"});
     query.filter_release({"3"});
@@ -750,7 +750,7 @@ void RpmPackageQueryTest::test_update() {
     query1.filter_release({"3"});
 
     PackageQuery query2(base);
-    query2.filter_name({"pkg-libs"});
+    query2.filter_name("pkg-libs");
     CPPUNIT_ASSERT_EQUAL((size_t)3, query2.size());
 
     query1.update(query2);
@@ -777,7 +777,7 @@ void RpmPackageQueryTest::test_intersection() {
 
     // packages with Name == "pkg-libs"
     PackageQuery query2(base);
-    query2.filter_name({"pkg-libs"});
+    query2.filter_name("pkg-libs");
     CPPUNIT_ASSERT_EQUAL((size_t)3, query2.size());
 
     query1.intersection(query2);
@@ -800,7 +800,7 @@ void RpmPackageQueryTest::test_difference() {
     // packages with Release == "3" and name == "pkg-libs"
     PackageQuery query2(base);
     query2.filter_release({"3"});
-    query2.filter_name({"pkg-libs"});
+    query2.filter_name("pkg-libs");
     CPPUNIT_ASSERT_EQUAL((size_t)1, query2.size());
 
     query1.difference(query2);

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -281,7 +281,7 @@ void RpmPackageQueryTest::test_filter_name_packgset() {
     // packages with Name == "pkg"
     PackageQuery query1(base);
     query1.filter_name("pkg");
-    query1.filter_arch({"src"});
+    query1.filter_arch("src");
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
@@ -382,7 +382,7 @@ void RpmPackageQueryTest::test_filter_name_arch() {
     // packages with Name == "pkg"
     PackageQuery query1(base);
     query1.filter_name("pkg");
-    query1.filter_arch({"src"});
+    query1.filter_arch("src");
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
@@ -656,7 +656,7 @@ void RpmPackageQueryTest::test_filter_chain() {
     query.filter_epoch("0");
     query.filter_version("1.2");
     query.filter_release("3");
-    query.filter_arch({"x86_64"});
+    query.filter_arch("x86_64");
     query.filter_provides("foo", libdnf5::sack::QueryCmp::NEQ);
     query.filter_requires({"foo"}, libdnf5::sack::QueryCmp::NEQ);
 

--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -156,7 +156,7 @@ libdnf5::rpm::Package BaseTestCase::get_pkg(const std::string & nevra, bool inst
 libdnf5::rpm::Package BaseTestCase::get_pkg(const std::string & nevra, const char * repo) {
     libdnf5::rpm::PackageQuery query(base);
     query.filter_nevra({nevra});
-    query.filter_repo_id({repo});
+    query.filter_repo_id(repo);
     return first_query_pkg(query, nevra + " (repo: " + repo + ")");
 }
 

--- a/test/tutorial/query/query.cpp
+++ b/test/tutorial/query/query.cpp
@@ -6,7 +6,7 @@
 libdnf5::rpm::PackageQuery query(base);
 
 // Filter the packages, the filters can be stacked one after another.
-query.filter_name({"one"});
+query.filter_name("one");
 
 // Iterate over the filtered packages in the query.
 for (const auto & pkg : query) {


### PR DESCRIPTION
This is required for Python binding, because when string argument is provided, binding convert it to vector of characters. The change might be problematic because filter_provides({"dnf"}) stop to work.