### PR TITLE
Additional features for config-manager

### DIFF
--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -56,7 +56,8 @@ std::string get_url_part(const std::string & url, CURLUPart what_part) {
 
 
 // Computes CRC32 checksum of input string.
-// Slow bitwise implementation. Used to calculate the checksum of the omitted part of long URLs.
+// Slow bitwise implementation. Used to calculate the hash of the omitted middle part of a long `repoid` if the `repoid`
+// is generated from a URL. Not used for cryptography.
 uint32_t crc32(std::string_view input) {
     const uint32_t polynomial = 0x04C11DB7;
     uint32_t crc = 0;
@@ -96,15 +97,15 @@ std::string escape(const std::string & text) {
 }
 
 
-// Regular expressions to sanitise filename
+// Regular expressions to sanitise repository id
 const std::regex RE_SCHEME{R"(^\w+:/*(\w+:|www\.)?)"};
 const std::regex RE_SLASH{R"([?/:&#|~\*\[\]\(\)'\\]+)"};
 const std::regex RE_BEGIN{"^[,.]*"};
 const std::regex RE_FINAL{"[,.]*$"};
 
-// Returns a filename suitable for the filesystem and for repository id.
+// Generates a repository id from a URL.
 // Strips dangerous and common characters, encodes some characters and limits the length.
-std::string sanitize_url(const std::string & url) {
+std::string generate_repoid_from_url(const std::string & url) {
     std::string ret;
     ret = std::regex_replace(url, RE_SCHEME, "");
     ret = std::regex_replace(ret, RE_SLASH, "_");
@@ -112,8 +113,8 @@ std::string sanitize_url(const std::string & url) {
     ret = std::regex_replace(ret, RE_FINAL, "");
     ret = escape(ret);
 
-    // Limits length of url.
-    // Copies the first and last 100 characters. The substring in between is replaced by a crc32 checksum.
+    // Limits the length of the repository id.
+    // Copies the first and last 100 characters. The substring in between is replaced by a crc32 hash.
     if (ret.size() > 250) {
         std::string_view tmp{ret};
         ret = fmt::format(
@@ -396,7 +397,7 @@ void ConfigManagerAddRepoCommand::create_repo(
     }
 
     if (repo_id.empty()) {
-        repo_id = sanitize_url(url);
+        repo_id = generate_repoid_from_url(url);
     }
 
     if (save_filename.empty()) {

--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -423,7 +423,7 @@ void ConfigManagerAddRepoCommand::create_repo(
     parser.add_section(repo_id);
 
     // Sets the default repository name. May be overwritten with "--set=name=<name>".
-    parser.set_value(repo_id, "name", "created by dnf5 config-manager");
+    parser.set_value(repo_id, "name", repo_id + " - Created by dnf5 config-manager");
     // Enables repository by default. The repository can be disabled with "--set=enabled=0".
     parser.set_value(repo_id, "enabled", "1");
 

--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -493,7 +493,8 @@ void ConfigManagerAddRepoCommand::test_if_ids_not_already_exist(
             std::error_code ec;
             std::filesystem::directory_iterator di(dir, ec);
             if (ec) {
-                logger->warning("Cannot read repositories from directory \"{}\": {}", dir.string(), ec.message());
+                write_warning(
+                    *logger, M_("Cannot read repositories from directory \"{}\": {}"), dir.string(), ec.message());
                 continue;
             }
             for (auto & dentry : di) {

--- a/dnf5-plugins/config-manager_plugin/setopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/setopt.cpp
@@ -259,7 +259,8 @@ std::set<std::string> ConfigManagerSetOptCommand::load_existing_repo_ids() const
             std::error_code ec;
             std::filesystem::directory_iterator di(dir, ec);
             if (ec) {
-                logger->warning("Cannot read repositories from directory \"{}\": {}", dir.string(), ec.message());
+                write_warning(
+                    *logger, M_("Cannot read repositories from directory \"{}\": {}"), dir.string(), ec.message());
                 continue;
             }
             for (auto & dentry : di) {

--- a/dnf5-plugins/config-manager_plugin/shared.hpp
+++ b/dnf5-plugins/config-manager_plugin/shared.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf5/conf/config_main.hpp>
 #include <libdnf5/conf/const.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
 #include <filesystem>
@@ -36,6 +37,14 @@ struct ConfigManagerError : public libdnf5::Error {
     const char * get_domain_name() const noexcept override { return "dnf5"; }
     const char * get_name() const noexcept override { return "ConfigManagerError"; }
 };
+
+// Writes the warning message to the log and to stderr.
+// The original message is written to the log and translated version to stderr.
+template <typename... Args>
+void write_warning(libdnf5::Logger & log, BgettextMessage msg, Args &&... args) {
+    log.warning(b_gettextmsg_get_id(msg), args...);
+    std::cerr << libdnf5::utils::sformat(TM_(msg, 1), args...) << std::endl;
+}
 
 // Checks if the `path` directory exists. If not, according to the `create_missing_dirs` argument,
 // the directories (missing paths elements) are created or `ConfigManagerError` exception is thrown.

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -32,10 +32,17 @@ using namespace libdnf5;
 
 namespace {
 
-bool remove_from_config(ConfigParser & parser, const std::string & section_id, const std::set<std::string> & keys) {
+bool remove_from_config(
+    ConfigParser & parser,
+    const std::string & section_id,
+    const std::set<std::string> & keys,
+    std::set<std::string> & used_keys) {
     bool removed = false;
     for (const auto & key : keys) {
-        removed |= parser.remove_option(section_id, key);
+        if (parser.remove_option(section_id, key)) {
+            removed = true;
+            used_keys.insert(key);
+        }
     }
     return removed;
 }
@@ -82,7 +89,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                         tmp_repo_conf.opt_binds().at(repo_key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
                         ctx.base.get_logger()->warning(
-                            "config-manager: Request to remove unknown repository option from config file: {}", key);
+                            "config-manager: Request to remove unsupported repository option: {}", key);
                     }
 
                     in_repos_opts_to_remove[repo_id].insert(repo_key);
@@ -92,7 +99,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                         tmp_config.opt_binds().at(key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
                         ctx.base.get_logger()->warning(
-                            "config-manager: Request to remove unknown main option from config file: {}", key);
+                            "config-manager: Request to remove unsupported main option: {}", key);
                     }
 
                     // Save the global option for later removing from the file.
@@ -110,48 +117,91 @@ void ConfigManagerUnsetOptCommand::configure() {
     const auto & config = ctx.base.get_config();
 
     // Remove options from main configuration file.
-    const auto & cfg_filepath = get_config_file_path(ctx.base.get_config());
-    if (!main_opts_to_remove.empty() && std::filesystem::exists(cfg_filepath)) {
-        ConfigParser parser;
-        bool changed = false;
+    if (!main_opts_to_remove.empty()) {
+        const auto & cfg_filepath = get_config_file_path(ctx.base.get_config());
+        if (std::filesystem::exists(cfg_filepath)) {
+            ConfigParser parser;
+            bool changed = false;
+            std::set<std::string> used_keys;
 
-        parser.read(cfg_filepath);
+            parser.read(cfg_filepath);
 
-        changed |= remove_from_config(parser, "main", main_opts_to_remove);
+            changed |= remove_from_config(parser, "main", main_opts_to_remove, used_keys);
 
-        if (changed) {
-            parser.write(cfg_filepath, false);
+            // Generate warning for unused options
+            for (const auto & key : main_opts_to_remove) {
+                if (!used_keys.contains(key)) {
+                    ctx.base.get_logger()->warning(
+                        "config-manager: Request to remove main option but it is not present in the config file: {}",
+                        key);
+                }
+            }
+
+            if (changed) {
+                parser.write(cfg_filepath, false);
+            }
+        } else {
+            ctx.base.get_logger()->warning(
+                "config-manager: Request to remove main option but config file not found: {}", cfg_filepath.string());
         }
     }
 
-    auto repos_override_file_path = get_config_manager_repos_override_file_path(config);
-
     // Remove options from repositories overrides configuration file, remove empty sections.
-    if (!in_repos_opts_to_remove.empty() && std::filesystem::exists(repos_override_file_path)) {
-        ConfigParser parser;
-        bool changed = false;
-        parser.read(repos_override_file_path);
+    if (!in_repos_opts_to_remove.empty()) {
+        const auto & repos_override_file_path = get_config_manager_repos_override_file_path(config);
+        if (std::filesystem::exists(repos_override_file_path)) {
+            ConfigParser parser;
+            bool changed = false;
+            std::map<std::string, std::set<std::string>> used_repos_opts;
 
-        std::vector<std::string> empty_config_sections;
-        for (const auto & [repo_id, setopts] : parser.get_data()) {
-            for (const auto & [in_repoid, keys] : in_repos_opts_to_remove) {
-                if (sack::match_string(repo_id, sack::QueryCmp::GLOB, in_repoid)) {
-                    changed |= remove_from_config(parser, repo_id, keys);
+            parser.read(repos_override_file_path);
+
+            std::vector<std::string> empty_config_sections;
+            for (const auto & [repo_id, setopts] : parser.get_data()) {
+                for (const auto & [in_repoid, keys] : in_repos_opts_to_remove) {
+                    if (sack::match_string(repo_id, sack::QueryCmp::GLOB, in_repoid)) {
+                        auto & used_repoid_opts = used_repos_opts[in_repoid];
+                        changed |= remove_from_config(parser, repo_id, keys, used_repoid_opts);
+                    }
+                }
+                if (setopts.empty()) {
+                    empty_config_sections.emplace_back(repo_id);
                 }
             }
-            if (setopts.empty()) {
-                empty_config_sections.emplace_back(repo_id);
+
+            // Generate warning for unused repoids and options
+            for (const auto & [in_repoid, keys] : in_repos_opts_to_remove) {
+                if (const auto used_repoid_opts = used_repos_opts.find(in_repoid);
+                    used_repoid_opts == used_repos_opts.end()) {
+                    ctx.base.get_logger()->warning(
+                        "config-manager: Request to remove repository option but repoid is not present "
+                        "in the overrides: {}",
+                        in_repoid);
+                } else {
+                    for (const auto & key : keys) {
+                        if (!used_repoid_opts->second.contains(key))
+                            ctx.base.get_logger()->warning(
+                                "config-manager: Request to remove repository option but it is not present "
+                                "in the overrides: {}.{}",
+                                in_repoid,
+                                key);
+                    }
+                }
             }
-        }
 
-        // Clean config - remove empty sections.
-        for (const auto & section : empty_config_sections) {
-            parser.remove_section(section);
-            changed = true;
-        }
+            // Clean config - remove empty sections.
+            for (const auto & section : empty_config_sections) {
+                parser.remove_section(section);
+                changed = true;
+            }
 
-        if (changed) {
-            parser.write(repos_override_file_path, false);
+            if (changed) {
+                parser.write(repos_override_file_path, false);
+            }
+        } else {
+            ctx.base.get_logger()->warning(
+                "config-manager: Request to remove repository option but file with overrides not found: {}",
+                repos_override_file_path.string());
         }
     }
 }

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -88,8 +88,10 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     try {
                         tmp_repo_conf.opt_binds().at(repo_key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
-                        ctx.base.get_logger()->warning(
-                            "config-manager: Request to remove unsupported repository option: {}", key);
+                        write_warning(
+                            *ctx.base.get_logger(),
+                            M_("config-manager: Request to remove unsupported repository option: {}"),
+                            key);
                     }
 
                     in_repos_opts_to_remove[repo_id].insert(repo_key);
@@ -98,8 +100,10 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     try {
                         tmp_config.opt_binds().at(key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
-                        ctx.base.get_logger()->warning(
-                            "config-manager: Request to remove unsupported main option: {}", key);
+                        write_warning(
+                            *ctx.base.get_logger(),
+                            M_("config-manager: Request to remove unsupported main option: {}"),
+                            key);
                     }
 
                     // Save the global option for later removing from the file.
@@ -131,8 +135,10 @@ void ConfigManagerUnsetOptCommand::configure() {
             // Generate warning for unused options
             for (const auto & key : main_opts_to_remove) {
                 if (!used_keys.contains(key)) {
-                    ctx.base.get_logger()->warning(
-                        "config-manager: Request to remove main option but it is not present in the config file: {}",
+                    write_warning(
+                        *ctx.base.get_logger(),
+                        M_("config-manager: Request to remove main option but it is not present in the config file: "
+                           "{}"),
                         key);
                 }
             }
@@ -141,8 +147,10 @@ void ConfigManagerUnsetOptCommand::configure() {
                 parser.write(cfg_filepath, false);
             }
         } else {
-            ctx.base.get_logger()->warning(
-                "config-manager: Request to remove main option but config file not found: {}", cfg_filepath.string());
+            write_warning(
+                *ctx.base.get_logger(),
+                M_("config-manager: Request to remove main option but config file not found: {}"),
+                cfg_filepath.string());
         }
     }
 
@@ -173,16 +181,18 @@ void ConfigManagerUnsetOptCommand::configure() {
             for (const auto & [in_repoid, keys] : in_repos_opts_to_remove) {
                 if (const auto used_repoid_opts = used_repos_opts.find(in_repoid);
                     used_repoid_opts == used_repos_opts.end()) {
-                    ctx.base.get_logger()->warning(
-                        "config-manager: Request to remove repository option but repoid is not present "
-                        "in the overrides: {}",
+                    write_warning(
+                        *ctx.base.get_logger(),
+                        M_("config-manager: Request to remove repository option but repoid is not present "
+                           "in the overrides: {}"),
                         in_repoid);
                 } else {
                     for (const auto & key : keys) {
                         if (!used_repoid_opts->second.contains(key))
-                            ctx.base.get_logger()->warning(
-                                "config-manager: Request to remove repository option but it is not present "
-                                "in the overrides: {}.{}",
+                            write_warning(
+                                *ctx.base.get_logger(),
+                                M_("config-manager: Request to remove repository option but it is not present "
+                                   "in the overrides: {}.{}"),
                                 in_repoid,
                                 key);
                     }
@@ -199,8 +209,9 @@ void ConfigManagerUnsetOptCommand::configure() {
                 parser.write(repos_override_file_path, false);
             }
         } else {
-            ctx.base.get_logger()->warning(
-                "config-manager: Request to remove repository option but file with overrides not found: {}",
+            write_warning(
+                *ctx.base.get_logger(),
+                M_("config-manager: Request to remove repository option but file with overrides not found: {}"),
                 repos_override_file_path.string());
         }
     }

--- a/dnf5-plugins/config-manager_plugin/unsetvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetvar.cpp
@@ -64,13 +64,21 @@ void ConfigManagerUnsetVarCommand::configure() {
         }
 
         if (!std::filesystem::exists(vars_dir)) {
+            ctx.base.get_logger()->warning(
+                "config-manager: Request to remove variable but vars directory was not found: {}", vars_dir.string());
             return;
         }
 
         for (const auto & name : vars_to_remove) {
             const auto filepath = vars_dir / name;
             try {
-                std::filesystem::remove(filepath);
+                if (std::filesystem::exists(filepath)) {
+                    std::filesystem::remove(filepath);
+                } else {
+                    ctx.base.get_logger()->warning(
+                        "config-manager: Request to remove variable but it is not present in the vars directory: {}",
+                        name);
+                }
             } catch (const std::filesystem::filesystem_error & e) {
                 throw ConfigManagerError(
                     M_("Cannot remove variable file \"{}\": {}"), filepath.native(), std::string{e.what()});

--- a/dnf5-plugins/config-manager_plugin/unsetvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetvar.cpp
@@ -64,8 +64,10 @@ void ConfigManagerUnsetVarCommand::configure() {
         }
 
         if (!std::filesystem::exists(vars_dir)) {
-            ctx.base.get_logger()->warning(
-                "config-manager: Request to remove variable but vars directory was not found: {}", vars_dir.string());
+            write_warning(
+                *ctx.base.get_logger(),
+                M_("config-manager: Request to remove variable but vars directory was not found: {}"),
+                vars_dir.string());
             return;
         }
 
@@ -75,8 +77,10 @@ void ConfigManagerUnsetVarCommand::configure() {
                 if (std::filesystem::exists(filepath)) {
                     std::filesystem::remove(filepath);
                 } else {
-                    ctx.base.get_logger()->warning(
-                        "config-manager: Request to remove variable but it is not present in the vars directory: {}",
+                    write_warning(
+                        *ctx.base.get_logger(),
+                        M_("config-manager: Request to remove variable but it is not present in the vars directory: "
+                           "{}"),
                         name);
                 }
             } catch (const std::filesystem::filesystem_error & e) {


### PR DESCRIPTION
It solves tasks in the https://github.com/rpm-software-management/dnf5/issues/1011 issue except for documentation and does not replace crc32 with library functions.

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1429 adjustment of CI tests. 

Closes: #1011 .