### PR TITLE
Added urlprotocol option

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/conf/option.hpp>
 
 #include <memory>
+#include <set>
 #include <vector>
 
 
@@ -40,6 +41,8 @@ public:
     void run() override;
 
 private:
+    std::set<std::string> urlprotocol_valid_options;
+    std::set<std::string> urlprotocol_option;
     libdnf5::OptionBool * resolve_option{nullptr};
     libdnf5::OptionBool * alldeps_option{nullptr};
     libdnf5::OptionBool * url_option{nullptr};

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -45,7 +45,14 @@ Options
     | To be used together with ``--resolve``, it downloads all dependencies, not skipping the already installed ones.
 
 ``--destdir=<path>``
-    Set directory used for downloading packages to. Default location is to the current working directory.
+    | Set directory used for downloading packages to. Default location is to the current working directory.
+
+``--url``
+    | Prints the list of URLs where the rpms can be downloaded instead of downloading.
+
+``--urlprotocol``
+    | To be used together with ``--url``. It filters out the URLs to the specified protocols: ``http``, ``https``, ``ftp``, or ``file``. This option can be used multiple times.
+
 
 
 Examples
@@ -62,6 +69,10 @@ Examples
 
 ``dnf5 download --destdir /tmp/my_packages maven-compiler-plugin``
     | Download the ``maven-compiler-plugin`` package to ``/tmp/my_packages`` directory.
+
+``dnf5 download --url --urlprotocol http python``
+    | List the http URL to download the python package
+
 
 See Also
 ========

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -329,7 +329,7 @@ std::vector<std::string> Package::get_remote_locations(const std::set<std::strin
     auto repo_mirrors = get_repo()->get_mirrors();
     for (const auto & mirror : repo_mirrors) {
         for (const auto & protocol : protocols) {
-            if (utils::string::starts_with(mirror, protocol)) {
+            if (utils::string::starts_with(mirror, protocol + ":")) {
                 auto path = lr_pathconcat(mirror.c_str(), location.c_str(), NULL);
                 remote_locations.emplace_back(path);
                 lr_free(path);
@@ -341,7 +341,7 @@ std::vector<std::string> Package::get_remote_locations(const std::set<std::strin
     auto repo_baseurls = get_repo()->get_config().get_baseurl_option().get_value();
     for (const auto & baseurl : repo_baseurls) {
         for (const auto & protocol : protocols) {
-            if (utils::string::starts_with(baseurl, protocol)) {
+            if (utils::string::starts_with(baseurl, protocol + ":")) {
                 auto path = lr_pathconcat(baseurl.c_str(), location.c_str(), NULL);
                 remote_locations.emplace_back(path);
                 lr_free(path);


### PR DESCRIPTION
Fixes #950 

- Implements --urlprotocols to the download command and limits the valid package urls to the set url protocols.
- If no protocols are specified, all protocols are considered valid.