### PR TITLE
doc: Add --destdir option to upgrade command manual

### DIFF
--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -45,6 +45,9 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--destdir=<path>``
+    Set directory used for downloading packages to. Default location is to the current working directory.
+
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to upgrade. All remaining packages will be upgraded.
 


### PR DESCRIPTION
This patch documents a new option added in commit
5b81b10d20372c8f653843e66428d7eaeccd838e ("Added upgrade option").

Fixes: #603