### PR TITLE
Disable dnf and dnf5daemon tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,3 +42,27 @@ jobs:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: main
+    tmt_plan: /plans/integration/behave-dnf5
+  - job: tests
+    trigger: pull_request
+    targets:
+      - fedora-all
+    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
+    fmf_ref: main
+    tmt_plan: /plans/integration/behave-createrepo_c
+  - job: tests
+    trigger: pull_request
+    manual_trigger: true
+    targets:
+      - fedora-all
+    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
+    fmf_ref: main
+    tmt_plan: /plans/integration/behave-dnf
+  - job: tests
+    trigger: pull_request
+    manual_trigger: true
+    targets:
+      - fedora-all
+    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
+    fmf_ref: main
+    tmt_plan: /plans/integration/behave-dnf5daemon


### PR DESCRIPTION
Disable autorun of DNF and DNF5DAEMON. They can always be run with `/packit test` in a PR comment.

DNF tests are failing due to wrongly configured tmt.
The new tmt plans are tested in https://github.com/rpm-software-management/dnf/pull/2034

DNF5DAEMON tests are expected to fail due to a PR which specifies config overrides. https://github.com/rpm-software-management/dnf5/pull/1201
