### PR TITLE
Show which packages are installed in the search command output

### DIFF
--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -96,7 +96,11 @@ void print_search_results(const SearchResults & results) {
             } else {
                 std::cout << highlight(package.get_name()) << "." << package.get_arch();
             }
-            std::cout << ": " << highlight(package.get_summary()) << std::endl;
+            std::cout << ": " << highlight(package.get_summary());
+            if (package.is_installed()) {
+                std::cout << " [installed]";
+            }
+            std::cout << std::endl;
         }
     }
 }


### PR DESCRIPTION
Apends " [installed]" to the end of the line if the package is installed.

Example output:
```
> dnf5 search dolphin
Updating and loading repositories:
Repositories loaded.
Matched fields: name (exact)
 dolphin.aarch64: KDE File Manager [installed]
Matched fields: name, summary
 dolphin-connector-devel.aarch64: Development files for Dolphin Connector
 dolphin-devel.aarch64: Developer files for dolphin
 dolphin-emu-data.noarch: Dolphin Emulator data files
 dolphin-emu-nogui.aarch64: Dolphin Emulator without a graphical user interface
 dolphin-emu-tool.aarch64: Dolphin Emulator CLI utility
 dolphin-libs.aarch64: Dolphin runtime libraries [installed]
 dolphin-plugins.aarch64: Dolphin plugins for revision control systems [installed]
 mat2-dolphin.noarch: Dolphin integration for mat2
 nextcloud-client-dolphin.aarch64: Dolphin overlay icons
 owncloud-client-dolphin.aarch64: Dolphin overlay icons
 tnef-dolphin.aarch64: Provides TNEF extract extension for KDE's Dolphin file manager
Matched fields: name
 dolphin-connector.aarch64: Simple MySQL C API wrapper for C++
 dolphin-emu.aarch64: GameCube / Wii / Triforce Emulator
 golang-github-seandolphin-bqschema-devel.noarch: Create Google Big Query schema directly from Go structs
```