### PR TITLE
Make cachedir relative to installroot

### DIFF
--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -30,10 +30,10 @@ relative to where all packages will be installed. Think of it like doing
 ``chroot <root> dnf``, except using ``--installroot`` allows ``DNF5`` to work
 before the chroot is created.
 
-`cachedir`, `log` files, `releasever`, and `gpgkey` are taken from or stored in
-the installroot. GPG keys are imported into the installroot from a path
-relative to the host which can be specified in the repository section of
-configuration files.
+`cachedir`, `system_cachedir`, `log` files, `releasever`, and `gpgkey` are
+taken from or stored in the installroot. GPG keys are imported into the
+installroot from a path relative to the host which can be specified in the
+repository section of configuration files.
 
 `configuration` file, `reposdir`, and `vars` are taken from inside the
 installroot, unless the command-line argument ``--use-host-config`` is
@@ -43,6 +43,8 @@ will be used.
 Note: When a path is specified within a command line argument
 (``--config=CONFIG_FILE_PATH`` in case of `configuration` file,
 ``--setopt=reposdir=/path/to/repodir`` for `reposdir`,
+``--setopt=cachedir=/path/to/cachedir`` for `cachedir`,
+``--setopt=system_cachedir=/path/to/system_cachedir`` for `system_cachedir`,
 ``--setopt=logdir=/path/to/logdir`` for `logdir`, or
 ``--setopt=varsdir=/paths/to/varsdir`` for `vars`), then this path is always
 relative to the host with no exceptions. `pluginpath` and `pluginconfpath` are

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -165,12 +165,22 @@ void Base::setup() {
             vars_installroot = config.get_installroot_option().get_value();
         }
     }
-    // Unless the logdir is specified on the command line, logdir should be
-    // relative to the installroot
+    // Unless the cachedir or logdir are specified on the command line, they
+    // should be relative to the installroot
     if (config.get_logdir_option().get_priority() < Option::Priority::COMMANDLINE) {
         const std::filesystem::path logdir_path{config.get_logdir_option().get_value()};
-        const auto full_path = (installroot_path / logdir_path.relative_path()).string();
-        config.get_logdir_option().set(Option::Priority::INSTALLROOT, full_path);
+        const auto full_path = installroot_path / logdir_path.relative_path();
+        config.get_logdir_option().set(Option::Priority::INSTALLROOT, full_path.string());
+    }
+    if (config.get_cachedir_option().get_priority() < Option::Priority::COMMANDLINE) {
+        const std::filesystem::path cachedir_path{config.get_cachedir_option().get_value()};
+        const auto full_path = installroot_path / cachedir_path.relative_path();
+        config.get_cachedir_option().set(Option::Priority::INSTALLROOT, full_path.string());
+    }
+    if (config.get_system_cachedir_option().get_priority() < Option::Priority::COMMANDLINE) {
+        const std::filesystem::path system_cachedir_path{config.get_system_cachedir_option().get_value()};
+        const auto full_path = installroot_path / system_cachedir_path.relative_path();
+        config.get_system_cachedir_option().set(Option::Priority::INSTALLROOT, full_path.string());
     }
 
     load_plugins();


### PR DESCRIPTION
Like `logdir`, the `cachedir` configuration option should be treated as relative to the installroot, unless it is specified on the command line via `--setopt=cachedir=/path/to/cachedir`. This is the behavior of the cachedir with DNF 4.

Currently, the host cache directory is used by default, conflicting with what our docs say (man 7 dnf5-installroot):
> cachedir, log files, releasever, and gpgkey are taken from or stored in the installroot.

After this change, the default cachedir is `$installroot/var/cache/libdnf5`, which is consistent with the docs.

For https://bugzilla.redhat.com/show_bug.cgi?id=2256945.