### PR TITLE
Workaround for swig-4.2.0 missing fragment dependency

### DIFF
--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -15,6 +15,11 @@
 %import "common.i"
 %import "conf.i"
 
+#if SWIG_VERSION == 0x040200
+// https://github.com/swig/swig/issues/2744
+%fragment("SwigPyIterator_T");
+#endif
+
 %exception {
     try {
         $action


### PR DESCRIPTION
Fixes error:
repoPYTHON_wrap.cxx:5656:56: error: expected template-name before '<' token
 5656 |     struct SwigPyMapIterator_T : SwigPyIteratorClosed_T<OutIterator, ValueType, FromOper>

due to missing SWIG %fragment dependency on SwigPyIterator_T which provides the missing base class SwigPyIteratorClosed_T.

See https://github.com/swig/swig/issues/2744