### PR TITLE
D-Bus: Fix download_end signal name in org.rpm.dnf.v0.Base interface

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -94,7 +94,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
         Downloading has ended.
     -->
-    <signal name="repo_load_end">
+    <signal name="download_end">
         <arg name="session_object_path" type="o" />
         <arg name="download_id" type="s" />
         <arg name="status" type="i" />


### PR DESCRIPTION
Commit a7036588575e3e15e5e62d28d3517305154a8b0a (dnfdaemon: Fix download callbacks) renamed repo_load_end signal to download_end, but forgot to change the name in org.rpm.dnf.v0.Base interface introspection file.

Fixes: https://github.com/rpm-software-management/dnf5/issues/1146