### PR TITLE
CI: Upgrade action/checkout to a version with Node.js 20

### DIFF
--- a/.github/workflows/do-release.yaml
+++ b/.github/workflows/do-release.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && github.repository_owner == 'rpm-software-management'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create GitHub release
         run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]  # gcc is the default
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/rpm-software-management/dnf-ci-host
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install pre-commit
       run: pip install pre-commit
     - name: State to use Workspace Dir

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
GitHub CI warns that Node.js 16 is deprecated:

    CCache Build (clang)
    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This patch moves action/checkout from v3 to v4 which is based on Node.js 20. It's fully compatible
<https://github.com/actions/checkout/compare/v3...v4.0.0>.