### PR TITLE
Add pImpl to `libdnf5::advisory::*` classes

### DIFF
--- a/include/libdnf5/advisory/advisory.hpp
+++ b/include/libdnf5/advisory/advisory.hpp
@@ -45,9 +45,15 @@ public:
 /// An advisory, represents advisory used to track security updates
 class Advisory {
 public:
-    bool operator==(const Advisory & other) const noexcept { return id == other.id && base == other.base; }
+    Advisory(const Advisory & src);
+    Advisory & operator=(const Advisory & src);
 
-    bool operator!=(const Advisory & other) const noexcept { return !(*this == other); }
+    Advisory(Advisory && src) noexcept;
+    Advisory & operator=(Advisory && src) noexcept;
+
+    bool operator==(const Advisory & other) const noexcept;
+
+    bool operator!=(const Advisory & other) const noexcept;
 
     /// Destroy the Advisory object
     ~Advisory();
@@ -141,9 +147,8 @@ private:
     friend class AdvisorySetIterator;
     friend class AdvisorySet;
 
-    BaseWeakPtr base;
-
-    AdvisoryId id;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::advisory

--- a/include/libdnf5/advisory/advisory_collection.hpp
+++ b/include/libdnf5/advisory/advisory_collection.hpp
@@ -33,6 +33,14 @@ namespace libdnf5::advisory {
 //TODO(amatej): add unit tests for AdvisoryCollection
 class AdvisoryCollection {
 public:
+    AdvisoryCollection(const AdvisoryCollection & src);
+    AdvisoryCollection & operator=(const AdvisoryCollection & src);
+
+    AdvisoryCollection(AdvisoryCollection && src) noexcept;
+    AdvisoryCollection & operator=(AdvisoryCollection && src) noexcept;
+
+    ~AdvisoryCollection();
+
     /// Whether this AdvisoryCollection is applicable. True when at least one AdvisoryModule in this
     /// AdvisoryCollection is active on the system, False otherwise.
     bool is_applicable() const;
@@ -70,7 +78,6 @@ private:
 
     AdvisoryCollection(const BaseWeakPtr & base, AdvisoryId advisory, int index);
 
-    //TODO(amatej): Hide into an Impl?
     /// Get all AdvisoryPackages stored in this AdvisoryCollection
     ///
     /// @param output           std::vector of AdvisorPackages used as output.
@@ -80,19 +87,8 @@ private:
     ///                         The filename is stored as a c string (not libsolv id) this incurs slowdown.
     void get_packages(std::vector<AdvisoryPackage> & output, bool with_filenames = false);
 
-    //TODO(amatej): Hide into an Impl?
-    /// Get all AdvisoryModules stored in this AdvisoryCollection
-    /// @param output           std::vector of AdvisorModules used as output.
-    ///                         This is much faster than returning new std::vector and later joining
-    ///                         them when collecting AdvisoryModules from multiple collections.
-    void get_modules(std::vector<AdvisoryModule> & output);
-
-    BaseWeakPtr base;
-
-    AdvisoryId advisory;
-
-    /// AdvisoryCollections don't have their own Id, therefore store it's index in its Advisory (just like AdvisoryReference)
-    int index;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::advisory

--- a/include/libdnf5/advisory/advisory_query.hpp
+++ b/include/libdnf5/advisory/advisory_query.hpp
@@ -28,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/common/sack/query_cmp.hpp"
-#include "libdnf5/rpm/package.hpp"
 #include "libdnf5/rpm/package_set.hpp"
 
 
@@ -48,11 +47,11 @@ public:
     /// @param base     Reference to Base
     explicit AdvisoryQuery(libdnf5::Base & base);
 
-    AdvisoryQuery(const AdvisoryQuery & src) = default;
-    AdvisoryQuery & operator=(const AdvisoryQuery & src) = default;
+    AdvisoryQuery(const AdvisoryQuery & src);
+    AdvisoryQuery & operator=(const AdvisoryQuery & src);
 
-    AdvisoryQuery(AdvisoryQuery && src) = default;
-    AdvisoryQuery & operator=(AdvisoryQuery && src) = default;
+    AdvisoryQuery(AdvisoryQuery && src) noexcept;
+    AdvisoryQuery & operator=(AdvisoryQuery && src) noexcept;
 
     ~AdvisoryQuery();
 
@@ -113,7 +112,8 @@ public:
         const libdnf5::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) const;
 
 private:
-    BaseWeakPtr base;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::advisory

--- a/include/libdnf5/advisory/advisory_reference.hpp
+++ b/include/libdnf5/advisory/advisory_reference.hpp
@@ -23,13 +23,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "advisory.hpp"
 
 #include <memory>
-#include <vector>
-
 
 namespace libdnf5::advisory {
 
 class AdvisoryReference {
 public:
+    AdvisoryReference(const AdvisoryReference & src);
+    AdvisoryReference & operator=(const AdvisoryReference & src);
+
+    AdvisoryReference(AdvisoryReference && src) noexcept;
+    AdvisoryReference & operator=(AdvisoryReference && src) noexcept;
+
+    ~AdvisoryReference();
+
     /// Get id of this advisory reference, this id is like a name of this reference
     /// (it is not libsolv id).
     ///
@@ -68,13 +74,8 @@ private:
     /// @return New AdvisoryReference instance.
     AdvisoryReference(const BaseWeakPtr & base, AdvisoryId advisory, int index);
 
-    BaseWeakPtr base;
-    AdvisoryId advisory;
-
-    /// We cannot store IDs of reference data (id, type, title, url) because they
-    /// don't have ids set in libsolv (they are only strings), therefore we store
-    /// index of the reference.
-    int index;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::advisory

--- a/libdnf5/advisory/advisory.cpp
+++ b/libdnf5/advisory/advisory.cpp
@@ -31,18 +31,55 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::advisory {
 
-Advisory::Advisory(const libdnf5::BaseWeakPtr & base, AdvisoryId id) : base(base), id(id) {}
+class Advisory::Impl {
+public:
+    Impl(const libdnf5::BaseWeakPtr & base, AdvisoryId id) : base(base), id(id) {}
+
+private:
+    friend Advisory;
+
+    BaseWeakPtr base;
+
+    AdvisoryId id;
+};
+
+Advisory::Advisory(const libdnf5::BaseWeakPtr & base, AdvisoryId id) : p_impl(std::make_unique<Impl>(base, id)) {}
+
+Advisory::Advisory(const Advisory & src) : p_impl(new Impl(*src.p_impl)) {}
+Advisory & Advisory::operator=(const Advisory & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+
+Advisory::Advisory(Advisory && src) noexcept = default;
+Advisory & Advisory::operator=(Advisory && src) noexcept = default;
+
+bool Advisory::operator==(const Advisory & other) const noexcept {
+    return p_impl->id == other.p_impl->id && p_impl->base == other.p_impl->base;
+}
+
+bool Advisory::operator!=(const Advisory & other) const noexcept {
+    return !(*this == other);
+}
+
 
 std::string Advisory::get_name() const {
     const char * name;
-    name = get_rpm_pool(base).lookup_str(id.id, SOLVABLE_NAME);
+    name = get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, SOLVABLE_NAME);
 
     if (strncmp(
             libdnf5::solv::SOLVABLE_NAME_ADVISORY_PREFIX, name, libdnf5::solv::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH) !=
         0) {
         throw RuntimeError(
             M_("Bad libsolv id for advisory \"{}\", solvable name \"{}\" doesn't have advisory prefix \"{}\""),
-            id.id,
+            p_impl->id.id,
             std::string(name),
             std::string(libdnf5::solv::SOLVABLE_NAME_ADVISORY_PREFIX));
     }
@@ -51,63 +88,63 @@ std::string Advisory::get_name() const {
 }
 
 std::string Advisory::get_type() const {
-    return std::string(get_rpm_pool(base).lookup_str(id.id, SOLVABLE_PATCHCATEGORY));
+    return std::string(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, SOLVABLE_PATCHCATEGORY));
 }
 
 std::string Advisory::get_severity() const {
     //TODO(amatej): should we call SolvPrivate::internalize_libsolv_repo(solvable->repo);
     //              before pool.lookup_str?
     //              If so do this just once in solv::advisroy_private
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, UPDATE_SEVERITY));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, UPDATE_SEVERITY));
 }
 
 unsigned long long Advisory::get_buildtime() const {
-    return get_rpm_pool(base).lookup_num(id.id, SOLVABLE_BUILDTIME);
+    return get_rpm_pool(p_impl->base).lookup_num(p_impl->id.id, SOLVABLE_BUILDTIME);
 }
 
 std::string Advisory::get_title() const {
     // SOLVABLE_SUMMARY is misnamed, it actually stores the title
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, SOLVABLE_SUMMARY));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, SOLVABLE_SUMMARY));
 }
 
 std::string Advisory::get_vendor() const {
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, SOLVABLE_VENDOR));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, SOLVABLE_VENDOR));
 }
 
 std::string Advisory::get_rights() const {
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, UPDATE_RIGHTS));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, UPDATE_RIGHTS));
 }
 
 std::string Advisory::get_status() const {
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, UPDATE_STATUS));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, UPDATE_STATUS));
 }
 
 std::string Advisory::get_message() const {
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, UPDATE_MESSAGE));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, UPDATE_MESSAGE));
 }
 
 std::string Advisory::get_description() const {
-    return libdnf5::utils::string::c_to_str(get_rpm_pool(base).lookup_str(id.id, SOLVABLE_DESCRIPTION));
+    return libdnf5::utils::string::c_to_str(get_rpm_pool(p_impl->base).lookup_str(p_impl->id.id, SOLVABLE_DESCRIPTION));
 }
 
 AdvisoryId Advisory::get_id() const {
-    return id;
+    return p_impl->id;
 }
 
 std::vector<AdvisoryReference> Advisory::get_references(std::vector<std::string> types) const {
-    auto & pool = get_rpm_pool(base);
+    auto & pool = get_rpm_pool(p_impl->base);
 
     std::vector<AdvisoryReference> output;
 
     Dataiterator di;
-    dataiterator_init(&di, *pool, 0, id.id, UPDATE_REFERENCE, 0, 0);
+    dataiterator_init(&di, *pool, 0, p_impl->id.id, UPDATE_REFERENCE, 0, 0);
 
     for (int index = 0; dataiterator_step(&di); index++) {
         dataiterator_setpos(&di);
         std::string current_type = std::string(pool.lookup_str(SOLVID_POS, UPDATE_REFERENCE_TYPE));
 
         if (types.empty() || std::find(types.begin(), types.end(), current_type) != types.end()) {
-            output.emplace_back(AdvisoryReference(base, id, index));
+            output.emplace_back(AdvisoryReference(p_impl->base, p_impl->id, index));
         }
     }
 
@@ -119,11 +156,11 @@ std::vector<AdvisoryCollection> Advisory::get_collections() const {
     std::vector<AdvisoryCollection> output;
 
     Dataiterator di;
-    dataiterator_init(&di, *get_rpm_pool(base), 0, id.id, UPDATE_COLLECTIONLIST, 0, 0);
+    dataiterator_init(&di, *get_rpm_pool(p_impl->base), 0, p_impl->id.id, UPDATE_COLLECTIONLIST, 0, 0);
 
     for (int index = 0; dataiterator_step(&di); index++) {
         dataiterator_setpos(&di);
-        output.emplace_back(AdvisoryCollection(base, id, index));
+        output.emplace_back(AdvisoryCollection(p_impl->base, p_impl->id, index));
     }
 
     dataiterator_free(&di);

--- a/libdnf5/advisory/advisory_collection.cpp
+++ b/libdnf5/advisory/advisory_collection.cpp
@@ -26,10 +26,50 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::advisory {
 
+class AdvisoryCollection::Impl {
+public:
+    explicit Impl(const libdnf5::BaseWeakPtr & base, AdvisoryId advisory, int index)
+        : advisory(advisory),
+          index(index),
+          base(base) {}
+
+    /// Get all AdvisoryModules stored in this AdvisoryCollection
+    /// @param output           std::vector of AdvisorModules used as output.
+    ///                         This is much faster than returning new std::vector and later joining
+    ///                         them when collecting AdvisoryModules from multiple collections.
+    void get_modules(std::vector<AdvisoryModule> & output);
+
+private:
+    friend AdvisoryCollection;
+
+    AdvisoryId advisory;
+
+    /// AdvisoryCollections don't have their own Id, therefore store it's index in its Advisory (just like AdvisoryReference)
+    int index;
+
+    BaseWeakPtr base;
+};
+
 AdvisoryCollection::AdvisoryCollection(const libdnf5::BaseWeakPtr & base, AdvisoryId advisory, int index)
-    : base(base),
-      advisory(advisory),
-      index(index) {}
+    : p_impl(std::make_unique<Impl>(base, advisory, index)) {}
+
+AdvisoryCollection::~AdvisoryCollection() = default;
+
+AdvisoryCollection::AdvisoryCollection(const AdvisoryCollection & src) : p_impl(new Impl(*src.p_impl)) {}
+AdvisoryCollection & AdvisoryCollection::operator=(const AdvisoryCollection & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+
+AdvisoryCollection::AdvisoryCollection(AdvisoryCollection && src) noexcept = default;
+AdvisoryCollection & AdvisoryCollection::operator=(AdvisoryCollection && src) noexcept = default;
 
 bool AdvisoryCollection::is_applicable() const {
     //TODO(amatej): check if collection is applicable
@@ -44,20 +84,20 @@ std::vector<AdvisoryPackage> AdvisoryCollection::get_packages() {
 
 std::vector<AdvisoryModule> AdvisoryCollection::get_modules() {
     std::vector<AdvisoryModule> output;
-    get_modules(output);
+    p_impl->get_modules(output);
     return output;
 }
 
 void AdvisoryCollection::get_packages(std::vector<AdvisoryPackage> & output, bool with_filemanes) {
     Dataiterator di;
     const char * filename = nullptr;
-    auto & pool = get_rpm_pool(base);
+    auto & pool = get_rpm_pool(p_impl->base);
     int count = 0;
 
-    dataiterator_init(&di, *pool, 0, advisory.id, UPDATE_COLLECTIONLIST, 0, 0);
+    dataiterator_init(&di, *pool, 0, p_impl->advisory.id, UPDATE_COLLECTIONLIST, 0, 0);
     while (dataiterator_step(&di)) {
         dataiterator_setpos(&di);
-        if (count == index) {
+        if (count == p_impl->index) {
             Dataiterator di_inner;
             dataiterator_init(&di_inner, *pool, 0, SOLVID_POS, UPDATE_COLLECTION, 0, 0);
             while (dataiterator_step(&di_inner)) {
@@ -72,9 +112,9 @@ void AdvisoryCollection::get_packages(std::vector<AdvisoryPackage> & output, boo
                     filename = pool.lookup_str(SOLVID_POS, UPDATE_COLLECTION_FILENAME);
                 }
                 output.emplace_back(AdvisoryPackage(new AdvisoryPackage::Impl(
-                    base,
-                    advisory,
-                    index,
+                    p_impl->base,
+                    p_impl->advisory,
+                    p_impl->index,
                     name,
                     evr,
                     arch,
@@ -91,7 +131,7 @@ void AdvisoryCollection::get_packages(std::vector<AdvisoryPackage> & output, boo
     dataiterator_free(&di);
 }
 
-void AdvisoryCollection::get_modules(std::vector<AdvisoryModule> & output) {
+void AdvisoryCollection::Impl::get_modules(std::vector<AdvisoryModule> & output) {
     Dataiterator di;
     auto & pool = get_rpm_pool(base);
     int count = 0;
@@ -121,11 +161,11 @@ void AdvisoryCollection::get_modules(std::vector<AdvisoryModule> & output) {
 }
 
 AdvisoryId AdvisoryCollection::get_advisory_id() const {
-    return advisory;
+    return p_impl->advisory;
 }
 
 Advisory AdvisoryCollection::get_advisory() const {
-    return Advisory(base, advisory);
+    return Advisory(p_impl->base, p_impl->advisory);
 }
 
 }  // namespace libdnf5::advisory

--- a/libdnf5/advisory/advisory_reference.cpp
+++ b/libdnf5/advisory/advisory_reference.cpp
@@ -27,25 +27,65 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::advisory {
 
+class AdvisoryReference::Impl {
+public:
+    explicit Impl(const libdnf5::BaseWeakPtr & base, AdvisoryId advisory, int index)
+        : base(base),
+          advisory(advisory),
+          index(index) {}
+
+private:
+    friend AdvisoryReference;
+
+    BaseWeakPtr base;
+
+    AdvisoryId advisory;
+
+    /// We cannot store IDs of reference data (id, type, title, url) because they
+    /// don't have ids set in libsolv (they are only strings), therefore we store
+    /// index of the reference.
+    int index;
+};
+
 AdvisoryReference::AdvisoryReference(const libdnf5::BaseWeakPtr & base, AdvisoryId advisory, int index)
-    : base(base),
-      advisory(advisory),
-      index(index) {}
+    : p_impl(std::make_unique<Impl>(base, advisory, index)) {}
+
+AdvisoryReference::~AdvisoryReference() = default;
+
+AdvisoryReference::AdvisoryReference(const AdvisoryReference & src) : p_impl(new Impl(*src.p_impl)) {}
+AdvisoryReference & AdvisoryReference::operator=(const AdvisoryReference & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+
+AdvisoryReference::AdvisoryReference(AdvisoryReference && src) noexcept = default;
+AdvisoryReference & AdvisoryReference::operator=(AdvisoryReference && src) noexcept = default;
 
 std::string AdvisoryReference::get_id() const {
-    return std::string(get_rpm_pool(base).get_str_from_pool(UPDATE_REFERENCE_ID, advisory.id, index));
+    return std::string(
+        get_rpm_pool(p_impl->base).get_str_from_pool(UPDATE_REFERENCE_ID, p_impl->advisory.id, p_impl->index));
 }
 std::string AdvisoryReference::get_type() const {
-    return std::string(get_rpm_pool(base).get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, index));
+    return std::string(
+        get_rpm_pool(p_impl->base).get_str_from_pool(UPDATE_REFERENCE_TYPE, p_impl->advisory.id, p_impl->index));
 }
 const char * AdvisoryReference::get_type_cstring() const {
-    return get_rpm_pool(base).get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, index);
+    return get_rpm_pool(p_impl->base).get_str_from_pool(UPDATE_REFERENCE_TYPE, p_impl->advisory.id, p_impl->index);
 }
 std::string AdvisoryReference::get_title() const {
-    return std::string(get_rpm_pool(base).get_str_from_pool(UPDATE_REFERENCE_TITLE, advisory.id, index));
+    return std::string(
+        get_rpm_pool(p_impl->base).get_str_from_pool(UPDATE_REFERENCE_TITLE, p_impl->advisory.id, p_impl->index));
 }
 std::string AdvisoryReference::get_url() const {
-    return std::string(get_rpm_pool(base).get_str_from_pool(UPDATE_REFERENCE_HREF, advisory.id, index));
+    return std::string(
+        get_rpm_pool(p_impl->base).get_str_from_pool(UPDATE_REFERENCE_HREF, p_impl->advisory.id, p_impl->index));
 }
 
 }  // namespace libdnf5::advisory


### PR DESCRIPTION
Add pImpl to `libdnf5::advisory::*` classes

This PR is into a new dnf5-5.2.0.0 branch to keep the main branch ABI compatible.
For: https://github.com/rpm-software-management/dnf5/issues/1025
