### PR TITLE
Add pImpl to several classes

### DIFF
--- a/include/libdnf5/base/log_event.hpp
+++ b/include/libdnf5/base/log_event.hpp
@@ -44,27 +44,29 @@ public:
         const libdnf5::transaction::TransactionItemType spec_type,
         const std::string & spec);
     LogEvent(libdnf5::GoalProblem problem, const SolverProblems & solver_problems);
-    ~LogEvent() = default;
+    ~LogEvent();
+
+    LogEvent(const LogEvent & src);
+    LogEvent & operator=(const LogEvent & src);
+
+    LogEvent(LogEvent && src) noexcept;
+    LogEvent & operator=(LogEvent && src) noexcept;
 
     /// @return GoalAction for which goal event was created
-    libdnf5::GoalAction get_action() const { return action; };
+    libdnf5::GoalAction get_action() const;
     /// @return GoalProblem that specify the type of report
-    libdnf5::GoalProblem get_problem() const { return problem; };
+    libdnf5::GoalProblem get_problem() const;
     /// @return Additional information (internal), that are required for formatted string
-    const std::set<std::string> get_additional_data() const { return additional_data; };
+    const std::set<std::string> & get_additional_data() const;
     /// @return GoalJobSetting if it is relevant for the particular GoalProblem
-    const libdnf5::GoalJobSettings * get_job_settings() const {
-        return job_settings ? &job_settings.value() : nullptr;
-    };
+    const libdnf5::GoalJobSettings * get_job_settings() const;
     /// @return SPEC if it is relevant for the particular GoalProblem
-    const std::string * get_spec() const { return spec ? &spec.value() : nullptr; };
+    const std::string * get_spec() const;
     /// @return SolverProblems if they are relevant for the particular GoalProblem
-    const SolverProblems * get_solver_problems() const { return solver_problems ? &solver_problems.value() : nullptr; };
+    const SolverProblems * get_solver_problems() const;
 
     /// Convert an element from resolve log to string;
-    std::string to_string() const {
-        return to_string(action, problem, additional_data, job_settings, spec_type, spec, solver_problems);
-    };
+    std::string to_string() const;
 
 private:
     /// Convert an element from resolve log to string;
@@ -77,14 +79,8 @@ private:
         const std::optional<std::string> & spec,
         const std::optional<SolverProblems> & solver_problems);
 
-    libdnf5::GoalAction action;
-    libdnf5::GoalProblem problem;
-
-    std::set<std::string> additional_data;
-    std::optional<libdnf5::GoalJobSettings> job_settings;
-    std::optional<libdnf5::transaction::TransactionItemType> spec_type;
-    std::optional<std::string> spec;
-    std::optional<SolverProblems> solver_problems;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/include/libdnf5/base/solver_problems.hpp
+++ b/include/libdnf5/base/solver_problems.hpp
@@ -24,8 +24,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "goal_elements.hpp"
 
-#include "libdnf5/common/impl_ptr.hpp"
-
 
 namespace libdnf5::base {
 
@@ -52,9 +50,7 @@ public:
     /// be rendered into a string by the `problem_to_string()` method.
     // @replaces libdnf/Goal.describeProblemRules(unsigned i, bool pkgs);
     // @replaces libdnf/Goal.describeAllProblemRules(bool pkgs);
-    std::vector<std::vector<std::pair<libdnf5::ProblemRules, std::vector<std::string>>>> get_problems() const {
-        return problems;
-    };
+    std::vector<std::vector<std::pair<libdnf5::ProblemRules, std::vector<std::string>>>> get_problems() const;
 
     /// Convert SolverProblems class to string representative;
     std::string to_string() const;
@@ -65,7 +61,8 @@ public:
 private:
     friend class Transaction;
 
-    std::vector<std::vector<std::pair<libdnf5::ProblemRules, std::vector<std::string>>>> problems;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/include/libdnf5/conf/config_parser.hpp
+++ b/include/libdnf5/conf/config_parser.hpp
@@ -23,7 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/common/preserve_order_map.hpp"
 
-#include <map>
 #include <string>
 
 
@@ -86,6 +85,15 @@ struct ConfigParser {
 public:
     using Container = PreserveOrderMap<std::string, PreserveOrderMap<std::string, std::string>>;
 
+    ConfigParser();
+    ~ConfigParser();
+
+    ConfigParser(const ConfigParser & src);
+    ConfigParser & operator=(const ConfigParser & src);
+
+    ConfigParser(ConfigParser && src) noexcept;
+    ConfigParser & operator=(ConfigParser && src) noexcept;
+
     /**
     * @brief Reads/parse one INI file
     *
@@ -132,10 +140,8 @@ public:
     Container & get_data() noexcept;
 
 private:
-    Container data;
-    int item_number{0};
-    std::string header;
-    std::map<std::string, std::string> raw_items;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -23,7 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/base/base_weak.hpp"
 
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -60,8 +59,10 @@ public:
         Priority priority;
     };
 
-    Vars(const libdnf5::BaseWeakPtr & base) : base(base) {}
+    Vars(const libdnf5::BaseWeakPtr & base);
     Vars(libdnf5::Base & base);
+
+    ~Vars();
 
     /// @brief Substitute DNF vars in the input text.
     ///
@@ -69,7 +70,7 @@ public:
     /// @return The substituted text
     std::string substitute(const std::string & text) const;
 
-    const std::map<std::string, Variable> & get_variables() const { return variables; }
+    const std::map<std::string, Variable> & get_variables() const;
 
     /// @brief Set particular variable to a value
     ///
@@ -89,17 +90,17 @@ public:
     ///
     /// @param name Name of the variable
     /// @return true if there is such an element, otherwise false
-    bool contains(const std::string & name) const { return variables.find(name) != variables.end(); }
+    bool contains(const std::string & name) const;
 
     /// @brief Get value of particular variable.
     ///
     /// @param name Name of the variable
-    const std::string & get_value(const std::string & name) const { return variables.at(name).value; }
+    const std::string & get_value(const std::string & name) const;
 
     /// @brief Get particular variable.
     ///
     /// @param name Name of the variable
-    const Variable & get(const std::string & name) const { return variables.at(name); }
+    const Variable & get(const std::string & name) const;
 
     static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
@@ -160,8 +161,8 @@ private:
     /// @return releasever_major, releasever_minor
     static std::tuple<std::string, std::string> split_releasever(const std::string & releasever);
 
-    BaseWeakPtr base;
-    std::map<std::string, Variable> variables;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -98,10 +98,10 @@ public:
         const std::vector<std::string> & paths, bool calculate_checksum = false);
 
     /// @return `true` if the system repository has been initialized (via `get_system_repo()`).
-    bool has_system_repo() const noexcept { return system_repo; }
+    bool has_system_repo() const noexcept;
 
     /// @return `true` if the command line repository has been initialized (via `get_cmdline_repo()`).
-    bool has_cmdline_repo() const noexcept { return cmdline_repo; }
+    bool has_cmdline_repo() const noexcept;
 
     /// Dumps libsolv's rpm debugdata of all loaded repositories.
     /// @param dir The directory into which to dump the debugdata.
@@ -135,7 +135,7 @@ public:
     /// @param import_keys If true, attempts to download and import keys for repositories that failed key validation
     void update_and_load_repos(libdnf5::repo::RepoQuery & repos, bool import_keys = true);
 
-    RepoSackWeakPtr get_weak_ptr() { return RepoSackWeakPtr(this, &sack_guard); }
+    RepoSackWeakPtr get_weak_ptr();
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
@@ -152,19 +152,19 @@ public:
     /// are created from info in system state.
     void fix_group_missing_xml();
 
+    ~RepoSack();
+
 private:
     friend class libdnf5::Base;
     friend class RepoQuery;
     friend class rpm::PackageSack;
 
-    explicit RepoSack(const libdnf5::BaseWeakPtr & base) : base(base) {}
+    explicit RepoSack(const libdnf5::BaseWeakPtr & base);
     explicit RepoSack(libdnf5::Base & base);
 
     /// Loads repositories configuration overrides from drop-in directories. No new repositories are created.
     /// Only the configuration of the corresponding existing repositories is modified.
     void load_repos_configuration_overrides();
-
-    WeakPtrGuard<RepoSack, false> sack_guard;
 
     /// If not created yet, creates the cmdline repository and returns it.
     /// @return The cmdline repository.
@@ -172,11 +172,8 @@ private:
 
     void internalize_repos();
 
-    BaseWeakPtr base;
-
-    repo::Repo * system_repo{nullptr};
-    repo::Repo * cmdline_repo{nullptr};
-    bool repos_updated_and_loaded{false};
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::repo

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -85,9 +85,14 @@ class RpmSignature {
 public:
     enum class CheckResult { OK, SKIPPED, FAILED_KEY_MISSING, FAILED_NOT_TRUSTED, FAILED_NOT_SIGNED, FAILED };
 
-    explicit RpmSignature(const libdnf5::BaseWeakPtr & base) : base(base) {}
-    explicit RpmSignature(Base & base) : RpmSignature(base.get_weak_ptr()) {}
-    ~RpmSignature(){};
+    explicit RpmSignature(const libdnf5::BaseWeakPtr & base);
+    explicit RpmSignature(Base & base);
+    ~RpmSignature();
+    RpmSignature(const RpmSignature & src);
+    RpmSignature & operator=(const RpmSignature & src);
+
+    RpmSignature(RpmSignature && src) noexcept;
+    RpmSignature & operator=(RpmSignature && src) noexcept;
 
     /// Check signature of the `package` using public keys stored in rpm database.
     /// @param package: package to check.
@@ -97,7 +102,7 @@ public:
     ///         CheckResult::FAILED_NOT_TRUSTED - signature is valid but the key is not trusted
     ///         CheckResult::FAILED_NOT_SIGNED - package is not signed but signature is required
     ///         CheckResult::FAILED - check failed for another reason
-    CheckResult check_package_signature(Package package) const;
+    CheckResult check_package_signature(const Package & pkg) const;
 
     /// Import public key into rpm database.
     /// @param key: GPG key to be imported into rpm database.
@@ -114,7 +119,8 @@ public:
     static std::string check_result_to_string(CheckResult result);
 
 private:
-    BaseWeakPtr base;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::rpm

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -47,17 +47,15 @@ using RpmKeyPktPtr = std::unique_ptr<uint8_t, std::function<void(uint8_t * pkt)>
 
 class KeyInfo {
 public:
-    const std::string & get_key_id() const noexcept { return key_id; }
+    const std::string & get_key_id() const noexcept;
     std::string get_short_key_id() const;
-    const std::vector<std::string> & get_user_ids() const noexcept { return user_ids; }
-    const std::string & get_fingerprint() const noexcept { return fingerprint; }
-    const std::string & get_url() const noexcept { return key_url; }
-    const std::string & get_path() const noexcept { return key_path; }
-    const std::string & get_raw_key() const noexcept { return raw_key; }
-    const long int & get_timestamp() const noexcept { return timestamp; }
+    const std::vector<std::string> & get_user_ids() const noexcept;
+    const std::string & get_fingerprint() const noexcept;
+    const std::string & get_url() const noexcept;
+    const std::string & get_path() const noexcept;
+    const std::string & get_raw_key() const noexcept;
+    const long int & get_timestamp() const noexcept;
 
-protected:
-    friend class RpmSignature;
     KeyInfo(
         const std::string & key_url,
         const std::string & key_path,
@@ -66,13 +64,21 @@ protected:
         const std::string & fingerprint,
         long int timestamp,
         const std::string & raw_key);
-    std::string key_url;
-    std::string key_path;
-    std::string key_id;
-    std::vector<std::string> user_ids;
-    std::string fingerprint;
-    long int timestamp;
-    std::string raw_key;
+
+    ~KeyInfo();
+
+    KeyInfo(const KeyInfo & src);
+    KeyInfo & operator=(const KeyInfo & src);
+
+    KeyInfo(KeyInfo && src) noexcept;
+    KeyInfo & operator=(KeyInfo && src) noexcept;
+
+protected:
+    void add_user_id(const char * user_id);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 class RpmSignature {

--- a/include/libdnf5/transaction/transaction.hpp
+++ b/include/libdnf5/transaction/transaction.hpp
@@ -80,7 +80,14 @@ class Transaction {
 public:
     using State = TransactionState;
 
-    virtual ~Transaction() = default;
+    virtual ~Transaction();
+
+    Transaction(const Transaction & src);
+    Transaction & operator=(const Transaction & src);
+
+    Transaction(Transaction && src) noexcept;
+    Transaction & operator=(Transaction && src) noexcept;
+
 
     bool operator==(const Transaction & other) const;
     bool operator<(const Transaction & other) const;
@@ -90,52 +97,52 @@ public:
     /// Return 0 if the id wasn't set yet
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getId()
-    int64_t get_id() const noexcept { return id; }
+    int64_t get_id() const noexcept;
 
     /// Get date and time of the transaction start
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
-    int64_t get_dt_start() const noexcept { return dt_begin; }
+    int64_t get_dt_start() const noexcept;
 
     /// Get date and time of the transaction end
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_dt_begin()
-    int64_t get_dt_end() const noexcept { return dt_end; }
+    int64_t get_dt_end() const noexcept;
 
     /// Get RPM database version before the transaction
     /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_begin()
-    const std::string & get_rpmdb_version_begin() const noexcept { return rpmdb_version_begin; }
+    const std::string & get_rpmdb_version_begin() const noexcept;
 
     /// Get RPM database version after the transaction
     /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_rpmdb_version_end()
-    const std::string & get_rpmdb_version_end() const noexcept { return rpmdb_version_end; }
+    const std::string & get_rpmdb_version_end() const noexcept;
 
     /// Get $releasever variable value that was used during the transaction
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_releasever()
-    const std::string & get_releasever() const noexcept { return releasever; }
+    const std::string & get_releasever() const noexcept;
 
     /// Get UID of a user that started the transaction
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_user_id()
-    uint32_t get_user_id() const noexcept { return user_id; }
+    uint32_t get_user_id() const noexcept;
 
     /// Get the description of the transaction (e.g. the CLI command that was executed)
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.get_cmdline()
-    const std::string & get_description() const noexcept { return description; }
+    const std::string & get_description() const noexcept;
 
     /// Get a user-specified comment describing the transaction
-    const std::string & get_comment() const noexcept { return comment; }
+    const std::string & get_comment() const noexcept;
 
     /// Get transaction state
     ///
     // @replaces libdnf:transaction/Transaction.hpp:method:Transaction.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
 
     /// Return all comps environments associated with the transaction
     ///
@@ -182,52 +189,52 @@ private:
     /// Set Transaction database id (primary key)
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setId(int64_t value)
-    void set_id(int64_t value) { id = value; }
+    void set_id(int64_t value);
 
     /// Set a user-specified comment describing the transaction
-    void set_comment(const std::string & value) { comment = value; }
+    void set_comment(const std::string & value);
 
     /// Set date and time of the transaction start
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtBegin(int64_t value)
-    void set_dt_start(int64_t value) { dt_begin = value; }
+    void set_dt_start(int64_t value);
 
     /// Set date and time of the transaction end
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setDtEnd(int64_t value)
-    void set_dt_end(int64_t value) { dt_end = value; }
+    void set_dt_end(int64_t value);
 
     /// Set the description of the transaction (e.g. the CLI command that was executed)
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setCmdline(const std::string & value)
-    void set_description(const std::string & value) { description = value; }
+    void set_description(const std::string & value);
 
     /// Set UID of a user that started the transaction
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setUserId(uint32_t value)
-    void set_user_id(uint32_t value) { user_id = value; }
+    void set_user_id(uint32_t value);
 
     /// Set $releasever variable value that was used during the transaction
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setReleasever(const std::string & value)
-    void set_releasever(const std::string & value) { releasever = value; }
+    void set_releasever(const std::string & value);
 
     /// Set RPM database version after the transaction
     /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionEnd(const std::string & value)
-    void set_rpmdb_version_end(const std::string & value) { rpmdb_version_end = value; }
+    void set_rpmdb_version_end(const std::string & value);
 
     /// Set RPM database version before the transaction
     /// Format: `<rpm_count>`:`<sha1 of sorted SHA1HEADER fields of installed RPMs>`
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setRpmdbVersionBegin(const std::string & value)
-    void set_rpmdb_version_begin(const std::string & value) { rpmdb_version_begin = value; }
+    void set_rpmdb_version_begin(const std::string & value);
 
     /// Set transaction state
     ///
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.setState(libdnf::TransactionState value)
-    void set_state(State value) { state = value; }
+    void set_state(State value);
 
     /// Create a new rpm package in the transaction and return a reference to it.
     /// The package is owned by the transaction.
@@ -274,26 +281,8 @@ private:
     // @replaces libdnf:transaction/private/Transaction.hpp:method:Transaction.finish(libdnf::TransactionState state)
     void finish(TransactionState state);
 
-    int64_t id{0};
-
-    int64_t dt_begin = 0;
-    int64_t dt_end = 0;
-    std::string rpmdb_version_begin;
-    std::string rpmdb_version_end;
-    // TODO(dmach): move to a new "vars" table?
-    std::string releasever;
-    uint32_t user_id = 0;
-    std::string description;
-    std::string comment;
-    State state = State::STARTED;
-
-    std::optional<std::vector<std::pair<int, std::string>>> console_output;
-
-    std::optional<std::vector<CompsEnvironment>> comps_environments;
-    std::optional<std::vector<CompsGroup>> comps_groups;
-    std::optional<std::vector<Package>> packages;
-
-    BaseWeakPtr base;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/libdnf5/base/log_event.cpp
+++ b/libdnf5/base/log_event.cpp
@@ -27,8 +27,31 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::base {
 
+class LogEvent::Impl {
+public:
+    Impl(
+        libdnf5::GoalAction action,
+        libdnf5::GoalProblem problem,
+        const std::set<std::string> & additional_data,
+        const libdnf5::GoalJobSettings & settings,
+        libdnf5::transaction::TransactionItemType spec_type,
+        const std::string & spec);
 
-LogEvent::LogEvent(
+    Impl(libdnf5::GoalAction action, libdnf5::GoalProblem problem, const SolverProblems & solver_problems);
+
+private:
+    friend LogEvent;
+
+    libdnf5::GoalAction action;
+    libdnf5::GoalProblem problem;
+    std::set<std::string> additional_data;
+    std::optional<libdnf5::GoalJobSettings> job_settings;
+    std::optional<libdnf5::transaction::TransactionItemType> spec_type;
+    std::optional<std::string> spec;
+    std::optional<SolverProblems> solver_problems;
+};
+
+LogEvent::Impl::Impl(
     libdnf5::GoalAction action,
     libdnf5::GoalProblem problem,
     const std::set<std::string> & additional_data,
@@ -40,7 +63,21 @@ LogEvent::LogEvent(
       additional_data(additional_data),
       job_settings(settings),
       spec_type(spec_type),
-      spec(spec) {
+      spec(spec) {}
+
+LogEvent::Impl::Impl(libdnf5::GoalAction action, libdnf5::GoalProblem problem, const SolverProblems & solver_problems)
+    : action(action),
+      problem(problem),
+      solver_problems(solver_problems) {}
+
+LogEvent::LogEvent(
+    libdnf5::GoalAction action,
+    libdnf5::GoalProblem problem,
+    const std::set<std::string> & additional_data,
+    const libdnf5::GoalJobSettings & settings,
+    const libdnf5::transaction::TransactionItemType spec_type,
+    const std::string & spec)
+    : p_impl(std::make_unique<Impl>(action, problem, additional_data, settings, spec_type, spec)) {
     libdnf_assert(
         !(problem == libdnf5::GoalProblem::SOLVER_ERROR ||
           problem == libdnf5::GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT),
@@ -50,9 +87,7 @@ LogEvent::LogEvent(
 }
 
 LogEvent::LogEvent(libdnf5::GoalProblem problem, const SolverProblems & solver_problems)
-    : action(libdnf5::GoalAction::RESOLVE),
-      problem(problem),
-      solver_problems(solver_problems) {
+    : p_impl(std::make_unique<Impl>(libdnf5::GoalAction::RESOLVE, problem, solver_problems)) {
     libdnf_assert(
         problem == libdnf5::GoalProblem::SOLVER_ERROR ||
             problem == libdnf5::GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT,
@@ -60,6 +95,23 @@ LogEvent::LogEvent(libdnf5::GoalProblem problem, const SolverProblems & solver_p
         "libdnf5::GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT is supported");
 }
 
+LogEvent::~LogEvent() = default;
+
+LogEvent::LogEvent(const LogEvent & src) : p_impl(new Impl(*src.p_impl)) {}
+LogEvent::LogEvent(LogEvent && src) noexcept = default;
+
+LogEvent & LogEvent::operator=(const LogEvent & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+LogEvent & LogEvent::operator=(LogEvent && src) noexcept = default;
 
 std::string LogEvent::to_string(
     libdnf5::GoalAction action,
@@ -167,5 +219,33 @@ std::string LogEvent::to_string(
     return ret;
 }
 
+libdnf5::GoalAction LogEvent::get_action() const {
+    return p_impl->action;
+};
+libdnf5::GoalProblem LogEvent::get_problem() const {
+    return p_impl->problem;
+};
+const std::set<std::string> & LogEvent::get_additional_data() const {
+    return p_impl->additional_data;
+};
+const libdnf5::GoalJobSettings * LogEvent::get_job_settings() const {
+    return p_impl->job_settings ? &p_impl->job_settings.value() : nullptr;
+};
+const std::string * LogEvent::get_spec() const {
+    return p_impl->spec ? &p_impl->spec.value() : nullptr;
+};
+const SolverProblems * LogEvent::get_solver_problems() const {
+    return p_impl->solver_problems ? &p_impl->solver_problems.value() : nullptr;
+};
+std::string LogEvent::to_string() const {
+    return to_string(
+        p_impl->action,
+        p_impl->problem,
+        p_impl->additional_data,
+        p_impl->job_settings,
+        p_impl->spec_type,
+        p_impl->spec,
+        p_impl->solver_problems);
+};
 
 }  // namespace libdnf5::base

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -41,7 +41,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <cstring>
 #include <filesystem>
 #include <memory>
-#include <optional>
 
 #define ASCII_LOWERCASE "abcdefghijklmnopqrstuvwxyz"
 #define ASCII_UPPERCASE "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -121,6 +120,19 @@ static std::string detect_arch() {
 // ==================================================================
 
 
+class Vars::Impl {
+public:
+    Impl(const BaseWeakPtr & base);
+
+private:
+    friend Vars;
+
+    std::map<std::string, Variable> variables;
+    BaseWeakPtr base;
+};
+
+Vars::Impl::Impl(const BaseWeakPtr & base) : base(base) {}
+
 std::unique_ptr<std::string> Vars::detect_release(const BaseWeakPtr & base, const std::string & install_root_path) {
     std::unique_ptr<std::string> release_ver;
 
@@ -159,6 +171,10 @@ std::unique_ptr<std::string> Vars::detect_release(const BaseWeakPtr & base, cons
 
 
 Vars::Vars(Base & base) : Vars(base.get_weak_ptr()) {}
+
+Vars::Vars(const libdnf5::BaseWeakPtr & base) : p_impl(std::make_unique<Impl>(base)) {}
+
+Vars::~Vars() = default;
 
 const unsigned int MAXIMUM_EXPRESSION_DEPTH = 32;
 
@@ -223,7 +239,7 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
             auto pos_after_variable = static_cast<size_t>(std::distance(res.begin(), it));
 
             // Find the substituting string and the end of the variable expression
-            auto variable_mapping = variables.find(res.substr(pos_variable, pos_after_variable - pos_variable));
+            auto variable_mapping = p_impl->variables.find(res.substr(pos_variable, pos_after_variable - pos_variable));
             const std::string * subst_str = nullptr;
 
             size_t pos_after_variable_expression;
@@ -262,7 +278,7 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
                         // If variable is unset or empty, the expansion of word is
                         // substituted. Otherwise, the value of variable is
                         // substituted.
-                        if (variable_mapping == variables.end() || variable_mapping->second.value.empty()) {
+                        if (variable_mapping == p_impl->variables.end() || variable_mapping->second.value.empty()) {
                             subst_str = &expanded_word;
                         } else {
                             subst_str = &variable_mapping->second.value;
@@ -271,7 +287,7 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
                         // ${variable:+word} (alternate value)
                         // If variable is unset or empty nothing is substituted.
                         // Otherwise, the expansion of word is substituted.
-                        if (variable_mapping == variables.end() || variable_mapping->second.value.empty()) {
+                        if (variable_mapping == p_impl->variables.end() || variable_mapping->second.value.empty()) {
                             const std::string empty{};
                             subst_str = &empty;
                         } else {
@@ -285,7 +301,7 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
                     pos_after_variable_expression = pos_after_word + 1;
                 } else if (res[pos_after_variable] == '}') {
                     // ${variable}
-                    if (variable_mapping != variables.end()) {
+                    if (variable_mapping != p_impl->variables.end()) {
                         subst_str = &variable_mapping->second.value;
                     }
                     // Move past the closing '}'
@@ -297,7 +313,7 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
                 }
             } else {
                 // No braces, we have a $variable
-                if (variable_mapping != variables.end()) {
+                if (variable_mapping != p_impl->variables.end()) {
                     subst_str = &variable_mapping->second.value;
                 }
                 pos_after_variable_expression = pos_after_variable;
@@ -358,10 +374,10 @@ void Vars::set(const std::string & name, const std::string & value, Priority pri
     // set_unsafe sets the variable without checking whether it's read-only
     std::function<void(const std::string, const std::string, Priority)> set_unsafe =
         [&](const std::string & name, const std::string & value, Priority prio) {
-            auto it = variables.find(name);
+            auto it = p_impl->variables.find(name);
 
             // Do nothing if the var is already set with a higher priority
-            if (it != variables.end() && prio < it->second.priority) {
+            if (it != p_impl->variables.end() && prio < it->second.priority) {
                 return;
             }
 
@@ -376,8 +392,8 @@ void Vars::set(const std::string & name, const std::string & value, Priority pri
                 }
             }
 
-            if (it == variables.end()) {
-                variables.insert({name, {value, prio}});
+            if (it == p_impl->variables.end()) {
+                p_impl->variables.insert({name, {value, prio}});
             } else {
                 it->second.value = value;
                 it->second.priority = prio;
@@ -390,8 +406,8 @@ void Vars::set_lazy(
     const std::string & name,
     const std::function<const std::unique_ptr<const std::string>()> & get_value,
     const Priority prio) {
-    auto it = variables.find(name);
-    if (it == variables.end() || prio > it->second.priority) {
+    auto it = p_impl->variables.find(name);
+    if (it == p_impl->variables.end() || prio > it->second.priority) {
         const auto maybe_value = get_value();
         if (maybe_value != nullptr) {
             set(name, *maybe_value, prio);
@@ -419,13 +435,15 @@ void Vars::detect_vars(const std::string & installroot) {
     set_lazy(
         "basearch",
         [this]() -> auto {
-            auto base_arch = libdnf5::rpm::get_base_arch(variables["arch"].value);
+            auto base_arch = libdnf5::rpm::get_base_arch(p_impl->variables["arch"].value);
             return base_arch.empty() ? nullptr : std::make_unique<std::string>(std::move(base_arch));
         },
         Priority::AUTO);
 
     set_lazy(
-        "releasever", [this, &installroot]() -> auto { return detect_release(base, installroot); }, Priority::AUTO);
+        "releasever",
+        [this, &installroot]() -> auto { return detect_release(p_impl->base, installroot); },
+        Priority::AUTO);
 }
 
 static void dir_close(DIR * d) {
@@ -433,7 +451,7 @@ static void dir_close(DIR * d) {
 }
 
 void Vars::load_from_dir(const std::string & directory) {
-    auto & logger = *base->get_logger();
+    auto & logger = *p_impl->base->get_logger();
     if (DIR * dir = opendir(directory.c_str())) {
         std::unique_ptr<DIR, decltype(&dir_close)> dir_guard(dir, &dir_close);
         while (auto ent = readdir(dir)) {
@@ -480,6 +498,22 @@ void Vars::load_from_env() {
             }
         }
     }
+}
+
+const std::map<std::string, Vars::Variable> & Vars::get_variables() const {
+    return p_impl->variables;
+}
+
+bool Vars::contains(const std::string & name) const {
+    return p_impl->variables.find(name) != p_impl->variables.end();
+}
+
+const std::string & Vars::get_value(const std::string & name) const {
+    return p_impl->variables.at(name).value;
+}
+
+const Vars::Variable & Vars::get(const std::string & name) const {
+    return p_impl->variables.at(name);
 }
 
 }  // namespace libdnf5

--- a/libdnf5/repo/repo_pgp.cpp
+++ b/libdnf5/repo/repo_pgp.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_pgp.hpp"
 
 #include "libdnf5/base/base.hpp"
-#include "libdnf5/logger/logger.hpp"
 #include "libdnf5/repo/repo_errors.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 #include "libdnf5/utils/fs/temp.hpp"
@@ -39,7 +38,7 @@ Key::Key(const LrGpgKey * key, const LrGpgSubkey * subkey, const std::string & u
           lr_gpg_subkey_get_timestamp(subkey),
           lr_gpg_key_get_raw_key(key)) {
     for (auto * const * item = lr_gpg_key_get_userids(key); *item; ++item) {
-        user_ids.push_back(*item);
+        add_user_id(*item);
     }
 }
 


### PR DESCRIPTION
This PR is into a new dnf5-5.2.0.0 branch to keep the main branch API compatible.

Another part for: https://github.com/rpm-software-management/dnf5/issues/1025

Specifically for `RpmSignature` I am proposing to convert it into a namespace rather than adding a `pImpl` to it, it is described in more details in the commit message.