### PR TITLE
download: add `--srpm` option

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -47,6 +47,7 @@ private:
     libdnf5::OptionBool * resolve_option{nullptr};
     libdnf5::OptionBool * alldeps_option{nullptr};
     libdnf5::OptionBool * url_option{nullptr};
+    libdnf5::OptionBool * srpm_option{nullptr};
 
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_to_download_options{nullptr};
 };

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -106,6 +106,10 @@ Downgrade command
  * When any argument does not match any package or it is not installed, DNF5 fail. The behavior can be modified by
    the ``--skip-unavailable`` option.
 
+Download command
+----------------
+ * Option ``--source`` was renamed to ``--srpm``.
+
 Group command
 -------------
  * Dropped ``group mark install`` and ``group mark remove`` subcommands in favour of the

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -56,6 +56,8 @@ Options
 ``--arch``
     | Limit to packages of given architectures. This option can be used multiple times.
 
+``--srpm``
+    | Download the source rpm. Enables source repositories of all enabled binary repositories.
 
 Examples
 ========
@@ -78,6 +80,8 @@ Examples
 ``dnf5 download python --arch x86_64``
     | Downloads python with the ``x86_64`` architecture.
 
+``dnf5 download dnf5 --srpm``
+    | Download the ``dnf5`` source rpm.
 
 See Also
 ========


### PR DESCRIPTION
Fixes #947

Implements the `--source` option for the download command to download only the source rpm(s).