### PR TITLE
build: Include <unistd.h> for isatty()

### DIFF
--- a/libdnf5-cli/output/advisorylist.cpp
+++ b/libdnf5-cli/output/advisorylist.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/string.hpp"
 
 #include <libsmartcols/libsmartcols.h>
+#include <unistd.h>
 
 namespace libdnf5::cli::output {
 


### PR DESCRIPTION
A compilation fails on some systems with:

    /home/rpm/rpmbuild/BUILD/libdnf5-cli/output/advisorylist.cpp: In function 'libscols_table* libdnf5::cli::output::create_advisorylist_table(std::string)':
    /home/rpm/rpmbuild/BUILD/libdnf5-cli/output/advisorylist.cpp:33:9: error: 'isatty' was not declared in this scope
       33 |     if (isatty(1)) {
	  |         ^~~~~~

The cause is a missing "#include <unistd.h>" in the compilation unit.

This bug was introduced in commit
d8d9c631faf259d0d4d88671fe2029749a081f66 (Add output formatting for advisory list and info into libdnf-cli).

Fixes: #1168