### PR TITLE
Fix --skip-unavailable documentation

### DIFF
--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -48,7 +48,7 @@ Options
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not possible to synchronize. All remaining packages will be synchronized.
 
 
 Examples

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -46,7 +46,7 @@ Options
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not possible to downgrade. All remaining packages will be downgraded.
 
 
 Examples

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -106,7 +106,8 @@ Options
     | Used with ``install`` command to resolve any dependency problems by removing packages that are causing problems from the transaction.
 
 ``--skip-unavailable``
-    | Used with ``install`` and ``upgrade`` to allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Used with ``install`` and ``upgrade`` to allow skipping packages that are not possible to install or upgrade.
+    | All remaining packages will be installed or upgraded.
 
 
 Examples

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -46,7 +46,7 @@ Options
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not available in repositories. All available packages will be installed.
 
 ``--advisories=ADVISORY_NAME,...``
     | Consider only content contained in advisories with specified name.

--- a/doc/commands/mark.8.rst
+++ b/doc/commands/mark.8.rst
@@ -72,7 +72,7 @@ Options
 =======
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not installed on the system. All remaining installed packages will be marked.
 
 
 Examples

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -45,7 +45,7 @@ Options
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not possible to reinstall. All remaining packages will be reinstalled.
 
 
 Examples

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -46,7 +46,7 @@ Options
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
 ``--skip-unavailable``
-    | Allow skipping build dependencies not available in repositories. All available build dependencies will be installed.
+    | Allow skipping packages that are not possible to upgrade. All remaining packages will be upgraded.
 
 ``--advisories=ADVISORY_NAME,...``
     | Consider only content contained in advisories with specified name.

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -25,10 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/comps/group/package.hpp"
 #include "libdnf5/conf/config_main.hpp"
 #include "libdnf5/rpm/nevra.hpp"
-#include "libdnf5/transaction/transaction_item_reason.hpp"
 
 #include <cstdint>
-#include <optional>
 
 
 namespace libdnf5 {


### PR DESCRIPTION
I think it must have been forgotten and just copied from builddep plugin.

Also removes two unused includes.

I have discovered this while restructuring `GoalJobSettings` and documenting them for https://github.com/rpm-software-management/dnf5/issues/1025.