### PR TITLE
Implement system-upgrade and arbitrary offline transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python
 option(WITH_COMPS "Build with comps groups and environments support" ON)
 option(WITH_MODULEMD "Build with modulemd modules support" ON)
 option(WITH_ZCHUNK "Build with zchunk delta compression support" ON)
+option(WITH_SYSTEMD "Build with systemd and D-Bus features" ON)
 option(ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 
 # build options - documentation

--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting.hpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting.hpp
@@ -46,4 +46,4 @@ private:
 
 }  // namespace dnf5
 
-#endif  // DNF5_COMMANDS_CHANGELOG_HPP
+#endif  // DNF5_COMMANDS_NEEDS_RESTARTING_HPP

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -259,6 +259,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/dnf5/aliases.d
 %config %{_datadir}/dnf5/aliases.d/compatibility.conf
 %config %{_unitdir}/dnf5-offline-transaction.service
+%config %{_unitdir}/dnf5-offline-transaction-cleanup.service
 %dir %{_libdir}/dnf5
 %dir %{_libdir}/dnf5/plugins
 %dir %{_datadir}/dnf5/dnf5-plugins

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -84,6 +84,7 @@ Provides:       dnf5-command(system-upgrade)
 %else
 %bcond_without zchunk
 %endif
+%bcond_without systemd
 
 %bcond_with    html
 %if 0%{?rhel} == 8
@@ -136,9 +137,7 @@ BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
 BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
-BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
-BuildRequires:  systemd-devel
 BuildRequires:  toml11-static
 
 %if %{with clang}
@@ -163,6 +162,11 @@ BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 
 %if %{with zchunk}
 BuildRequires:  pkgconfig(zck) >= %{zchunk_version}
+%endif
+
+%if %{with systemd}
+BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
+BuildRequires:  systemd-devel
 %endif
 
 %if %{with html} || %{with man}
@@ -750,6 +754,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \
     -DWITH_MODULEMD=%{?with_modulemd:ON}%{!?with_modulemd:OFF} \
     -DWITH_ZCHUNK=%{?with_zchunk:ON}%{!?with_zchunk:OFF} \
+    -DWITH_SYSTEMD=%{?with_systemd:ON}%{!?with_systemd:OFF} \
     \
     -DWITH_HTML=%{?with_html:ON}%{!?with_html:OFF} \
     -DWITH_MAN=%{?with_man:ON}%{!?with_man:OFF} \

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -262,8 +262,6 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/dnf5
 %dir %{_datadir}/dnf5/aliases.d
 %config %{_datadir}/dnf5/aliases.d/compatibility.conf
-%config %{_unitdir}/dnf5-offline-transaction.service
-%config %{_unitdir}/dnf5-offline-transaction-cleanup.service
 %dir %{_libdir}/dnf5
 %dir %{_libdir}/dnf5/plugins
 %dir %{_datadir}/dnf5/dnf5-plugins
@@ -316,6 +314,12 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_mandir}/man5/dnf5.conf.5.*
 %{_mandir}/man5/dnf5.conf-todo.5.*
 %{_mandir}/man5/dnf5.conf-deprecated.5.*
+
+%if %{with systemd}
+%{_unitdir}/dnf5-offline-transaction.service
+%{_unitdir}/dnf5-offline-transaction-cleanup.service
+%{_unitdir}/system-update.target.wants/dnf5-offline-transaction.service
+%endif
 
 # ========== libdnf5 ==========
 %package -n libdnf5
@@ -806,6 +810,13 @@ done
 # Remove if condition when Fedora 37 is EOL
 %if 0%{?fedora} > 37 || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/microdnf
+%endif
+
+%if %{with systemd}
+mkdir -p %{buildroot}%{_unitdir}/system-update.target.wants/
+pushd %{buildroot}%{_unitdir}/system-update.target.wants/
+  ln -sr ../dnf5-offline-transaction.service
+popd
 %endif
 
 %find_lang dnf5

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -167,6 +167,10 @@ BuildRequires:  pkgconfig(zck) >= %{zchunk_version}
 %if %{with systemd}
 BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
 BuildRequires:  systemd-devel
+
+ # We need to get the SYSTEMD_SYSTEM_UNIT_DIR from
+ # /usr/share/pkgconfig/systemd.pc
+BuildRequires:  systemd
 %endif
 
 %if %{with html} || %{with man}

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -62,6 +62,8 @@ Provides:       dnf5-command(advisory)
 Provides:       dnf5-command(clean)
 Provides:       dnf5-command(download)
 Provides:       dnf5-command(makecache)
+Provides:       dnf5-command(offline)
+Provides:       dnf5-command(system-upgrade)
 
 
 # ========== build options ==========
@@ -134,7 +136,9 @@ BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
 BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
+BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
+BuildRequires:  systemd-devel
 BuildRequires:  toml11-static
 
 %if %{with clang}
@@ -254,6 +258,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/dnf5
 %dir %{_datadir}/dnf5/aliases.d
 %config %{_datadir}/dnf5/aliases.d/compatibility.conf
+%config %{_unitdir}/dnf5-offline-transaction.service
 %dir %{_libdir}/dnf5
 %dir %{_libdir}/dnf5/plugins
 %dir %{_datadir}/dnf5/dnf5-plugins

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -2,7 +2,8 @@ if(NOT WITH_DNF5)
     return()
 endif()
 
-set(SYSTEMD_SYSTEM_UNIT_DIR /usr/lib/systemd/system)
+pkg_check_modules(SYSTEMD REQUIRED systemd)
+pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)
 
 find_package(Threads)
 
@@ -56,11 +57,10 @@ install(FILES bash-completion/dnf5 DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR}
 install(FILES "README.plugins" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins" RENAME "README")
 install(DIRECTORY "config/usr/" DESTINATION "${CMAKE_INSTALL_PREFIX}" PATTERN ".gitkeep" EXCLUDE)
 install(DIRECTORY "config/etc/" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}" PATTERN ".gitkeep" EXCLUDE)
-install(DIRECTORY "config/systemd/system/" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}" PATTERN ".gitkeep" EXCLUDE)
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${SYSTEMD_SYSTEM_UNIT_DIR}/dnf5-offline-transaction.service
-    ${SYSTEMD_SYSTEM_UNIT_DIR}/system-update.target.wants/dnf5-offline-transaction.service)"
-)
+
+if(WITH_SYSTEMD)
+  install(DIRECTORY "config/systemd/system/" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}" PATTERN ".gitkeep" EXCLUDE)
+endif()
 
 # Makes an empty directory for dnf5-plugins configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/dnf5-plugins")

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -34,11 +34,15 @@ target_link_libraries(dnf5 PRIVATE common libdnf5 libdnf5-cli Threads::Threads)
 install(TARGETS dnf5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
-pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++)
-pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
 
-target_link_libraries(dnf5 PRIVATE ${RPM_LIBRARIES} ${SDBUS_CPP_LIBRARIES} ${LIBSYSTEMD_LIBRARIES})
-
+if(WITH_SYSTEMD)
+  pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++)
+  pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
+  add_definitions(-DWITH_SYSTEMD)
+  target_link_libraries(dnf5 PRIVATE ${RPM_LIBRARIES} ${SDBUS_CPP_LIBRARIES} ${LIBSYSTEMD_LIBRARIES})
+else()
+  target_link_libraries(dnf5 PRIVATE ${RPM_LIBRARIES})
+endif()
 
 find_package(bash-completion)
 if(BASH_COMPLETION_FOUND)

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -2,8 +2,6 @@ if(NOT WITH_DNF5)
     return()
 endif()
 
-pkg_check_modules(SYSTEMD REQUIRED systemd)
-pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)
 
 find_package(Threads)
 
@@ -59,6 +57,8 @@ install(DIRECTORY "config/usr/" DESTINATION "${CMAKE_INSTALL_PREFIX}" PATTERN ".
 install(DIRECTORY "config/etc/" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}" PATTERN ".gitkeep" EXCLUDE)
 
 if(WITH_SYSTEMD)
+  pkg_check_modules(SYSTEMD REQUIRED systemd)
+  pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)
   install(DIRECTORY "config/systemd/system/" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}" PATTERN ".gitkeep" EXCLUDE)
 endif()
 

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -2,6 +2,8 @@ if(NOT WITH_DNF5)
     return()
 endif()
 
+set(SYSTEMD_SYSTEM_UNIT_DIR /usr/lib/systemd/system)
+
 find_package(Threads)
 
 # set gettext domain for translations
@@ -32,7 +34,10 @@ target_link_libraries(dnf5 PRIVATE common libdnf5 libdnf5-cli Threads::Threads)
 install(TARGETS dnf5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
-target_link_libraries(dnf5 PRIVATE ${RPM_LIBRARIES})
+pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++)
+pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
+
+target_link_libraries(dnf5 PRIVATE ${RPM_LIBRARIES} ${SDBUS_CPP_LIBRARIES} ${LIBSYSTEMD_LIBRARIES})
 
 
 find_package(bash-completion)
@@ -47,6 +52,11 @@ install(FILES bash-completion/dnf5 DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR}
 install(FILES "README.plugins" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins" RENAME "README")
 install(DIRECTORY "config/usr/" DESTINATION "${CMAKE_INSTALL_PREFIX}" PATTERN ".gitkeep" EXCLUDE)
 install(DIRECTORY "config/etc/" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}" PATTERN ".gitkeep" EXCLUDE)
+install(DIRECTORY "config/systemd/system/" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}" PATTERN ".gitkeep" EXCLUDE)
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${SYSTEMD_SYSTEM_UNIT_DIR}/dnf5-offline-transaction.service
+    ${SYSTEMD_SYSTEM_UNIT_DIR}/system-update.target.wants/dnf5-offline-transaction.service)"
+)
 
 # Makes an empty directory for dnf5-plugins configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/dnf5-plugins")

--- a/dnf5/commands/autoremove/autoremove.cpp
+++ b/dnf5/commands/autoremove/autoremove.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "autoremove.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 
 namespace dnf5 {
@@ -35,6 +36,7 @@ void AutoremoveCommand::set_parent_command() {
 void AutoremoveCommand::set_argument_parser() {
     get_argument_parser_command()->set_description(
         "Remove all unneeded packages originally installed as dependencies.");
+    create_offline_option(*this);
 }
 
 void AutoremoveCommand::configure() {

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -52,6 +52,7 @@ void DistroSyncCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
+    create_offline_option(*this);
 }
 
 void DistroSyncCommand::configure() {

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -56,6 +56,7 @@ void DowngradeCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
+    create_offline_option(*this);
 }
 
 void DowngradeCommand::configure() {

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -44,6 +44,7 @@ void GroupInstallCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
     create_downloadonly_option(*this);
+    create_offline_option(*this);
 }
 
 void GroupInstallCommand::configure() {

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group_remove.hpp"
 
+#include <dnf5/shared_options.hpp>
 #include <libdnf5/comps/comps.hpp>
 #include <libdnf5/comps/group/group.hpp>
 #include <libdnf5/comps/group/query.hpp>
@@ -36,6 +37,7 @@ void GroupRemoveCommand::set_argument_parser() {
 
     no_packages = std::make_unique<GroupNoPackagesOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
+    create_offline_option(*this);
 }
 
 void GroupRemoveCommand::configure() {

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -40,6 +40,7 @@ void GroupUpgradeCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_offline_option(*this);
 }
 
 void GroupUpgradeCommand::configure() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -67,6 +67,7 @@ void InstallCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
+    create_offline_option(*this);
 }
 
 void InstallCommand::configure() {

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -114,7 +114,7 @@ private:
 /// Extend RpmTransCB to also display messages with Plymouth
 class PlymouthTransCB : public RpmTransCB {
 public:
-    PlymouthTransCB(PlymouthOutput plymouth) : plymouth(std::move(plymouth)) {}
+    PlymouthTransCB(Context & context, PlymouthOutput plymouth) : RpmTransCB(context), plymouth(std::move(plymouth)) {}
     void elem_progress(
         [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
         [[maybe_unused]] uint64_t amount,
@@ -412,7 +412,7 @@ void OfflineExecuteCommand::run() {
     }
 
     PlymouthOutput plymouth;
-    auto callbacks = std::make_unique<PlymouthTransCB>(plymouth);
+    auto callbacks = std::make_unique<PlymouthTransCB>(ctx, plymouth);
     /* callbacks->get_multi_progress_bar()->set_total_num_of_bars(num_of_actions); */
     transaction.set_callbacks(std::move(callbacks));
 

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -412,6 +412,9 @@ void OfflineExecuteCommand::run() {
 
     auto transaction = goal->resolve();
     if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
+        std::cerr << "Failed to resolve transaction. This indicates some bigger problem, since the offline transaction "
+                     "was already successfully resolved before. Was the cache at "
+                  << datadir << " modified?" << std::endl;
         throw libdnf5::cli::GoalResolveError(transaction);
     }
 

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -268,7 +268,7 @@ void OfflineRebootCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
 
     cmd.set_description(
-        _("Prepare the system to perform the offline transaction and reboots to start the transaction."));
+        _("Prepare the system to perform the offline transaction and reboot to start the transaction."));
 
     poweroff_after =
         dynamic_cast<libdnf5::OptionBool *>(parser.add_init_value(std::make_unique<libdnf5::OptionBool>(true)));
@@ -329,7 +329,7 @@ void OfflineExecuteCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_complete(false);
     cmd.set_description(_(
-        "Internal use only, not intended to be run by the user. Executes the transaction in the offline environment."));
+        "Internal use only, not intended to be run by the user. Execute the transaction in the offline environment."));
 }
 
 void OfflineExecuteCommand::pre_configure() {
@@ -611,6 +611,10 @@ void OfflineLogCommand::run() {
     throw libdnf5::cli::CommandExitError(
         1, M_("systemd is not supported in this build of DNF 5; the `log` subcommand is unavailable."));
 #endif
+}
+
+void OfflineStatusCommand::set_argument_parser() {
+    get_argument_parser_command()->set_description(_("Show status of the current offline transaction"));
 }
 
 void OfflineStatusCommand::run() {

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -377,6 +377,10 @@ void OfflineExecuteCommand::run() {
 
     log_status("Starting offline transaction. This will take a while.", libdnf5::offline::OFFLINE_STARTED_ID);
 
+    std::cout << "Warning: the `_execute` command is for internal use only and is not intended to be run directly by "
+                 "the user. To initiate the system upgrade/offline transaction, you should run `dnf5 offline reboot`."
+              << std::endl;
+
     if (!std::filesystem::is_symlink(get_magic_symlink())) {
         throw libdnf5::cli::CommandExitError(0, M_("Trigger file does not exist. Exiting."));
     }

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -1,0 +1,582 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "offline.hpp"
+
+#include "utils/string.hpp"
+
+#include "libdnf5/offline/offline.hpp"
+
+#include <libdnf5-cli/utils/userconfirm.hpp>
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/conf/option_path.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/fs/file.hpp>
+#include <sys/wait.h>
+#include <systemd/sd-journal.h>
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace libdnf5::cli;
+
+const std::string & ID_TO_IDENTIFY_BOOTS = libdnf5::offline::OFFLINE_STARTED_ID;
+
+int call(const std::string & command, const std::vector<std::string> & args) {
+    std::vector<char *> c_args;
+    c_args.emplace_back(const_cast<char *>(command.c_str()));
+    for (const auto & arg : args) {
+        c_args.emplace_back(const_cast<char *>(arg.c_str()));
+    }
+    c_args.emplace_back(nullptr);
+
+    const auto pid = fork();
+    if (pid == -1) {
+        return -1;
+    }
+    if (pid == 0) {
+        int rc = execvp(command.c_str(), c_args.data());
+        exit(rc == 0 ? 0 : -1);
+    } else {
+        int status;
+        int rc = waitpid(pid, &status, 0);
+        if (rc == -1) {
+            return -1;
+        }
+        if (WIFEXITED(status)) {
+            return WEXITSTATUS(status);
+        }
+        if (WIFSIGNALED(status)) {
+            return 128 + WTERMSIG(status);
+        }
+        return -1;
+    }
+}
+
+namespace dnf5 {
+
+/// Helper for displaying messages with Plymouth
+///
+/// Derived from DNF 4 system-upgrade PlymouthOutput implementation. Filters
+/// duplicate calls, and stops calling the plymouth binary if we fail to
+/// contact it.
+class PlymouthOutput {
+public:
+    bool ping() { return plymouth({"ping"}); }
+    bool set_mode() { return plymouth({"change-mode", "--system-upgrade"}); }
+    bool message(const std::string & message) {
+        if (last_message.has_value() && message == last_message) {
+            plymouth({"hide-message", "--text", last_message.value()});
+        }
+        last_message = message;
+        return plymouth({"display-message", "--text", message});
+    }
+    bool progress(const int percentage) {
+        return plymouth({"system-update", "--progress", std::to_string(percentage)});
+    }
+
+private:
+    bool alive = true;
+    std::map<std::string, std::vector<std::string>> last_subcommand_args;
+    std::optional<std::string> last_message;
+    bool plymouth(const std::vector<std::string> & args) {
+        const auto & command = args.at(0);
+        const auto & last_args = last_subcommand_args.find(command);
+
+        bool dupe_cmd = (last_args != last_subcommand_args.end() && args == last_args->second);
+        if ((alive && !dupe_cmd) || command == "--ping") {
+            alive = call(PATH_TO_PLYMOUTH, args) == 0;
+            last_subcommand_args[command] = args;
+        }
+        return alive;
+    }
+};
+
+/// Extend RpmTransCB to also display messages with Plymouth
+class PlymouthTransCB : public RpmTransCB {
+public:
+    PlymouthTransCB(PlymouthOutput plymouth) : plymouth(std::move(plymouth)) {}
+    void elem_progress(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] uint64_t amount,
+        [[maybe_unused]] uint64_t total) override {
+        RpmTransCB::elem_progress(item, amount, total);
+
+        plymouth.progress(static_cast<int>(100 * static_cast<double>(amount) / static_cast<double>(total)));
+
+        std::string action;
+        switch (item.get_action()) {
+            case libdnf5::transaction::TransactionItemAction::UPGRADE:
+                action = "Upgrading";
+                break;
+            case libdnf5::transaction::TransactionItemAction::DOWNGRADE:
+                action = "Downgrading";
+                break;
+            case libdnf5::transaction::TransactionItemAction::REINSTALL:
+                action = "Reinstalling";
+                break;
+            case libdnf5::transaction::TransactionItemAction::INSTALL:
+                action = "Installing";
+                break;
+            case libdnf5::transaction::TransactionItemAction::REMOVE:
+                action = "Removing";
+                break;
+            case libdnf5::transaction::TransactionItemAction::REPLACED:
+                action = "Replacing";
+                break;
+            case libdnf5::transaction::TransactionItemAction::REASON_CHANGE:
+            case libdnf5::transaction::TransactionItemAction::ENABLE:
+            case libdnf5::transaction::TransactionItemAction::DISABLE:
+            case libdnf5::transaction::TransactionItemAction::RESET:
+                throw std::logic_error(fmt::format(
+                    "Unexpected action in TransactionPackage: {}",
+                    static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
+                        item.get_action())));
+                break;
+        }
+        const auto & message = fmt::format("[{}/{}] {} {}...", amount, total, action, item.get_package().get_name());
+        plymouth.message(message);
+    }
+
+private:
+    PlymouthOutput plymouth;
+};
+
+void OfflineCommand::pre_configure() {
+    throw_missing_command();
+}
+
+void OfflineCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("subcommands").register_argument(arg_parser_this_cmd);
+}
+
+void OfflineCommand::set_argument_parser() {
+    get_argument_parser_command()->set_description("Manage offline transactions");
+}
+
+void OfflineCommand::register_subcommands() {
+    register_subcommand(std::make_unique<OfflineCleanCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineRebootCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineExecuteCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineLogCommand>(get_context()));
+}
+
+OfflineSubcommand::OfflineSubcommand(Context & context, const std::string & name) : Command(context, name) {}
+
+void OfflineSubcommand::set_argument_parser() {
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cachedir =
+        dynamic_cast<libdnf5::OptionPath *>(parser.add_init_value(std::make_unique<libdnf5::OptionPath>(datadir)));
+
+    auto * download_dir_arg = parser.add_new_named_arg("downloaddir");
+    download_dir_arg->set_long_name("downloaddir");
+    download_dir_arg->set_description("Redirect download of packages to provided <path>");
+    download_dir_arg->link_value(cachedir);
+    cmd.register_named_arg(download_dir_arg);
+}
+
+void OfflineSubcommand::configure() {
+    auto & ctx = get_context();
+    const std::filesystem::path installroot{ctx.base.get_config().get_installroot_option().get_value()};
+    magic_symlink = installroot / "system-update";
+    datadir = libdnf5::offline::get_offline_datadir(installroot);
+    std::filesystem::create_directories(datadir);
+    state = std::make_optional<libdnf5::offline::OfflineTransactionState>(datadir / "offline-transaction-state.toml");
+
+    system_releasever = *libdnf5::Vars::detect_release(ctx.base.get_weak_ptr(), installroot);
+    target_releasever = ctx.base.get_vars()->get_value("releasever");
+}
+
+void OfflineSubcommand::log_status(const std::string & message, const std::string & message_id) const {
+    const auto & version = get_application_version();
+    const std::string & version_string = fmt::format("{}.{}.{}", version.major, version.minor, version.micro);
+    sd_journal_send(
+        "MESSAGE=%s",
+        message.c_str(),
+        "MESSAGE_ID=%s",
+        message_id.c_str(),
+        "SYSTEM_RELEASEVER=%s",
+        get_system_releasever().c_str(),
+        "TARGET_RELEASEVER=%s",
+        get_target_releasever().c_str(),
+        "DNF_VERSION=%s",
+        version_string.c_str(),
+        NULL);
+}
+
+void check_state(const libdnf5::offline::OfflineTransactionState & state) {
+    const auto & read_exception = state.get_read_exception();
+    if (read_exception != nullptr) {
+        try {
+            std::rethrow_exception(read_exception);
+        } catch (const std::exception & ex) {
+            const std::string message{ex.what()};
+            throw libdnf5::cli::CommandExitError(
+                1,
+                M_("Error reading state: {}. Rerun the command you used to initiate the offline transaction, e.g. "
+                   "`dnf5 system-upgrade download [OPTIONS]`."),
+                message);
+        }
+    }
+}
+
+void reboot(bool poweroff = false) {
+    const std::string systemd_destination_name{"org.freedesktop.systemd1"};
+    const std::string systemd_object_path{"/org/freedesktop/systemd1"};
+    const std::string systemd_manager_interface{"org.freedesktop.systemd1.Manager"};
+
+    if (std::getenv("DNF_SYSTEM_UPGRADE_NO_REBOOT")) {
+        std::cerr << "DNF_SYSTEM_UPGRADE_NO_REBOOT is set, not rebooting." << std::endl;
+        return;
+    }
+
+    poweroff = !poweroff;
+    std::unique_ptr<sdbus::IConnection> connection;
+    try {
+        connection = sdbus::createSystemBusConnection();
+    } catch (const sdbus::Error & ex) {
+        const std::string error_message{ex.what()};
+        throw libdnf5::cli::CommandExitError(1, M_("Couldn't connect to D-Bus: {}"), error_message);
+    }
+    auto proxy = sdbus::createProxy(systemd_destination_name, systemd_object_path);
+    if (poweroff) {
+        proxy->callMethod("Poweroff").onInterface(systemd_manager_interface);
+    } else {
+        proxy->callMethod("Reboot").onInterface(systemd_manager_interface);
+    }
+}
+
+void clean_datadir(Context & ctx, const std::filesystem::path & datadir) {
+    ctx.base.get_logger()->info("Cleaning up downloaded data...");
+
+    for (const auto & entry : std::filesystem::directory_iterator(datadir)) {
+        std::filesystem::remove_all(entry.path());
+    }
+}
+
+void OfflineRebootCommand::set_argument_parser() {
+    OfflineSubcommand::set_argument_parser();
+
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_description("Prepare the system to perform the offline transaction and reboots to start the transaction.");
+
+    poweroff_after =
+        dynamic_cast<libdnf5::OptionBool *>(parser.add_init_value(std::make_unique<libdnf5::OptionBool>(true)));
+
+    auto * poweroff_after_arg = parser.add_new_named_arg("poweroff");
+    poweroff_after_arg->set_long_name("poweroff");
+    poweroff_after_arg->set_description("Power off the system after the operation is complete");
+    poweroff_after_arg->link_value(poweroff_after);
+
+    cmd.register_named_arg(poweroff_after_arg);
+}
+
+void OfflineRebootCommand::run() {
+    auto & ctx = get_context();
+
+    check_state(*state);
+    if (state->get_data().status != libdnf5::offline::STATUS_DOWNLOAD_COMPLETE) {
+        throw libdnf5::cli::CommandExitError(1, M_("system is not ready for offline transaction"));
+    }
+    if (std::filesystem::is_symlink(get_magic_symlink())) {
+        throw libdnf5::cli::CommandExitError(1, M_("offline {} is already scheduled"), state->get_data().verb);
+    }
+
+    if (!std::filesystem::is_directory(get_datadir())) {
+        throw libdnf5::cli::CommandExitError(1, M_("data directory {} does not exist"), get_datadir().string());
+    }
+
+    if (state->get_data().verb == "system-upgrade download") {
+        std::cout << "The system will now reboot to upgrade to release version " << state->get_data().target_releasever
+                  << "." << std::endl;
+    } else {
+        std::cout << "The system will now reboot to perform the offline transaction initiated by the following command:"
+                  << std::endl
+                  << "\t" << state->get_data().cmd_line << std::endl;
+    }
+    if (!libdnf5::cli::utils::userconfirm::userconfirm(ctx.base.get_config())) {
+        return;
+    }
+
+    std::filesystem::create_symlink(get_datadir(), get_magic_symlink());
+
+    state->get_data().status = libdnf5::offline::STATUS_READY;
+    state->get_data().poweroff_after = poweroff_after->get_value();
+    state->write();
+
+    reboot(poweroff_after->get_value());
+}
+
+void OfflineExecuteCommand::set_argument_parser() {
+    OfflineSubcommand::set_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_description(
+        "Internal use only, not intended to be run by the user. Executes the transaction in the offline environment.");
+}
+
+void OfflineExecuteCommand::configure() {
+    OfflineSubcommand::configure();
+    auto & ctx = get_context();
+
+    ctx.set_load_system_repo(true);
+    ctx.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    check_state(*state);
+
+    // Set same set of enabled/disabled repos used during `system-upgrade download`
+    for (const auto & repo_id : state->get_data().enabled_repos) {
+        ctx.setopts.emplace_back(repo_id + ".enabled", "1");
+    }
+    for (const auto & repo_id : state->get_data().disabled_repos) {
+        ctx.setopts.emplace_back(repo_id + ".disabled", "1");
+    }
+
+    // Don't try to refresh metadata, we are offline
+    ctx.base.get_config().get_cacheonly_option().set(libdnf5::Option::Priority::PLUGINDEFAULT, "all");
+    // Don't ask any questions
+    ctx.base.get_config().get_assumeyes_option().set(libdnf5::Option::Priority::PLUGINDEFAULT, true);
+    // Override `assumeno` too since it takes priority over `assumeyes`
+    ctx.base.get_config().get_assumeno_option().set(libdnf5::Option::Priority::PLUGINDEFAULT, false);
+    // Upgrade operation already removes all element that must be removed.
+    // Additional removal could trigger unwanted changes in transaction.
+    ctx.base.get_config().get_clean_requirements_on_remove_option().set(
+        libdnf5::Option::Priority::PLUGINDEFAULT, false);
+    ctx.base.get_config().get_install_weak_deps_option().set(libdnf5::Option::Priority::PLUGINDEFAULT, false);
+}
+
+void OfflineExecuteCommand::run() {
+    auto & ctx = get_context();
+
+    log_status("Starting offline transaction. This will take a while.", libdnf5::offline::OFFLINE_STARTED_ID);
+
+    if (!std::filesystem::is_symlink(get_magic_symlink())) {
+        throw libdnf5::cli::CommandExitError(0, M_("Trigger file does not exist. Exiting."));
+    }
+
+    const auto & symlinked_path = std::filesystem::read_symlink(get_magic_symlink());
+    if (symlinked_path != get_datadir()) {
+        throw libdnf5::cli::CommandExitError(0, M_("Another offline transaction tool is running. Exiting."));
+    }
+
+    std::filesystem::remove(get_magic_symlink());
+
+    if (state->get_data().status != libdnf5::offline::STATUS_READY) {
+        throw libdnf5::cli::CommandExitError(1, M_("Use `dnf5 offline reboot` to begin the transaction."));
+    }
+
+    const auto & installroot = get_context().base.get_config().get_installroot_option().get_value();
+    const auto & datadir = libdnf5::offline::get_offline_datadir(installroot);
+    std::filesystem::create_directories(datadir);
+    const auto & transaction_json_path = datadir / libdnf5::offline::TRANSACTION_JSON_FILENAME;
+    auto transaction_json_file = libdnf5::utils::fs::File(transaction_json_path, "r");
+
+    const auto & json = transaction_json_file.read();
+    transaction_json_file.close();
+
+    const auto & goal = std::make_unique<libdnf5::Goal>(ctx.base);
+
+    auto settings = libdnf5::GoalJobSettings();
+    goal->add_serialized_transaction(json, settings);
+
+    auto transaction = goal->resolve();
+    if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
+        throw libdnf5::cli::GoalResolveError(transaction);
+    }
+
+    PlymouthOutput plymouth;
+    auto callbacks = std::make_unique<PlymouthTransCB>(plymouth);
+    /* callbacks->get_multi_progress_bar()->set_total_num_of_bars(num_of_actions); */
+    transaction.set_callbacks(std::move(callbacks));
+
+    const auto result = transaction.run();
+    std::cout << std::endl;
+    if (result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
+        std::cerr << "Transaction failed: " << libdnf5::base::Transaction::transaction_result_to_string(result)
+                  << std::endl;
+        for (auto const & entry : transaction.get_gpg_signature_problems()) {
+            std::cerr << entry << std::endl;
+        }
+        for (auto & problem : transaction.get_transaction_problems()) {
+            std::cerr << "  - " << problem << std::endl;
+        }
+        throw libdnf5::cli::SilentCommandExitError(1);
+    }
+
+    for (auto const & entry : transaction.get_gpg_signature_problems()) {
+        std::cerr << entry << std::endl;
+    }
+
+    std::string transaction_complete_message;
+    if (state->get_data().poweroff_after) {
+        transaction_complete_message = "Transaction complete! Cleaning up and powering off...";
+    } else {
+        transaction_complete_message = "Transaction complete! Cleaning up and rebooting...";
+    }
+    plymouth.message(transaction_complete_message);
+    log_status(transaction_complete_message, libdnf5::offline::OFFLINE_STARTED_ID);
+
+    // If the transaction succeeded, remove downloaded data
+    clean_datadir(ctx, get_datadir());
+
+    reboot(state->get_data().poweroff_after);
+}
+
+void OfflineCleanCommand::set_argument_parser() {
+    OfflineSubcommand::set_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_description("Remove any stored offline transaction and delete cached package files.");
+}
+
+void OfflineCleanCommand::run() {
+    auto & ctx = get_context();
+    clean_datadir(ctx, get_datadir());
+}
+
+struct BootEntry {
+    std::string boot_id;
+    std::string timestamp;
+    std::string system_releasever;
+    std::string target_releasever;
+};
+
+std::string get_journal_field(sd_journal * journal, const std::string & field) {
+    const char * data = nullptr;
+    size_t length = 0;
+    auto rc = sd_journal_get_data(journal, field.c_str(), reinterpret_cast<const void **>(&data), &length);
+    if (rc < 0 || data == nullptr) {
+        return "";
+    }
+    const auto prefix_length = field.length() + 1;
+    return std::string{data + prefix_length, length - prefix_length};
+}
+
+std::vector<BootEntry> find_boots(const std::string & message_id) {
+    std::vector<BootEntry> boots{};
+
+    sd_journal * journal = nullptr;
+    auto rc = sd_journal_open(&journal, SD_JOURNAL_LOCAL_ONLY);
+    if (rc < 0) {
+        throw libdnf5::RuntimeError(M_("Error reading journal: {}"), std::string{std::strerror(-rc)});
+    }
+
+    const auto & uid_filter_string = fmt::format("MESSAGE_ID={}", message_id);
+    rc = sd_journal_add_match(journal, uid_filter_string.c_str(), 0);
+    if (rc < 0) {
+        throw libdnf5::RuntimeError(M_("Add journal match failed: {}"), std::string{std::strerror(-rc)});
+    }
+
+    std::optional<std::string> current_boot_id;
+
+    SD_JOURNAL_FOREACH(journal) {
+        uint64_t usec = 0;
+        rc = sd_journal_get_realtime_usec(journal, &usec);
+        auto sec = usec / (1000 * 1000);
+        const auto & boot_id = get_journal_field(journal, "_BOOT_ID");
+        if (boot_id != current_boot_id) {
+            current_boot_id = boot_id;
+            boots.emplace_back(BootEntry{
+                boot_id,
+                libdnf5::utils::string::format_epoch(sec),
+                get_journal_field(journal, "SYSTEM_RELEASEVER"),
+                get_journal_field(journal, "TARGET_RELEASEVER"),
+            });
+        }
+    }
+
+    return boots;
+}
+
+void list_logs() {
+    const auto & boot_entries = find_boots(ID_TO_IDENTIFY_BOOTS);
+
+    if (boot_entries.empty()) {
+        std::cout << "No logs were found." << std::endl;
+        return;
+    }
+
+    std::cout << "The following boots appear to contain offline transaction logs:" << std::endl;
+    for (size_t index = 0; index < boot_entries.size(); index += 1) {
+        const auto & entry = boot_entries[index];
+        std::cout << fmt::format(
+                         "{} / {}: {} {}→{}",
+                         index + 1,
+                         entry.boot_id,
+                         entry.timestamp,
+                         entry.system_releasever,
+                         entry.target_releasever)
+                  << std::endl;
+    }
+}
+
+void show_log(size_t boot_index) {
+    const auto & boot_entries = find_boots(ID_TO_IDENTIFY_BOOTS);
+    if (boot_index >= boot_entries.size()) {
+        throw libdnf5::cli::CommandExitError(1, M_("Cannot find logs with this index."));
+    }
+
+    const auto & boot_id = boot_entries[boot_index].boot_id;
+    const auto rc = call(PATH_TO_JOURNALCTL, {"--boot", boot_id});
+
+    if (rc != 0 && rc != 141) {
+        throw libdnf5::cli::CommandExitError(1, M_("Unable to match systemd journal entry."));
+    }
+}
+
+void OfflineLogCommand::set_argument_parser() {
+    OfflineSubcommand::set_argument_parser();
+
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_description("Show logs from past offline transactions");
+
+    number = dynamic_cast<libdnf5::OptionString *>(parser.add_init_value(std::make_unique<libdnf5::OptionString>("")));
+
+    auto * number_arg = parser.add_new_named_arg("number");
+    number_arg->set_long_name("number");
+    number_arg->set_has_value(true);
+
+    number_arg->set_description("Which log to show. Run without any arguments to get a list of available logs.");
+    number_arg->link_value(number);
+    cmd.register_named_arg(number_arg);
+}
+
+void OfflineLogCommand::run() {
+    if (number->get_value().empty()) {
+        list_logs();
+    } else {
+        std::string number_string{number->get_value()};
+        show_log(std::stoul(number_string) - 1);
+    }
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -357,6 +357,10 @@ void OfflineExecuteCommand::pre_configure() {
     // Additional removal could trigger unwanted changes in transaction.
     ctx.base.get_config().get_clean_requirements_on_remove_option().set(false);
     ctx.base.get_config().get_install_weak_deps_option().set(false);
+    // Disable gpgcheck entirely, since GPG integrity will have already been
+    // checked when the transaction was prepared and serialized. This way, we
+    // don't need to keep track of which packages need to be gpgchecked.
+    ctx.base.get_config().get_gpgcheck_option().set(false);
 }
 
 void OfflineExecuteCommand::configure() {
@@ -371,6 +375,10 @@ void OfflineExecuteCommand::configure() {
     // Get the cache from the cachedir specified in the state file
     ctx.base.get_config().get_system_cachedir_option().set(state->get_data().cachedir);
     ctx.base.get_config().get_cachedir_option().set(state->get_data().cachedir);
+
+    if (!state->get_data().module_platform_id.empty()) {
+        ctx.base.get_config().get_module_platform_id_option().set(state->get_data().module_platform_id);
+    }
 
     // Set same set of enabled/disabled repos used during `system-upgrade download`
     for (const auto & repo_id : state->get_data().enabled_repos) {

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -65,19 +65,6 @@ private:
     std::string system_releasever;
 };
 
-class OfflineDownloadCommand : public OfflineSubcommand {
-public:
-    explicit OfflineDownloadCommand(Context & context) : OfflineSubcommand{context, "download"} {}
-    void set_argument_parser() override;
-    void configure() override;
-    void run() override;
-
-private:
-    libdnf5::OptionBool * no_downgrade{nullptr};
-    libdnf5::OptionBool * distro_sync{nullptr};
-    int state_version;
-};
-
 class OfflineRebootCommand : public OfflineSubcommand {
 public:
     explicit OfflineRebootCommand(Context & context) : OfflineSubcommand(context, "reboot") {}

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -21,10 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_OFFLINE_HPP
 
 #include <dnf5/context.hpp>
+#include <dnf5/offline.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_number.hpp>
-#include <libdnf5/offline/offline.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 #include <toml.hpp>
 
@@ -45,20 +45,17 @@ public:
 class OfflineSubcommand : public Command {
 public:
     explicit OfflineSubcommand(Context & context, const std::string & name);
-    void set_argument_parser() override;
+    void pre_configure() override;
     void configure() override;
 
 protected:
-    libdnf5::OptionPath * get_cachedir() const { return cachedir; };
     std::filesystem::path get_magic_symlink() const { return magic_symlink; };
     std::filesystem::path get_datadir() const { return datadir; };
-    std::optional<libdnf5::offline::OfflineTransactionState> state;
+    std::optional<dnf5::offline::OfflineTransactionState> state;
     std::string get_system_releasever() const { return system_releasever; };
     std::string get_target_releasever() const { return target_releasever; };
-    void log_status(const std::string & message, const std::string & message_id) const;
 
 private:
-    libdnf5::OptionPath * cachedir{nullptr};
     std::filesystem::path magic_symlink;
     std::filesystem::path datadir;
     std::string target_releasever;
@@ -79,6 +76,7 @@ class OfflineExecuteCommand : public OfflineSubcommand {
 public:
     explicit OfflineExecuteCommand(Context & context) : OfflineSubcommand(context, "_execute") {}
     void set_argument_parser() override;
+    void pre_configure() override;
     void configure() override;
     void run() override;
 };

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -97,6 +97,12 @@ private:
     libdnf5::OptionString * number{nullptr};
 };
 
+class OfflineStatusCommand : public OfflineSubcommand {
+public:
+    explicit OfflineStatusCommand(Context & context) : OfflineSubcommand(context, "status") {}
+    void run() override;
+};
+
 }  // namespace dnf5
 
 #endif  // DNF5_COMMANDS_OFFLINE_HPP

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -45,7 +45,6 @@ public:
 class OfflineSubcommand : public Command {
 public:
     explicit OfflineSubcommand(Context & context, const std::string & name);
-    void pre_configure() override;
     void configure() override;
 
 protected:

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -98,6 +98,7 @@ private:
 class OfflineStatusCommand : public OfflineSubcommand {
 public:
     explicit OfflineStatusCommand(Context & context) : OfflineSubcommand(context, "status") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -25,8 +25,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_number.hpp>
-#include <sdbus-c++/sdbus-c++.h>
-#include <toml.hpp>
 
 const std::filesystem::path PATH_TO_PLYMOUTH{"/usr/bin/plymouth"};
 const std::filesystem::path PATH_TO_JOURNALCTL{"/usr/bin/journalctl"};

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -1,0 +1,118 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_COMMANDS_OFFLINE_HPP
+#define DNF5_COMMANDS_OFFLINE_HPP
+
+#include <dnf5/context.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/conf/option_bool.hpp>
+#include <libdnf5/conf/option_number.hpp>
+#include <libdnf5/offline/offline.hpp>
+#include <sdbus-c++/sdbus-c++.h>
+#include <toml.hpp>
+
+const std::filesystem::path PATH_TO_PLYMOUTH{"/usr/bin/plymouth"};
+const std::filesystem::path PATH_TO_JOURNALCTL{"/usr/bin/journalctl"};
+
+namespace dnf5 {
+
+class OfflineCommand : public Command {
+public:
+    explicit OfflineCommand(Context & context) : Command(context, "offline") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
+};
+
+class OfflineSubcommand : public Command {
+public:
+    explicit OfflineSubcommand(Context & context, const std::string & name);
+    void set_argument_parser() override;
+    void configure() override;
+
+protected:
+    libdnf5::OptionPath * get_cachedir() const { return cachedir; };
+    std::filesystem::path get_magic_symlink() const { return magic_symlink; };
+    std::filesystem::path get_datadir() const { return datadir; };
+    std::optional<libdnf5::offline::OfflineTransactionState> state;
+    std::string get_system_releasever() const { return system_releasever; };
+    std::string get_target_releasever() const { return target_releasever; };
+    void log_status(const std::string & message, const std::string & message_id) const;
+
+private:
+    libdnf5::OptionPath * cachedir{nullptr};
+    std::filesystem::path magic_symlink;
+    std::filesystem::path datadir;
+    std::string target_releasever;
+    std::string system_releasever;
+};
+
+class OfflineDownloadCommand : public OfflineSubcommand {
+public:
+    explicit OfflineDownloadCommand(Context & context) : OfflineSubcommand{context, "download"} {}
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+
+private:
+    libdnf5::OptionBool * no_downgrade{nullptr};
+    libdnf5::OptionBool * distro_sync{nullptr};
+    int state_version;
+};
+
+class OfflineRebootCommand : public OfflineSubcommand {
+public:
+    explicit OfflineRebootCommand(Context & context) : OfflineSubcommand(context, "reboot") {}
+    void set_argument_parser() override;
+    void run() override;
+
+private:
+    libdnf5::OptionBool * poweroff_after{nullptr};
+};
+
+class OfflineExecuteCommand : public OfflineSubcommand {
+public:
+    explicit OfflineExecuteCommand(Context & context) : OfflineSubcommand(context, "_execute") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+};
+
+class OfflineCleanCommand : public OfflineSubcommand {
+public:
+    explicit OfflineCleanCommand(Context & context) : OfflineSubcommand(context, "clean") {}
+    void set_argument_parser() override;
+    void run() override;
+};
+
+class OfflineLogCommand : public OfflineSubcommand {
+public:
+    explicit OfflineLogCommand(Context & context) : OfflineSubcommand(context, "log") {}
+    void set_argument_parser() override;
+    void run() override;
+
+private:
+    libdnf5::OptionString * number{nullptr};
+};
+
+}  // namespace dnf5
+
+#endif  // DNF5_COMMANDS_OFFLINE_HPP

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -56,6 +56,7 @@ void ReinstallCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     create_allow_downgrade_options(*this);
+    create_offline_option(*this);
 }
 
 void ReinstallCommand::configure() {

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "remove.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 using namespace libdnf5::cli;
@@ -55,6 +57,8 @@ void RemoveCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, true); });
     cmd.register_positional_arg(keys);
+
+    create_offline_option(*this);
 }
 
 void RemoveCommand::configure() {

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -68,6 +68,8 @@ void SwapCommand::set_argument_parser() {
     cmd.register_positional_arg(install_spec_arg);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
+
+    create_offline_option(*this);
 }
 
 void SwapCommand::configure() {

--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -123,9 +123,7 @@ void SystemUpgradeDownloadCommand::run() {
     ctx.set_should_store_offline(true);
     ctx.download_and_run(transaction);
 
-    std::cout << _("Download complete! Use `dnf5 system-upgrade reboot` to start the upgrade.\n"
-                   "To cancel the upgrade and delete the downloaded upgrade files, use `dnf5 system-upgrade clean`.")
-              << std::endl;
+    std::cout << _("Download complete!") << std::endl;
 
     dnf5::offline::log_status(
         ctx, "Download finished.", dnf5::offline::DOWNLOAD_FINISHED_ID, system_releasever, target_releasever);

--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -30,7 +30,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
 #include <sys/wait.h>
-#include <systemd/sd-journal.h>
 
 #include <iostream>
 #include <string>
@@ -129,7 +128,7 @@ void SystemUpgradeDownloadCommand::run() {
               << std::endl;
 
     dnf5::offline::log_status(
-        "Download finished.", dnf5::offline::DOWNLOAD_FINISHED_ID, system_releasever, target_releasever);
+        ctx, "Download finished.", dnf5::offline::DOWNLOAD_FINISHED_ID, system_releasever, target_releasever);
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -65,7 +65,7 @@ void SystemUpgradeDownloadCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();
 
-    cmd.set_description(_("Downloads everything needed to upgrade to a new release"));
+    cmd.set_description(_("Download everything needed to upgrade to a new release"));
 
     no_downgrade =
         dynamic_cast<libdnf5::OptionBool *>(parser.add_init_value(std::make_unique<libdnf5::OptionBool>(true)));

--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -1,0 +1,158 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "system-upgrade.hpp"
+
+#include "../offline/offline.hpp"
+
+#include <libdnf5-cli/utils/userconfirm.hpp>
+#include <libdnf5/base/goal.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/conf/option_path.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/fs/file.hpp>
+#include <sys/wait.h>
+#include <systemd/sd-journal.h>
+
+#include <iostream>
+#include <string>
+
+using namespace libdnf5::cli;
+
+namespace dnf5 {
+
+void SystemUpgradeCommand::pre_configure() {
+    throw_missing_command();
+}
+
+void SystemUpgradeCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("subcommands").register_argument(arg_parser_this_cmd);
+}
+
+void SystemUpgradeCommand::set_argument_parser() {
+    get_argument_parser_command()->set_description("Prepare system for upgrade to a new release");
+}
+
+void SystemUpgradeCommand::register_subcommands() {
+    register_subcommand(std::make_unique<SystemUpgradeDownloadCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineCleanCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineRebootCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineLogCommand>(get_context()));
+}
+
+SystemUpgradeSubcommand::SystemUpgradeSubcommand(Context & context, const std::string & name)
+    : Command(context, name),
+      datadir(std::filesystem::path{libdnf5::SYSTEM_STATE_DIR} / "system-upgrade"),
+      state(datadir / "state.toml") {}
+
+void SystemUpgradeSubcommand::set_argument_parser() {
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cachedir =
+        dynamic_cast<libdnf5::OptionPath *>(parser.add_init_value(std::make_unique<libdnf5::OptionPath>(datadir)));
+
+    auto * download_dir_arg = parser.add_new_named_arg("downloaddir");
+    download_dir_arg->set_long_name("downloaddir");
+    download_dir_arg->set_description("Redirect download of packages to provided <path>");
+    download_dir_arg->link_value(cachedir);
+    cmd.register_named_arg(download_dir_arg);
+}
+
+void SystemUpgradeSubcommand::configure() {
+    auto & ctx = get_context();
+    const std::filesystem::path installroot{ctx.base.get_config().get_installroot_option().get_value()};
+    magic_symlink = installroot / "system-update";
+
+    system_releasever = *libdnf5::Vars::detect_release(ctx.base.get_weak_ptr(), installroot);
+    target_releasever = ctx.base.get_vars()->get_value("releasever");
+}
+
+void SystemUpgradeDownloadCommand::set_argument_parser() {
+    SystemUpgradeSubcommand::set_argument_parser();
+
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_description("Downloads everything needed to upgrade to a new release");
+
+    no_downgrade =
+        dynamic_cast<libdnf5::OptionBool *>(parser.add_init_value(std::make_unique<libdnf5::OptionBool>(true)));
+
+    auto * no_downgrade_arg = parser.add_new_named_arg("no-downgrade");
+    no_downgrade_arg->set_long_name("no-downgrade");
+    no_downgrade_arg->set_description(
+        "Do not install packages from the new release if they are older than what is currently installed");
+    no_downgrade_arg->link_value(no_downgrade);
+
+    cmd.register_named_arg(no_downgrade_arg);
+}
+
+void SystemUpgradeDownloadCommand::configure() {
+    SystemUpgradeSubcommand::configure();
+
+    auto & ctx = get_context();
+
+    // Check --releasever
+    if (get_target_releasever() == get_system_releasever()) {
+        throw libdnf5::cli::CommandExitError(1, M_("Need a --releasever greater than the current system version."));
+    }
+
+    ctx.set_load_system_repo(true);
+    ctx.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    ctx.base.get_config().get_cachedir_option().set(
+        libdnf5::Option::Priority::PLUGINDEFAULT, get_cachedir()->get_value());
+}
+
+void SystemUpgradeDownloadCommand::run() {
+    auto & ctx = get_context();
+
+    const auto & goal = std::make_unique<libdnf5::Goal>(ctx.base);
+
+    if (no_downgrade->get_value()) {
+        goal->add_rpm_upgrade();
+    } else {
+        goal->add_rpm_distro_sync();
+    }
+
+    auto transaction = goal->resolve();
+    if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
+        throw libdnf5::cli::GoalResolveError(transaction);
+    }
+
+    if (transaction.get_transaction_packages_count() == 0) {
+        throw libdnf5::cli::CommandExitError(
+            1, M_("The system-upgrade transaction is empty; your system is already up-to-date."));
+    }
+
+    ctx.should_store_offline = true;
+    ctx.download_and_run(transaction);
+
+    std::cout << "Download complete! Use `dnf5 system-upgrade reboot` to start the upgrade." << std::endl
+              << "To cancel the upgrade and delete the downloaded upgrade files, use `dnf5 system-upgrade clean`."
+              << std::endl;
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -43,7 +43,6 @@ public:
 
 private:
     libdnf5::OptionBool * no_downgrade{nullptr};
-    libdnf5::OptionPath * download_dir{nullptr};
     std::filesystem::path datadir{dnf5::offline::DEFAULT_DATADIR};
     std::string target_releasever;
     std::string system_releasever;

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_SYSTEM_UPGRADE_HPP
 
 #include <dnf5/context.hpp>
-#include <libdnf5/offline/offline.hpp>
+#include <dnf5/offline.hpp>
 
 namespace dnf5 {
 
@@ -34,40 +34,19 @@ public:
     void pre_configure() override;
 };
 
-class SystemUpgradeSubcommand : public Command {
+class SystemUpgradeDownloadCommand : public Command {
 public:
-    explicit SystemUpgradeSubcommand(Context & context, const std::string & name);
-    void set_argument_parser() override;
-    void configure() override;
-
-protected:
-    libdnf5::OptionPath * get_cachedir() const { return cachedir; };
-    std::filesystem::path get_datadir() const { return datadir; };
-    std::filesystem::path get_magic_symlink() const { return magic_symlink; };
-    libdnf5::offline::OfflineTransactionState get_state() const { return state; };
-    std::string get_system_releasever() const { return system_releasever; };
-    std::string get_target_releasever() const { return target_releasever; };
-    void log_status(const std::string & message, const std::string & message_id) const;
-
-private:
-    libdnf5::OptionPath * cachedir{nullptr};
-    std::filesystem::path datadir{libdnf5::offline::DEFAULT_DATADIR};
-    std::filesystem::path magic_symlink;
-    libdnf5::offline::OfflineTransactionState state;
-    std::string target_releasever;
-    std::string system_releasever;
-};
-
-class SystemUpgradeDownloadCommand : public SystemUpgradeSubcommand {
-public:
-    explicit SystemUpgradeDownloadCommand(Context & context) : SystemUpgradeSubcommand{context, "download"} {}
+    explicit SystemUpgradeDownloadCommand(Context & context) : Command{context, "download"} {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;
 
 private:
     libdnf5::OptionBool * no_downgrade{nullptr};
-    int state_version;
+    libdnf5::OptionPath * download_dir{nullptr};
+    std::filesystem::path datadir{dnf5::offline::DEFAULT_DATADIR};
+    std::string target_releasever;
+    std::string system_releasever;
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -1,0 +1,75 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_COMMANDS_SYSTEM_UPGRADE_HPP
+#define DNF5_COMMANDS_SYSTEM_UPGRADE_HPP
+
+#include <dnf5/context.hpp>
+#include <libdnf5/offline/offline.hpp>
+
+namespace dnf5 {
+
+class SystemUpgradeCommand : public Command {
+public:
+    explicit SystemUpgradeCommand(Context & context) : Command(context, "system-upgrade") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
+};
+
+class SystemUpgradeSubcommand : public Command {
+public:
+    explicit SystemUpgradeSubcommand(Context & context, const std::string & name);
+    void set_argument_parser() override;
+    void configure() override;
+
+protected:
+    libdnf5::OptionPath * get_cachedir() const { return cachedir; };
+    std::filesystem::path get_datadir() const { return datadir; };
+    std::filesystem::path get_magic_symlink() const { return magic_symlink; };
+    libdnf5::offline::OfflineTransactionState get_state() const { return state; };
+    std::string get_system_releasever() const { return system_releasever; };
+    std::string get_target_releasever() const { return target_releasever; };
+    void log_status(const std::string & message, const std::string & message_id) const;
+
+private:
+    libdnf5::OptionPath * cachedir{nullptr};
+    std::filesystem::path datadir{libdnf5::offline::DEFAULT_DATADIR};
+    std::filesystem::path magic_symlink;
+    libdnf5::offline::OfflineTransactionState state;
+    std::string target_releasever;
+    std::string system_releasever;
+};
+
+class SystemUpgradeDownloadCommand : public SystemUpgradeSubcommand {
+public:
+    explicit SystemUpgradeDownloadCommand(Context & context) : SystemUpgradeSubcommand{context, "download"} {}
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+
+private:
+    libdnf5::OptionBool * no_downgrade{nullptr};
+    int state_version;
+};
+
+}  // namespace dnf5
+
+#endif  // DNF5_COMMANDS_SYSTEM_UPGRADE_HPP

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -70,6 +70,7 @@ void UpgradeCommand::set_argument_parser() {
     create_destdir_option(*this);
     auto & destdir = parser.get_named_arg("upgrade.destdir", false);
     destdir.set_description(destdir.get_description() + " Automatically sets the --downloadonly option.");
+    create_offline_option(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);

--- a/dnf5/config/systemd/system/dnf5-offline-transaction-cleanup.service
+++ b/dnf5/config/systemd/system/dnf5-offline-transaction-cleanup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Offline upgrade/transaction using DNF 5 failed
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+# Remove the symlink if it's still there, to protect against reboot loops.
+ExecStart=/usr/bin/rm -fv /system-update
+# If anything goes wrong, reboot back to the normal system.
+ExecStart=/usr/bin/systemctl --no-block reboot

--- a/dnf5/config/systemd/system/dnf5-offline-transaction.service
+++ b/dnf5/config/systemd/system/dnf5-offline-transaction.service
@@ -7,6 +7,7 @@ DefaultDependencies=no
 Requires=sysinit.target
 After=sysinit.target systemd-journald.socket system-update-pre.target
 Before=poweroff.target reboot.target shutdown.target system-update.target
+OnFailure=dnf5-offline-transaction-cleanup.service
 
 [Service]
 # We are done when the script exits, not before

--- a/dnf5/config/systemd/system/dnf5-offline-transaction.service
+++ b/dnf5/config/systemd/system/dnf5-offline-transaction.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Offline upgrades/transactions using DNF 5
+ConditionPathExists=/system-update
+Documentation=https://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
+
+DefaultDependencies=no
+Requires=sysinit.target
+After=sysinit.target systemd-journald.socket system-update-pre.target
+Before=poweroff.target reboot.target shutdown.target system-update.target
+
+[Service]
+# We are done when the script exits, not before
+Type=oneshot
+# Upgrade output goes to journal and on-screen.
+StandardOutput=journal+console
+ExecStart=/usr/bin/dnf5 offline _execute
+
+[Install]
+WantedBy=system-update.target

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -131,6 +131,24 @@ descr = "Alias for 'makecache'"
 group_id = 'commands-compatibility-aliases'
 complete = false
 
+['offline-distrosync']
+type = 'command'
+attached_command = 'distro-sync'
+group_id = 'commands-compatibility-aliases'
+complete = true
+attached_named_args = [
+  { id_path = 'distro-sync.offline' }
+]
+
+['offline-upgrade']
+type = 'command'
+attached_command = 'upgrade'
+group_id = 'commands-compatibility-aliases'
+complete = true
+attached_named_args = [
+  { id_path = 'upgrade.offline' }
+]
+
 ['rei']
 type = 'command'
 attached_command = 'reinstall'

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -500,6 +500,10 @@ void Context::store_offline(libdnf5::base::Transaction & transaction) {
     }
     state.get_data().target_releasever = base.get_vars()->get_value("releasever");
 
+    if (!base.get_config().get_module_platform_id_option().empty()) {
+        state.get_data().module_platform_id = base.get_config().get_module_platform_id_option().get_value();
+    }
+
     state.write();
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -24,6 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/string.hpp"
 #include "utils/url.hpp"
 
+#include "libdnf5/offline/offline.hpp"
+
 #include <fmt/format.h>
 #include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
 #include <libdnf5-cli/tty.hpp>
@@ -36,6 +38,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/rpm/rpm_signature.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/fs/file.hpp>
 #include <libdnf5/utils/patterns.hpp>
 
 #include <algorithm>
@@ -184,234 +187,223 @@ void Context::load_repos(bool load_system) {
     print_info("Repositories loaded.");
 }
 
-namespace {
+RpmTransCB::RpmTransCB(Context & context) : context(context) {
+    multi_progress_bar.set_total_bar_visible_limit(
+        libdnf5::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
+}
 
-class RpmTransCB : public libdnf5::rpm::TransactionCallbacks {
-public:
-    RpmTransCB(Context & context) : context(context) {
-        multi_progress_bar.set_total_bar_visible_limit(
-            libdnf5::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
+RpmTransCB::~RpmTransCB() {
+    if (active_progress_bar &&
+        active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     }
-
-    ~RpmTransCB() {
-        if (active_progress_bar &&
-            active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-            active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
-        }
-        if (active_progress_bar) {
-            multi_progress_bar.print();
-        }
-    }
-
-    libdnf5::cli::progressbar::MultiProgressBar * get_multi_progress_bar() { return &multi_progress_bar; }
-
-    void install_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
-        uint64_t amount,
-        [[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
-        if (is_time_to_print()) {
-            multi_progress_bar.print();
-        }
-    }
-
-    void install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override {
-        const char * msg{nullptr};
-        switch (item.get_action()) {
-            case libdnf5::transaction::TransactionItemAction::UPGRADE:
-                msg = "Upgrading ";
-                break;
-            case libdnf5::transaction::TransactionItemAction::DOWNGRADE:
-                msg = "Downgrading ";
-                break;
-            case libdnf5::transaction::TransactionItemAction::REINSTALL:
-                msg = "Reinstalling ";
-                break;
-            case libdnf5::transaction::TransactionItemAction::INSTALL:
-            case libdnf5::transaction::TransactionItemAction::REMOVE:
-            case libdnf5::transaction::TransactionItemAction::REPLACED:
-                break;
-            case libdnf5::transaction::TransactionItemAction::REASON_CHANGE:
-            case libdnf5::transaction::TransactionItemAction::ENABLE:
-            case libdnf5::transaction::TransactionItemAction::DISABLE:
-            case libdnf5::transaction::TransactionItemAction::RESET:
-                auto & logger = *context.base.get_logger();
-                logger.warning(
-                    "Unexpected action in TransactionPackage: {}",
-                    static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
-                        item.get_action()));
-                return;
-        }
-        if (!msg) {
-            msg = "Installing ";
-        }
-        new_progress_bar(static_cast<int64_t>(total), msg + item.get_package().get_full_nevra());
-    }
-
-    void install_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
-        [[maybe_unused]] uint64_t amount,
-        [[maybe_unused]] uint64_t total) override {
+    if (active_progress_bar) {
         multi_progress_bar.print();
     }
+}
 
-    void transaction_progress(uint64_t amount, [[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
-        if (is_time_to_print()) {
-            multi_progress_bar.print();
-        }
-    }
+libdnf5::cli::progressbar::MultiProgressBar * RpmTransCB::get_multi_progress_bar() { return &multi_progress_bar; }
 
-    void transaction_start(uint64_t total) override {
-        new_progress_bar(static_cast<int64_t>(total), "Prepare transaction");
-    }
-
-    void transaction_stop([[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(total));
+void RpmTransCB::install_progress(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    uint64_t amount,
+    [[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    if (is_time_to_print()) {
         multi_progress_bar.print();
     }
+}
 
-    void uninstall_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
-        uint64_t amount,
-        [[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
-        if (is_time_to_print()) {
-            multi_progress_bar.print();
-        }
+void RpmTransCB::install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
+    const char * msg{nullptr};
+    switch (item.get_action()) {
+        case libdnf5::transaction::TransactionItemAction::UPGRADE:
+            msg = "Upgrading ";
+            break;
+        case libdnf5::transaction::TransactionItemAction::DOWNGRADE:
+            msg = "Downgrading ";
+            break;
+        case libdnf5::transaction::TransactionItemAction::REINSTALL:
+            msg = "Reinstalling ";
+            break;
+        case libdnf5::transaction::TransactionItemAction::INSTALL:
+        case libdnf5::transaction::TransactionItemAction::REMOVE:
+        case libdnf5::transaction::TransactionItemAction::REPLACED:
+            break;
+        case libdnf5::transaction::TransactionItemAction::REASON_CHANGE:
+        case libdnf5::transaction::TransactionItemAction::ENABLE:
+        case libdnf5::transaction::TransactionItemAction::DISABLE:
+        case libdnf5::transaction::TransactionItemAction::RESET:
+            auto & logger = *context.base.get_logger();
+            logger.warning(
+                "Unexpected action in TransactionPackage: {}",
+                static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
+                    item.get_action()));
+            return;
     }
-
-    void uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override {
-        const char * msg{nullptr};
-        if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE ||
-            item.get_action() == libdnf5::transaction::TransactionItemAction::REPLACED) {
-            msg = "Erasing ";
-        }
-        if (!msg) {
-            msg = "Cleanup ";
-        }
-        new_progress_bar(static_cast<int64_t>(total), msg + item.get_package().get_full_nevra());
+    if (!msg) {
+        msg = "Installing ";
     }
+    new_progress_bar(static_cast<int64_t>(total), msg + item.get_package().get_full_nevra());
+}
 
-    void uninstall_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
-        [[maybe_unused]] uint64_t amount,
-        [[maybe_unused]] uint64_t total) override {
+void RpmTransCB::install_stop(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] uint64_t amount,
+    [[maybe_unused]] uint64_t total) {
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::transaction_progress(uint64_t amount, [[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    if (is_time_to_print()) {
         multi_progress_bar.print();
     }
+}
 
+void RpmTransCB::transaction_start(uint64_t total) {
+    new_progress_bar(static_cast<int64_t>(total), "Prepare transaction");
+}
 
-    void unpack_error(const libdnf5::rpm::TransactionItem & item) override {
-        active_progress_bar->add_message(
-            libdnf5::cli::progressbar::MessageType::ERROR, "Unpack error: " + item.get_package().get_full_nevra());
-        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+void RpmTransCB::transaction_stop([[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(total));
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::uninstall_progress(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    uint64_t amount,
+    [[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    if (is_time_to_print()) {
         multi_progress_bar.print();
     }
+}
 
-    void cpio_error(const libdnf5::rpm::TransactionItem & item) override {
-        active_progress_bar->add_message(
-            libdnf5::cli::progressbar::MessageType::ERROR, "Cpio error: " + item.get_package().get_full_nevra());
-        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+void RpmTransCB::uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
+    const char * msg{nullptr};
+    if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE ||
+        item.get_action() == libdnf5::transaction::TransactionItemAction::REPLACED) {
+        msg = "Erasing ";
+    }
+    if (!msg) {
+        msg = "Cleanup ";
+    }
+    new_progress_bar(static_cast<int64_t>(total), msg + item.get_package().get_full_nevra());
+}
+
+void RpmTransCB::uninstall_stop(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] uint64_t amount,
+    [[maybe_unused]] uint64_t total) {
+    multi_progress_bar.print();
+}
+
+
+void RpmTransCB::unpack_error(const libdnf5::rpm::TransactionItem & item) {
+    active_progress_bar->add_message(
+        libdnf5::cli::progressbar::MessageType::ERROR, "Unpack error: " + item.get_package().get_full_nevra());
+    active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::cpio_error(const libdnf5::rpm::TransactionItem & item) {
+    active_progress_bar->add_message(
+        libdnf5::cli::progressbar::MessageType::ERROR, "Cpio error: " + item.get_package().get_full_nevra());
+    active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::script_error(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    libdnf5::rpm::Nevra nevra,
+    libdnf5::rpm::TransactionCallbacks::ScriptType type,
+    uint64_t return_code) {
+    active_progress_bar->add_message(
+        libdnf5::cli::progressbar::MessageType::ERROR,
+        fmt::format(
+            "Error in {} scriptlet: {} return code {}",
+            script_type_to_string(type),
+            to_full_nevra_string(nevra),
+            return_code));
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::script_start(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    libdnf5::rpm::Nevra nevra,
+    libdnf5::rpm::TransactionCallbacks::ScriptType type) {
+    active_progress_bar->add_message(
+        libdnf5::cli::progressbar::MessageType::INFO,
+        fmt::format("Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::script_stop(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    libdnf5::rpm::Nevra nevra,
+    libdnf5::rpm::TransactionCallbacks::ScriptType type,
+    [[maybe_unused]] uint64_t return_code) {
+    active_progress_bar->add_message(
+        libdnf5::cli::progressbar::MessageType::INFO,
+        fmt::format("Stop {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::elem_progress(
+    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] uint64_t amount,
+    [[maybe_unused]] uint64_t total) {
+    //std::cout << "Element progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
+}
+
+void RpmTransCB::verify_progress(uint64_t amount, [[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    if (is_time_to_print()) {
         multi_progress_bar.print();
     }
+}
 
-    void script_error(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
-        libdnf5::rpm::Nevra nevra,
-        libdnf5::rpm::TransactionCallbacks::ScriptType type,
-        uint64_t return_code) override {
-        active_progress_bar->add_message(
-            libdnf5::cli::progressbar::MessageType::ERROR,
-            fmt::format(
-                "Error in {} scriptlet: {} return code {}",
-                script_type_to_string(type),
-                to_full_nevra_string(nevra),
-                return_code));
-        multi_progress_bar.print();
+void RpmTransCB::verify_start([[maybe_unused]] uint64_t total) {
+    new_progress_bar(static_cast<int64_t>(total), "Verify package files");
+}
+
+void RpmTransCB::verify_stop([[maybe_unused]] uint64_t total) {
+    active_progress_bar->set_ticks(static_cast<int64_t>(total));
+    multi_progress_bar.print();
+}
+
+void RpmTransCB::new_progress_bar(int64_t total, const std::string & descr) {
+    if (active_progress_bar &&
+        active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     }
+    auto progress_bar =
+        std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), descr);
+    progress_bar->set_auto_finish(false);
+    progress_bar->start();
+    active_progress_bar = progress_bar.get();
+    multi_progress_bar.add_bar(std::move(progress_bar));
+}
 
-    void script_start(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
-        libdnf5::rpm::Nevra nevra,
-        libdnf5::rpm::TransactionCallbacks::ScriptType type) override {
-        active_progress_bar->add_message(
-            libdnf5::cli::progressbar::MessageType::INFO,
-            fmt::format("Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
-        multi_progress_bar.print();
+bool RpmTransCB::is_time_to_print() {
+    auto now = std::chrono::steady_clock::now();
+    auto delta = now - prev_print_time;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
+    if (ms > 100) {
+        // 100ms equals to 10 FPS and that seems to be smooth enough
+        prev_print_time = now;
+        return true;
     }
-
-    void script_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
-        libdnf5::rpm::Nevra nevra,
-        libdnf5::rpm::TransactionCallbacks::ScriptType type,
-        [[maybe_unused]] uint64_t return_code) override {
-        active_progress_bar->add_message(
-            libdnf5::cli::progressbar::MessageType::INFO,
-            fmt::format("Stop {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
-        multi_progress_bar.print();
-    }
-
-    void elem_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
-        [[maybe_unused]] uint64_t amount,
-        [[maybe_unused]] uint64_t total) override {
-        //std::cout << "Element progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
-    }
-
-    void verify_progress(uint64_t amount, [[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
-        if (is_time_to_print()) {
-            multi_progress_bar.print();
-        }
-    }
-
-    void verify_start([[maybe_unused]] uint64_t total) override {
-        new_progress_bar(static_cast<int64_t>(total), "Verify package files");
-    }
-
-    void verify_stop([[maybe_unused]] uint64_t total) override {
-        active_progress_bar->set_ticks(static_cast<int64_t>(total));
-        multi_progress_bar.print();
-    }
-
-private:
-    void new_progress_bar(int64_t total, const std::string & descr) {
-        if (active_progress_bar &&
-            active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-            active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
-        }
-        auto progress_bar =
-            std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), descr);
-        progress_bar->set_auto_finish(false);
-        progress_bar->start();
-        active_progress_bar = progress_bar.get();
-        multi_progress_bar.add_bar(std::move(progress_bar));
-    }
-
-    static bool is_time_to_print() {
-        auto now = std::chrono::steady_clock::now();
-        auto delta = now - prev_print_time;
-        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-        if (ms > 100) {
-            // 100ms equals to 10 FPS and that seems to be smooth enough
-            prev_print_time = now;
-            return true;
-        }
-        return false;
-    }
-
-    static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
-
-    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
-    libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
-    Context & context;
-};
+    return false;
+}
 
 std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time = std::chrono::steady_clock::now();
 
-}  // namespace
-
 void Context::download_and_run(libdnf5::base::Transaction & transaction) {
+    if (should_store_offline) {
+        base.get_config().get_tsflags_option().set(libdnf5::Option::Priority::RUNTIME, "test");
+    }
     transaction.download();
 
     if (base.get_config().get_downloadonly_option().get_value()) {
@@ -461,6 +453,57 @@ void Context::download_and_run(libdnf5::base::Transaction & transaction) {
         std::cerr << entry << std::endl;
     }
     // TODO(mblaha): print a summary of successful transaction
+
+    if (should_store_offline) {
+        store_offline(transaction);
+        std::cout << "Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the "
+                     "transaction."
+                  << std::endl;
+    }
+}
+
+void Context::store_offline(libdnf5::base::Transaction & transaction) {
+    const auto & installroot = base.get_config().get_installroot_option().get_value();
+    const auto & offline_datadir = libdnf5::offline::get_offline_datadir(installroot);
+    std::filesystem::create_directories(offline_datadir);
+
+    const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
+    libdnf5::offline::OfflineTransactionState state{state_path};
+
+    if (state.get_data().status != libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE) {
+        std::cout << "There is already an offline transaction queued, initiated by the following command:" << std::endl
+                  << "\t" << state.get_data().cmd_line << std::endl
+                  << "Continuing will cancel the old offline transaction and replace it with this one." << std::endl;
+        if (!libdnf5::cli::utils::userconfirm::userconfirm(base.get_config())) {
+            throw libdnf5::cli::SilentCommandExitError(0);
+        }
+    }
+
+    const std::filesystem::path transaction_json_path{offline_datadir / libdnf5::offline::TRANSACTION_JSON_FILENAME};
+
+    const std::string json = transaction.serialize();
+
+    auto transaction_json_file = libdnf5::utils::fs::File(transaction_json_path, "w");
+
+    transaction_json_file.write(json);
+    transaction_json_file.close();
+
+    state.get_data().status = libdnf5::offline::STATUS_DOWNLOAD_COMPLETE;
+    state.get_data().cachedir = base.get_config().get_cachedir_option().get_value();
+
+    std::vector<std::string> command_vector;
+    auto * current_command = get_selected_command();
+    while (current_command != get_root_command()) {
+        command_vector.emplace_back(current_command->get_argument_parser_command()->get_id());
+        current_command = current_command->get_parent_command();
+    }
+    state.get_data().verb = libdnf5::utils::string::join(command_vector, " ");
+    state.get_data().cmd_line = get_cmdline();
+
+    state.get_data().system_releasever = *libdnf5::Vars::detect_release(base.get_weak_ptr(), installroot);
+    state.get_data().target_releasever = base.get_vars()->get_value("releasever");
+
+    state.write();
 }
 
 libdnf5::Goal * Context::get_goal(bool new_if_not_exist) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -451,7 +451,8 @@ void Context::download_and_run(libdnf5::base::Transaction & transaction) {
     if (should_store_offline) {
         store_offline(transaction);
         std::cout << "Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the "
-                     "transaction."
+                     "transaction. To cancel the transaction and delete the downloaded files, use `dnf5 "
+                     "offline clean`."
                   << std::endl;
     }
 }

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -187,6 +187,85 @@ private:
     Actions action;
 };
 
+class RpmTransCB : public libdnf5::rpm::TransactionCallbacks {
+public:
+    RpmTransCB();
+    ~RpmTransCB();
+    libdnf5::cli::progressbar::MultiProgressBar * get_multi_progress_bar();
+
+    void install_progress(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        uint64_t amount,
+        [[maybe_unused]] uint64_t total) override;
+
+    void install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
+    void install_stop(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] uint64_t amount,
+        [[maybe_unused]] uint64_t total) override;
+
+    void transaction_progress(uint64_t amount, [[maybe_unused]] uint64_t total) override;
+
+    void transaction_start(uint64_t total) override;
+
+    void transaction_stop([[maybe_unused]] uint64_t total) override;
+
+    void uninstall_progress(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        uint64_t amount,
+        [[maybe_unused]] uint64_t total) override;
+
+    void uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
+
+    void uninstall_stop(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] uint64_t amount,
+        [[maybe_unused]] uint64_t total) override;
+
+
+    void unpack_error(const libdnf5::rpm::TransactionItem & item) override;
+
+    void cpio_error(const libdnf5::rpm::TransactionItem & item) override;
+
+    void script_error(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        libdnf5::rpm::Nevra nevra,
+        libdnf5::rpm::TransactionCallbacks::ScriptType type,
+        uint64_t return_code) override;
+
+    void script_start(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        libdnf5::rpm::Nevra nevra,
+        libdnf5::rpm::TransactionCallbacks::ScriptType type) override;
+
+    void script_stop(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        libdnf5::rpm::Nevra nevra,
+        libdnf5::rpm::TransactionCallbacks::ScriptType type,
+        [[maybe_unused]] uint64_t return_code) override;
+
+    void elem_progress(
+        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] uint64_t amount,
+        [[maybe_unused]] uint64_t total) override;
+
+    void verify_progress(uint64_t amount, [[maybe_unused]] uint64_t total) override;
+
+    void verify_start([[maybe_unused]] uint64_t total) override;
+
+    void verify_stop([[maybe_unused]] uint64_t total) override;
+
+private:
+    void new_progress_bar(int64_t total, const std::string & descr);
+
+    static bool is_time_to_print();
+
+    static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+    libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
+};
+
 void run_transaction(libdnf5::rpm::Transaction & transaction);
 
 /// Returns the names of matching packages and paths of matching package file names and directories.

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "version.hpp"
 
 #include <libdnf5-cli/argument_parser.hpp>
+#include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
 #include <libdnf5-cli/session.hpp>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/base/goal.hpp>
@@ -77,6 +78,10 @@ public:
     std::vector<std::pair<std::string, std::string>> repos_from_path;
     std::vector<std::string> enable_plugins_patterns;
     std::vector<std::string> disable_plugins_patterns;
+
+    bool should_store_offline = false;
+
+    void store_offline(libdnf5::base::Transaction & transaction);
 
     /// Gets user comment.
     const char * get_comment() const noexcept { return comment; }
@@ -153,6 +158,7 @@ private:
     std::vector<std::string> dump_repo_config_id_list;
     bool dump_variables{false};
     bool show_new_leaves{false};
+    std::string get_cmd_line();
 
     std::reference_wrapper<std::ostream> output_stream = std::cout;
 
@@ -189,7 +195,7 @@ private:
 
 class RpmTransCB : public libdnf5::rpm::TransactionCallbacks {
 public:
-    RpmTransCB();
+    RpmTransCB(Context & context);
     ~RpmTransCB();
     libdnf5::cli::progressbar::MultiProgressBar * get_multi_progress_bar();
 
@@ -264,6 +270,7 @@ private:
 
     libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
+    Context & context;
 };
 
 void run_transaction(libdnf5::rpm::Transaction & transaction);

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -79,8 +79,6 @@ public:
     std::vector<std::string> enable_plugins_patterns;
     std::vector<std::string> disable_plugins_patterns;
 
-    bool should_store_offline = false;
-
     void store_offline(libdnf5::base::Transaction & transaction);
 
     /// Gets user comment.
@@ -147,11 +145,18 @@ public:
 
     void set_output_stream(std::ostream & new_output_stream) { output_stream = new_output_stream; }
 
+    // Store the transaction to be run later in a minimal boot environment,
+    // using `dnf5 offline`
+    void set_should_store_offline(bool should_store_offline) { this->should_store_offline = should_store_offline; }
+    bool get_should_store_offline() const { return should_store_offline; }
+
 private:
     std::string cmdline;
 
     /// Points to user comment.
     const char * comment{nullptr};
+
+    bool should_store_offline = false;
 
     bool quiet{false};
     bool dump_main_config{false};

--- a/dnf5/include/dnf5/offline.cpp
+++ b/dnf5/include/dnf5/offline.cpp
@@ -17,11 +17,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <libdnf5/offline/offline.hpp>
+#include <dnf5/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
 
-namespace libdnf5::offline {
+namespace dnf5::offline {
 
 OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : path(std::move(path)) {
     read();
@@ -44,8 +44,8 @@ void OfflineTransactionState::write() {
     file.close();
 }
 
-std::filesystem::path get_offline_datadir(const std::filesystem::path & installroot) {
-    return installroot / DEFAULT_DATADIR.relative_path();
+std::filesystem::path get_offline_datadir() {
+    return DEFAULT_DATADIR;
 }
 
-}  // namespace libdnf5::offline
+}  // namespace dnf5::offline

--- a/dnf5/include/dnf5/offline.cpp
+++ b/dnf5/include/dnf5/offline.cpp
@@ -44,8 +44,4 @@ void OfflineTransactionState::write() {
     file.close();
 }
 
-std::filesystem::path get_offline_datadir() {
-    return DEFAULT_DATADIR;
-}
-
 }  // namespace dnf5::offline

--- a/dnf5/include/dnf5/offline.cpp
+++ b/dnf5/include/dnf5/offline.cpp
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "libdnf5/common/exception.hpp"
+
 #include <dnf5/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
@@ -28,6 +30,10 @@ OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : p
 }
 void OfflineTransactionState::read() {
     try {
+        const std::ifstream file{path};
+        if (!file.good()) {
+            throw libdnf5::FileSystemError(errno, path, M_("Error reading offline state file."));
+        }
         const auto & value = toml::parse(path);
         data = toml::find<OfflineTransactionStateData>(value, STATE_HEADER);
         if (data.state_version != STATE_VERSION) {

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -44,7 +44,7 @@ const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
 const std::string STATUS_DOWNLOAD_INCOMPLETE{"download-incomplete"};
 const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
 const std::string STATUS_READY{"ready"};
-const std::string STATUS_UPGRADE_INCOMPLETE{"upgrade-incomplete"};
+const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
 
 const int STATE_VERSION = 0;
 const std::string STATE_HEADER{"offline-transaction-state"};
@@ -73,6 +73,7 @@ public:
     OfflineTransactionState(std::filesystem::path path);
     OfflineTransactionStateData & get_data() { return data; };
     const std::exception_ptr & get_read_exception() const { return read_exception; };
+    std::filesystem::path get_path() const { return path; };
 
 private:
     void read();

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -17,22 +17,27 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_OFFLINE_HPP
-#define LIBDNF5_OFFLINE_HPP
+#ifndef DNF5_OFFLINE_HPP
+#define DNF5_OFFLINE_HPP
+
+#include "dnf5/version.hpp"
 
 #include <dnf5/context.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_number.hpp>
 #include <sdbus-c++/sdbus-c++.h>
+#include <systemd/sd-journal.h>
 #include <toml.hpp>
 
-namespace libdnf5::offline {
+namespace dnf5::offline {
 
 // Unique identifiers used to mark and identify system-upgrade boots in
 // journald logs. These are the same as they are in `dnf4 system-upgrade`, so
 // `dnf5 offline log` will find offline transactions performed by DNF 4 and
 // vice-versa.
+const std::string DOWNLOAD_FINISHED_ID{"9348174c5cc74001a71ef26bd79d302e"};
+const std::string REBOOT_REQUESTED_ID{"9348174c5cc74001a71ef26bd79d302e"};
 const std::string OFFLINE_STARTED_ID{"3e0a5636d16b4ca4bbe5321d06c6aa62"};
 const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
 
@@ -48,7 +53,7 @@ const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTE
 const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
 const std::filesystem::path TRANSACTION_JSON_FILENAME{"offline-transaction.json"};
 
-std::filesystem::path get_offline_datadir(const std::filesystem::path & installroot);
+std::filesystem::path get_offline_datadir();
 
 struct OfflineTransactionStateData {
     int state_version = STATE_VERSION;
@@ -77,10 +82,16 @@ private:
     OfflineTransactionStateData data;
 };
 
-}  // namespace libdnf5::offline
+void log_status(
+    const std::string & message,
+    const std::string & message_id,
+    const std::string & system_releasever,
+    const std::string & target_releasever);
+
+}  // namespace dnf5::offline
 
 TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
-    libdnf5::offline::OfflineTransactionStateData,
+    dnf5::offline::OfflineTransactionStateData,
     state_version,
     status,
     cachedir,
@@ -92,4 +103,4 @@ TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
     enabled_repos,
     disabled_repos)
 
-#endif  // LIBDNF5_OFFLINE_HPP
+#endif  // DNF5_OFFLINE_HPP

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -26,8 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_number.hpp>
-#include <sdbus-c++/sdbus-c++.h>
-#include <systemd/sd-journal.h>
 #include <toml.hpp>
 
 namespace dnf5::offline {
@@ -83,6 +81,7 @@ private:
 };
 
 void log_status(
+    Context & context,
     const std::string & message,
     const std::string & message_id,
     const std::string & system_releasever,

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -53,8 +53,6 @@ const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTE
 const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
 const std::filesystem::path TRANSACTION_JSON_FILENAME{"offline-transaction.json"};
 
-std::filesystem::path get_offline_datadir();
-
 struct OfflineTransactionStateData {
     int state_version = STATE_VERSION;
     std::string status = STATUS_DOWNLOAD_INCOMPLETE;

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -64,6 +64,7 @@ struct OfflineTransactionStateData {
     bool poweroff_after = false;
     std::vector<std::string> enabled_repos;
     std::vector<std::string> disabled_repos;
+    std::string module_platform_id;
 };
 
 class OfflineTransactionState {
@@ -99,6 +100,7 @@ TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
     cmd_line,
     poweroff_after,
     enabled_repos,
-    disabled_repos)
+    disabled_repos,
+    module_platform_id)
 
 #endif  // DNF5_OFFLINE_HPP

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -73,6 +73,9 @@ void create_downloadonly_option(dnf5::Command & command);
 /// The values are stored in the `forcearch` configuration option
 [[deprecated("--forcearch is now a global argument")]] void create_forcearch_option(dnf5::Command & command);
 
+/// Create the `--offline` option for a command provided as an argument.
+void create_offline_option(dnf5::Command & command);
+
 }  // namespace dnf5
 
 #endif  // DNF5_COMMANDS_SHARED_OPTIONS_HPP

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -36,6 +36,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/makecache/makecache.hpp"
 #include "commands/mark/mark.hpp"
 #include "commands/module/module.hpp"
+#include "commands/offline/offline.hpp"
 #include "commands/provides/provides.hpp"
 #include "commands/reinstall/reinstall.hpp"
 #include "commands/remove/remove.hpp"
@@ -43,6 +44,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/repoquery/repoquery.hpp"
 #include "commands/search/search.hpp"
 #include "commands/swap/swap.hpp"
+#include "commands/system-upgrade/system-upgrade.hpp"
 #include "commands/upgrade/upgrade.hpp"
 #include "commands/versionlock/versionlock.hpp"
 #include "dnf5/context.hpp"
@@ -691,6 +693,8 @@ static void add_commands(Context & context) {
     context.add_and_initialize_command(std::make_unique<DownloadCommand>(context));
     context.add_and_initialize_command(std::make_unique<MakeCacheCommand>(context));
     context.add_and_initialize_command(std::make_unique<VersionlockCommand>(context));
+    context.add_and_initialize_command(std::make_unique<SystemUpgradeCommand>(context));
+    context.add_and_initialize_command(std::make_unique<OfflineCommand>(context));
 }
 
 static void load_plugins(Context & context) {

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -20,9 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dnf5/shared_options.hpp"
 
+#include "dnf5/offline.hpp"
+
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
-#include <libdnf5/offline/offline.hpp>
 #include <libdnf5/rpm/arch.hpp>
 
 namespace dnf5 {
@@ -120,12 +121,11 @@ void create_offline_option(dnf5::Command & command) {
                                      [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
                                      [[maybe_unused]] const char * option,
                                      [[maybe_unused]] const char * value) {
-        const auto & installroot = ctx.base.get_config().get_installroot_option().get_value();
-        const auto & offline_datadir = libdnf5::offline::get_offline_datadir(installroot);
+        const auto & offline_datadir = dnf5::offline::get_offline_datadir();
         std::filesystem::create_directories(offline_datadir);
 
         ctx.base.get_config().get_cachedir_option().set(libdnf5::Option::Priority::RUNTIME, offline_datadir);
-        ctx.should_store_offline = true;
+        ctx.set_should_store_offline(true);
         return true;
     });
     command.get_argument_parser_command()->register_named_arg(offline);

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -121,10 +121,10 @@ void create_offline_option(dnf5::Command & command) {
                                      [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
                                      [[maybe_unused]] const char * option,
                                      [[maybe_unused]] const char * value) {
-        const auto & offline_datadir = dnf5::offline::get_offline_datadir();
-        std::filesystem::create_directories(offline_datadir);
-
-        ctx.base.get_config().get_cachedir_option().set(libdnf5::Option::Priority::RUNTIME, offline_datadir);
+        // The installroot will be prepended to the cachedir and system_cachedir later in Base.setup()
+        const auto & offline_datadir = dnf5::offline::DEFAULT_DATADIR;
+        ctx.base.get_config().get_system_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
+        ctx.base.get_config().get_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
         ctx.set_should_store_offline(true);
         return true;
     });

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -156,6 +156,14 @@ Needs-restarting command
  * Dropped ``-r, --reboothint`` option; this is now the default behavior.
  * Dropped ``-u, --useronly`` option.
 
+Offline-distrosync command
+--------------------------
+ * Now an alias of ``dnf5 distro-sync --offline``
+
+Offline-upgrade command
+--------------------------
+ * Now an alias of ``dnf5 upgrade --offline``
+
 Remove command
 --------------
  * Command does not remove packages according to provides, but only according NEVRA or file provide match
@@ -187,6 +195,10 @@ Repoquery command
  * Option ``--resolve`` was changed to ``--providers-of=PACKAGE_ATTRIBUTE``. It no longer interacts with the formatting ``--requires``,
    ``--provides``, ``--suggests``,... options instead it takes the PACKAGE_ATTRIBUTE value directly.
    E.g., ``dnf rq --resolve --requires glibc`` -> ``dnf rq --providers-of=requires glibc``.
+
+System-upgrade command
+--------------------------
+ * Moved from a plugin to a built-in command
 
 Upgrade command
 ---------------

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -50,6 +50,9 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to synchronize. All remaining packages will be synchronized.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -48,6 +48,9 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to downgrade. All remaining packages will be downgraded.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -112,6 +112,9 @@ Options
     | Used with ``install`` and ``upgrade`` to allow skipping packages that are not possible to install or upgrade.
     | All remaining packages will be installed or upgraded.
 
+``--offline``
+    | Used with ``install``, ``remove``, and ``upgrade``. Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/commands/index.rst
+++ b/doc/commands/index.rst
@@ -26,6 +26,7 @@ DNF5 Commands
     repoquery.8
     search.8
     swap.8
+    system-upgrade.8
     upgrade.8
     versionlock.8
 

--- a/doc/commands/index.rst
+++ b/doc/commands/index.rst
@@ -19,6 +19,7 @@ DNF5 Commands
     leaves.8
     makecache.8
     mark.8
+    offline.8
     provides.8
     reinstall.8
     remove.8

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -80,6 +80,9 @@ Options
 ``--newpackage``
     | Consider only content contained in newpackage advisories.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/commands/offline.8.rst
+++ b/doc/commands/offline.8.rst
@@ -1,0 +1,87 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _offline_command_ref-label:
+
+################
+ Offline Command
+################
+
+Synopsis
+========
+
+``dnf5 offline <subcommand> [options]``
+
+
+Description
+===========
+
+The ``offline`` command is used to manage "offline" transactions---transactions that run when the system is booted into a minimal environment. Running a transaction in this stripped-down environment can be safer than running it when the system is booted normally since the transaction is less likely to interfere with running processes.
+
+Offline transactions can be initiated by specifying the ``--offline`` flag on any operation (``install``, ``upgrade``, ``distro-sync``, etc.), or via ``dnf5 system-upgrade download``. Once an offline transaction is initiated, run ``dnf5 offline reboot`` to reboot and begin the transaction.
+
+Data for offline transactions is stored under the "system state" directory at ``/usr/lib/sysimage/libdnf5/offline``.
+
+Subcommands
+===========
+
+``clean``
+    Removes any stored offline transaction and deletes cached package files.
+
+``log``
+    Used to see a list of boots during which an offline transaction was attempted, or show the logs from an attempted offline transaction. The logs for one of the boots can be shown by specifying one of the numbers in the first column with the ``--number`` argument. Negative numbers can be used to number the boots from last to first. For example, ``log --number=-1`` can be used to see the logs for the last offline transaction.
+
+``reboot``
+    Prepares the system to perform the offline transaction and reboots to start the transaction. This command can only be run after an offline transaction is initiated (e.g. by ``dnf5 system-upgrade download``).
+
+``status``
+    Shows the status of the current offline transaction.
+
+Options
+=======
+
+``--number=<boot number>``
+    Used with the ``log`` subcommand. Show the log specified by the number. Run ``dnf5 offline log`` with ``--number`` first to get a list of logs to choose from.
+
+``--poweroff``
+    Used with the ``reboot`` subcommand. The system will power off after the transaction is completed instead of restarting. If the transaction failed, the system will reboot instead of powering off even with this flag.
+
+Examples
+========
+
+``dnf5 install --offline hello``
+    | Prepares the installation of the ``hello`` package as an offline transaction.
+
+``dnf5 offline status``
+    | Shows the status of the current offline transaction.
+
+``dnf5 offline reboot --poweroff``
+    | Reboot and run the offline transaction, then power the system off after the transaction is complete.
+
+``dnf5 offline log``
+    | List boots during which an offline transaction was attempted.
+
+``dnf5 offline log --number=-1``
+    | View the log from the latest boot during which an offline transaction was attempted.
+
+
+See Also
+========
+
+    | :manpage:`dnf5-system-upgrade(8)`, :ref:`System-upgrade command <system_upgrade_command_ref-label>`
+    | https://www.freedesktop.org/wiki/Software/systemd/SystemUpdates

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -47,6 +47,9 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to reinstall. All remaining packages will be reinstalled.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -38,6 +38,13 @@ If you want to keep the dependencies that were installed together with the given
 set the ``clean_requirements_on_remove`` configuration option to ``False``.
 
 
+Options
+=======
+
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
+
 Examples
 ========
 

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -41,6 +41,8 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
 
 
 Examples

--- a/doc/commands/system-upgrade.8.rst
+++ b/doc/commands/system-upgrade.8.rst
@@ -1,0 +1,95 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _system_upgrade_command_ref-label:
+
+################
+ System-upgrade Command
+################
+
+Synopsis
+========
+
+``dnf5 system-upgrade <subcommand> [options]``
+
+
+Description
+===========
+
+The ``system-upgrade`` command is used to upgrade the system to a new major release. First, the ``download`` subcommand downloads packages while the system is running normally. Then, the ``reboot`` subcommand reboots the system into a minimal "offline" environment to apply the upgrades.
+
+``dnf5 system-upgrade`` is a recommended way to upgrade a system to a new major release. Before you proceed, ensure that your system is fully upgraded (``dnf5 --refresh upgrade``).
+
+``system-upgrade`` shares many subcommands with the :ref:`offline subcommand <offline_command_ref-label>`.
+
+
+Subcommands
+===========
+
+``clean``
+    | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+
+``download``
+    | Downloads all packages needed to upgrade to a new major release and checks that they can be installed.
+
+``log``
+    | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+
+``reboot``
+    | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+
+Options
+=======
+
+``--releasever=<version>``
+    | Required. The version to upgrade to. Sets ``$releasever`` in all enabled repos. Usually a number, or ``rawhide``.
+
+``--no-downgrade``
+    | Behave like ``dnf5 update``: do not install packages from the new release if they are older than what is currently installed. This is the opposite of the default behavior, which behaves like ``dnf5 distro-sync``, always installing packages from the new release, even if they are older than the currently-installed version.
+
+``--number=<boot number>``
+    | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+
+``--poweroff``
+    | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+
+
+Examples
+========
+
+Typical upgrade usage
+---------------------
+
+``dnf5 --refresh upgrade``
+
+``dnf5 system-upgrade download --releasever 40``
+
+``dnf5 system-upgrade reboot``
+
+
+Show logs from last upgrade attempt
+-----------------------------------
+
+``dnf5 system-upgrade log --number=-1``
+
+
+See Also
+========
+
+    | :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
+    | https://www.freedesktop.org/wiki/Software/systemd/SystemUpdates

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -87,6 +87,9 @@ Options
 ``--newpackage``
     | Consider only content contained in newpackage advisories.
 
+``--offline``
+    | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
+
 
 Examples
 ========

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -365,6 +365,7 @@ Commands in detail:
     | :manpage:`dnf5-leaves(8)`, :ref:`Leaves command <leaves_command_ref-label>`
     | :manpage:`dnf5-makecache(8)`, :ref:`Makecache command <makecache_command_ref-label>`
     | :manpage:`dnf5-mark(8)`, :ref:`Mark command <mark_command_ref-label>`
+    | :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
     | :manpage:`dnf5-provides(8)`, :ref:`Provides command <provides_command_ref-label>`
     | :manpage:`dnf5-reinstall(8)`, :ref:`Reinstall command <reinstall_command_ref-label>`
     | :manpage:`dnf5-remove(8)`, :ref:`Remove command <remove_command_ref-label>`
@@ -372,6 +373,7 @@ Commands in detail:
     | :manpage:`dnf5-repoquery(8)`, :ref:`Repoquery command <repoquery_command_ref-label>`
     | :manpage:`dnf5-search(8)`, :ref:`Search command <search_command_ref-label>`
     | :manpage:`dnf5-swap(8)`, :ref:`Swap command <swap_command_ref-label>`
+    | :manpage:`dnf5-system-upgrade(8)`, :ref:`System-upgrade command <system_upgrade_command_ref-label>`
     | :manpage:`dnf5-upgrade(8)`, :ref:`Upgrade command <upgrade_command_ref-label>`
 
 ..

--- a/include/libdnf5/offline/offline.hpp
+++ b/include/libdnf5/offline/offline.hpp
@@ -29,6 +29,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::offline {
 
+// Unique identifiers used to mark and identify system-upgrade boots in
+// journald logs. These are the same as they are in `dnf4 system-upgrade`, so
+// `dnf5 offline log` will find offline transactions performed by DNF 4 and
+// vice-versa.
 const std::string OFFLINE_STARTED_ID{"3e0a5636d16b4ca4bbe5321d06c6aa62"};
 const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
 

--- a/include/libdnf5/offline/offline.hpp
+++ b/include/libdnf5/offline/offline.hpp
@@ -1,0 +1,91 @@
+/*
+Copyright (C) 2024 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_OFFLINE_HPP
+#define LIBDNF5_OFFLINE_HPP
+
+#include <dnf5/context.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/conf/option_bool.hpp>
+#include <libdnf5/conf/option_number.hpp>
+#include <sdbus-c++/sdbus-c++.h>
+#include <toml.hpp>
+
+namespace libdnf5::offline {
+
+const std::string OFFLINE_STARTED_ID{"3e0a5636d16b4ca4bbe5321d06c6aa62"};
+const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
+
+const std::string STATUS_DOWNLOAD_INCOMPLETE{"download-incomplete"};
+const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
+const std::string STATUS_READY{"ready"};
+const std::string STATUS_UPGRADE_INCOMPLETE{"upgrade-incomplete"};
+
+const int STATE_VERSION = 0;
+const std::string STATE_HEADER{"offline-transaction-state"};
+
+const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
+const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
+const std::filesystem::path TRANSACTION_JSON_FILENAME{"offline-transaction.json"};
+
+std::filesystem::path get_offline_datadir(const std::filesystem::path & installroot);
+
+struct OfflineTransactionStateData {
+    int state_version = STATE_VERSION;
+    std::string status = STATUS_DOWNLOAD_INCOMPLETE;
+    std::string cachedir;
+    std::string target_releasever;
+    std::string system_releasever;
+    std::string verb;
+    std::string cmd_line;
+    bool poweroff_after = false;
+    std::vector<std::string> enabled_repos;
+    std::vector<std::string> disabled_repos;
+};
+
+class OfflineTransactionState {
+public:
+    void write();
+    OfflineTransactionState(std::filesystem::path path);
+    OfflineTransactionStateData & get_data() { return data; };
+    const std::exception_ptr & get_read_exception() const { return read_exception; };
+
+private:
+    void read();
+    std::exception_ptr read_exception;
+    std::filesystem::path path;
+    OfflineTransactionStateData data;
+};
+
+}  // namespace libdnf5::offline
+
+TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
+    libdnf5::offline::OfflineTransactionStateData,
+    state_version,
+    status,
+    cachedir,
+    target_releasever,
+    system_releasever,
+    verb,
+    cmd_line,
+    poweroff_after,
+    enabled_repos,
+    disabled_repos)
+
+#endif  // LIBDNF5_OFFLINE_HPP

--- a/libdnf5/offline/offline.cpp
+++ b/libdnf5/offline/offline.cpp
@@ -1,0 +1,51 @@
+/*
+Copyright (C) 2024 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf5/offline/offline.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/fs/file.hpp>
+
+namespace libdnf5::offline {
+
+OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : path(std::move(path)) {
+    read();
+}
+void OfflineTransactionState::read() {
+    try {
+        const auto & value = toml::parse(path);
+        data = toml::find<OfflineTransactionStateData>(value, STATE_HEADER);
+        if (data.state_version != STATE_VERSION) {
+            throw libdnf5::RuntimeError(M_("incompatible version of state data"));
+        }
+    } catch (const std::exception & ex) {
+        read_exception = std::current_exception();
+        data = OfflineTransactionStateData{};
+    }
+}
+void OfflineTransactionState::write() {
+    auto file = libdnf5::utils::fs::File(path, "w");
+    file.write(toml::format(toml::value{{STATE_HEADER, data}}));
+    file.close();
+}
+
+std::filesystem::path get_offline_datadir(const std::filesystem::path & installroot) {
+    return installroot / DEFAULT_DATADIR.relative_path();
+}
+
+}  // namespace libdnf5::offline


### PR DESCRIPTION
This PR supersedes https://github.com/rpm-software-management/dnf5/pull/1209.

Resolves https://github.com/rpm-software-management/dnf5/issues/1052.

Together with https://github.com/rpm-software-management/dnf5/pull/1264, resolves https://github.com/rpm-software-management/dnf5/issues/1224.

This patch implements `dnf5 system-upgrade` as a regular command rather than a plugin. `system-upgrade` is responsible for performing offline upgrades of the system to a new major release. It has three main subcommands:

- `dnf5 system-upgrade download --releasever XX`: Does a dry run of an upgrade to a new `releasever` and stores the resulting transaction for later.
- `dnf5 system-upgrade reboot`: Creates a "magic symlink" at `/system-update` to trigger the start of `dnf5-offline-transaction.service` on the next boot, then reboots. See https://www.freedesktop.org/software/systemd/man/latest/systemd.offline-updates.html. `dnf5-offline-transaction.service` will take the place of the usual boot target so we can preform the upgrade without disturbing too many running processes.
- `dnf5 system-upgrade _execute`: Not intended to be run by the user directly, but rather by `dnf5-offline-transaction.service`. Loads the transaction saved by `system-upgrade download` and performs the upgrade. Interacts with [Plymouth](https://www.freedesktop.org/wiki/Software/Plymouth/) (if it's available) to show upgrade progress on the animated boot screen. The usual DNF 5 stdout is additionally logged to journald. Reboots or powers off when the upgrade is complete.

This PR also adds a new command, `dnf5 offline`, which shares the `reboot`, `log`, and `clean` subcommands with `dnf5 system-upgrade`, and adds a new `--offline` argument that allows any operation to be performed offline, as proposed here: https://github.com/rpm-software-management/dnf5/issues/1224#issuecomment-1936651917. For example, the process for running an offline upgrade would look like:

```
$ sudo dnf5 upgrade --offline mypackage
Updating and loading repositories:
Repositories loaded.
...
Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction.
$ sudo dnf5 offline reboot
The system will now reboot to perform the offline transaction initiated by the following command:
	dnf5 upgrade --offline mypackage
Is this ok [y/N]: 
```

The following commands support `--offline`: `autoremove`, `distro-sync`, `downgrade`, `install`, `group install`, `group upgrade`, `reinstall`, `remove`, `swap`, and `upgrade`.

A caveat of making `system-upgrade` and `offline` regular commands instead of plugins is that `libsystemd` and `sdbus-c++` now have to be build dependencies of `dnf5`, since `dnf5 offline log` uses these libraries to display logs from offline transactions.

Remaining tasks:

- [x] Add `dnf5 offline-distrosync` and `dnf5 offline-upgrade` aliases to `dnf5 distro-sync --offline` and `dnf5 upgrade --offline`, respectively
- [x] Add `systemd` build condition so we don't have to always depend on libsystemd+sdbus-c++ 
- [x] `dnf5 offline status` subcommand 
- [x] Documentation
- [x] Go back through commit history of `dnf-plugins-extras` to make sure no historical issues with DNF 4 system-upgrade are present in the new implementation

I'll implement the tests in a separate PR if that works. We have the DNF 4 tests to go from: https://github.com/rpm-software-management/dnf-plugins-core/blob/master/tests/test_system_upgrade.py