### PR TITLE
When limiting installonly pkg handle each provider just once

### DIFF
--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -19,7 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "goal_private.hpp"
 
-#include "rpm/package_sack_impl.hpp"
 #include "solv/pool.hpp"
 
 #include "libdnf5/common/exception.hpp"


### PR DESCRIPTION
First gather all unique providers of installonly provides and then
handle each set of packages (providers) with the same name.

Previously the handling was done per provide, this could result in repeated
handling of a single package if it provided multiple installonly
provides. Such as `kernel` and `installonlypkg(kernel)`.
This could also lead to problems when multiple versions of installonly
pkgs didn't have the same installonly provides.

https://bugzilla.redhat.com/show_bug.cgi?id=2263675

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1454