### PR TITLE
package_query: Fix filter_version with non EQ comparator

### DIFF
--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -982,7 +982,7 @@ inline static void filter_version_internal(
         std::string vr(pool.split_evr(pool.get_evr(candidate_id)).v);
         vr.append("-0");
         int cmp = pool.evrcmp_str(vr.c_str(), formatted_c_pattern, EVRCMP_COMPARE);
-        if (cmp_eq(cmp)) {
+        if (cmp_fnc(cmp)) {
             filter_result.add_unsafe(candidate_id);
         }
     }
@@ -1050,7 +1050,7 @@ inline static void filter_release_internal(
         std::string vr("0-");
         vr.append(pool.split_evr(pool.get_evr(candidate_id)).r);
         int cmp = pool.evrcmp_str(vr.c_str(), formatted_c_pattern, EVRCMP_COMPARE);
-        if (cmp_eq(cmp)) {
+        if (cmp_fnc(cmp)) {
             filter_result.add_unsafe(candidate_id);
         }
     }

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -501,6 +501,29 @@ void RpmPackageQueryTest::test_filter_version() {
 
     expected = {get_pkg("pkg-libs-1:1.3-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
+
+    // packages with version < "1.3"
+    PackageQuery query3(base);
+    query3.filter_version({"1.3"}, libdnf5::sack::QueryCmp::LT);
+
+    expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query3));
+
+    // packages with version <= "1.3"
+    PackageQuery query4(base);
+    query4.filter_version({"1.3"}, libdnf5::sack::QueryCmp::LTE);
+
+    expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query4));
 }
 
 
@@ -523,6 +546,25 @@ void RpmPackageQueryTest::test_filter_release() {
 
     expected = {get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
+
+    // packages with release > "3"
+    PackageQuery query3(base);
+    query3.filter_release({"3"}, libdnf5::sack::QueryCmp::GT);
+
+    expected = {get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query3));
+
+    // packages with release >= "3"
+    PackageQuery query4(base);
+    query4.filter_release({"3"}, libdnf5::sack::QueryCmp::GTE);
+
+    expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query4));
 }
 
 void RpmPackageQueryTest::test_filter_priority() {


### PR DESCRIPTION
The current implementation of the `filter_version` and `filter_release` filters
always uses the `cmp_eq` comparator. This means that these filters only work
with EQ and NEQ comparisons. The patch fixes these filters to work
correctly with LT, LTE, GT, and GTE comparisons as well.