### PR TITLE
Add repo_query.hpp for swig-4.2.1 support

### DIFF
--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -37,6 +37,7 @@
     #include "libdnf5/comps/environment/query.hpp"
     #include "libdnf5/comps/environment/sack.hpp"
     #include "libdnf5/comps/comps.hpp"
+    #include "libdnf5/repo/repo_query.hpp"
     #include "libdnf5/repo/repo.hpp"
 %}
 


### PR DESCRIPTION
The pending SWIG 4.2.1 release fixes a type tables bug requiring the definition of RepoQuery.

The generated type tables now allow for casting `RepoQuery` up the inheritance hierarchy to libdnf5::sack::Query<RepoWeakPtr> to libdnf5::Set<libdnf5::repo::RepoWeakPtr>.

See https://github.com/swig/swig/issues/2804.