### PR TITLE
Packaging: Require an exact release of libdnf5-cli by dnf5-plugins

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -655,6 +655,7 @@ Summary:        Plugins for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
 Requires:       libcurl%{?_isa} >= 7.62.0
+Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Provides:       dnf5-command(builddep)
 Provides:       dnf5-command(changelog)
 Provides:       dnf5-command(config-manager)


### PR DESCRIPTION
rpminspect complains on a dnf5 build:

    Subpackage dnf5-plugins on x86_64 carries 'Requires:
    libdnf5-cli.so.1()(64bit)' which comes from subpackage libdnf5-cli
    but does not carry an explicit package version requirement. Please
    add 'Requires: libdnf5-cli = %{version}-%{release}' to the spec
    file to avoid the need to test interoperability between various
    combinations of old and new subpackages.

This patch adds the dependency into dnf5.spec.
The very same dependency already exists in dnf5daemon-client and libdnf5-cli bindings.