### PR TITLE
modules: Sort the module info table

### DIFF
--- a/include/libdnf5-cli/output/moduleinfo.hpp
+++ b/include/libdnf5-cli/output/moduleinfo.hpp
@@ -31,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libsmartcols/libsmartcols.h>
 
-#include <set>
+#include <map>
 #include <string>
 
 namespace libdnf5::cli::output {
@@ -98,9 +98,13 @@ void ModuleInfo::add_module_item(ModuleItem & module_item) {
 
 template <class Query>
 void print_moduleinfo_table(Query & module_list) {
-    for (auto & module_item : module_list) {
+    std::map<std::string, libdnf5::module::ModuleItem> module_map;
+    for (const auto & module_item : module_list) {
+        module_map.emplace(module_item.get_full_identifier() + ":" + module_item.get_repo_id(), module_item);
+    }
+    for (auto & module_item : module_map) {
         libdnf5::cli::output::ModuleInfo module_info;
-        module_info.add_module_item(module_item);
+        module_info.add_module_item(module_item.second);
         module_info.print();
         std::cout << std::endl;
     }

--- a/include/libdnf5-cli/output/modulelist.hpp
+++ b/include/libdnf5-cli/output/modulelist.hpp
@@ -73,7 +73,6 @@ static void add_line_into_modulelist_table(
 
 template <class Query>
 void print_modulelist_table(Query & module_list) {
-    // TODO(pkratoch): Sort the table
     struct libscols_table * table = create_modulelist_table();
     std::set<std::pair<std::string, std::string>> name_stream_pairs;
     for (auto & module_item : module_list) {


### PR DESCRIPTION
Also removes the note to sort the module list table, because it's already sorted.