### PR TITLE
build: Adapt to changes in Fedora packaging of bash-completion

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -118,7 +118,11 @@ Provides:       dnf5-command(makecache)
 
 # ========== build requires ==========
 
+%if 0%{?fedora} > 40 || 0 %{?rhel} > 10
+BuildRequires:  bash-completion-devel
+%else
 BuildRequires:  bash-completion
+%endif
 BuildRequires:  cmake
 BuildRequires:  doxygen
 BuildRequires:  gettext


### PR DESCRIPTION
Fedora 41 moved a CMake script for bash-completion from bash-completion to bash-completion-devel package
<https://bugzilla.redhat.com/show_bug.cgi?id=1457164>. That broke building dnf5.spec:

~~~~
RPM build errors:
    Directory not found: /builddir/build/BUILDROOT/dnf5-5.1.12-1.20240216152113944400.pr1250.22.gd9fb3e11.fc41.x86_64/usr/share/bash-completion
    Directory not found: /builddir/build/BUILDROOT/dnf5-5.1.12-1.20240216152113944400.pr1250.22.gd9fb3e11.fc41.x86_64/usr/share/bash-completion/completions
    File not found: /builddir/build/BUILDROOT/dnf5-5.1.12-1.20240216152113944400.pr1250.22.gd9fb3e11.fc41.x86_64/usr/share/bash-completion/completions/dnf5
~~~~

This adapts to the change.

Fixes: #1252