### PR TITLE
Revert "Use focusbest: prefer latest deps versions over smaller transactions

### DIFF
--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -407,9 +407,6 @@ libdnf5::GoalProblem GoalPrivate::resolve() {
     libsolv_solver.set_flag(SOLVER_FLAG_ALLOW_VENDORCHANGE, vendor_change);
     libsolv_solver.set_flag(SOLVER_FLAG_DUP_ALLOW_VENDORCHANGE, vendor_change);
 
-    // Ensure the solver tries to use the latest versions of dependencies, even if it results in a bigger transaction
-    libsolv_solver.set_flag(SOLVER_FLAG_FOCUS_BEST, 1);
-
     if (libsolv_solver.solve(job)) {
         return libdnf5::GoalProblem::SOLVER_ERROR;
     }


### PR DESCRIPTION
This reverts commit 2d9df1c43b0b2f7027a6366dc1d64c0e646d1e2a.

The current behavior of `SOLVER_FLAG_FOCUS_BEST` turned out not be viable at this time, more details in: https://github.com/rpm-software-management/dnf5/issues/1106

Depending on https://github.com/openSUSE/libsolv/issues/549 we can either make the `SOLVER_FLAG_FOCUS_BEST` functionality configurable with a new option or use some different approach.

Closes https://github.com/rpm-software-management/dnf5/issues/1106