### PR TITLE
group: Fix using allowerasing option

### DIFF
--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -39,6 +39,7 @@ void GroupInstallCommand::set_argument_parser() {
     no_packages = std::make_unique<GroupNoPackagesOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
@@ -56,6 +57,7 @@ void GroupInstallCommand::configure() {
 void GroupInstallCommand::run() {
     auto & ctx = get_context();
     auto goal = ctx.get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
 
     libdnf5::GoalJobSettings settings;
     if (no_packages->get_value()) {

--- a/dnf5/commands/group/group_install.hpp
+++ b/dnf5/commands/group/group_install.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 
 #include <memory>
 #include <vector>
@@ -37,6 +38,8 @@ public:
     void set_argument_parser() override;
     void configure() override;
     void run() override;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 
     std::unique_ptr<GroupWithOptionalOption> with_optional{nullptr};
     std::unique_ptr<GroupNoPackagesOption> no_packages{nullptr};

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -57,6 +57,9 @@ void GroupRemoveCommand::run() {
     for (const auto & spec : group_specs->get_value()) {
         goal->add_group_remove(spec, libdnf5::transaction::TransactionItemReason::USER, settings);
     }
+
+    // To enable removal of dependency packages it requires to use allow_erasing
+    goal->set_allow_erasing(true);
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -37,6 +37,7 @@ void GroupUpgradeCommand::set_argument_parser() {
 
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
 
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
 }
@@ -52,7 +53,7 @@ void GroupUpgradeCommand::configure() {
 void GroupUpgradeCommand::run() {
     auto & ctx = get_context();
     auto goal = ctx.get_goal();
-    goal->set_allow_erasing(true);
+    goal->set_allow_erasing(allow_erasing->get_value());
 
     libdnf5::GoalJobSettings settings;
     for (const auto & spec : group_specs->get_value()) {

--- a/dnf5/commands/group/group_upgrade.hpp
+++ b/dnf5/commands/group/group_upgrade.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 
 #include <memory>
 #include <vector>
@@ -37,6 +38,8 @@ public:
     void set_argument_parser() override;
     void configure() override;
     void run() override;
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
 
     std::unique_ptr<GroupSpecArguments> group_specs{nullptr};
 };

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -102,6 +102,9 @@ Options
 ``--contains-pkgs``
     | Show only groups containing packages with specified names. List option, supports globs.
 
+``--allowerasing``
+    | Used with ``install`` and ``upgrade`` to allow erasing of installed packages to resolve any potential dependency problems.
+
 ``--skip-broken``
     | Used with ``install`` command to resolve any dependency problems by removing packages that are causing problems from the transaction.
 


### PR DESCRIPTION
Allow passing `--allowerasing` option in group subcommands.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1165.