### PR TITLE
dnfdaemon: Allow configuration overrides for root

### DIFF
--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -90,6 +90,7 @@ const char * const SIGNAL_TRANSACTION_FINISHED = "transaction_finished";
 const char * const POLKIT_REPOCONF_WRITE = "org.rpm.dnf.v0.rpm.RepoConf.write";
 const char * const POLKIT_EXECUTE_RPM_TRANSACTION = "org.rpm.dnf.v0.rpm.execute_transaction";
 const char * const POLKIT_CONFIRM_KEY_IMPORT = "org.rpm.dnf.v0.rpm.Repo.confirm_key";
+const char * const POLKIT_CONFIG_OVERRIDE = "org.rpm.dnf.v0.base.Config.override";
 
 // errors
 const char * const ERROR = "org.rpm.dnf.v0.Error";

--- a/dnf5daemon-server/polkit/org.rpm.dnf.v0.policy
+++ b/dnf5daemon-server/polkit/org.rpm.dnf.v0.policy
@@ -35,4 +35,14 @@
         <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
+
+  <action id="org.rpm.dnf.v0.base.Config.override">
+    <description>Override libdnf5 configuration options</description>
+    <message>Authentication is required to override libdnf5 configuration options.</message>
+    <defaults>
+        <allow_any>auth_admin</allow_any>
+        <allow_inactive>auth_admin</allow_inactive>
+        <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
 </policyconfig>

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -79,7 +79,8 @@ public:
     };
     std::string get_sender() const { return sender; };
 
-    bool check_authorization(const std::string & actionid, const std::string & sender);
+    bool check_authorization(
+        const std::string & actionid, const std::string & sender, bool allow_user_interaction = true);
     void fill_sack();
     bool read_all_repos();
     std::optional<std::string> session_locale;


### PR DESCRIPTION
Root user is allowed to override all config options.