### PR TITLE
PackageQuery: Add `filter_{latest,earliest}_evr_ignore_arch`

### DIFF
--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -618,12 +618,26 @@ public:
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST_PER_ARCH
     void filter_latest_evr(int limit = 1);
 
+    /// Group packages by `name`. Then within each group, keep packages that correspond with up to `limit` of (all but) latest `evr`s in the group.
+    ///
+    /// @param limit            If `limit` > 0, keep `limit` number `evr`s in each group.
+    ///                         If `limit` < 0, keep all **but** `limit` last `evr`s in each group.
+    /// @since 5.2
+    void filter_latest_evr_any_arch(int limit = 1);
+
     /// Group packages by `name` and `arch`. Then within each group, keep packages that correspond with up to `limit` of (all but) earliest `evr`s in the group.
     ///
     /// @param limit            If `limit` > 0, keep `limit` number `evr`s in each group.
     ///                         If `limit` < 0, keep all **but** `limit` last `evr`s in each group.
     /// @since 5.0
     void filter_earliest_evr(int limit = 1);
+
+    /// Group packages by `name`. Then within each group, keep packages that correspond with up to `limit` of (all but) earliest `evr`s in the group.
+    ///
+    /// @param limit            If `limit` > 0, keep `limit` number `evr`s in each group.
+    ///                         If `limit` < 0, keep all **but** `limit` last `evr`s in each group.
+    /// @since 5.2
+    void filter_earliest_evr_any_arch(int limit = 1);
 
     /// Group packages by `name` and `arch`. Then within each group, keep packages that belong to a repo with the highest priority (the lowest number).
     /// The filter works only on available packages, installed packages are not affected.

--- a/test/data/repos-solv/solv-multiarch.repo
+++ b/test/data/repos-solv/solv-multiarch.repo
@@ -1,0 +1,13 @@
+=Ver: 3.0
+
+=Pkg: foo 1.2 1 x86_64
+=Prv: foo = 1.2 1
+
+=Pkg: foo 1.2 2 noarch
+=Prv: foo = 1.2 2
+
+=Pkg: bar 4.5 1 noarch
+=Prv: bar = 4.5 1
+
+=Pkg: bar 4.5 2 x86_64
+=Prv: bar = 4.5 2

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -115,6 +115,31 @@ void RpmPackageQueryTest::test_filter_latest_evr() {
     }
 }
 
+void RpmPackageQueryTest::test_filter_latest_evr_ignore_arch() {
+    add_repo_solv("solv-multiarch");
+
+    {
+        // Result of filter_latest_evr should include a package from each arch
+        PackageQuery query(base);
+        query.filter_latest_evr(1);
+        std::vector<Package> expected = {
+            get_pkg("foo-0:1.2-1.x86_64"),
+            get_pkg("foo-0:1.2-2.noarch"),
+            get_pkg("bar-0:4.5-1.noarch"),
+            get_pkg("bar-0:4.5-2.x86_64"),
+        };
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
+    }
+    {
+        // Result of filter_latest_evr_ignore_arch should include only the latest
+        // packages, regardless of arch
+        PackageQuery query(base);
+        query.filter_latest_evr_any_arch(1);
+        std::vector<Package> expected = {get_pkg("foo-0:1.2-2.noarch"), get_pkg("bar-0:4.5-2.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
+    }
+}
+
 void RpmPackageQueryTest::test_filter_earliest_evr() {
     add_repo_solv("solv-repo1");
     add_repo_solv("solv-24pkgs");
@@ -169,6 +194,31 @@ void RpmPackageQueryTest::test_filter_earliest_evr() {
         PackageQuery query(base);
         query.filter_earliest_evr(-23);
         std::vector<Package> expected = {get_pkg("pkg-0:1-24.noarch")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
+    }
+}
+
+void RpmPackageQueryTest::test_filter_earliest_evr_ignore_arch() {
+    add_repo_solv("solv-multiarch");
+
+    {
+        // Result of filter_earliest_evr should include a package from each arch
+        PackageQuery query(base);
+        query.filter_earliest_evr(1);
+        std::vector<Package> expected = {
+            get_pkg("foo-0:1.2-1.x86_64"),
+            get_pkg("foo-0:1.2-2.noarch"),
+            get_pkg("bar-0:4.5-1.noarch"),
+            get_pkg("bar-0:4.5-2.x86_64"),
+        };
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
+    }
+    {
+        // Result of filter_earliest_evr_ignore_arch should include only the earliest
+        // packages, regardless of arch
+        PackageQuery query(base);
+        query.filter_earliest_evr_any_arch(1);
+        std::vector<Package> expected = {get_pkg("foo-0:1.2-1.x86_64"), get_pkg("bar-0:4.5-1.noarch")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 }

--- a/test/libdnf5/rpm/test_package_query.hpp
+++ b/test/libdnf5/rpm/test_package_query.hpp
@@ -33,7 +33,9 @@ class RpmPackageQueryTest : public BaseTestCase {
 #ifndef WITH_PERFORMANCE_TESTS
     CPPUNIT_TEST(test_size);
     CPPUNIT_TEST(test_filter_latest_evr);
+    CPPUNIT_TEST(test_filter_latest_evr_ignore_arch);
     CPPUNIT_TEST(test_filter_earliest_evr);
+    CPPUNIT_TEST(test_filter_earliest_evr_ignore_arch);
     CPPUNIT_TEST(test_filter_name);
     CPPUNIT_TEST(test_filter_name_packgset);
     CPPUNIT_TEST(test_filter_nevra_packgset);
@@ -66,7 +68,9 @@ public:
 
     void test_size();
     void test_filter_latest_evr();
+    void test_filter_latest_evr_ignore_arch();
     void test_filter_earliest_evr();
+    void test_filter_earliest_evr_ignore_arch();
     void test_filter_name();
     void test_filter_name_packgset();
     void test_filter_nevra_packgset();


### PR DESCRIPTION
Resolves https://github.com/rpm-software-management/dnf5/issues/1111.

`filter_latest_evr` and `filter_earliest_evr` group packages by architecture and keep the latest package on each architecture. After `filter_latest_evr`, a PackageQuery might have anaconda-1-1.noarch as well as anaconda-2.2.x86_64.

This commit adds `filter_latest_evr_ignore_arch` and `filter_earliest_evr_ignore_arch` which filter for packages with the latest versions regardless of their architecture. Filtering the above anaconda example with `filter_latest_evr_ignore_arch` would result in just {anaconda-2.2.x86_64} since it is the latest version of the package for any arch.

This is an ABI-breaking change and thus is targeted at dnf5 5.2.