### PR TITLE
Make info and list commane case insesitive

### DIFF
--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -43,10 +43,10 @@ void ListCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Lists packages depending on the packages' relation to the system");
+    cmd.set_description(_("Lists packages depending on the packages' relation to the system"));
 
     auto specs = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::UNLIMITED, nullptr, nullptr);
-    specs->set_description("List of keys to match");
+    specs->set_description(_("List of keys to match case insensitively"));
     specs->set_parse_hook_func(
         [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
             for (int i = 0; i < argc; ++i) {
@@ -58,24 +58,24 @@ void ListCommand::set_argument_parser() {
     cmd.register_positional_arg(specs);
 
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
+        *this, "showduplicates", '\0', _("Show all versions of the packages, not only the latest ones."), false);
 
     auto conflicts =
         parser.add_conflict_args_group(std::make_unique<std::vector<libdnf5::cli::ArgumentParser::Argument *>>());
 
     installed = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "installed", '\0', "List installed packages.", false);
+        *this, "installed", '\0', _("List installed packages."), false);
     conflicts->push_back(installed->arg);
 
     available = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "available", '\0', "List available packages.", false);
+        *this, "available", '\0', _("List available packages."), false);
     conflicts->push_back(available->arg);
 
     extras = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this,
         "extras",
         '\0',
-        "List extras, that is packages installed on the system that are not available in any known repository.",
+        _("List extras, that is packages installed on the system that are not available in any known repository."),
         false);
     conflicts->push_back(extras->arg);
 
@@ -83,20 +83,20 @@ void ListCommand::set_argument_parser() {
         *this,
         "obsoletes",
         '\0',
-        "List packages installed on the system that are obsoleted by packages in any known repository.",
+        _("List packages installed on the system that are obsoleted by packages in any known repository."),
         false);
     conflicts->push_back(obsoletes->arg);
 
     recent = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "recent", '\0', "List packages recently added into the repositories.", false);
+        *this, "recent", '\0', _("List packages recently added into the repositories."), false);
     conflicts->push_back(recent->arg);
 
     upgrades = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "upgrades", '\0', "List upgrades available for the installed packages.", false);
+        *this, "upgrades", '\0', _("List upgrades available for the installed packages."), false);
     conflicts->push_back(upgrades->arg);
 
     autoremove = std::make_unique<libdnf5::cli::session::BoolOption>(
-        *this, "autoremove", '\0', "List packages which will be removed by the 'dnf autoremove' command.", false);
+        *this, "autoremove", '\0', _("List packages which will be removed by the 'dnf autoremove' command."), false);
     conflicts->push_back(autoremove->arg);
 
     installed->arg->set_conflict_arguments(conflicts);

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -152,7 +152,11 @@ void ListCommand::run() {
     if (!pkg_specs.empty()) {
         base_query = libdnf5::rpm::PackageQuery(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
         libdnf5::ResolveSpecSettings settings{
-            .with_nevra = true, .with_provides = false, .with_filenames = false, .with_binaries = false};
+            .ignore_case = true,
+            .with_nevra = true,
+            .with_provides = false,
+            .with_filenames = false,
+            .with_binaries = false};
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery pkg_query(full_package_query);
             pkg_query.resolve_pkg_spec(spec, settings, true);


### PR DESCRIPTION
It unifies behavior with repoquery command and DNF4

Closes: https://github.com/rpm-software-management/dnf5/issues/1259

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1460