### PR TITLE
Limit search pattern for remove command

### DIFF
--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -65,8 +65,16 @@ void RemoveCommand::configure() {
 
 void RemoveCommand::run() {
     auto goal = get_context().get_goal();
+
+    // Limit remove spec capabity to prevent multiple matches. Remove command should not match anything after performing
+    // a remove action with the same spec. NEVRA and filenames are the only types that have no overlaps.
+    libdnf5::GoalJobSettings settings;
+    settings.with_nevra = true;
+    settings.with_provides = false;
+    settings.with_filenames = true;
+    settings.with_binaries = false;
     for (const auto & spec : pkg_specs) {
-        goal->add_remove(spec);
+        goal->add_remove(spec, settings);
     }
     // To enable removal of dependency packages it requires to use allow_erasing
     goal->set_allow_erasing(true);

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -412,7 +412,14 @@ sdbus::MethodReply Rpm::remove(sdbus::MethodCall & call) {
 
     // fill the goal
     auto & goal = session.get_goal();
+
+    // Limit remove spec capabity to prevent multiple matches. Remove command should not match anything after performing
+    // a remove action with the same spec. NEVRA and filenames are the only types that have no overlaps.
     libdnf5::GoalJobSettings setting;
+    setting.with_nevra = true;
+    setting.with_provides = false;
+    setting.with_filenames = true;
+    setting.with_binaries = false;
     for (const auto & spec : specs) {
         goal.add_remove(spec, setting);
     }

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -148,6 +148,10 @@ Needs-restarting command
  * Dropped ``-r, --reboothint`` option; this is now the default behavior.
  * Dropped ``-u, --useronly`` option.
 
+Remove command
+--------------
+ * Command does not remove packages according to provides, but only according NEVRA or file provide match
+
 Repoclosure command
 -------------------
  * Dropped ``--pkg`` option. Positional arguments can be used to specify packages to check closure for.

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -25,13 +25,15 @@
 Synopsis
 ========
 
-``dnf5 remove [options] <package-spec>...``
+``dnf5 remove [options] [<spec>...]``
 
 
 Description
 ===========
 
 The ``remove`` command in ``DNF5`` is used for removing installed packages from the system.
+Arguments defined in ``spec`` list are used as ``<package-file-spec>``.
+
 If you want to keep the dependencies that were installed together with the given package,
 set the ``clean_requirements_on_remove`` configuration option to ``False``.
 

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -32,8 +32,8 @@ Description
 ===========
 
 The ``repoquery`` command in ``DNF5`` is used for querying packages by matching
-various input criteria from the user. Arguments defined in ``spec`` list could be
-either file paths or package specs.
+various input criteria from the user. Arguments defined in ``spec`` list are used
+as ``<package-file-spec>``.
 
 
 Options


### PR DESCRIPTION
It prevents additional removal after succesful remove using the same spec. Spec `foo`. The original code during the first run removes (dnf5 remove foo) all packages with the name `foo`. In the next run (dnf5 remove foo) it removes all packages providing `foo`. The next run will remove packages providing binary `foo`. This behavior is inconsistent.

Resolves: https://issues.redhat.com/browse/RHEL-5747

CI-tests - https://github.com/rpm-software-management/ci-dnf-stack/pull/1430