### PR TITLE
Add tmt tests identifiers

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -38,6 +38,7 @@ jobs:
       - fedora-all
   - job: tests
     trigger: pull_request
+    identifier: "dnf5-tests"
     targets:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
@@ -45,6 +46,7 @@ jobs:
     tmt_plan: /plans/integration/behave-dnf5
   - job: tests
     trigger: pull_request
+    identifier: "createrepo_c-tests"
     targets:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
@@ -52,6 +54,7 @@ jobs:
     tmt_plan: /plans/integration/behave-createrepo_c
   - job: tests
     trigger: pull_request
+    identifier: "dnf-tests"
     manual_trigger: true
     targets:
       - fedora-all
@@ -60,6 +63,7 @@ jobs:
     tmt_plan: /plans/integration/behave-dnf
   - job: tests
     trigger: pull_request
+    identifier: "dnf5daemon-tests"
     manual_trigger: true
     targets:
       - fedora-all

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,7 +43,7 @@ jobs:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: main
-    tmt_plan: /plans/integration/behave-dnf5
+    tmt_plan: "^/plans/integration/behave-dnf5$"
   - job: tests
     trigger: pull_request
     identifier: "createrepo_c-tests"
@@ -51,7 +51,7 @@ jobs:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: main
-    tmt_plan: /plans/integration/behave-createrepo_c
+    tmt_plan: "^/plans/integration/behave-createrepo_c$"
   - job: tests
     trigger: pull_request
     identifier: "dnf-tests"
@@ -60,7 +60,7 @@ jobs:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: main
-    tmt_plan: /plans/integration/behave-dnf
+    tmt_plan: "^/plans/integration/behave-dnf$"
   - job: tests
     trigger: pull_request
     identifier: "dnf5daemon-tests"
@@ -69,4 +69,4 @@ jobs:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: main
-    tmt_plan: /plans/integration/behave-dnf5daemon
+    tmt_plan: "^/plans/integration/behave-dnf5daemon$"


### PR DESCRIPTION
To allow manual triggering of test suites on the GitHub PR with `/packit test –identifier <id>`.