### PR TITLE
Drop dnf obsoletion temporarily

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -2,7 +2,7 @@
 %global project_version_minor 1
 %global project_version_patch 11
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 10]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 41 || 0%{?rhel} > 10]
 
 Name:           dnf5
 Version:        %{project_version_major}.%{project_version_minor}.%{project_version_patch}


### PR DESCRIPTION
To allow us and others to prepare for switching dnf5 as the default in Rawhide.