### PR TITLE
Fix a warning when building docs.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -208,7 +208,7 @@ Changes of configuration:
 =========================
 
 Default of ``best`` configuration option changed to ``true``
---------------------------------------------------------
+------------------------------------------------------------
 The new default value ensures that important updates will not be skipped and issues in distribution will be reported
 earlier.
 


### PR DESCRIPTION
Fixes: `WARNING: Title underline too short.`