### PR TITLE
Disable zchunk on RHEL

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -77,7 +77,11 @@ Provides:       dnf5-command(makecache)
 
 %bcond_without comps
 %bcond_without modulemd
+%if 0%{?rhel}
+%bcond_with    zchunk
+%else
 %bcond_without zchunk
+%endif
 
 %bcond_with    html
 %if 0%{?rhel} == 8


### PR DESCRIPTION
zchunk is not supported in RHEL, and other related packages also disable their zchunk dependency on RHEL.