### PR TITLE
Move number placeholder to postposition in copr_repo.cpp

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_repo.cpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.cpp
@@ -381,7 +381,7 @@ static std::string nth_delimited_item(const std::string & string, size_t n, char
             return token;
         i++;
     }
-    std::string msg = libdnf5::utils::sformat(_("Can't find {} item in {}"), n, string);
+    std::string msg = libdnf5::utils::sformat(_("Can't find item {} in {}"), n, string);
     throw std::runtime_error(msg);
 }
 


### PR DESCRIPTION
Since the first placeholder `{}` is the number of an item (not the number of items), placing the placeholder after the word "item" makes the sentence clearer.

See discussion #1160.