### PR TITLE
I18N: Annotate literals in advisory command

### DIFF
--- a/dnf5daemon-client/commands/advisory/arguments.hpp
+++ b/dnf5daemon-client/commands/advisory/arguments.hpp
@@ -150,6 +150,8 @@ public:
               command,
               "advisory-severities",
               '\0',
+              /* Note for translators: "critical" etc. quoted words are
+                 literals that should not be translated. */
               _("Limit to packages in advisories with specified severity. List option. Can be "
                 "\"critical\", \"important\", \"moderate\", \"low\", \"none\"."),
               _("ADVISORY_SEVERITY,..."),


### PR DESCRIPTION
The comment is extracted by "xgettext -c" and placed to gettext catalogs. It helps the translators not know which words not to translate:

    #. Note for translators: "critical" etc. quoted words are
    #. literals that should not be translated.
    #: commands/advisory/arguments.hpp:155
    msgid ""
    "Limit to packages in advisories with specified severity. List option. Can be "
    "\"critical\", \"important\", \"moderate\", \"low\", \"none\"."
    msgstr ""

Fixes: #1159