### PR TITLE
Build: Require GCC 10.1 for std::in_range<>()

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -136,7 +136,7 @@ BuildRequires:  toml11-static
 %if %{with clang}
 BuildRequires:  clang
 %else
-BuildRequires:  gcc-c++
+BuildRequires:  gcc-c++ >= 10.1
 %endif
 
 %if %{with tests}


### PR DESCRIPTION
A GCC 9.2 user reported this failure:

    In file included from /home/rpm/rpmbuild/BUILD/common/utils/string.cpp:21:
    /home/rpm/rpmbuild/BUILD/common/utils/string.hpp: In function 'std::string libdnf5::utils::string::format_epoch(T)':
    /home/rpm/rpmbuild/BUILD/common/utils/string.hpp:115:14: error: 'in_range' is not a member of 'std'
      115 |     if (std::in_range<time_t>(epoch_num)) {
	  |              ^~~~~~~~

The cause is that std::in_range<>() is a C++20 feature added to GCC in version 10.1.

This patch sets the minimal version in dnf5.spec.

Originally, I also wanted to add a check into a build script to fail early. std::in_range<>() is supported if the compiler defines __cpp_lib_integer_comparison_functions >= 202002L feature test macro.

However, checking for it in CMake is very difficult: target_compile_features() does not recognize this specific feature. check_cxx_symbol_exists() is unable to retrieve the macro value. CheckSourceCompiles() requires CMake 3.19 (a year after GCC 10.1).

So I scratched out the idea of adding a check into the build script.

Fixes: #1167