### PR TITLE
rpm: New callbacks to wrap whole rpm transaction

### DIFF
--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -125,6 +125,24 @@ sdbus::Signal DbusTransactionCB::create_signal_pkg(
 }
 
 
+void DbusTransactionCB::before_begin(uint64_t total) {
+    try {
+        auto signal = create_signal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_BEFORE_BEGIN);
+        signal << total;
+        dbus_object->emitSignal(signal);
+    } catch (...) {
+    }
+}
+
+void DbusTransactionCB::after_complete(bool success) {
+    try {
+        auto signal = create_signal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_AFTER_COMPLETE);
+        signal << success;
+        dbus_object->emitSignal(signal);
+    } catch (...) {
+    }
+}
+
 void DbusTransactionCB::install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
     try {
         dnfdaemon::RpmTransactionItemActions action;

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -93,6 +93,10 @@ public:
     explicit DbusTransactionCB(Session & session) : DbusCallback(session) {}
     virtual ~DbusTransactionCB() = default;
 
+    // overall transaction progress
+    void before_begin(uint64_t total) override;
+    void after_complete(bool success) override;
+
     // transaction preparation
     void transaction_start(uint64_t total) override;
     void transaction_progress(uint64_t amount, uint64_t total) override;

--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -70,6 +70,8 @@ const char * const SIGNAL_DOWNLOAD_MIRROR_FAILURE = "download_mirror_failure";
 
 const char * const SIGNAL_REPO_KEY_IMPORT_REQUEST = "repo_key_import_request";
 
+const char * const SIGNAL_TRANSACTION_BEFORE_BEGIN = "transaction_before_begin";
+const char * const SIGNAL_TRANSACTION_AFTER_COMPLETE = "transaction_after_complete";
 const char * const SIGNAL_TRANSACTION_TRANSACTION_START = "transaction_transaction_start";
 const char * const SIGNAL_TRANSACTION_TRANSACTION_PROGRESS = "transaction_transaction_progress";
 const char * const SIGNAL_TRANSACTION_TRANSACTION_STOP = "transaction_transaction_stop";

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -189,6 +189,26 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     </method>
 
     <!--
+        transaction_before_begin:
+        @total: number of elements in the rpm transaction
+
+        Send right before the rpm transaction is run.
+    -->
+    <signal name="transaction_before_begin">
+        <arg name="total" type="t" />
+    </signal>
+
+    <!--
+        transaction_after_complete:
+        @success: true if the rpm transaction was completed successfully
+
+        Send right after the rpm transaction run finished.
+    -->
+    <signal name="transaction_after_complete">
+        <arg name="success" type="b" />
+    </signal>
+
+    <!--
         transaction_action_start:
         @nevra: full NEVRA of the package
         @action: one of the dnfdaemon::RpmTransactionItem::Actions enum

--- a/include/libdnf5/rpm/transaction_callbacks.hpp
+++ b/include/libdnf5/rpm/transaction_callbacks.hpp
@@ -69,6 +69,13 @@ public:
 
     virtual ~TransactionCallbacks() = default;
 
+    /// Called right before the rpm transaction is run
+    /// @param total Number of elements in the rpm transaction
+    virtual void before_begin(uint64_t total) {}
+    /// Called after the transaction run finished
+    /// @param success Whether the rpm transaction was completed successfully
+    virtual void after_complete(bool success) {}
+
     virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void install_start(const TransactionItem & item, uint64_t total) {}
     virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -211,7 +211,16 @@ int Transaction::run() {
     }
     rpmtsSetNotifyStyle(ts, 1);
     rpmtsSetNotifyCallback(ts, ts_callback, &callbacks_holder);
+    auto * const callbacks = callbacks_holder.callbacks.get();
+    if (callbacks) {
+        int nelements = rpmtsNElements(ts);
+        libdnf_assert(nelements >= 0, "librpm rpmtsNElements() returned negative number of transaction elements.");
+        callbacks->before_begin(static_cast<uint64_t>(nelements));
+    }
     auto rc = rpmtsRun(ts, nullptr, ignore_set);
+    if (callbacks) {
+        callbacks->after_complete(rc == 0);
+    }
     rpmtsSetNotifyCallback(ts, nullptr, nullptr);
 
     return rc;


### PR DESCRIPTION
There is currently no way for dnf5daemon user to find out when the rpm
transaction began and when it finished.
The change introduces two new callbacks on rpm::TransactionCallbacks class:

TransactionCallbacks::before_begin(int total)

    executed right before the rpm transaction is run
    parameter total contains number of elements in the rpm transaction.

TransactionCallbacks::after_complete(bool success)

    executed right after the rpm transaction finished
    parameter success indicates whether the transaction finished successfully.

These callbacks are then used in dnf5daemon-server to send respective signals
to the client.

For https://github.com/rpm-software-management/dnf5/issues/1189

Replaces https://github.com/rpm-software-management/dnf5/pull/1250
Originally opened on the main branch, but since it causes ABI breakage by adding new virtual methods to public class, moved here.