### PR TITLE
Urlprotocol option

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -97,8 +97,7 @@ void DownloadCommand::set_argument_parser() {
         [&ctx, this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
-                throw libdnf5::cli::ArgumentParserInvalidValueError(
-                    M_(std::format("Invalid urlprotocol option: {}", value)));
+                throw libdnf5::cli::ArgumentParserInvalidValueError(M_("Invalid urlprotocol option: {}"), value)
             }
             urlprotocol_option.emplace_back(value);
         });

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -94,7 +94,7 @@ void DownloadCommand::set_argument_parser() {
     urlprotocol->set_long_name("urlprotocol");
     urlprotocol->set_description("When running with --url, limit to specific protocols");
     urlprotocol->set_parse_hook_func(
-        [&ctx, &urlprotocol_option, &urlprotocol_valid_options](
+        [&ctx, this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
@@ -196,7 +196,7 @@ void DownloadCommand::run() {
         for (auto & [nerva, pkg] : download_pkgs) {
             auto urls = pkg.get_remote_locations();
             libdnf_assert(!urls.empty(), "Failed to get mirror for package: \"{}\"", pkg.get_name());
-            auto valid_url = std::find_if(urls.begin(), urls.end(), [&urlprotocol_option](std::string url) {
+            auto valid_url = std::find_if(urls.begin(), urls.end(), [this](std::string url) {
                 for (auto protocol : urlprotocol_option) {
                     if (url.starts_with(protocol)) {
                         return true;

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -96,6 +96,7 @@ void DownloadCommand::set_argument_parser() {
     urlprotocol->set_parse_hook_func(
         [this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            std::cout << "Values: " << option << value << std::endl;
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
                     M_("Invalid urlprotocol option: {}"), std::string(value));

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -79,8 +79,6 @@ void DownloadCommand::set_argument_parser() {
     alldeps->set_const_value("true");
     alldeps->link_value(alldeps_option);
 
-<<<<<<< HEAD
-=======
     auto url = parser.add_new_named_arg("url");
     url->set_long_name("url");
     url->set_description("Print the list of urls where the rpms can be downloaded instead of downloading");
@@ -106,17 +104,12 @@ void DownloadCommand::set_argument_parser() {
             urlprotocol_option.emplace(value);
             return true;
         });
-
->>>>>>> 31411c22 (Added urlprotocol)
     cmd.register_named_arg(alldeps);
     create_destdir_option(*this);
     cmd.register_named_arg(resolve);
     cmd.register_positional_arg(keys);
-<<<<<<< HEAD
-=======
     cmd.register_named_arg(url);
     cmd.register_named_arg(urlprotocol);
->>>>>>> 31411c22 (Added urlprotocol)
 }
 
 void DownloadCommand::configure() {
@@ -185,40 +178,37 @@ void DownloadCommand::run() {
     if (!download_pkgs.empty()) {
         libdnf5::repo::PackageDownloader downloader(ctx.base);
 
-<<<<<<< HEAD
         // for download command, we don't want to mark the packages for removal
         downloader.force_keep_packages(true);
 
         for (auto & [nevra, pkg] : download_pkgs) {
             downloader.add(pkg);
-=======
-    if (url_option->get_value()) {
-        // If no urlprotocols are specified, then any urlprotocol is acceptable
-        if (urlprotocol_option.empty()) {
-            urlprotocol_option = urlprotocol_valid_options;
-        }
-        for (auto & [nerva, pkg] : download_pkgs) {
-            auto urls = pkg.get_remote_locations();
-            libdnf_assert(!urls.empty(), "Failed to get mirror for package: \"{}\"", pkg.get_name());
-            auto valid_url = std::find_if(urls.begin(), urls.end(), [this](std::string url) {
-                for (auto protocol : urlprotocol_option) {
-                    if (url.starts_with(protocol)) {
-                        return true;
-                    }
+            if (url_option->get_value()) {
+                // If no urlprotocols are specified, then any urlprotocol is acceptable
+                if (urlprotocol_option.empty()) {
+                    urlprotocol_option = urlprotocol_valid_options;
                 }
-                return false;
-            });
-            if (valid_url == urls.end()) {
-                libdnf_assert(true, "Failed to get mirror for package: \"{}\"", pkg.get_name());
+                for (auto & [nerva, pkg] : download_pkgs) {
+                    auto urls = pkg.get_remote_locations();
+                    libdnf_assert(!urls.empty(), "Failed to get mirror for package: \"{}\"", pkg.get_name());
+                    auto valid_url = std::find_if(urls.begin(), urls.end(), [this](std::string url) {
+                        for (auto protocol : urlprotocol_option) {
+                            if (url.starts_with(protocol)) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    });
+                    if (valid_url == urls.end()) {
+                        libdnf_assert(true, "Failed to get mirror for package: \"{}\"", pkg.get_name());
+                    }
+                    std::cout << *valid_url << std::endl;
+                }
+
+                std::cout << "Downloading Packages:" << std::endl;
+                downloader.download();
+                std::cout << std::endl;
             }
-            std::cout << *valid_url << std::endl;
->>>>>>> 31411c22 (Added urlprotocol)
         }
 
-        std::cout << "Downloading Packages:" << std::endl;
-        downloader.download();
-        std::cout << std::endl;
-    }
-}
-
-}  // namespace dnf5
+    }  // namespace dnf5

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -97,7 +97,8 @@ void DownloadCommand::set_argument_parser() {
         [&ctx, this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
-                throw libdnf5::cli::ArgumentParserInvalidValueError(M_("Invalid urlprotocol option: {}"), value);
+                throw libdnf5::cli::ArgumentParserInvalidValueError(
+                    M_("Invalid urlprotocol option: {}"), std::string(value));
             }
             urlprotocol_option.emplace(value);
         });

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -93,6 +93,8 @@ void DownloadCommand::set_argument_parser() {
     auto urlprotocol = parser.add_new_named_arg("urlprotocol");
     urlprotocol->set_long_name("urlprotocol");
     urlprotocol->set_description("When running with --url, limit to specific protocols");
+    urlprotocol->set_has_value(true);
+    urlprotocol->set_arg_value_help("{http, https, rsync, ftp},...");
     urlprotocol->set_parse_hook_func(
         [this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -91,7 +91,7 @@ void DownloadCommand::set_argument_parser() {
     urlprotocol->set_long_name("urlprotocol");
     urlprotocol->set_description("When running with --url, limit to specific protocols");
     urlprotocol->set_parse_hook_func(
-        [&ctx](
+        [&ctx, &urlprotocol_option, &urlprotocol_valid_options](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
@@ -188,13 +188,13 @@ void DownloadCommand::run() {
     if (url_option->get_value()) {
         // If no urlprotocols are specified, then any urlprotocol is acceptable
         if (urlprotocol_option.empty()) {
-            urlprotocol_option = urlprotocol_valid_options
+            urlprotocol_option = urlprotocol_valid_options;
         }
         for (auto & [nerva, pkg] : download_pkgs) {
             auto urls = pkg.get_remote_locations();
             libdnf_assert(!urls.empty(), "Failed to get mirror for package: \"{}\"", pkg.get_name());
-            auto valid_url = std::find_if(urls.begin(), urls.end(), [&](std::string url) {
-                for (auto protocol : urlprotocols) {
+            auto valid_url = std::find_if(urls.begin(), urls.end(), [&urlprotocol_option](std::string url) {
+                for (auto protocol : urlprotocol_option) {
                     if (url.starts_with(protocol)) {
                         return true;
                     }

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -98,7 +98,7 @@ void DownloadCommand::set_argument_parser() {
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
-                    M_(std::format("Invalid urlprotocol option: {}", value)))
+                    M_(std::format("Invalid urlprotocol option: {}", value)));
             }
             urlprotocol_option.emplace_back(value);
         });

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -97,9 +97,9 @@ void DownloadCommand::set_argument_parser() {
         [&ctx, this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
-                throw libdnf5::cli::ArgumentParserInvalidValueError(M_("Invalid urlprotocol option: {}"), value)
+                throw libdnf5::cli::ArgumentParserInvalidValueError(M_("Invalid urlprotocol option: {}"), value);
             }
-            urlprotocol_option.emplace_back(value);
+            urlprotocol_option.emplace(value);
         });
 
 >>>>>>> 31411c22 (Added urlprotocol)

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -87,6 +87,9 @@ void DownloadCommand::set_argument_parser() {
     url->set_const_value("true");
     url->link_value(url_option);
 
+
+    urlprotocol_valid_options = {"http", "https", "rsync", "ftp"};
+    urlprotocol_option = {};
     auto urlprotocol = parser.add_new_named_arg("urlprotocol");
     urlprotocol->set_long_name("urlprotocol");
     urlprotocol->set_description("When running with --url, limit to specific protocols");
@@ -95,7 +98,7 @@ void DownloadCommand::set_argument_parser() {
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
-                    _M(std::format("Invalid urlprotocol option: {}", value)))
+                    M_(std::format("Invalid urlprotocol option: {}", value)))
             }
             urlprotocol_option.emplace_back(value);
         });

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -94,13 +94,14 @@ void DownloadCommand::set_argument_parser() {
     urlprotocol->set_long_name("urlprotocol");
     urlprotocol->set_description("When running with --url, limit to specific protocols");
     urlprotocol->set_parse_hook_func(
-        [&ctx, this](
+        [this](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
                 throw libdnf5::cli::ArgumentParserInvalidValueError(
                     M_("Invalid urlprotocol option: {}"), std::string(value));
             }
             urlprotocol_option.emplace(value);
+            return true;
         });
 
 >>>>>>> 31411c22 (Added urlprotocol)

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -28,6 +28,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/rpm/package_set.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
+#include <algorithm>
+#include <format>
 #include <iostream>
 #include <map>
 
@@ -77,10 +79,37 @@ void DownloadCommand::set_argument_parser() {
     alldeps->set_const_value("true");
     alldeps->link_value(alldeps_option);
 
+<<<<<<< HEAD
+=======
+    auto url = parser.add_new_named_arg("url");
+    url->set_long_name("url");
+    url->set_description("Print the list of urls where the rpms can be downloaded instead of downloading");
+    url->set_const_value("true");
+    url->link_value(url_option);
+
+    auto urlprotocol = parser.add_new_named_arg("urlprotocol");
+    urlprotocol->set_long_name("urlprotocol");
+    urlprotocol->set_description("When running with --url, limit to specific protocols");
+    urlprotocol->set_parse_hook_func(
+        [&ctx](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            if (urlprotocol_valid_options.find(value) == urlprotocol_valid_options.end()) {
+                throw libdnf5::cli::ArgumentParserInvalidValueError(
+                    _M(std::format("Invalid urlprotocol option: {}", value)))
+            }
+            urlprotocol_option.emplace_back(value);
+        });
+
+>>>>>>> 31411c22 (Added urlprotocol)
     cmd.register_named_arg(alldeps);
     create_destdir_option(*this);
     cmd.register_named_arg(resolve);
     cmd.register_positional_arg(keys);
+<<<<<<< HEAD
+=======
+    cmd.register_named_arg(url);
+    cmd.register_named_arg(urlprotocol);
+>>>>>>> 31411c22 (Added urlprotocol)
 }
 
 void DownloadCommand::configure() {
@@ -149,11 +178,34 @@ void DownloadCommand::run() {
     if (!download_pkgs.empty()) {
         libdnf5::repo::PackageDownloader downloader(ctx.base);
 
+<<<<<<< HEAD
         // for download command, we don't want to mark the packages for removal
         downloader.force_keep_packages(true);
 
         for (auto & [nevra, pkg] : download_pkgs) {
             downloader.add(pkg);
+=======
+    if (url_option->get_value()) {
+        // If no urlprotocols are specified, then any urlprotocol is acceptable
+        if (urlprotocol_option.empty()) {
+            urlprotocol_option = urlprotocol_valid_options
+        }
+        for (auto & [nerva, pkg] : download_pkgs) {
+            auto urls = pkg.get_remote_locations();
+            libdnf_assert(!urls.empty(), "Failed to get mirror for package: \"{}\"", pkg.get_name());
+            auto valid_url = std::find_if(urls.begin(), urls.end(), [&](std::string url) {
+                for (auto protocol : urlprotocols) {
+                    if (url.starts_with(protocol)) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+            if (valid_url == urls.end()) {
+                libdnf_assert(true, "Failed to get mirror for package: \"{}\"", pkg.get_name());
+            }
+            std::cout << *valid_url << std::endl;
+>>>>>>> 31411c22 (Added urlprotocol)
         }
 
         std::cout << "Downloading Packages:" << std::endl;

--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -41,8 +41,8 @@ public:
     void run() override;
 
 private:
-    std::set<std::string> urlprotocol_valid_options = {"http", "https", "rsync", "ftp"};
-    std::set<std::string> urlprotocol_option = {};
+    std::set<std::string> urlprotocol_valid_options;
+    std::set<std::string> urlprotocol_option;
     libdnf5::OptionBool * resolve_option{nullptr};
     libdnf5::OptionBool * alldeps_option{nullptr};
 

--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/conf/option.hpp>
 
 #include <memory>
+#include <set>
 #include <vector>
 
 
@@ -40,6 +41,8 @@ public:
     void run() override;
 
 private:
+    std::set<std::string> urlprotocol_valid_options = {"http", "https", "rsync", "ftp"};
+    std::set<std::string> urlprotocol_option = {};
     libdnf5::OptionBool * resolve_option{nullptr};
     libdnf5::OptionBool * alldeps_option{nullptr};
 


### PR DESCRIPTION
Fixes #950

- Implements --urlprotocols to the download command and limits the valid package urls to the set url protocols.
- If no protocols are specified, all protocols are considered valid.

This PR is based on my url PR #1155