### PR TITLE
I18N: Do not mark empty strings for a translation

### DIFF
--- a/include/libdnf5/utils/bgettext/bgettext-mark-domain.h
+++ b/include/libdnf5/utils/bgettext/bgettext-mark-domain.h
@@ -26,6 +26,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "bgettext-mark-common.h"
 
+// clang-format off
+// Use EMPTY_MESSAGE instead of M_(""). Otherwise, xgettext breaks catalogs.
+#define EMPTY_MESSAGE \
+    { .bgettextMsg = "\004" GETTEXT_DOMAIN "\00" "" }
 #define M_(msgId) \
     { .bgettextMsg = "\004" GETTEXT_DOMAIN "\00" msgId }
 #define MP_(msgId, msgIdPlural) \
@@ -34,5 +38,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     { .bgettextMsg = "\006" GETTEXT_DOMAIN "\00" context "\004" msgId }
 #define MCP_(context, msgId, msgIdPlural) \
     { .bgettextMsg = "\007" GETTEXT_DOMAIN "\00" context "\004" msgId "\00" msgIdPlural }
+//clang-format on
 
 #endif /* _BGETTEXT_MARK_DOMAIN_H_ */

--- a/include/libdnf5/utils/bgettext/bgettext-mark.h
+++ b/include/libdnf5/utils/bgettext/bgettext-mark.h
@@ -22,6 +22,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "bgettext-mark-common.h"
 
+// clang-format off
+// Use EMPTY_MESSAGE instead of M_(""). Otherwise, xgettext breaks catalogs.
+#define EMPTY_MESSAGE \
+    { .bgettextMsg = "\000" "" }
 #define M_(msgId) \
     { .bgettextMsg = "\000" msgId }
 #define MP_(msgId, msgIdPlural) \
@@ -30,5 +34,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     { .bgettextMsg = "\002" context "\004" msgId }
 #define MCP_(context, msgId, msgIdPlural) \
     { .bgettextMsg = "\003" context "\004" msgId "\00" msgIdPlural }
+// clang-format on
 
 #endif /* _BGETTEXT_MARK_H_ */

--- a/libdnf5-cli/exception.cpp
+++ b/libdnf5-cli/exception.cpp
@@ -46,6 +46,6 @@ const char * GoalResolveError::what() const noexcept {
     return message.c_str();
 }
 
-SilentCommandExitError::SilentCommandExitError(int exit_code) : Error(M_("")), exit_code(exit_code) {}
+SilentCommandExitError::SilentCommandExitError(int exit_code) : Error(EMPTY_MESSAGE), exit_code(exit_code) {}
 
 }  // namespace libdnf5::cli

--- a/libdnf5-cli/po/ka.po
+++ b/libdnf5-cli/po/ka.po
@@ -1,3 +1,20 @@
+# Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-09 02:52+0000\n"
+"PO-Revision-Date: 2023-11-16 19:01+0000\n"
+"Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
+"Language-Team: Georgian <https://translate.fedoraproject.org/projects/dnf5/"
+"libdnf5-cli/ka/>\n"
+"Language: ka\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.2\n"
+
 #: argument_parser.cpp:62
 msgid "\"{}\" not allowed together with named argument \"{}\""
 msgstr "\"{}\" დაუშვებელია მითითებულ არგუმენტთან \"{}\" ერთად"
@@ -100,24 +117,6 @@ msgstr "ოპერაცია გაუქმებულია მომხ�
 #: exception.cpp:33
 msgid "Failed to resolve the transaction"
 msgstr "ტრანზაქციის ამოხსნის შეცდომა"
-
-# Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023.
-#: exception.cpp:49
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 02:52+0000\n"
-"PO-Revision-Date: 2023-11-16 19:01+0000\n"
-"Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
-"Language-Team: Georgian <https://translate.fedoraproject.org/projects/dnf5/"
-"libdnf5-cli/ka/>\n"
-"Language: ka\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.2\n"
 
 #: session.cpp:79
 msgid "Missing command"

--- a/libdnf5-cli/po/libdnf5-cli.pot
+++ b/libdnf5-cli/po/libdnf5-cli.pot
@@ -1,3 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-02 10:48+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
 #: argument_parser.cpp:62
 msgid "\"{}\" not allowed together with named argument \"{}\""
 msgstr ""
@@ -98,26 +117,6 @@ msgstr ""
 #: exception.cpp:33
 msgid "Failed to resolve the transaction"
 msgstr ""
-
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#: exception.cpp:49
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-02 10:48+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
 
 #: session.cpp:79
 msgid "Missing command"

--- a/libdnf5-cli/po/sv.po
+++ b/libdnf5-cli/po/sv.po
@@ -114,26 +114,6 @@ msgstr ""
 msgid "Failed to resolve the transaction"
 msgstr ""
 
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#: exception.cpp:49
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 02:52+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
-
 #: session.cpp:79
 msgid "Missing command"
 msgstr ""


### PR DESCRIPTION
An empty string has a special meaning in gettext and marking such string produces invalid catalogs with a duplicate message ID entry.

Fixes: #1158