### PR TITLE
Add pImpl to libdnf5::transaction::* classes

### DIFF
--- a/include/libdnf5/transaction/comps_environment.hpp
+++ b/include/libdnf5/transaction/comps_environment.hpp
@@ -47,6 +47,12 @@ public:
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.toStr()
     std::string to_string() const { return get_environment_id(); }
 
+    CompsEnvironment(const CompsEnvironment & src);
+    CompsEnvironment & operator=(const CompsEnvironment & src);
+    CompsEnvironment(CompsEnvironment && src) noexcept;
+    CompsEnvironment & operator=(CompsEnvironment && src) noexcept;
+    ~CompsEnvironment();
+
 private:
     friend Transaction;
     friend CompsEnvironmentDbUtils;
@@ -57,42 +63,42 @@ private:
     /// Get text id of the environment (xml element: `<comps><environment><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getEnvironmentId()
-    const std::string & get_environment_id() const noexcept { return environment_id; }
+    const std::string & get_environment_id() const noexcept;
 
     /// Set text id of the environment (xml element: `<comps><environment><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setEnvironmentId(const std::string & value)
-    void set_environment_id(const std::string & value) { environment_id = value; }
+    void set_environment_id(const std::string & value);
 
     /// Get name of the environment (xml element: `<comps><environment><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getName()
-    const std::string & get_name() const noexcept { return name; }
+    const std::string & get_name() const noexcept;
 
     /// Set name of the environment (xml element: `<comps><environment><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setName(const std::string & value)
-    void set_name(const std::string & value) { name = value; }
+    void set_name(const std::string & value);
 
     /// Get translated name of the environment in the current locale (xml element: `<comps><environment><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getTranslatedName()
-    const std::string & get_translated_name() const noexcept { return translated_name; }
+    const std::string & get_translated_name() const noexcept;
 
     /// Set translated name of the environment in the current locale (xml element: `<comps><environment><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setTranslatedName(const std::string & value)
-    void set_translated_name(const std::string & value) { translated_name = value; }
+    void set_translated_name(const std::string & value);
 
     /// Get types of the packages to be installed with the environment (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getPackageTypes()
-    libdnf5::comps::PackageType get_package_types() const noexcept { return package_types; }
+    libdnf5::comps::PackageType get_package_types() const noexcept;
 
     /// Set types of the packages to be installed with the environment (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.setPackageTypes(libdnf::CompsPackageType value)
-    void set_package_types(libdnf5::comps::PackageType value) { package_types = value; }
+    void set_package_types(libdnf5::comps::PackageType value);
 
     /// Create a new CompsEnvironmentGroup object and return a reference to it.
     /// The object is owned by the CompsEnvironment.
@@ -101,23 +107,28 @@ private:
     /// Get list of groups associated with the environment.
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentItem.getGroups()
-    std::vector<CompsEnvironmentGroup> & get_groups() { return groups; }
+    std::vector<CompsEnvironmentGroup> & get_groups();
 
     // TODO(dmach): rewrite into TransactionSack.list_installed_environments(); how to deal with references to different transactions? We don't want all of them loaded into memory.
     //static std::vector< TransactionItemPtr > getTransactionItemsByPattern(
     //    libdnf5::utils::SQLite3Ptr conn,
     //    const std::string &pattern);
 
-    std::string environment_id;
-    std::string name;
-    std::string translated_name;
-    libdnf5::comps::PackageType package_types = libdnf5::comps::PackageType::DEFAULT;
-    std::vector<CompsEnvironmentGroup> groups;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 
 // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:class:CompsEnvironmentGroup
 class CompsEnvironmentGroup {
+public:
+    ~CompsEnvironmentGroup();
+    CompsEnvironmentGroup(const CompsEnvironmentGroup & src);
+    CompsEnvironmentGroup & operator=(const CompsEnvironmentGroup & src);
+    CompsEnvironmentGroup(CompsEnvironmentGroup && src) noexcept;
+    CompsEnvironmentGroup & operator=(CompsEnvironmentGroup && src) noexcept;
+    CompsEnvironmentGroup();
+
 private:
     friend Transaction;
     friend CompsEnvironmentGroupDbUtils;
@@ -125,47 +136,45 @@ private:
     /// Get database id (primary key)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getId()
-    int64_t get_id() const noexcept { return id; }
+    int64_t get_id() const noexcept;
 
     /// Set database id (primary key)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setId(int64_t value)
-    void set_id(int64_t value) { id = value; }
+    void set_id(int64_t value);
 
     /// Get groupid of a group associated with a comps environment (xml element: `<comps><environment><grouplist><groupid>VALUE</groupid>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupId()
-    const std::string & get_group_id() const noexcept { return group_id; }
+    const std::string & get_group_id() const noexcept;
 
     /// Set groupid of a group associated with a comps environment (xml element: `<comps><environment><grouplist><groupid>VALUE</groupid>`)
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupId(const std::string & value)
-    void set_group_id(const std::string & value) { group_id = value; }
+    void set_group_id(const std::string & value);
 
     /// Get a flag that determines if the group was present after the transaction it's associated with has finished.
     /// If the group was installed before running the transaction, it's still counted as installed.
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getInstalled()
-    bool get_installed() const noexcept { return installed; }
+    bool get_installed() const noexcept;
 
     /// Set a flag that determines if the group was present after the transaction it's associated with has finished.
     /// If the group was installed before running the transaction, it's still counted as installed.
     ///
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setInstalled(bool value)
-    void set_installed(bool value) { installed = value; }
+    void set_installed(bool value);
 
     // TODO(dmach): this is not entirely clear; investigate and document
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.getGroupType()
-    libdnf5::comps::PackageType get_group_type() const noexcept { return group_type; }
+    libdnf5::comps::PackageType get_group_type() const noexcept;
 
     // TODO(dmach): this is not entirely clear; investigate and document
     // @replaces libdnf:transaction/CompsEnvironmentItem.hpp:method:CompsEnvironmentGroup.setGroupType(libdnf::CompsPackageType value)
-    void set_group_type(libdnf5::comps::PackageType value) { group_type = value; }
+    void set_group_type(libdnf5::comps::PackageType value);
 
-    int64_t id = 0;
-    std::string group_id;
-    bool installed = false;
-    libdnf5::comps::PackageType group_type;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/include/libdnf5/transaction/comps_group.hpp
+++ b/include/libdnf5/transaction/comps_group.hpp
@@ -47,6 +47,12 @@ public:
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.toStr()
     std::string to_string() const { return get_group_id(); }
 
+    CompsGroup(const CompsGroup & src);
+    CompsGroup & operator=(const CompsGroup & src);
+    CompsGroup(CompsGroup && src) noexcept;
+    CompsGroup & operator=(CompsGroup && src) noexcept;
+    ~CompsGroup();
+
 private:
     friend Transaction;
     friend CompsGroupPackage;
@@ -58,42 +64,42 @@ private:
     /// Get text id of the group (xml element: `<comps><group><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getGroupId()
-    const std::string & get_group_id() const noexcept { return group_id; }
+    const std::string & get_group_id() const noexcept;
 
     /// Get text id of the group (xml element: `<comps><group><id>VALUE</id>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setGroupId(const std::string & value)
-    void set_group_id(const std::string & value) { group_id = value; }
+    void set_group_id(const std::string & value);
 
     /// Get name of the group (xml element: `<comps><group><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getName()
-    const std::string & get_name() const noexcept { return name; }
+    const std::string & get_name() const noexcept;
 
     /// Set name of the group (xml element: `<comps><group><name>VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setName(const std::string & value)
-    void set_name(const std::string & value) { name = value; }
+    void set_name(const std::string & value);
 
     /// Get translated name of the group in the current locale (xml element: `<comps><group><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getTranslatedName()
-    const std::string & get_translated_name() const noexcept { return translated_name; }
+    const std::string & get_translated_name() const noexcept;
 
     /// Set translated name of the group in the current locale (xml element: `<comps><group><name xml:lang="...">VALUE</name>...`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setTranslatedName(const std::string & value)
-    void set_translated_name(const std::string & value) { translated_name = value; }
+    void set_translated_name(const std::string & value);
 
     /// Get types of the packages to be installed with the group (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackageTypes()
-    libdnf5::comps::PackageType get_package_types() const noexcept { return package_types; }
+    libdnf5::comps::PackageType get_package_types() const noexcept;
 
     /// Set types of the packages to be installed with the group (related xml elements: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.setPackageTypes(libdnf::CompsPackageType value)
-    void set_package_types(libdnf5::comps::PackageType value) { package_types = value; }
+    void set_package_types(libdnf5::comps::PackageType value);
 
     /// Create a new CompsGroupPackage object and return a reference to it.
     /// The object is owned by the CompsGroup.
@@ -102,18 +108,15 @@ private:
     /// Get list of packages associated with the group.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupItem.getPackages()
-    std::vector<CompsGroupPackage> & get_packages() { return packages; }
+    std::vector<CompsGroupPackage> & get_packages();
 
     // TODO(dmach): rewrite into TransactionSack.list_installed_groups(); how to deal with references to different transactions? We don't want all of them loaded into memory.
     //static std::vector< TransactionItemPtr > getTransactionItemsByPattern(
     //    libdnf5::utils::SQLite3Ptr conn,
     //    const std::string &pattern);
 
-    std::string group_id;
-    std::string name;
-    std::string translated_name;
-    libdnf5::comps::PackageType package_types;
-    std::vector<CompsGroupPackage> packages;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 
@@ -121,6 +124,14 @@ private:
 ///
 // @replaces libdnf:transaction/CompsGroupItem.hpp:class:CompsGroupPackage
 class CompsGroupPackage {
+public:
+    ~CompsGroupPackage();
+    CompsGroupPackage(const CompsGroupPackage & src);
+    CompsGroupPackage & operator=(const CompsGroupPackage & src);
+    CompsGroupPackage(CompsGroupPackage && src) noexcept;
+    CompsGroupPackage & operator=(CompsGroupPackage && src) noexcept;
+    CompsGroupPackage();
+
 private:
     friend Transaction;
     friend CompsGroupPackageDbUtils;
@@ -128,51 +139,49 @@ private:
     /// Get database id (primary key)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getId()
-    int64_t get_id() const noexcept { return id; }
+    int64_t get_id() const noexcept;
 
     /// Set database id (primary key)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setId(int64_t value)
-    void set_id(int64_t value) { id = value; }
+    void set_id(int64_t value);
 
     /// Get name of a package associated with a comps group (xml element: `<comps><group><packagelist><packagereq>VALUE</packagereq>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getName()
-    const std::string & get_name() const noexcept { return name; }
+    const std::string & get_name() const noexcept;
 
     /// Set name of a package associated with a comps group (xml element: `<comps><group><packagelist><packagereq>VALUE</packagereq>`)
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setName(const std::string & value)
-    void set_name(const std::string & value) { name = value; }
+    void set_name(const std::string & value);
 
     /// Get a flag that determines if the package was present after the transaction it's associated with has finished.
     /// If the package was installed before running the transaction, it's still counted as installed.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getInstalled()
-    bool get_installed() const noexcept { return installed; }
+    bool get_installed() const noexcept;
 
     /// Set a flag that determines if the package was present after the transaction it's associated with has finished.
     /// If the package was installed before running the transaction, it's still counted as installed.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setInstalled(bool value)
-    void set_installed(bool value) { installed = value; }
+    void set_installed(bool value);
 
     /// Get type of package associated with a comps group (xml element: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     /// See `enum class comps::PackageType` documentation for more details.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.getPackageType()
-    libdnf5::comps::PackageType get_package_type() const noexcept { return package_type; }
+    libdnf5::comps::PackageType get_package_type() const noexcept;
 
     /// Set type of package associated with a comps group (xml element: `<comps><group><packagelist><packagereq type="VALUE" ...>`)
     /// See `enum class libdnf5::comps::PackageType` documentation for more details.
     ///
     // @replaces libdnf:transaction/CompsGroupItem.hpp:method:CompsGroupPackage.setPackageType(libdnf::PackageType value)
-    void set_package_type(libdnf5::comps::PackageType value) { package_type = value; }
+    void set_package_type(libdnf5::comps::PackageType value);
 
-    int64_t id = 0;
-    std::string name;
-    bool installed = false;
-    libdnf5::comps::PackageType package_type = libdnf5::comps::PackageType::DEFAULT;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/include/libdnf5/transaction/rpm_package.hpp
+++ b/include/libdnf5/transaction/rpm_package.hpp
@@ -21,10 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_TRANSACTION_RPM_PACKAGE_HPP
 
 #include "transaction_item.hpp"
-#include "transaction_item_reason.hpp"
 
 #include <memory>
-#include <vector>
 
 
 namespace libdnf5::transaction {
@@ -42,32 +40,38 @@ public:
     /// Get package name
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getName()
-    const std::string & get_name() const noexcept { return name; }
+    const std::string & get_name() const noexcept;
 
     /// Get package epoch
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getEpoch()
-    const std::string & get_epoch() const noexcept { return epoch; }
+    const std::string & get_epoch() const noexcept;
 
     /// Get package release
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getRelease()
-    const std::string & get_release() const noexcept { return release; }
+    const std::string & get_release() const noexcept;
 
     /// Get package arch
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getArch()
-    const std::string & get_arch() const noexcept { return arch; }
+    const std::string & get_arch() const noexcept;
 
     /// Get package version
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.getVersion()
-    const std::string & get_version() const noexcept { return version; }
+    const std::string & get_version() const noexcept;
 
     /// Get string representation of the object, which equals to package NEVRA
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.toStr()
     std::string to_string() const;
+
+    ~Package();
+    Package(const Package & src);
+    Package & operator=(const Package & src);
+    Package(Package && src) noexcept;
+    Package & operator=(Package && src) noexcept;
 
 private:
     friend RpmDbUtils;
@@ -78,7 +82,7 @@ private:
     /// Set package name
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setName(const std::string & value)
-    void set_name(const std::string & value) { name = value; }
+    void set_name(const std::string & value);
 
     /// Get package epoch as an integer
     uint32_t get_epoch_int() const;
@@ -86,22 +90,22 @@ private:
     /// Set package epoch
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setEpoch(int32_t value)
-    void set_epoch(const std::string & value) { epoch = value; }
+    void set_epoch(const std::string & value);
 
     /// Set package version
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setVersion(const std::string & value)
-    void set_version(const std::string & value) { version = value; }
+    void set_version(const std::string & value);
 
     /// Set package release
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setRelease(const std::string & value)
-    void set_release(const std::string & value) { release = value; }
+    void set_release(const std::string & value);
 
     /// Set package arch
     ///
     // @replaces libdnf:transaction/RPMItem.hpp:method:RPMItem.setArch(const std::string & value)
-    void set_arch(const std::string & value) { arch = value; }
+    void set_arch(const std::string & value);
 
     /*
     // TODO(dmach): Implement TransactionSack.new_filter().filter_package_pattern()
@@ -115,11 +119,8 @@ private:
 
     bool operator<(const Package & other) const;
 
-    std::string name;
-    std::string epoch;
-    std::string version;
-    std::string release;
-    std::string arch;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/include/libdnf5/transaction/transaction_history.hpp
+++ b/include/libdnf5/transaction/transaction_history.hpp
@@ -36,8 +36,13 @@ class TransactionHistory {
 public:
     explicit TransactionHistory(const libdnf5::BaseWeakPtr & base);
     explicit TransactionHistory(libdnf5::Base & base);
+    ~TransactionHistory();
+    TransactionHistory(const TransactionHistory & src) = delete;
+    TransactionHistory & operator=(const TransactionHistory & src) = delete;
+    TransactionHistory(TransactionHistory && src) noexcept = delete;
+    TransactionHistory & operator=(TransactionHistory && src) noexcept = delete;
 
-    TransactionHistoryWeakPtr get_weak_ptr() { return TransactionHistoryWeakPtr(this, &guard); }
+    TransactionHistoryWeakPtr get_weak_ptr();
 
     /// Lists all transaction IDs from the transaction history database. The
     /// result is sorted in ascending order.
@@ -72,9 +77,8 @@ private:
     /// Create a new Transaction object.
     libdnf5::transaction::Transaction new_transaction();
 
-    BaseWeakPtr base;
-
-    WeakPtrGuard<TransactionHistory, false> guard;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/include/libdnf5/transaction/transaction_item.hpp
+++ b/include/libdnf5/transaction/transaction_item.hpp
@@ -50,22 +50,28 @@ public:
     /// Get action associated with the transaction item in the transaction
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getAction()
-    Action get_action() const noexcept { return action; }
+    Action get_action() const noexcept;
 
     /// Get reason of the action associated with the transaction item in the transaction
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getReason()
-    Reason get_reason() const noexcept { return reason; }
+    Reason get_reason() const noexcept;
 
     /// Get transaction item repoid (text identifier of a repository)
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getRepoid()
-    const std::string & get_repoid() const noexcept { return repoid; }
+    const std::string & get_repoid() const noexcept;
 
     /// Get transaction item state
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.getState()
-    State get_state() const noexcept { return state; }
+    State get_state() const noexcept;
+
+    ~TransactionItem();
+    TransactionItem(const TransactionItem & src);
+    TransactionItem & operator=(const TransactionItem & src);
+    TransactionItem(TransactionItem && src) noexcept;
+    TransactionItem & operator=(TransactionItem && src) noexcept;
 
 private:
     friend RpmDbUtils;
@@ -82,15 +88,15 @@ private:
     explicit TransactionItem(const Transaction & trans);
 
     /// Get database id (primary key) of the transaction item (table 'trans_item')
-    int64_t get_id() const noexcept { return id; }
+    int64_t get_id() const noexcept;
 
     /// Set database id (primary key) of the transaction item (table 'trans_item')
-    void set_id(int64_t value) { id = value; }
+    void set_id(int64_t value);
 
     /// Set action associated with the transaction item in the transaction
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setAction(libdnf::TransactionItemAction value)
-    void set_action(Action value) { action = value; }
+    void set_action(Action value);
 
     /// Get name of the action associated with the transaction item in the transaction
     ///
@@ -105,17 +111,17 @@ private:
     /// Set reason of the action associated with the transaction item in the transaction
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setReason(libdnf::TransactionItemReason value)
-    void set_reason(Reason value) { reason = value; }
+    void set_reason(Reason value);
 
     /// Set transaction item state
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setState(libdnf::TransactionItemState value)
-    void set_state(State value) { state = value; }
+    void set_state(State value);
 
     /// Get transaction item repoid (text identifier of a repository)
     ///
     // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItemBase.setRepoid(const std::string & value)
-    void set_repoid(const std::string & value) { repoid = value; }
+    void set_repoid(const std::string & value);
 
     /// Has the item appeared on the system during the transaction?
     ///
@@ -139,29 +145,14 @@ private:
     // TODO(dmach): Review and bring back if needed
     //void saveState();
 
-    // TODO(dmach): move to sack, resolve for all packages; return the user who initially installed the package
-    // @replaces libdnf:transaction/TransactionItem.hpp:method:TransactionItem.getInstalledBy()
-    uint32_t getInstalledBy() const;
-
     /// Get database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
-    int64_t get_item_id() const noexcept { return item_id; }
+    int64_t get_item_id() const noexcept;
 
     /// Set database id (primary key) of the item (table 'item'; other item tables such 'rpm' inherit from it via 1:1 relation)
-    void set_item_id(int64_t value) { item_id = value; }
-    int64_t id = 0;
-    Action action = Action::INSTALL;
-    Reason reason = Reason::NONE;
-    State state = State::STARTED;
-    std::string repoid;
+    void set_item_id(int64_t value);
 
-    int64_t item_id = 0;
-
-    // TODO(lukash) this won't be safe in bindings (or in general when a
-    // TransactionItem is kept around after a Transaction is destroyed), but we
-    // can't easily use a WeakPtr here, since the Transactions are expected to
-    // be at least movable, and the WeakPtrGuard would make the Transaction
-    // unmovable
-    const Transaction * trans = nullptr;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::transaction

--- a/libdnf5/transaction/comps_environment.cpp
+++ b/libdnf5/transaction/comps_environment.cpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/transaction/comps_environment.hpp"
 
 #include "db/comps_environment.hpp"
-#include "db/comps_environment_group.hpp"
 
 #include "libdnf5/transaction/transaction.hpp"
 #include "libdnf5/transaction/transaction_item.hpp"
@@ -30,7 +29,124 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5::transaction {
 
 
-CompsEnvironment::CompsEnvironment(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+class CompsEnvironment::Impl {
+public:
+private:
+    friend CompsEnvironment;
+
+    std::string environment_id;
+    std::string name;
+    std::string translated_name;
+    libdnf5::comps::PackageType package_types = libdnf5::comps::PackageType::DEFAULT;
+    std::vector<CompsEnvironmentGroup> groups;
+};
+
+CompsEnvironment::CompsEnvironment(const Transaction & trans)
+    : TransactionItem::TransactionItem(trans),
+      p_impl(std::make_unique<Impl>()) {}
+
+CompsEnvironment::CompsEnvironment(const CompsEnvironment & src)
+    : TransactionItem(src),
+      p_impl(new Impl(*src.p_impl)) {}
+CompsEnvironment::CompsEnvironment(CompsEnvironment && src) noexcept = default;
+
+CompsEnvironment & CompsEnvironment::operator=(const CompsEnvironment & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+CompsEnvironment & CompsEnvironment::operator=(CompsEnvironment && src) noexcept = default;
+CompsEnvironment::~CompsEnvironment() = default;
+
+
+const std::string & CompsEnvironment::get_environment_id() const noexcept {
+    return p_impl->environment_id;
+}
+void CompsEnvironment::set_environment_id(const std::string & value) {
+    p_impl->environment_id = value;
+}
+const std::string & CompsEnvironment::get_name() const noexcept {
+    return p_impl->name;
+}
+void CompsEnvironment::set_name(const std::string & value) {
+    p_impl->name = value;
+}
+const std::string & CompsEnvironment::get_translated_name() const noexcept {
+    return p_impl->translated_name;
+}
+void CompsEnvironment::set_translated_name(const std::string & value) {
+    p_impl->translated_name = value;
+}
+libdnf5::comps::PackageType CompsEnvironment::get_package_types() const noexcept {
+    return p_impl->package_types;
+}
+void CompsEnvironment::set_package_types(libdnf5::comps::PackageType value) {
+    p_impl->package_types = value;
+}
+CompsEnvironmentGroup & CompsEnvironment::new_group() {
+    return p_impl->groups.emplace_back();
+}
+std::vector<CompsEnvironmentGroup> & CompsEnvironment::get_groups() {
+    return p_impl->groups;
+}
+
+class CompsEnvironmentGroup::Impl {
+private:
+    friend CompsEnvironmentGroup;
+    int64_t id = 0;
+    std::string group_id;
+    bool installed = false;
+    libdnf5::comps::PackageType group_type;
+};
+
+
+CompsEnvironmentGroup::CompsEnvironmentGroup(const CompsEnvironmentGroup & src) : p_impl(new Impl(*src.p_impl)) {}
+CompsEnvironmentGroup::CompsEnvironmentGroup(CompsEnvironmentGroup && src) noexcept = default;
+
+CompsEnvironmentGroup & CompsEnvironmentGroup::operator=(const CompsEnvironmentGroup & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+CompsEnvironmentGroup & CompsEnvironmentGroup::operator=(CompsEnvironmentGroup && src) noexcept = default;
+CompsEnvironmentGroup::CompsEnvironmentGroup() : p_impl(std::make_unique<Impl>()) {}
+CompsEnvironmentGroup::~CompsEnvironmentGroup() = default;
+int64_t CompsEnvironmentGroup::get_id() const noexcept {
+    return p_impl->id;
+}
+void CompsEnvironmentGroup::set_id(int64_t value) {
+    p_impl->id = value;
+}
+const std::string & CompsEnvironmentGroup::get_group_id() const noexcept {
+    return p_impl->group_id;
+}
+void CompsEnvironmentGroup::set_group_id(const std::string & value) {
+    p_impl->group_id = value;
+}
+bool CompsEnvironmentGroup::get_installed() const noexcept {
+    return p_impl->installed;
+}
+void CompsEnvironmentGroup::set_installed(bool value) {
+    p_impl->installed = value;
+}
+libdnf5::comps::PackageType CompsEnvironmentGroup::get_group_type() const noexcept {
+    return p_impl->group_type;
+}
+void CompsEnvironmentGroup::set_group_type(libdnf5::comps::PackageType value) {
+    p_impl->group_type = value;
+}
 
 
 /*
@@ -68,11 +184,6 @@ CompsEnvironmentItem::getTransactionItemsByPattern(libdnf5::utils::SQLite3Ptr co
     return result;
 }
 */
-
-
-CompsEnvironmentGroup & CompsEnvironment::new_group() {
-    return groups.emplace_back();
-}
 
 
 }  // namespace libdnf5::transaction

--- a/libdnf5/transaction/comps_group.cpp
+++ b/libdnf5/transaction/comps_group.cpp
@@ -21,19 +21,128 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/transaction/comps_group.hpp"
 
 #include "db/comps_group.hpp"
-#include "db/comps_group_package.hpp"
 
 #include "libdnf5/transaction/transaction.hpp"
 #include "libdnf5/transaction/transaction_item.hpp"
 
-#include <algorithm>
-
 
 namespace libdnf5::transaction {
 
+class CompsGroup::Impl {
+private:
+    friend CompsGroup;
 
-CompsGroup::CompsGroup(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+    std::string group_id;
+    std::string name;
+    std::string translated_name;
+    libdnf5::comps::PackageType package_types;
+    std::vector<CompsGroupPackage> packages;
+};
 
+
+CompsGroup::CompsGroup(const Transaction & trans)
+    : TransactionItem::TransactionItem(trans),
+      p_impl(std::make_unique<Impl>()) {}
+
+CompsGroup::CompsGroup(const CompsGroup & src) : TransactionItem(src), p_impl(new Impl(*src.p_impl)) {}
+CompsGroup::CompsGroup(CompsGroup && src) noexcept = default;
+
+CompsGroup & CompsGroup::operator=(const CompsGroup & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+CompsGroup & CompsGroup::operator=(CompsGroup && src) noexcept = default;
+CompsGroup::~CompsGroup() = default;
+
+const std::string & CompsGroup::get_group_id() const noexcept {
+    return p_impl->group_id;
+}
+void CompsGroup::set_group_id(const std::string & value) {
+    p_impl->group_id = value;
+}
+const std::string & CompsGroup::get_name() const noexcept {
+    return p_impl->name;
+}
+void CompsGroup::set_name(const std::string & value) {
+    p_impl->name = value;
+}
+const std::string & CompsGroup::get_translated_name() const noexcept {
+    return p_impl->translated_name;
+}
+void CompsGroup::set_translated_name(const std::string & value) {
+    p_impl->translated_name = value;
+}
+libdnf5::comps::PackageType CompsGroup::get_package_types() const noexcept {
+    return p_impl->package_types;
+}
+void CompsGroup::set_package_types(libdnf5::comps::PackageType value) {
+    p_impl->package_types = value;
+}
+CompsGroupPackage & CompsGroup::new_package() {
+    return p_impl->packages.emplace_back();
+}
+std::vector<CompsGroupPackage> & CompsGroup::get_packages() {
+    return p_impl->packages;
+}
+
+class CompsGroupPackage::Impl {
+private:
+    friend CompsGroupPackage;
+    int64_t id = 0;
+    std::string name;
+    bool installed = false;
+    libdnf5::comps::PackageType package_type = libdnf5::comps::PackageType::DEFAULT;
+};
+
+CompsGroupPackage::CompsGroupPackage(const CompsGroupPackage & src) : p_impl(new Impl(*src.p_impl)) {}
+CompsGroupPackage::CompsGroupPackage(CompsGroupPackage && src) noexcept = default;
+
+CompsGroupPackage & CompsGroupPackage::operator=(const CompsGroupPackage & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+CompsGroupPackage & CompsGroupPackage::operator=(CompsGroupPackage && src) noexcept = default;
+CompsGroupPackage::CompsGroupPackage() : p_impl(std::make_unique<Impl>()) {}
+CompsGroupPackage::~CompsGroupPackage() = default;
+
+int64_t CompsGroupPackage::get_id() const noexcept {
+    return p_impl->id;
+}
+void CompsGroupPackage::set_id(int64_t value) {
+    p_impl->id = value;
+}
+const std::string & CompsGroupPackage::get_name() const noexcept {
+    return p_impl->name;
+}
+void CompsGroupPackage::set_name(const std::string & value) {
+    p_impl->name = value;
+}
+bool CompsGroupPackage::get_installed() const noexcept {
+    return p_impl->installed;
+}
+void CompsGroupPackage::set_installed(bool value) {
+    p_impl->installed = value;
+}
+libdnf5::comps::PackageType CompsGroupPackage::get_package_type() const noexcept {
+    return p_impl->package_type;
+}
+void CompsGroupPackage::set_package_type(libdnf5::comps::PackageType value) {
+    p_impl->package_type = value;
+}
 
 /*
 std::vector< TransactionItemPtr >
@@ -70,10 +179,6 @@ CompsGroup::getTransactionItemsByPattern(libdnf5::utils::SQLite3Ptr conn, const 
     return result;
 }
 */
-
-CompsGroupPackage & CompsGroup::new_package() {
-    return packages.emplace_back();
-}
 
 
 }  // namespace libdnf5::transaction

--- a/libdnf5/transaction/rpm_package.cpp
+++ b/libdnf5/transaction/rpm_package.cpp
@@ -25,16 +25,73 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/rpm/nevra.hpp"
 #include "libdnf5/transaction/transaction.hpp"
 
-#include <algorithm>
-#include <map>
 #include <sstream>
 
 
 namespace libdnf5::transaction {
 
+class Package::Impl {
+private:
+    friend Package;
+    std::string name;
+    std::string epoch;
+    std::string version;
+    std::string release;
+    std::string arch;
+};
 
-Package::Package(const Transaction & trans) : TransactionItem::TransactionItem(trans) {}
+Package::Package(const Transaction & trans)
+    : TransactionItem::TransactionItem(trans),
+      p_impl(std::make_unique<Impl>()) {}
 
+Package::Package(const Package & src) : TransactionItem(src), p_impl(new Impl(*src.p_impl)) {}
+Package::Package(Package && src) noexcept = default;
+
+Package & Package::operator=(const Package & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+Package & Package::operator=(Package && src) noexcept = default;
+Package::~Package() = default;
+
+const std::string & Package::get_name() const noexcept {
+    return p_impl->name;
+}
+const std::string & Package::get_epoch() const noexcept {
+    return p_impl->epoch;
+}
+const std::string & Package::get_release() const noexcept {
+    return p_impl->release;
+}
+const std::string & Package::get_arch() const noexcept {
+    return p_impl->arch;
+}
+const std::string & Package::get_version() const noexcept {
+    return p_impl->version;
+}
+
+void Package::set_name(const std::string & value) {
+    p_impl->name = value;
+}
+void Package::set_epoch(const std::string & value) {
+    p_impl->epoch = value;
+}
+void Package::set_version(const std::string & value) {
+    p_impl->version = value;
+}
+void Package::set_release(const std::string & value) {
+    p_impl->release = value;
+}
+void Package::set_arch(const std::string & value) {
+    p_impl->arch = value;
+}
 
 uint32_t Package::get_epoch_int() const {
     if (get_epoch().empty()) {

--- a/libdnf5/transaction/transaction_item.cpp
+++ b/libdnf5/transaction/transaction_item.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/transaction/transaction_item.hpp"
 
-
 #include "libdnf5/transaction/transaction.hpp"
 #include "libdnf5/transaction/transaction_item_action.hpp"
 
@@ -67,8 +66,7 @@ TransactionItem & TransactionItem::operator=(const TransactionItem & mpkg) {
 }
 TransactionItem & TransactionItem::operator=(TransactionItem && mpkg) noexcept = default;
 
-TransactionItem::Impl::Impl(const Transaction & trans)
-    : trans(&trans) {}
+TransactionItem::Impl::Impl(const Transaction & trans) : trans(&trans) {}
 
 std::string TransactionItem::get_action_name() {
     return transaction_item_action_to_string(p_impl->action);
@@ -80,8 +78,7 @@ std::string TransactionItem::get_action_short() {
 }
 
 
-TransactionItem::TransactionItem(const Transaction & trans)
-    : p_impl(std::make_unique<Impl>(trans)) {}
+TransactionItem::TransactionItem(const Transaction & trans) : p_impl(std::make_unique<Impl>(trans)) {}
 
 
 bool TransactionItem::is_inbound_action() const {
@@ -99,26 +96,50 @@ const Transaction & TransactionItem::get_transaction() const {
     return *p_impl->trans;
 }
 
-TransactionItemAction TransactionItem::get_action() const noexcept { return p_impl->action; }
-TransactionItemReason TransactionItem::get_reason() const noexcept { return p_impl->reason; }
-const std::string & TransactionItem::get_repoid() const noexcept { return p_impl->repoid; }
-TransactionItemState TransactionItem::get_state() const noexcept { return p_impl->state; }
+TransactionItemAction TransactionItem::get_action() const noexcept {
+    return p_impl->action;
+}
+TransactionItemReason TransactionItem::get_reason() const noexcept {
+    return p_impl->reason;
+}
+const std::string & TransactionItem::get_repoid() const noexcept {
+    return p_impl->repoid;
+}
+TransactionItemState TransactionItem::get_state() const noexcept {
+    return p_impl->state;
+}
 
-int64_t TransactionItem::get_id() const noexcept { return p_impl->id; }
+int64_t TransactionItem::get_id() const noexcept {
+    return p_impl->id;
+}
 
-void TransactionItem::set_id(int64_t value) { p_impl->id = value; }
+void TransactionItem::set_id(int64_t value) {
+    p_impl->id = value;
+}
 
-void TransactionItem::set_action(Action value) { p_impl->action = value; }
+void TransactionItem::set_action(Action value) {
+    p_impl->action = value;
+}
 
-void TransactionItem::set_reason(Reason value) { p_impl->reason = value; }
+void TransactionItem::set_reason(Reason value) {
+    p_impl->reason = value;
+}
 
-void TransactionItem::set_state(State value) { p_impl->state = value; }
+void TransactionItem::set_state(State value) {
+    p_impl->state = value;
+}
 
-void TransactionItem::set_repoid(const std::string & value) { p_impl->repoid = value; }
+void TransactionItem::set_repoid(const std::string & value) {
+    p_impl->repoid = value;
+}
 
-int64_t TransactionItem::get_item_id() const noexcept { return p_impl->item_id; }
+int64_t TransactionItem::get_item_id() const noexcept {
+    return p_impl->item_id;
+}
 
-void TransactionItem::set_item_id(int64_t value) { p_impl->item_id = value; }
+void TransactionItem::set_item_id(int64_t value) {
+    p_impl->item_id = value;
+}
 
 /*
 void

--- a/libdnf5/transaction/transaction_item.cpp
+++ b/libdnf5/transaction/transaction_item.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/transaction/transaction_item.hpp"
 
-#include "db/repo.hpp"
 
 #include "libdnf5/transaction/transaction.hpp"
 #include "libdnf5/transaction/transaction_item_action.hpp"
@@ -28,34 +27,98 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::transaction {
 
+class TransactionItem::Impl {
+public:
+    Impl(const Transaction & trans);
+
+private:
+    friend TransactionItem;
+
+    int64_t id = 0;
+    Action action = Action::INSTALL;
+    Reason reason = Reason::NONE;
+    State state = State::STARTED;
+    std::string repoid;
+    int64_t item_id = 0;
+
+    // TODO(lukash) this won't be safe in bindings (or in general when a
+    // TransactionItem is kept around after a Transaction is destroyed), but we
+    // can't easily use a WeakPtr here, since the Transactions are expected to
+    // be at least movable, and the WeakPtrGuard would make the Transaction
+    // unmovable
+    const Transaction * trans = nullptr;
+};
+
+TransactionItem::~TransactionItem() = default;
+
+TransactionItem::TransactionItem(const TransactionItem & mpkg) : p_impl(new Impl(*mpkg.p_impl)) {}
+TransactionItem::TransactionItem(TransactionItem && mpkg) noexcept = default;
+
+TransactionItem & TransactionItem::operator=(const TransactionItem & mpkg) {
+    if (this != &mpkg) {
+        if (p_impl) {
+            *p_impl = *mpkg.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*mpkg.p_impl);
+        }
+    }
+
+    return *this;
+}
+TransactionItem & TransactionItem::operator=(TransactionItem && mpkg) noexcept = default;
+
+TransactionItem::Impl::Impl(const Transaction & trans)
+    : trans(&trans) {}
 
 std::string TransactionItem::get_action_name() {
-    return transaction_item_action_to_string(action);
+    return transaction_item_action_to_string(p_impl->action);
 }
 
 
 std::string TransactionItem::get_action_short() {
-    return transaction_item_action_to_letter(action);
+    return transaction_item_action_to_letter(p_impl->action);
 }
 
 
-TransactionItem::TransactionItem(const Transaction & trans) : trans{&trans} {}
+TransactionItem::TransactionItem(const Transaction & trans)
+    : p_impl(std::make_unique<Impl>(trans)) {}
 
 
 bool TransactionItem::is_inbound_action() const {
-    return transaction_item_action_is_inbound(action);
+    return transaction_item_action_is_inbound(p_impl->action);
 }
 
 
 bool TransactionItem::is_outbound_action() const {
-    return transaction_item_action_is_outbound(action);
+    return transaction_item_action_is_outbound(p_impl->action);
 }
 
 
 const Transaction & TransactionItem::get_transaction() const {
-    libdnf_assert(trans, "Transaction in TransactionItem was not set.");
-    return *trans;
+    libdnf_assert(p_impl->trans, "Transaction in TransactionItem was not set.");
+    return *p_impl->trans;
 }
+
+TransactionItemAction TransactionItem::get_action() const noexcept { return p_impl->action; }
+TransactionItemReason TransactionItem::get_reason() const noexcept { return p_impl->reason; }
+const std::string & TransactionItem::get_repoid() const noexcept { return p_impl->repoid; }
+TransactionItemState TransactionItem::get_state() const noexcept { return p_impl->state; }
+
+int64_t TransactionItem::get_id() const noexcept { return p_impl->id; }
+
+void TransactionItem::set_id(int64_t value) { p_impl->id = value; }
+
+void TransactionItem::set_action(Action value) { p_impl->action = value; }
+
+void TransactionItem::set_reason(Reason value) { p_impl->reason = value; }
+
+void TransactionItem::set_state(State value) { p_impl->state = value; }
+
+void TransactionItem::set_repoid(const std::string & value) { p_impl->repoid = value; }
+
+int64_t TransactionItem::get_item_id() const noexcept { return p_impl->item_id; }
+
+void TransactionItem::set_item_id(int64_t value) { p_impl->item_id = value; }
 
 /*
 void


### PR DESCRIPTION
This includes `TransactionItem`, `CompsEnvironment`, `CompsEnvironmentGroup`, `CompsGroup`, `CompsGroupPackage`, `Package` and `TransactionHistory`.

This PR is into a new dnf5-5.2.0.0 branch to keep the main branch API compatible.

Another part for: https://github.com/rpm-software-management/dnf5/issues/1025