### PR TITLE
Deduplicate strings for translations

### DIFF
--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -181,7 +181,7 @@ void ConfigManagerAddRepoCommand::set_argument_parser() {
                                      const char * value) {
         auto val = strchr(value + 1, '=');
         if (!val) {
-            throw cli::ArgumentParserError(M_("set: Badly formatted argument value \"{}\""), std::string{value});
+            throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), 'set', std::string{value});
         }
         std::string key{value, val};
         std::string key_value{val + 1};

--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -181,7 +181,7 @@ void ConfigManagerAddRepoCommand::set_argument_parser() {
                                      const char * value) {
         auto val = strchr(value + 1, '=');
         if (!val) {
-            throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), 'set', std::string{value});
+            throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), std::string{"set"}, std::string{value});
         }
         std::string key{value, val};
         std::string key_value{val + 1};

--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -181,7 +181,8 @@ void ConfigManagerAddRepoCommand::set_argument_parser() {
                                      const char * value) {
         auto val = strchr(value + 1, '=');
         if (!val) {
-            throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), std::string{"set"}, std::string{value});
+            throw cli::ArgumentParserError(
+                M_("{}: Badly formatted argument value \"{}\""), std::string{"set"}, std::string{value});
         }
         std::string key{value, val};
         std::string key_value{val + 1};

--- a/dnf5-plugins/config-manager_plugin/setopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/setopt.cpp
@@ -79,7 +79,7 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
             auto value = argv[i];
             auto val = strchr(value + 1, '=');
             if (!val) {
-                throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), 'optval', std::string{value});
+                throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), std::string{"optval"}, std::string{value});
             }
             std::string key{value, val};
             std::string key_value{val + 1};
@@ -88,14 +88,14 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
                 if (dot_pos == key.size() - 1) {
                     throw cli::ArgumentParserError(
                         M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
-                        'optval', std::string{value});
+                        std::string{"optval"}, std::string{value});
                 }
 
                 // Save the repository option for later processing (solving glob pattern, writing to file).
                 auto repo_id = key.substr(0, dot_pos);
                 if (repo_id.empty()) {
                     throw cli::ArgumentParserError(
-                        M_("{}: Empty repository id is not allowed: {}"), 'optval', std::string{value});
+                        M_("{}: Empty repository id is not allowed: {}"), std::string{"optval"}, std::string{value});
                 }
                 auto repo_key = key.substr(dot_pos + 1);
 

--- a/dnf5-plugins/config-manager_plugin/setopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/setopt.cpp
@@ -79,7 +79,8 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
             auto value = argv[i];
             auto val = strchr(value + 1, '=');
             if (!val) {
-                throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), std::string{"optval"}, std::string{value});
+                throw cli::ArgumentParserError(
+                    M_("{}: Badly formatted argument value \"{}\""), std::string{"optval"}, std::string{value});
             }
             std::string key{value, val};
             std::string key_value{val + 1};
@@ -88,7 +89,8 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
                 if (dot_pos == key.size() - 1) {
                     throw cli::ArgumentParserError(
                         M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
-                        std::string{"optval"}, std::string{value});
+                        std::string{"optval"},
+                        std::string{value});
                 }
 
                 // Save the repository option for later processing (solving glob pattern, writing to file).

--- a/dnf5-plugins/config-manager_plugin/setopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/setopt.cpp
@@ -79,7 +79,7 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
             auto value = argv[i];
             auto val = strchr(value + 1, '=');
             if (!val) {
-                throw cli::ArgumentParserError(M_("optval: Badly formatted argument value \"{}\""), std::string{value});
+                throw cli::ArgumentParserError(M_("{}: Badly formatted argument value \"{}\""), 'optval', std::string{value});
             }
             std::string key{value, val};
             std::string key_value{val + 1};
@@ -87,15 +87,15 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
             if (dot_pos != std::string::npos) {
                 if (dot_pos == key.size() - 1) {
                     throw cli::ArgumentParserError(
-                        M_("optval: Badly formatted argument value: Last key character cannot be '.': {}"),
-                        std::string{value});
+                        M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
+                        'optval', std::string{value});
                 }
 
                 // Save the repository option for later processing (solving glob pattern, writing to file).
                 auto repo_id = key.substr(0, dot_pos);
                 if (repo_id.empty()) {
                     throw cli::ArgumentParserError(
-                        M_("optval: Empty repository id is not allowed: {}"), std::string{value});
+                        M_("{}: Empty repository id is not allowed: {}"), 'optval', std::string{value});
                 }
                 auto repo_key = key.substr(dot_pos + 1);
 

--- a/dnf5-plugins/config-manager_plugin/setvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/setvar.cpp
@@ -46,7 +46,7 @@ void ConfigManagerSetVarCommand::set_argument_parser() {
                 auto val = strchr(value + 1, '=');
                 if (!val) {
                     throw cli::ArgumentParserError(
-                        M_("varval: Badly formatted argument value \"{}\""), std::string{value});
+                        M_("{}: Badly formatted argument value \"{}\""), 'varval', std::string{value});
                 }
                 std::string var_name{value, val};
                 std::string var_value{val + 1};

--- a/dnf5-plugins/config-manager_plugin/setvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/setvar.cpp
@@ -46,7 +46,7 @@ void ConfigManagerSetVarCommand::set_argument_parser() {
                 auto val = strchr(value + 1, '=');
                 if (!val) {
                     throw cli::ArgumentParserError(
-                        M_("{}: Badly formatted argument value \"{}\""), 'varval', std::string{value});
+                        M_("{}: Badly formatted argument value \"{}\""), std::string{"varval"}, std::string{value});
                 }
                 std::string var_name{value, val};
                 std::string var_value{val + 1};

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -62,7 +62,8 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                 if (dot_pos != std::string::npos) {
                     if (dot_pos == key.size() - 1) {
                         throw cli::ArgumentParserError(
-                            M_("remove-opt: Badly formatted argument value: Last key character cannot be '.': {}"),
+                            M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
+                            'remove-opt',
                             std::string{value});
                     }
 
@@ -70,7 +71,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     auto repo_id = key.substr(0, dot_pos);
                     if (repo_id.empty()) {
                         throw cli::ArgumentParserError(
-                            M_("remove-opt: Empty repository id is not allowed: {}"), std::string{value});
+                            M_("{}: Empty repository id is not allowed: {}"), 'remove-opt', std::string{value});
                     }
                     auto repo_key = key.substr(dot_pos + 1);
 

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -71,7 +71,9 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     auto repo_id = key.substr(0, dot_pos);
                     if (repo_id.empty()) {
                         throw cli::ArgumentParserError(
-                            M_("{}: Empty repository id is not allowed: {}"), std::string{"remove-opt"}, std::string{value});
+                            M_("{}: Empty repository id is not allowed: {}"),
+                            std::string{"remove-opt"},
+                            std::string{value});
                     }
                     auto repo_key = key.substr(dot_pos + 1);
 

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -63,7 +63,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     if (dot_pos == key.size() - 1) {
                         throw cli::ArgumentParserError(
                             M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
-                            'remove-opt',
+                            std::string{"remove-opt"},
                             std::string{value});
                     }
 
@@ -71,7 +71,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                     auto repo_id = key.substr(0, dot_pos);
                     if (repo_id.empty()) {
                         throw cli::ArgumentParserError(
-                            M_("{}: Empty repository id is not allowed: {}"), 'remove-opt', std::string{value});
+                            M_("{}: Empty repository id is not allowed: {}"), std::string{"remove-opt"}, std::string{value});
                     }
                     auto repo_key = key.substr(dot_pos + 1);
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -224,7 +224,7 @@ void RootCommand::set_argument_parser() {
             auto val = strchr(value + 1, '=');
             if (!val) {
                 throw libdnf5::cli::ArgumentParserError(
-                    M_("{}: Badly formatted argument value \"{}\""), 'setopt', std::string(value));
+                    M_("{}: Badly formatted argument value \"{}\""), std::string{"setopt"}, std::string(value));
             }
             auto key = std::string(value, val);
             auto dot_pos = key.rfind('.');
@@ -232,7 +232,7 @@ void RootCommand::set_argument_parser() {
                 if (dot_pos == key.size() - 1) {
                     throw libdnf5::cli::ArgumentParserError(
                         M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
-                        'setopt',
+                        std::string{"setopt"},
                         std::string(value));
                 }
                 // Store repository option to vector. Use it later when repositories configuration will be loaded.
@@ -263,7 +263,7 @@ void RootCommand::set_argument_parser() {
             auto val = strchr(value + 1, '=');
             if (!val) {
                 throw libdnf5::cli::ArgumentParserError(
-                    M_("{}: Badly formatted argument value \"{}\""), 'setvar', std::string(value));
+                    M_("{}: Badly formatted argument value \"{}\""), std::string{"setvar"}, std::string(value));
             }
             auto name = std::string(value, val);
             try {

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -224,14 +224,15 @@ void RootCommand::set_argument_parser() {
             auto val = strchr(value + 1, '=');
             if (!val) {
                 throw libdnf5::cli::ArgumentParserError(
-                    M_("setopt: Badly formatted argument value \"{}\""), std::string(value));
+                    M_("{}: Badly formatted argument value \"{}\""), 'setopt', std::string(value));
             }
             auto key = std::string(value, val);
             auto dot_pos = key.rfind('.');
             if (dot_pos != std::string::npos) {
                 if (dot_pos == key.size() - 1) {
                     throw libdnf5::cli::ArgumentParserError(
-                        M_("setopt: Badly formatted argument value: Last key character cannot be '.': {}"),
+                        M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
+                        'setopt',
                         std::string(value));
                 }
                 // Store repository option to vector. Use it later when repositories configuration will be loaded.
@@ -262,7 +263,7 @@ void RootCommand::set_argument_parser() {
             auto val = strchr(value + 1, '=');
             if (!val) {
                 throw libdnf5::cli::ArgumentParserError(
-                    M_("setvar: Badly formatted argument value \"{}\""), std::string(value));
+                    M_("{}: Badly formatted argument value \"{}\""), 'setvar', std::string(value));
             }
             auto name = std::string(value, val);
             try {

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -38,6 +38,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/logger/memory_buffer_logger.hpp>
 #include <libdnf5/logger/stream_logger.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <locale.h>
 #include <string.h>
 
@@ -149,10 +150,10 @@ void RootCommand::set_argument_parser() {
         auto dot_pos = key.rfind('.');
         if (dot_pos != std::string::npos) {
             if (dot_pos == key.size() - 1) {
-                throw std::runtime_error(
+                throw libdnf5::cli::ArgumentParserError(
                     M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
-                    'setopt',
-                    value;
+                    std::string{"setopt"},
+                    std::string(value));
             }
         }
         // Store option to vector for later use

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -150,7 +150,9 @@ void RootCommand::set_argument_parser() {
         if (dot_pos != std::string::npos) {
             if (dot_pos == key.size() - 1) {
                 throw std::runtime_error(
-                    std::string("setopt: Badly formatted argument value: Last key character cannot be '.': ") + value);
+                    M_("{}: Badly formatted argument value: Last key character cannot be '.': {}"),
+                    'setopt',
+                    value;
             }
         }
         // Store option to vector for later use


### PR DESCRIPTION
Make similar strings equals by replacing argument names with placeholders `{}`. This benefits translators that will see less strings for translation, but the major advantage is to assure consistency across similar translated strings.