### PR TITLE
Add pImpl to `libdnf5::repo::*`

### DIFF
--- a/dnf5/commands/clean/clean.cpp
+++ b/dnf5/commands/clean/clean.cpp
@@ -171,9 +171,9 @@ void CleanCommand::run() {
 
     std::cout << fmt::format(
                      "Removed {} files, {} directories. {} errors occurred.",
-                     statistics.files_removed,
-                     statistics.dirs_removed,
-                     statistics.errors)
+                     statistics.get_files_removed(),
+                     statistics.get_dirs_removed(),
+                     statistics.get_errors())
               << std::endl;
 }
 

--- a/include/libdnf5/repo/repo_cache.hpp
+++ b/include/libdnf5/repo/repo_cache.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/common/exception.hpp"
+#include "libdnf5/common/impl_ptr.hpp"
 
 #include <filesystem>
 #include <string>
@@ -31,11 +32,26 @@ namespace libdnf5::repo {
 
 
 struct RepoCacheRemoveStatistics {
-    std::size_t files_removed;  // Number of removed files and links.
-    std::size_t dirs_removed;   // Number of removed directorires.
-    std::size_t errors;         // Numbes of errors.
+    RepoCacheRemoveStatistics();
+    ~RepoCacheRemoveStatistics();
+
+    RepoCacheRemoveStatistics(const RepoCacheRemoveStatistics & src);
+    RepoCacheRemoveStatistics & operator=(const RepoCacheRemoveStatistics & src);
+
+    RepoCacheRemoveStatistics(RepoCacheRemoveStatistics && src) noexcept;
+    RepoCacheRemoveStatistics & operator=(RepoCacheRemoveStatistics && src) noexcept;
+
+    std::size_t get_files_removed();  // Number of removed files and links.
+    std::size_t get_dirs_removed();   // Number of removed directorires.
+    std::size_t get_errors();         // Numbes of errors.
 
     RepoCacheRemoveStatistics & operator+=(const RepoCacheRemoveStatistics & rhs) noexcept;
+
+private:
+    friend class RepoCache;
+
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 
@@ -61,6 +77,14 @@ public:
     /// @param base            WeakPtr on the Base instance.
     /// @param repo_cache_dir  Path to repository cache directory.
     RepoCache(const libdnf5::BaseWeakPtr & base, const std::filesystem::path & repo_cache_dir);
+
+    ~RepoCache();
+
+    RepoCache(const RepoCache & src);
+    RepoCache & operator=(const RepoCache & src);
+
+    RepoCache(RepoCache && src) noexcept;
+    RepoCache & operator=(RepoCache && src) noexcept;
 
     /// Construct a new repository cache management instance.
     ///
@@ -124,8 +148,10 @@ public:
     std::string get_repoid();
 
 private:
-    libdnf5::BaseWeakPtr base;
-    std::filesystem::path cache_dir;
+    friend RepoCacheRemoveStatistics;
+
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 

--- a/include/libdnf5/repo/repo_query.hpp
+++ b/include/libdnf5/repo/repo_query.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_REPO_REPO_QUERY_HPP
 
 #include "libdnf5/base/base_weak.hpp"
+#include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/common/sack/query.hpp"
 #include "libdnf5/common/sack/query_cmp.hpp"
 #include "libdnf5/common/weak_ptr.hpp"
@@ -56,9 +57,17 @@ public:
     /// @param base     Reference to Base
     explicit RepoQuery(libdnf5::Base & base);
 
+    ~RepoQuery();
+
+    RepoQuery(const RepoQuery & src);
+    RepoQuery & operator=(const RepoQuery & src);
+
+    RepoQuery(RepoQuery && src) noexcept;
+    RepoQuery & operator=(RepoQuery && src) noexcept;
+
     /// @return Weak pointer to the Base object.
     /// @since 5.0
-    libdnf5::BaseWeakPtr get_base() { return base; }
+    libdnf5::BaseWeakPtr get_base();
 
     /// Filter repos by their `enabled` state.
     ///
@@ -114,7 +123,8 @@ public:
     void filter_type(Repo::Type type, sack::QueryCmp cmp = libdnf5::sack::QueryCmp::EQ);
 
 private:
-    BaseWeakPtr base;
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::repo

--- a/libdnf5/repo/repo_cache_private.hpp
+++ b/libdnf5/repo/repo_cache_private.hpp
@@ -20,7 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_REPO_CACHE_PRIVATE_HPP
 #define LIBDNF5_REPO_REPO_CACHE_PRIVATE_HPP
 
+#include "libdnf5/logger/logger.hpp"
 #include "libdnf5/repo/repo_cache.hpp"
+#include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
 
 namespace libdnf5::repo {
@@ -34,6 +36,35 @@ constexpr const char * CACHE_SOLV_FILES_DIR = "solv";
 
 }  // namespace
 
+
+class RepoCacheRemoveStatistics::Impl {
+private:
+    friend RepoCacheRemoveStatistics;
+    friend RepoCache;
+
+    std::size_t files_removed;  // Number of removed files and links.
+    std::size_t dirs_removed;   // Number of removed directorires.
+    std::size_t errors;         // Numbes of errors.
+};
+
+class RepoCache::Impl {
+public:
+    Impl(const libdnf5::BaseWeakPtr & base, std::filesystem::path repo_cache_dir)
+        : base(base),
+          cache_dir(std::move(repo_cache_dir)) {
+        if (cache_dir.empty()) {
+            throw RepoCacheError(M_("Empty path to the repository cache directory."));
+        }
+    }
+
+private:
+    friend RepoCache;
+
+    RepoCache::RemoveStatistics remove_recursive(const std::filesystem::path & dir_path, Logger & log);
+    RepoCache::RemoveStatistics cache_remove_attributes(const std::filesystem::path & path, Logger & log);
+    libdnf5::BaseWeakPtr base;
+    std::filesystem::path cache_dir;
+};
 
 }  // namespace libdnf5::repo
 


### PR DESCRIPTION
This PR is into a new dnf5-5.2.0.0 branch to keep the main branch ABI compatible.

For: https://github.com/rpm-software-management/dnf5/issues/1025

I am leaving the interface classes `RepoCallbacks` and `DownloadCallbacks` unmodified.