### PR TITLE
dnf5daemon-server: Add RPM package Group attribute 

### DIFF
--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -56,7 +56,8 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"nevra", PackageAttribute::nevra},
     {"full_nevra", PackageAttribute::full_nevra},
     {"reason", PackageAttribute::reason},
-    {"vendor", PackageAttribute::vendor}};
+    {"vendor", PackageAttribute::vendor},
+    {"group", PackageAttribute::group}};
 
 std::vector<std::string> reldeplist_to_strings(const libdnf5::rpm::ReldepList & reldeps) {
     std::vector<std::string> lst;
@@ -187,6 +188,9 @@ dnfdaemon::KeyValueMap package_to_map(
                 break;
             case PackageAttribute::vendor:
                 dbus_package.emplace(attr, libdnf_package.get_vendor());
+                break;
+            case PackageAttribute::group:
+                dbus_package.emplace(attr, libdnf_package.get_group());
                 break;
         }
     }

--- a/dnf5daemon-server/package.hpp
+++ b/dnf5daemon-server/package.hpp
@@ -65,7 +65,8 @@ enum class PackageAttribute {
     nevra,
     full_nevra,
     reason,
-    vendor
+    vendor,
+    group
 };
 
 dnfdaemon::KeyValueMap package_to_map(


### PR DESCRIPTION
This is needed for porting over dnfdragora from dnfdaemon.