### PR TITLE
Added arch option to the download command

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -43,6 +43,7 @@ public:
 private:
     std::set<std::string> urlprotocol_valid_options;
     std::set<std::string> urlprotocol_option;
+    std::set<std::string> arch_option;
     libdnf5::OptionBool * resolve_option{nullptr};
     libdnf5::OptionBool * alldeps_option{nullptr};
     libdnf5::OptionBool * url_option{nullptr};

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -53,6 +53,8 @@ Options
 ``--urlprotocol``
     | To be used together with ``--url``. It filters out the URLs to the specified protocols: ``http``, ``https``, ``ftp``, or ``file``. This option can be used multiple times.
 
+``--arch``
+    | Limit to packages of given architectures. This option can be used multiple times.
 
 
 Examples
@@ -71,7 +73,10 @@ Examples
     | Download the ``maven-compiler-plugin`` package to ``/tmp/my_packages`` directory.
 
 ``dnf5 download --url --urlprotocol http python``
-    | List the http URL to download the python package
+    | List the http URL to download the python package.
+
+``dnf5 download python --arch x86_64``
+    | Downloads python with the ``x86_64`` architecture.
 
 
 See Also


### PR DESCRIPTION
Fixes: #946 

Add the --arch option to the download command. Filters queried compatible packages based on the specified architectures. If the architecture needs to be changed, the users can use the global --forcearch to change the base architecture.