### PR TITLE
Add pImpl to `libdnf5::base::transaction_*` classes

### DIFF
--- a/include/libdnf5/base/transaction_environment.hpp
+++ b/include/libdnf5/base/transaction_environment.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_BASE_TRANSACTION_ENVIRONMENT_HPP
 #define LIBDNF5_BASE_TRANSACTION_ENVIRONMENT_HPP
 
-#include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/transaction.hpp"
 #include "libdnf5/comps/environment/environment.hpp"
 #include "libdnf5/transaction/transaction_item_action.hpp"
@@ -36,46 +35,42 @@ public:
     using Reason = transaction::TransactionItemReason;
     using State = transaction::TransactionItemState;
     using Action = transaction::TransactionItemAction;
-    using PackageType = libdnf5::comps::PackageType;
 
     /// @return the underlying environment.
-    libdnf5::comps::Environment get_environment() const { return environment; }
+    libdnf5::comps::Environment get_environment() const;
 
     /// @return the action being performed on the transaction environment.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
+    Action get_action() const noexcept;
 
     /// @return the state of the environment in the transaction.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
 
     /// @return the reason of the action being performed on the transaction environment.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
+    Reason get_reason() const noexcept;
 
     /// @return package types requested to be installed with the group.
-    bool get_with_optional() const noexcept { return with_optional; }
+    bool get_with_optional() const noexcept;
+
+    ~TransactionEnvironment();
+
+    TransactionEnvironment(const TransactionEnvironment & mpkg);
+    TransactionEnvironment & operator=(const TransactionEnvironment & mpkg);
+    TransactionEnvironment(TransactionEnvironment && mpkg) noexcept;
+    TransactionEnvironment & operator=(TransactionEnvironment && mpkg) noexcept;
 
 private:
     friend class Transaction::Impl;
 
-    TransactionEnvironment(
-        const libdnf5::comps::Environment & grp, Action action, Reason reason, const bool with_optional)
-        : environment(grp),
-          action(action),
-          reason(reason),
-          with_optional(with_optional) {}
+    TransactionEnvironment(const libdnf5::comps::Environment & grp, Action action, Reason reason, bool with_optional);
 
-    void set_state(State value) noexcept { state = value; }
-
-    libdnf5::comps::Environment environment;
-    Action action;
-    Reason reason;
-    State state{State::STARTED};
-    bool with_optional;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/include/libdnf5/base/transaction_group.hpp
+++ b/include/libdnf5/base/transaction_group.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_BASE_TRANSACTION_GROUP_HPP
 #define LIBDNF5_BASE_TRANSACTION_GROUP_HPP
 
-#include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/transaction.hpp"
 #include "libdnf5/comps/group/group.hpp"
 #include "libdnf5/comps/group/package.hpp"
@@ -29,8 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/transaction/transaction_item_action.hpp"
 #include "libdnf5/transaction/transaction_item_reason.hpp"
 #include "libdnf5/transaction/transaction_item_state.hpp"
-
-#include <optional>
 
 
 namespace libdnf5::base {
@@ -43,42 +40,40 @@ public:
     using PackageType = libdnf5::comps::PackageType;
 
     /// @return the underlying group.
-    libdnf5::comps::Group get_group() const { return group; }
+    libdnf5::comps::Group get_group() const;
 
     /// @return the action being performed on the transaction group.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
+    Action get_action() const noexcept;
 
     /// @return the state of the group in the transaction.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
 
     /// @return the reason of the action being performed on the transaction group.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
+    Reason get_reason() const noexcept;
 
     /// @return package types requested to be installed with the group.
-    PackageType get_package_types() const noexcept { return package_types; }
+    PackageType get_package_types() const noexcept;
+
+    ~TransactionGroup();
+
+    TransactionGroup(const TransactionGroup & mpkg);
+    TransactionGroup & operator=(const TransactionGroup & mpkg);
+    TransactionGroup(TransactionGroup && mpkg) noexcept;
+    TransactionGroup & operator=(TransactionGroup && mpkg) noexcept;
 
 private:
     friend class Transaction::Impl;
 
-    TransactionGroup(const libdnf5::comps::Group & grp, Action action, Reason reason, const PackageType types)
-        : group(grp),
-          action(action),
-          reason(reason),
-          package_types(types) {}
+    TransactionGroup(const libdnf5::comps::Group & grp, Action action, Reason reason, const PackageType & types);
 
-    void set_state(State value) noexcept { state = value; }
-
-    libdnf5::comps::Group group;
-    Action action;
-    Reason reason;
-    State state{State::STARTED};
-    PackageType package_types;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/include/libdnf5/base/transaction_module.hpp
+++ b/include/libdnf5/base/transaction_module.hpp
@@ -21,14 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_BASE_TRANSACTION_MODULE_HPP
 #define LIBDNF5_BASE_TRANSACTION_MODULE_HPP
 
-#include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/transaction.hpp"
-#include "libdnf5/module/module_item.hpp"
 #include "libdnf5/transaction/transaction_item_action.hpp"
 #include "libdnf5/transaction/transaction_item_reason.hpp"
 #include "libdnf5/transaction/transaction_item_state.hpp"
-
-#include <optional>
 
 
 namespace libdnf5::base {
@@ -40,42 +36,40 @@ public:
     using Action = transaction::TransactionItemAction;
 
     /// @return the module name.
-    std::string get_module_name() const { return module_name; }
+    std::string get_module_name() const;
 
     /// @return the module stream.
-    std::string get_module_stream() const { return module_stream; }
+    std::string get_module_stream() const;
 
     /// @return the action being performed on the transaction module.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
+    Action get_action() const noexcept;
 
     /// @return the state of the module item in the transaction.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
 
     /// @return the reason of the action being performed on the transaction module.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
+    Reason get_reason() const noexcept;
+
+    ~TransactionModule();
+
+    TransactionModule(const TransactionModule & mpkg);
+    TransactionModule & operator=(const TransactionModule & mpkg);
+    TransactionModule(TransactionModule && mpkg) noexcept;
+    TransactionModule & operator=(TransactionModule && mpkg) noexcept;
 
 private:
     friend class Transaction::Impl;
 
-    TransactionModule(const std::string & module_name, const std::string & module_stream, Action action, Reason reason)
-        : module_name(module_name),
-          module_stream(module_stream),
-          action(action),
-          reason(reason) {}
+    TransactionModule(const std::string & module_name, const std::string & module_stream, Action action, Reason reason);
 
-    void set_state(State value) noexcept { state = value; }
-
-    std::string module_name;
-    std::string module_stream;
-    Action action;
-    Reason reason;
-    State state{State::STARTED};
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/include/libdnf5/base/transaction_package.hpp
+++ b/include/libdnf5/base/transaction_package.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_BASE_TRANSACTION_PACKAGE_HPP
 #define LIBDNF5_BASE_TRANSACTION_PACKAGE_HPP
 
-#include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/transaction.hpp"
 #include "libdnf5/rpm/package.hpp"
 #include "libdnf5/transaction/transaction_item_action.hpp"
@@ -43,70 +42,55 @@ public:
     using State = transaction::TransactionItemState;
 
     /// @return the underlying package.
-    libdnf5::rpm::Package get_package() const { return package; }
+    libdnf5::rpm::Package get_package() const;
 
     /// @return the action being performed on the transaction package.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
+    Action get_action() const noexcept;
 
     /// @return the state of the package in the transaction.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
 
     /// @return the reason of the action being performed on the transaction package.
     //
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
+    Reason get_reason() const noexcept;
 
     /// @return packages replaced by this transaction package.
-    const std::vector<rpm::Package> get_replaces() const noexcept { return replaces; }
+    std::vector<rpm::Package> get_replaces() const noexcept;
 
     /// @return packages that replace this transaction package (for transaction
     /// packages that are leaving the system).
-    const std::vector<rpm::Package> & get_replaced_by() const noexcept { return replaced_by; }
+    const std::vector<rpm::Package> & get_replaced_by() const noexcept;
 
     /// The REASON_CHANGE action requires group id in case the reason is changed to GROUP
     /// @return id of group the package belongs to
-    const std::string * get_reason_change_group_id() const noexcept {
-        return reason_change_group_id ? &reason_change_group_id.value() : nullptr;
-    }
+    const std::string * get_reason_change_group_id() const noexcept;
+
+    ~TransactionPackage();
+
+    TransactionPackage(const TransactionPackage & mpkg);
+    TransactionPackage & operator=(const TransactionPackage & mpkg);
+    TransactionPackage(TransactionPackage && mpkg) noexcept;
+    TransactionPackage & operator=(TransactionPackage && mpkg) noexcept;
 
 private:
     friend class Transaction::Impl;
     friend class ::BaseGoalTest;
     friend class ::RpmTransactionTest;
 
-    TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason)
-        : package(pkg),
-          action(action),
-          reason(reason) {}
+    TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason);
 
-    TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason, State state)
-        : package(pkg),
-          action(action),
-          reason(reason),
-          state(state) {}
+    TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason, State state);
 
     TransactionPackage(
-        const libdnf5::rpm::Package & pkg, Action action, Reason reason, std::optional<std::string> group_id)
-        : package(pkg),
-          action(action),
-          reason(reason),
-          reason_change_group_id(group_id) {}
+        const libdnf5::rpm::Package & pkg, Action action, Reason reason, const std::optional<std::string> & group_id);
 
-    void set_reason(Reason value) noexcept { reason = value; }
-    void set_state(State value) noexcept { state = value; }
-
-    libdnf5::rpm::Package package;
-    Action action;
-    Reason reason;
-    State state{State::STARTED};
-    std::optional<std::string> reason_change_group_id;
-
-    std::vector<rpm::Package> replaces;
-    std::vector<rpm::Package> replaced_by;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::base

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solver_problems_internal.hpp"
 #include "transaction/transaction_sr.hpp"
 #include "transaction_impl.hpp"
+#include "transaction_package_impl.hpp"
 #include "utils/locker.hpp"
 #include "utils/string.hpp"
 
@@ -409,7 +410,7 @@ void Transaction::Impl::set_transaction(
         rpm::Package obsoleted(base, rpm::PackageId(replaced_id));
         TransactionPackage tspkg(obsoleted, TransactionPackage::Action::REPLACED, obsoleted.get_reason());
         for (auto id : replaced_by_ids) {
-            tspkg.replaced_by.emplace_back(rpm::Package(base, rpm::PackageId(id)));
+            tspkg.p_impl->replaced_by_append(rpm::Package(base, rpm::PackageId(id)));
         }
         packages.emplace_back(std::move(tspkg));
     }
@@ -462,7 +463,7 @@ void Transaction::Impl::set_transaction(
                     pkg.get_action() == transaction::TransactionItemAction::REMOVE ||
                     (reason_override->second > pkg.get_reason() &&
                      pkg.get_action() != transaction::TransactionItemAction::REASON_CHANGE)) {
-                    pkg.reason = reason_override->second;
+                    pkg.p_impl->set_reason(reason_override->second);
                 }
             }
         }
@@ -504,10 +505,10 @@ TransactionPackage Transaction::Impl::make_transaction_package(
     for (auto replaced_id : obs) {
         rpm::Package replaced_pkg(base, rpm::PackageId(replaced_id));
         reason = std::max(reason, replaced_pkg.get_reason());
-        tspkg.replaces.emplace_back(std::move(replaced_pkg));
+        tspkg.p_impl->replaces_append(std::move(replaced_pkg));
         replaced[replaced_id].push_back(id);
     }
-    tspkg.set_reason(reason);
+    tspkg.p_impl->set_reason(reason);
 
     return tspkg;
 }

--- a/libdnf5/base/transaction_environment.cpp
+++ b/libdnf5/base/transaction_environment.cpp
@@ -1,0 +1,88 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/base/transaction_environment.hpp"
+
+#include <utility>
+
+namespace libdnf5::base {
+
+class TransactionEnvironment::Impl {
+public:
+    Impl(libdnf5::comps::Environment grp, Action action, Reason reason, bool with_optional);
+
+private:
+    friend TransactionEnvironment;
+
+    State state{State::STARTED};
+    Action action;
+    bool with_optional;
+    Reason reason;
+    libdnf5::comps::Environment environment;
+};
+
+TransactionEnvironment::~TransactionEnvironment() = default;
+
+TransactionEnvironment::TransactionEnvironment(const TransactionEnvironment & mpkg) : p_impl(new Impl(*mpkg.p_impl)) {}
+TransactionEnvironment::TransactionEnvironment(TransactionEnvironment && mpkg) noexcept = default;
+
+TransactionEnvironment & TransactionEnvironment::operator=(const TransactionEnvironment & mpkg) {
+    if (this != &mpkg) {
+        if (p_impl) {
+            *p_impl = *mpkg.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*mpkg.p_impl);
+        }
+    }
+
+    return *this;
+}
+TransactionEnvironment & TransactionEnvironment::operator=(TransactionEnvironment && mpkg) noexcept = default;
+
+TransactionEnvironment::Impl::Impl(libdnf5::comps::Environment grp, Action action, Reason reason, bool with_optional)
+    : action(action),
+      with_optional(with_optional),
+      reason(reason),
+      environment(std::move(grp)) {}
+
+TransactionEnvironment::TransactionEnvironment(
+    const libdnf5::comps::Environment & grp, Action action, Reason reason, bool with_optional)
+    : p_impl(std::make_unique<Impl>(grp, action, reason, with_optional)) {}
+
+libdnf5::comps::Environment TransactionEnvironment::get_environment() const {
+    return p_impl->environment;
+}
+
+transaction::TransactionItemAction TransactionEnvironment::get_action() const noexcept {
+    return p_impl->action;
+}
+
+transaction::TransactionItemState TransactionEnvironment::get_state() const noexcept {
+    return p_impl->state;
+}
+
+transaction::TransactionItemReason TransactionEnvironment::get_reason() const noexcept {
+    return p_impl->reason;
+}
+
+bool TransactionEnvironment::get_with_optional() const noexcept {
+    return p_impl->with_optional;
+}
+
+}  // namespace libdnf5::base

--- a/libdnf5/base/transaction_group.cpp
+++ b/libdnf5/base/transaction_group.cpp
@@ -1,0 +1,88 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/base/transaction_group.hpp"
+
+#include <utility>
+
+namespace libdnf5::base {
+
+class TransactionGroup::Impl {
+public:
+    Impl(libdnf5::comps::Group grp, Action action, Reason reason, const PackageType & types);
+
+private:
+    friend TransactionGroup;
+
+    State state{State::STARTED};
+    Action action;
+    Reason reason;
+    libdnf5::comps::Group group;
+    PackageType package_types;
+};
+
+TransactionGroup::~TransactionGroup() = default;
+
+TransactionGroup::TransactionGroup(const TransactionGroup & mpkg) : p_impl(new Impl(*mpkg.p_impl)) {}
+TransactionGroup::TransactionGroup(TransactionGroup && mpkg) noexcept = default;
+
+TransactionGroup & TransactionGroup::operator=(const TransactionGroup & mpkg) {
+    if (this != &mpkg) {
+        if (p_impl) {
+            *p_impl = *mpkg.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*mpkg.p_impl);
+        }
+    }
+
+    return *this;
+}
+TransactionGroup & TransactionGroup::operator=(TransactionGroup && mpkg) noexcept = default;
+
+TransactionGroup::Impl::Impl(libdnf5::comps::Group grp, Action action, Reason reason, const PackageType & types)
+    : action(action),
+      reason(reason),
+      group(std::move(grp)),
+      package_types(types) {}
+
+TransactionGroup::TransactionGroup(
+    const libdnf5::comps::Group & grp, Action action, Reason reason, const PackageType & types)
+    : p_impl(std::make_unique<Impl>(grp, action, reason, types)) {}
+
+libdnf5::comps::Group TransactionGroup::get_group() const {
+    return p_impl->group;
+}
+
+transaction::TransactionItemAction TransactionGroup::get_action() const noexcept {
+    return p_impl->action;
+}
+
+transaction::TransactionItemState TransactionGroup::get_state() const noexcept {
+    return p_impl->state;
+}
+
+transaction::TransactionItemReason TransactionGroup::get_reason() const noexcept {
+    return p_impl->reason;
+}
+
+libdnf5::comps::PackageType TransactionGroup::get_package_types() const noexcept {
+    return p_impl->package_types;
+}
+
+}  // namespace libdnf5::base

--- a/libdnf5/base/transaction_module.cpp
+++ b/libdnf5/base/transaction_module.cpp
@@ -1,0 +1,88 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/base/transaction_module.hpp"
+
+#include <utility>
+
+namespace libdnf5::base {
+
+class TransactionModule::Impl {
+public:
+    Impl(std::string module_name, std::string module_stream, Action action, Reason reason);
+
+private:
+    friend TransactionModule;
+
+    State state{State::STARTED};
+    Action action;
+    Reason reason;
+    std::string module_name;
+    std::string module_stream;
+};
+
+TransactionModule::~TransactionModule() = default;
+
+TransactionModule::TransactionModule(const TransactionModule & mpkg) : p_impl(new Impl(*mpkg.p_impl)) {}
+TransactionModule::TransactionModule(TransactionModule && mpkg) noexcept = default;
+
+TransactionModule & TransactionModule::operator=(const TransactionModule & mpkg) {
+    if (this != &mpkg) {
+        if (p_impl) {
+            *p_impl = *mpkg.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*mpkg.p_impl);
+        }
+    }
+
+    return *this;
+}
+TransactionModule & TransactionModule::operator=(TransactionModule && mpkg) noexcept = default;
+
+TransactionModule::Impl::Impl(std::string module_name, std::string module_stream, Action action, Reason reason)
+    : action(action),
+      reason(reason),
+      module_name(std::move(module_name)),
+      module_stream(std::move(module_stream)) {}
+
+TransactionModule::TransactionModule(
+    const std::string & module_name, const std::string & module_stream, Action action, Reason reason)
+    : p_impl(std::make_unique<Impl>(module_name, module_stream, action, reason)) {}
+
+transaction::TransactionItemAction TransactionModule::get_action() const noexcept {
+    return p_impl->action;
+}
+
+transaction::TransactionItemState TransactionModule::get_state() const noexcept {
+    return p_impl->state;
+}
+
+transaction::TransactionItemReason TransactionModule::get_reason() const noexcept {
+    return p_impl->reason;
+}
+
+std::string TransactionModule::get_module_name() const {
+    return p_impl->module_name;
+}
+
+std::string TransactionModule::get_module_stream() const {
+    return p_impl->module_stream;
+}
+
+}  // namespace libdnf5::base

--- a/libdnf5/base/transaction_package.cpp
+++ b/libdnf5/base/transaction_package.cpp
@@ -1,0 +1,105 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/base/transaction_package.hpp"
+
+#include "transaction_package_impl.hpp"
+
+#include <utility>
+
+namespace libdnf5::base {
+
+TransactionPackage::~TransactionPackage() = default;
+
+TransactionPackage::TransactionPackage(const TransactionPackage & mpkg) : p_impl(new Impl(*mpkg.p_impl)) {}
+TransactionPackage::TransactionPackage(TransactionPackage && mpkg) noexcept = default;
+
+TransactionPackage & TransactionPackage::operator=(const TransactionPackage & mpkg) {
+    if (this != &mpkg) {
+        if (p_impl) {
+            *p_impl = *mpkg.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*mpkg.p_impl);
+        }
+    }
+
+    return *this;
+}
+TransactionPackage & TransactionPackage::operator=(TransactionPackage && mpkg) noexcept = default;
+
+TransactionPackage::Impl::Impl(
+    libdnf5::rpm::Package pkg, Action action, Reason reason, State state, std::optional<std::string> group_id)
+    : package(std::move(pkg)),
+      state(state),
+      action(action),
+      reason(reason),
+      reason_change_group_id(std::move(group_id)) {}
+
+TransactionPackage::TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason)
+    : p_impl(std::make_unique<Impl>(pkg, action, reason, State::STARTED)) {}
+
+TransactionPackage::TransactionPackage(const libdnf5::rpm::Package & pkg, Action action, Reason reason, State state)
+    : p_impl(std::make_unique<Impl>(pkg, action, reason, state)) {}
+
+TransactionPackage::TransactionPackage(
+    const libdnf5::rpm::Package & pkg, Action action, Reason reason, const std::optional<std::string> & group_id)
+    : p_impl(std::make_unique<Impl>(pkg, action, reason, State::STARTED, group_id)) {}
+
+
+transaction::TransactionItemAction TransactionPackage::get_action() const noexcept {
+    return p_impl->action;
+}
+
+transaction::TransactionItemState TransactionPackage::get_state() const noexcept {
+    return p_impl->state;
+}
+
+transaction::TransactionItemReason TransactionPackage::get_reason() const noexcept {
+    return p_impl->reason;
+}
+
+libdnf5::rpm::Package TransactionPackage::get_package() const {
+    return p_impl->package;
+}
+
+const std::string * TransactionPackage::get_reason_change_group_id() const noexcept {
+    return p_impl->reason_change_group_id ? &p_impl->reason_change_group_id.value() : nullptr;
+}
+
+std::vector<rpm::Package> TransactionPackage::get_replaces() const noexcept {
+    return p_impl->replaces;
+}
+
+const std::vector<rpm::Package> & TransactionPackage::get_replaced_by() const noexcept {
+    return p_impl->replaced_by;
+}
+
+void TransactionPackage::Impl::replaced_by_append(rpm::Package && pkg) {
+    replaced_by.push_back(std::move(pkg));
+}
+
+void TransactionPackage::Impl::replaces_append(rpm::Package && pkg) {
+    replaces.push_back(std::move(pkg));
+}
+
+void TransactionPackage::Impl::set_reason(Reason value) noexcept {
+    reason = value;
+}
+
+}  // namespace libdnf5::base

--- a/libdnf5/base/transaction_package_impl.hpp
+++ b/libdnf5/base/transaction_package_impl.hpp
@@ -1,0 +1,54 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_BASE_TRANSACTION_PACKAGE_IMPL_HPP
+#define LIBDNF5_BASE_TRANSACTION_PACKAGE_IMPL_HPP
+
+#include "libdnf5/base/transaction_package.hpp"
+
+namespace libdnf5::base {
+
+class TransactionPackage::Impl {
+public:
+    Impl(
+        libdnf5::rpm::Package pkg,
+        Action action,
+        Reason reason,
+        State state,
+        std::optional<std::string> group_id = std::nullopt);
+
+    void replaced_by_append(rpm::Package && pkg);
+    void replaces_append(rpm::Package && pkg);
+    void set_reason(Reason value) noexcept;
+
+private:
+    friend TransactionPackage;
+
+    libdnf5::rpm::Package package;
+    State state;
+    Action action;
+    Reason reason;
+    std::optional<std::string> reason_change_group_id;
+    std::vector<rpm::Package> replaces;
+    std::vector<rpm::Package> replaced_by;
+};
+
+}  // namespace libdnf5::base
+
+#endif  // LIBDNF5_BASE_TRANSACTION_PACKAGE_IMPL_HPP


### PR DESCRIPTION
This includes package, group, environment and module.

This PR is into a new dnf5-5.2.0.0 branch to keep the main branch API compatible.

Another part for: https://github.com/rpm-software-management/dnf5/issues/1025