### PR TITLE
Added destdir option to update command

### DIFF
--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -67,6 +67,7 @@ void UpgradeCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
     create_downloadonly_option(*this);
+    create_destdir_option(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);


### PR DESCRIPTION
- Added the option -destdir to the dnf5 update command
Fixes: #603 
 
Example Command Run:
<img width="758" alt="Screenshot 2023-12-14 at 5 49 18 AM" src="https://github.com/rpm-software-management/dnf5/assets/44981122/46a875da-1e31-4983-91fb-e7801475e831">

Example Output Files:
<img width="1751" alt="image" src="https://github.com/rpm-software-management/dnf5/assets/44981122/6e28de6a-ae16-4e68-9560-476cc3de0eec">
