### PR TITLE
Add pImpl to `libdnf5::module::*` classes

### DIFF
--- a/include/libdnf5/module/module_dependency.hpp
+++ b/include/libdnf5/module/module_dependency.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_MODULE_MODULE_DEPENDENCY_HPP
 #define LIBDNF5_MODULE_MODULE_DEPENDENCY_HPP
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,30 +29,32 @@ namespace libdnf5::module {
 
 class ModuleDependency {
 public:
-    ModuleDependency(const std::string & module_name, const std::vector<std::string> & streams)
-        : module_name(module_name),
-          streams(streams) {}
+    ModuleDependency(const std::string & module_name, const std::vector<std::string> & streams);
 
-    ModuleDependency(std::string && module_name, std::vector<std::string> && streams)
-        : module_name(std::move(module_name)),
-          streams(std::move(streams)) {}
+    ModuleDependency(std::string && module_name, std::vector<std::string> && streams);
+
+    ~ModuleDependency();
+
+    ModuleDependency(const ModuleDependency & src);
+    ModuleDependency & operator=(const ModuleDependency & src);
+
+    ModuleDependency(ModuleDependency && src) noexcept;
+    ModuleDependency & operator=(ModuleDependency && src) noexcept;
 
     /// @return Name of the required module.
     /// @since 5.0
-    const std::string & get_module_name() const { return module_name; };
+    const std::string & get_module_name() const;
 
     /// @return Vector of streams. Prefix '-' denotes conflicting stream, otherwise, the stream is one of required.
     ///         If there are no other streams, any active stream of the module can satisfy the require.
     /// @since 5.0
-    const std::vector<std::string> & get_streams() const { return streams; };
+    const std::vector<std::string> & get_streams() const;
 
     std::string to_string();
 
 private:
-    friend class ModuleItem;
-
-    std::string module_name;
-    std::vector<std::string> streams;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf5/module/module_profile.hpp
+++ b/include/libdnf5/module/module_profile.hpp
@@ -61,6 +61,8 @@ public:
     // @replaces libdnf:module:modulemd/ModuleProfile.hpp:ctor:ModuleProfile.ModuleProfile()
     ModuleProfile(const ModuleProfile & src);
     ModuleProfile & operator=(const ModuleProfile & src);
+    ModuleProfile(ModuleProfile && src) noexcept;
+    ModuleProfile & operator=(ModuleProfile && src) noexcept;
     ~ModuleProfile();
 
 private:
@@ -69,9 +71,8 @@ private:
     // @replaces libdnf:module:modulemd/ModuleProfile.hpp:ctor:ModuleProfile.ModuleProfile(ModulemdProfile * profile)
     ModuleProfile(_ModulemdProfile * profile, const bool is_default);
 
-    // @replaces libdnf:module:modulemd/ModuleProfile.hpp:attribute:ModuleProfile.profile
-    _ModulemdProfile * profile{nullptr};
-    bool is_default_profile = false;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf5/module/module_query.hpp
+++ b/include/libdnf5/module/module_query.hpp
@@ -42,6 +42,14 @@ public:
     /// @param empty    `true` to create empty query, `false` to create query with all modules
     explicit ModuleQuery(const libdnf5::BaseWeakPtr & base, bool empty = false);
 
+    ~ModuleQuery();
+
+    ModuleQuery(const ModuleQuery & src);
+    ModuleQuery & operator=(const ModuleQuery & src);
+
+    ModuleQuery(ModuleQuery && src) noexcept;
+    ModuleQuery & operator=(ModuleQuery && src) noexcept;
+
     /// Create a new ModuleQuery instance.
     ///
     /// @param base     Reference to Base
@@ -50,7 +58,7 @@ public:
 
     /// @return Weak pointer to the Base object.
     /// @since 5.0
-    libdnf5::BaseWeakPtr get_base() { return base; }
+    libdnf5::BaseWeakPtr get_base();
 
     /// Filter ModuleItems by their `name`.
     ///
@@ -171,22 +179,10 @@ public:
     std::pair<bool, Nsvcap> resolve_module_spec(const std::string & module_spec);
 
 private:
-    // Getter callbacks that return attribute values from an object. Used in query filters.
-    struct Get {
-        static std::string name(const ModuleItem & obj) { return obj.get_name(); }
-        static std::string stream(const ModuleItem & obj) { return obj.get_stream(); }
-        static std::string version(const ModuleItem & obj) { return obj.get_version_str(); }
-        static std::string context(const ModuleItem & obj) { return obj.get_context(); }
-        static std::string arch(const ModuleItem & obj) { return obj.get_arch(); }
-        static bool is_enabled(const ModuleItem & obj);
-        static bool is_disabled(const ModuleItem & obj);
-    };
-
     friend ModuleItem;
 
-    static bool latest_cmp(const ModuleItem * module_item_1, const ModuleItem * module_item_2);
-
-    BaseWeakPtr base;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::module

--- a/include/libdnf5/module/nsvcap.hpp
+++ b/include/libdnf5/module/nsvcap.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_MODULE_NSCVAP_HPP
 #define LIBDNF5_MODULE_NSCVAP_HPP
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -50,17 +51,26 @@ public:
         NSC = 18,
     };
 
+    Nsvcap();
+    ~Nsvcap();
+
+    Nsvcap(const Nsvcap & src);
+    Nsvcap & operator=(const Nsvcap & src);
+
+    Nsvcap(Nsvcap && src) noexcept;
+    Nsvcap & operator=(Nsvcap && src) noexcept;
+
     /// The default forms and their order determine module_spec matching
     static const std::vector<Form> & get_default_module_spec_forms();
 
     /// Parse a string in a given form.
     /// If the parsing is successful, the attributes of this class are set accordingly, otherwise, they are left unchanged.
     ///
-    /// @param pattern          A string to parse.
+    /// @param nsvcap_str       A string to parse.
     /// @param form             A module form in which the string should be.
     /// @return                 `true` if the pattern matched the form, `false` otherwise.
     /// @since 5.0.6
-    bool parse(const std::string pattern, Form form);
+    bool parse(const std::string & nsvcap_str, Form form);
 
     /// Parse a string in one of the given forms.
     /// If the parsing is successful, the attributes of this class are set accordingly, otherwise, they are left unchanged.
@@ -69,7 +79,7 @@ public:
     /// @param forms            Module forms in one of which the string should be.
     /// @return                 `true` if the nsvcap_str matched one of the forms, `false` otherwise.
     /// @since 5.0.6
-    static std::vector<Nsvcap> parse(const std::string & pattern, std::vector<Form> forms);
+    static std::vector<Nsvcap> parse(const std::string & pattern, const std::vector<Form> & forms);
 
     /// Parse a string.
     /// If the parsing is successful, the attributes of this class are set accordingly, otherwise, they are left unchanged.
@@ -84,34 +94,30 @@ public:
     /// @since 5.0.6
     void clear();
 
-    const std::string & get_name() const noexcept { return name; }
-    const std::string & get_stream() const noexcept { return stream; }
-    const std::string & get_version() const noexcept { return version; }
-    const std::string & get_context() const noexcept { return context; }
-    const std::string & get_arch() const noexcept { return arch; }
-    const std::string & get_profile() const noexcept { return profile; }
+    const std::string & get_name() const noexcept;
+    const std::string & get_stream() const noexcept;
+    const std::string & get_version() const noexcept;
+    const std::string & get_context() const noexcept;
+    const std::string & get_arch() const noexcept;
+    const std::string & get_profile() const noexcept;
 
-    void set_name(const std::string & name) { this->name = name; }
-    void set_stream(const std::string & stream) { this->stream = stream; }
-    void set_version(const std::string & version) { this->version = version; }
-    void set_context(const std::string & context) { this->context = context; }
-    void set_arch(const std::string & arch) { this->arch = arch; }
-    void set_profile(const std::string & profile) { this->profile = profile; }
+    void set_name(const std::string & name);
+    void set_stream(const std::string & stream);
+    void set_version(const std::string & version);
+    void set_context(const std::string & context);
+    void set_arch(const std::string & arch);
+    void set_profile(const std::string & profile);
 
-    void set_name(std::string && name) { this->name = std::move(name); }
-    void set_stream(std::string && stream) { this->stream = std::move(stream); }
-    void set_version(std::string && version) { this->version = std::move(version); }
-    void set_context(std::string && context) { this->context = std::move(context); }
-    void set_arch(std::string && arch) { this->arch = std::move(arch); }
-    void set_profile(std::string && profile) { this->profile = std::move(profile); }
+    void set_name(std::string && name);
+    void set_stream(std::string && stream);
+    void set_version(std::string && version);
+    void set_context(std::string && context);
+    void set_arch(std::string && arch);
+    void set_profile(std::string && profile);
 
 private:
-    std::string name;
-    std::string stream;
-    std::string version;
-    std::string context;
-    std::string arch;
-    std::string profile;
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/libdnf5/module/module_dependency.cpp
+++ b/libdnf5/module/module_dependency.cpp
@@ -21,10 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/string.hpp"
 
-#include "libdnf5/module/module_item.hpp"
-#include "libdnf5/module/module_sack.hpp"
-#include "libdnf5/module/module_sack_weak.hpp"
-
 #include <modulemd-2.0/modulemd-module-stream.h>
 #include <modulemd-2.0/modulemd-profile.h>
 #include <modulemd-2.0/modulemd.h>
@@ -41,10 +37,58 @@ extern "C" {
 
 namespace libdnf5::module {
 
+class ModuleDependency::Impl {
+public:
+    Impl(const std::string & module_name, const std::vector<std::string> & streams)
+        : module_name(module_name),
+          streams(streams) {}
+
+    Impl(std::string && module_name, std::vector<std::string> && streams)
+        : module_name(std::move(module_name)),
+          streams(std::move(streams)) {}
+
+private:
+    friend ModuleDependency;
+
+    std::string module_name;
+    std::vector<std::string> streams;
+};
+
+ModuleDependency::ModuleDependency(const std::string & module_name, const std::vector<std::string> & streams)
+    : p_impl(std::make_unique<Impl>(module_name, streams)) {}
+
+ModuleDependency::ModuleDependency(std::string && module_name, std::vector<std::string> && streams)
+    : p_impl(std::make_unique<Impl>(std::move(module_name), std::move(streams))) {}
+
+ModuleDependency::~ModuleDependency() = default;
+
+ModuleDependency::ModuleDependency(const ModuleDependency & src) : p_impl(new Impl(*src.p_impl)) {}
+ModuleDependency::ModuleDependency(ModuleDependency && src) noexcept = default;
+
+ModuleDependency & ModuleDependency::operator=(const ModuleDependency & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+ModuleDependency & ModuleDependency::operator=(ModuleDependency && src) noexcept = default;
+
+const std::string & ModuleDependency::get_module_name() const {
+    return p_impl->module_name;
+};
+
+const std::vector<std::string> & ModuleDependency::get_streams() const {
+    return p_impl->streams;
+};
 
 std::string ModuleDependency::to_string() {
-    std::sort(streams.begin(), streams.end());
-    return fmt::format("{}:[{}]", module_name, utils::string::join(streams, ","));
+    std::sort(p_impl->streams.begin(), p_impl->streams.end());
+    return fmt::format("{}:[{}]", p_impl->module_name, utils::string::join(p_impl->streams, ","));
 }
 
 

--- a/libdnf5/module/nsvcap.cpp
+++ b/libdnf5/module/nsvcap.cpp
@@ -87,13 +87,44 @@ static const std::vector<Nsvcap::Form> MODULE_SPEC_FORMS{
     Nsvcap::Form::NSVCA,
     Nsvcap::Form::NSVCAP};
 
+class Nsvcap::Impl {
+private:
+    friend Nsvcap;
+
+    std::string name;
+    std::string stream;
+    std::string version;
+    std::string context;
+    std::string arch;
+    std::string profile;
+};
+
+Nsvcap::Nsvcap() : p_impl(std::make_unique<Impl>()) {}
+
+Nsvcap::~Nsvcap() = default;
+
+Nsvcap::Nsvcap(const Nsvcap & src) : p_impl(new Impl(*src.p_impl)) {}
+Nsvcap::Nsvcap(Nsvcap && src) noexcept = default;
+
+Nsvcap & Nsvcap::operator=(const Nsvcap & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+
+    return *this;
+}
+Nsvcap & Nsvcap::operator=(Nsvcap && src) noexcept = default;
 
 const std::vector<Nsvcap::Form> & Nsvcap::get_default_module_spec_forms() {
     return MODULE_SPEC_FORMS;
 }
 
 
-bool Nsvcap::parse(const std::string nsvcap_str, Nsvcap::Form form) {
+bool Nsvcap::parse(const std::string & nsvcap_str, Nsvcap::Form form) {
     enum { NAME = 1, STREAM = 2, VERSION = 3, CONTEXT = 4, ARCH = 5, PROFILE = 6, _LAST_ };
 
     if (nsvcap_str.length() > MAX_STRING_LENGTH_FOR_REGEX_MATCH) {
@@ -106,17 +137,17 @@ bool Nsvcap::parse(const std::string nsvcap_str, Nsvcap::Form form) {
     if (!matched || matched_result[NAME].str().size() == 0) {
         return false;
     }
-    name = matched_result[NAME].str();
-    version = matched_result[VERSION].str();
-    stream = matched_result[STREAM].str();
-    context = matched_result[CONTEXT].str();
-    arch = matched_result[ARCH].str();
-    profile = matched_result[PROFILE].str();
+    p_impl->name = matched_result[NAME].str();
+    p_impl->version = matched_result[VERSION].str();
+    p_impl->stream = matched_result[STREAM].str();
+    p_impl->context = matched_result[CONTEXT].str();
+    p_impl->arch = matched_result[ARCH].str();
+    p_impl->profile = matched_result[PROFILE].str();
     return true;
 }
 
 
-std::vector<Nsvcap> Nsvcap::parse(const std::string & pattern, std::vector<Nsvcap::Form> forms) {
+std::vector<Nsvcap> Nsvcap::parse(const std::string & pattern, const std::vector<Nsvcap::Form> & forms) {
     std::vector<Nsvcap> nsvcaps;
 
     Nsvcap nsvcap;
@@ -136,13 +167,69 @@ std::vector<Nsvcap> Nsvcap::parse(const std::string & pattern) {
 
 
 void Nsvcap::clear() {
-    name.clear();
-    stream.clear();
-    version.clear();
-    context.clear();
-    arch.clear();
-    profile.clear();
+    p_impl->name.clear();
+    p_impl->stream.clear();
+    p_impl->version.clear();
+    p_impl->context.clear();
+    p_impl->arch.clear();
+    p_impl->profile.clear();
 }
 
+const std::string & Nsvcap::get_name() const noexcept {
+    return p_impl->name;
+}
+const std::string & Nsvcap::get_stream() const noexcept {
+    return p_impl->stream;
+}
+const std::string & Nsvcap::get_version() const noexcept {
+    return p_impl->version;
+}
+const std::string & Nsvcap::get_context() const noexcept {
+    return p_impl->context;
+}
+const std::string & Nsvcap::get_arch() const noexcept {
+    return p_impl->arch;
+}
+const std::string & Nsvcap::get_profile() const noexcept {
+    return p_impl->profile;
+}
+
+void Nsvcap::set_name(const std::string & name) {
+    p_impl->name = name;
+}
+void Nsvcap::set_stream(const std::string & stream) {
+    p_impl->stream = stream;
+}
+void Nsvcap::set_version(const std::string & version) {
+    p_impl->version = version;
+}
+void Nsvcap::set_context(const std::string & context) {
+    p_impl->context = context;
+}
+void Nsvcap::set_arch(const std::string & arch) {
+    p_impl->arch = arch;
+}
+void Nsvcap::set_profile(const std::string & profile) {
+    p_impl->profile = profile;
+}
+
+void Nsvcap::set_name(std::string && name) {
+    p_impl->name = std::move(name);
+}
+void Nsvcap::set_stream(std::string && stream) {
+    p_impl->stream = std::move(stream);
+}
+void Nsvcap::set_version(std::string && version) {
+    p_impl->version = std::move(version);
+}
+void Nsvcap::set_context(std::string && context) {
+    p_impl->context = std::move(context);
+}
+void Nsvcap::set_arch(std::string && arch) {
+    p_impl->arch = std::move(arch);
+}
+void Nsvcap::set_profile(std::string && profile) {
+    p_impl->profile = std::move(profile);
+}
 
 }  // namespace libdnf5::module


### PR DESCRIPTION
This PR is into a new dnf5-5.2.0.0 branch to keep the main branch ABI compatible.

For: https://github.com/rpm-software-management/dnf5/issues/1025