### PR TITLE
dnfdaemon: Add new API for requests with large replies

### DIFF
--- a/dnf5daemon-client/CMakeLists.txt
+++ b/dnf5daemon-client/CMakeLists.txt
@@ -15,6 +15,9 @@ include_directories(..)
 
 pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++>=0.9.0)
 
+pkg_check_modules(JSONC REQUIRED json-c)
+include_directories(${JSONC_INCLUDE_DIRS})
+
 add_executable(${DNF5DAEMON_CLIENT_BIN} ${DNF5DAEMON_CLIENT_SOURCES})
 
 target_link_libraries(
@@ -24,6 +27,7 @@ target_link_libraries(
         libdnf5
         libdnf5-cli
         ${SDBUS_CPP_LIBRARIES}
+        ${JSONC_LIBRARIES}
         pthread
 )
 

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -23,14 +23,23 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "wrappers/dbus_package_wrapper.hpp"
 
 #include <dnf5daemon-server/dbus.hpp>
+#include <fcntl.h>
 #include <fmt/format.h>
+#include <json-c/json.h>
+#include <libdnf5-cli/exception.hpp>
 #include <libdnf5-cli/output/package_info_sections.hpp>
+#include <libdnf5/common/exception.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <limits.h>
+#include <poll.h>
 
+#include <array>
 #include <iostream>
+#include <string>
 
 namespace dnfdaemon::client {
 
@@ -98,6 +107,64 @@ dnfdaemon::KeyValueMap RepoqueryCommand::session_config() {
     return cfg;
 }
 
+/// Read package objects from json stream. The `json_stream` string is modified, all
+/// successfully parsed json objects are removed from it, possible partial json object
+/// is left for next round of parsing after the rest of the string arrives.
+std::vector<DbusPackageWrapper> json_to_packages(std::string & json_stream) {
+    libdnf_assert(json_stream.size() < INT32_MAX, "can not parse JSON string longer then INT32_MAX");
+    std::vector<DbusPackageWrapper> packages;
+
+    json_tokener * tokener;
+    tokener = json_tokener_new();
+    while (!json_stream.empty()) {
+        json_object * json_pkg =
+            json_tokener_parse_ex(tokener, json_stream.c_str(), static_cast<int>(json_stream.size()));
+        if (json_pkg) {
+            dnfdaemon::KeyValueMap dbuspkg;
+            json_object_object_foreach(json_pkg, key, val) {
+                switch (json_object_get_type(val)) {
+                    case json_type_boolean:
+                        dbuspkg[key] = static_cast<bool>(json_object_get_boolean(val));
+                        break;
+                    case json_type_int:
+                        dbuspkg[key] = static_cast<uint64_t>(json_object_get_int64(val));
+                        break;
+                    default:
+                        dbuspkg[key] = json_object_get_string(val);
+                }
+            }
+            packages.emplace_back(DbusPackageWrapper(dbuspkg));
+
+            auto parse_end = json_tokener_get_parse_end(tokener);
+            json_tokener_reset(tokener);
+            json_object_put(json_pkg);
+            if (parse_end < json_stream.size()) {
+                // more json objects on the line, remove parsed part and continue
+                json_stream = json_stream.substr(parse_end);
+            } else {
+                // everything has been parsed
+                json_stream.clear();
+            }
+        } else {
+            auto err = json_tokener_get_error(tokener);
+            if (err == json_tokener_continue) {
+                // only partial json string in the input line, continue on the next one
+                break;
+            } else {
+                // this is unrecoverable, throw error
+                json_tokener_free(tokener);
+                throw libdnf5::cli::CommandExitError(
+                    1,
+                    M_("Error parsing JSON object \"{}\": {}"),
+                    json_stream,
+                    std::string{json_tokener_error_desc(err)});
+            }
+        }
+    }
+    json_tokener_free(tokener);
+    return packages;
+}
+
 void RepoqueryCommand::run() {
     auto & ctx = get_context();
 
@@ -135,29 +202,86 @@ void RepoqueryCommand::run() {
         options.insert(std::pair<std::string, std::vector<std::string>>("package_attrs", {"full_nevra"}));
     }
 
-    dnfdaemon::KeyValueMapList packages;
-    ctx.session_proxy->callMethod("list")
+    std::array<int, 2> pipefd{};  // File descriptors for the pipe
+    if (pipe2(pipefd.data(), O_NONBLOCK) == -1) {
+        std::cerr << "Error: failed to create a pipe." << std::endl;
+        return;
+    }
+
+    std::string fd_id;
+    ctx.session_proxy->callMethod("list_fd")
         .onInterface(dnfdaemon::INTERFACE_RPM)
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options)
-        .storeResultsTo(packages);
+        .withArguments(sdbus::UnixFd{pipefd[1]})
+        .withArguments(fd_id);
+    close(pipefd[1]);
 
-    auto num_packages = packages.size();
-    for (auto & raw_package : packages) {
-        --num_packages;
-        DbusPackageWrapper package(raw_package);
-        if (info_option->get_value()) {
-            auto out = libdnf5::cli::output::PackageInfoSections();
-            out.setup_cols();
-            out.add_package(package);
-            out.print();
-            if (num_packages) {
-                std::cout << std::endl;
-            }
-        } else {
-            std::cout << package.get_full_nevra() << std::endl;
+    int in_fd = pipefd[0];
+
+    const size_t pipe_buffer_size = fcntl(in_fd, F_GETPIPE_SZ);
+    const int timeout = 30000;
+
+    std::array<pollfd, 1> pfds;
+    pfds[0].fd = in_fd;
+    pfds[0].events = POLLIN;
+
+    std::string message;
+    ssize_t total_bytes_read = 0;
+    ssize_t bytes_read = -1;
+
+    std::vector<char> buffer(pipe_buffer_size);  // Buffer for reading data
+    enum class STATUS { PENDING, FINISHED, FAILED } reading_status;
+    reading_status = STATUS::PENDING;
+    while (reading_status == STATUS::PENDING) {
+        switch (poll(pfds.data(), pfds.size(), timeout)) {
+            case -1:
+                // poll() failed
+                reading_status = STATUS::FAILED;
+                std::cerr << "Error: poll() failed." << std::endl;
+                break;
+            case 0:
+                // timeout was reached
+                reading_status = STATUS::FAILED;
+                std::cerr << "Error: timeout while waiting for data." << std::endl;
+                break;
+            default:
+                if ((pfds[0].revents & POLLIN) != 0) {
+                    bytes_read = read(in_fd, buffer.data(), pipe_buffer_size);
+                    if (bytes_read == -1) {
+                        // read error
+                        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                            reading_status = STATUS::FAILED;
+                            std::cerr << "Error: reading from the pipe failed." << std::endl;
+                        }
+                    } else if (bytes_read == 0) {
+                        // EOF
+                        reading_status = STATUS::FINISHED;
+                    } else {
+                        // data read
+                        message.append(buffer.data(), bytes_read);
+                        total_bytes_read += bytes_read;
+                        for (const auto & package : json_to_packages(message)) {
+                            if (info_option->get_value()) {
+                                auto out = libdnf5::cli::output::PackageInfoSections();
+                                out.setup_cols();
+                                out.add_package(package);
+                                out.print();
+                                std::cout << std::endl;
+                            } else {
+                                std::cout << package.get_full_nevra() << std::endl;
+                            }
+                        }
+                    }
+                } else if ((pfds[0].revents & POLLHUP) != 0) {
+                    // EOF
+                    reading_status = STATUS::FINISHED;
+                } else {
+                    reading_status = STATUS::FAILED;
+                }
         }
     }
+    close(in_fd);
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-server/CMakeLists.txt
+++ b/dnf5daemon-server/CMakeLists.txt
@@ -11,8 +11,11 @@ add_definitions(-DGETTEXT_DOMAIN=\"${GETTEXT_DOMAIN}\")
 
 include_directories(.)
 
+pkg_check_modules(JSONC REQUIRED json-c)
 pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++>=0.9.0)
 find_package(Threads)
+
+include_directories(${JSONC_INCLUDE_DIRS})
 
 add_executable(${DNF5DAEMON_SERVER_BIN} ${DNF5DAEMON_SERVER_SOURCES})
 
@@ -23,6 +26,7 @@ target_link_libraries(
         libdnf5
         libdnf5-cli
         ${SDBUS_CPP_LIBRARIES}
+        ${JSONC_LIBRARIES}
         Threads::Threads
 )
 

--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -85,6 +85,8 @@ const char * const SIGNAL_TRANSACTION_UNPACK_ERROR = "transaction_unpack_error";
 const char * const SIGNAL_TRANSACTION_ELEM_PROGRESS = "transaction_elem_progress";
 const char * const SIGNAL_TRANSACTION_FINISHED = "transaction_finished";
 
+const char * const SIGNAL_WRITE_TO_FD_FINISHED = "write_to_fd_finished";
+
 // polkit actions
 const char * const POLKIT_REPOCONF_WRITE = "org.rpm.dnf.v0.rpm.Repo.conf_write";
 const char * const POLKIT_EXECUTE_RPM_TRANSACTION = "org.rpm.dnf.v0.rpm.execute_transaction";

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -87,6 +87,24 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     </method>
 
     <!--
+        list_fd:
+        @options: an array of key/value pairs
+        @file_descriptor: File descriptor opened for writing used to transfer data
+        @transfer_id: Identifier of this transfer. Used for signaling the end of transfer.
+
+        Get list of packages that match to given filters.
+        Packages are transfered in form of stream of JSON objects. Each JSON
+        object is a dictionary representing one package.
+
+        The same options as in list() method are supported.
+    -->
+    <method name="list">
+        <arg name="options" type="a{sv}" direction="in"/>
+        <arg name="file_descriptor" type="h" direction="in"/>
+        <arg name="transfer_id" type="s" direction="in"/>
+    </method>
+
+    <!--
         install:
         @pkg_specs: an array of package specifications to be installed on the system
         @options: an array of key/value pairs to modify install behavior
@@ -382,6 +400,20 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <signal name="transaction_unpack_error">
         <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
+    </signal>
+
+    <!--
+        write_to_fd_finished:
+        @success: true if the tranfer finished successfully
+        @transfer_id: id of the tranfer was finished and its file descriptor closed
+        @error_msg: error message if the transfer was not successful.
+
+        Processing of the item has started.
+    -->
+    <signal name="write_to_fd_finished">
+        <arg name="success" type="b" />
+        <arg name="transfer_id" type="s" />
+        <arg name="error_msg" type="s" />
     </signal>
 </interface>
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -31,11 +31,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         @packages: array of returned packages with requested attributes
 
         Get list of packages that match to given filters.
+        Since the method returns packages directly in the D-Bus method reply
+        message, which has a limited size, there is a possibility that the
+        requested package set size would exceed this limit. If you request a
+        large number of packages and/or a great number of package attributes,
+        please consider using the list_fd() method.
 
         Following options and filters are supported:
 
             - package_attrs: list of strings
-                list of package attributes that are returned
+                list of package attributes that are returned. Supported attributes are name, epoch, version, release, arch, repo_id, from_repo_id, is_installed, install_size, download_size, sourcerpm, summary, url, license, description, files, changelogs, provides, requires, requires_pre, conflicts, obsoletes, recommends, suggests, enhances, supplements, evr, nevra, full_nevra, reason, vendor, group.
             - with_nevra: bool (default true)
                 match patterns against available packages NEVRAs
             - with_provides: bool (default true)
@@ -52,7 +57,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
             - patterns: list of strings
                 any package matching to any of patterns is returned
             - scope: string (default "all")
-                limit packages to one of "all", "installed", "available", "upgrades", "upradable"
+                limit packages to one of "all", "installed", "available", "upgrades", "upgradable"
             - arch: list of strings
                 limit the resulting set only to packages of given architectures
             - repo: list of strings
@@ -92,9 +97,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         @file_descriptor: File descriptor opened for writing used to transfer data
         @transfer_id: Identifier of this transfer. Used for signaling the end of transfer.
 
-        Get list of packages that match to given filters.
-        Packages are transfered in form of stream of JSON objects. Each JSON
-        object is a dictionary representing one package.
+        Retrieve a list of packages that match the provided filters.
+        Packages are transmitted as a stream of JSON objects, with each JSON object representing one package as a dictionary. This stream is then written into the given file_descriptor.
+        Unlike the list() method, this approach does not encounter issues with large output data.
+        The server has a 30-second timeout during which it waits for the client to read data from the pipe if the pipe is full.
 
         The same options as in list() method are supported.
     -->

--- a/dnf5daemon-server/main.cpp
+++ b/dnf5daemon-server/main.cpp
@@ -39,6 +39,8 @@ int main() {
     sigaddset(&mask, SIGINT);
     sigaddset(&mask, SIGTERM);
     pthread_sigmask(SIG_BLOCK, &mask, NULL);
+    // ignore SIGPIPE globally, handle pipe writing errors locally where they occur
+    signal(SIGPIPE, SIG_IGN);
 
     try {
         SessionManager session_manager;

--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -59,7 +59,7 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"vendor", PackageAttribute::vendor},
     {"group", PackageAttribute::group}};
 
-std::vector<std::string> reldeplist_to_strings(const libdnf5::rpm::ReldepList & reldeps) {
+static std::vector<std::string> reldeplist_to_strings(const libdnf5::rpm::ReldepList & reldeps) {
     std::vector<std::string> lst;
     for (auto reldep : reldeps) {
         lst.emplace_back(reldep.to_string());
@@ -67,7 +67,7 @@ std::vector<std::string> reldeplist_to_strings(const libdnf5::rpm::ReldepList & 
     return lst;
 }
 
-std::vector<dnfdaemon::Changelog> changelogs_to_list(const libdnf5::rpm::Package & libdnf_package) {
+static std::vector<dnfdaemon::Changelog> changelogs_to_list(const libdnf5::rpm::Package & libdnf_package) {
     std::vector<dnfdaemon::Changelog> changelogs;
 
     for (const auto & chlog : libdnf_package.get_changelogs()) {
@@ -197,7 +197,7 @@ dnfdaemon::KeyValueMap package_to_map(
     return dbus_package;
 }
 
-void add_string_list(json_object * json_pkg, const char * cattr, const std::vector<std::string> & vector) {
+static void add_string_list(json_object * json_pkg, const char * cattr, const std::vector<std::string> & vector) {
     json_object * array = json_object_new_array();
     json_object_object_add(json_pkg, cattr, array);
     for (const auto & elem : vector) {

--- a/dnf5daemon-server/package.hpp
+++ b/dnf5daemon-server/package.hpp
@@ -72,4 +72,10 @@ enum class PackageAttribute {
 dnfdaemon::KeyValueMap package_to_map(
     const libdnf5::rpm::Package & libdnf_package, const std::vector<std::string> & attributes);
 
+/// Convert given libdnf_package to a JSON string using requested attributes.
+/// @param libdnf_package Package to convert to JSON
+/// @param attributes A list of attributes of ligdnf_package that are included in JSON
+/// @return JSON String with the package represented as key:value dictionary.
+std::string package_to_json(const libdnf5::rpm::Package & libdnf_package, const std::vector<std::string> & attributes);
+
 #endif

--- a/dnf5daemon-server/services/comps/group.cpp
+++ b/dnf5daemon-server/services/comps/group.cpp
@@ -135,16 +135,17 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
     libdnf5::comps::GroupQuery query(base->get_weak_ptr());
 
     // patterns to search
-    const auto patterns = key_value_map_get<std::vector<std::string>>(options, "patterns", std::vector<std::string>());
+    const auto patterns =
+        dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "patterns", std::vector<std::string>());
     if (patterns.size() > 0) {
         libdnf5::comps::GroupQuery patterns_query(base->get_weak_ptr(), true);
-        const auto match_group_id = key_value_map_get<bool>(options, "match_group_id", true);
+        const auto match_group_id = dnfdaemon::key_value_map_get<bool>(options, "match_group_id", true);
         if (match_group_id) {
             libdnf5::comps::GroupQuery query_id(query);
             query_id.filter_groupid(patterns, libdnf5::sack::QueryCmp::IGLOB);
             patterns_query |= query_id;
         }
-        const auto match_group_name = key_value_map_get<bool>(options, "match_group_name", false);
+        const auto match_group_name = dnfdaemon::key_value_map_get<bool>(options, "match_group_name", false);
         if (match_group_name) {
             libdnf5::comps::GroupQuery query_name(query);
             query_name.filter_name(patterns, libdnf5::sack::QueryCmp::IGLOB);
@@ -154,12 +155,12 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
     }
 
     // filter hidden groups
-    const auto with_hidden = key_value_map_get<bool>(options, "with_hidden", false);
+    const auto with_hidden = dnfdaemon::key_value_map_get<bool>(options, "with_hidden", false);
     if (!with_hidden) {
         query.filter_uservisible(true);
     }
 
-    const auto scope = key_value_map_get<std::string>(options, "scope", "all");
+    const auto scope = dnfdaemon::key_value_map_get<std::string>(options, "scope", "all");
     if (scope == "installed") {
         query.filter_installed(true);
     } else if (scope == "available") {
@@ -181,7 +182,7 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
         throw sdbus::Error(dnfdaemon::ERROR, fmt::format("Unsupported scope for group filtering \"{}\".", scope));
     }
 
-    const auto contains_pkgs = key_value_map_get<std::vector<std::string>>(options, "contains_pkgs", {});
+    const auto contains_pkgs = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "contains_pkgs", {});
     if (!contains_pkgs.empty()) {
         query.filter_package_name(contains_pkgs, libdnf5::sack::QueryCmp::IGLOB);
     }
@@ -189,7 +190,7 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
     // create reply from the query
     dnfdaemon::KeyValueMapList out_groups;
     std::vector<std::string> attributes =
-        key_value_map_get<std::vector<std::string>>(options, "attributes", std::vector<std::string>{});
+        dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "attributes", std::vector<std::string>{});
     for (auto grp : query.list()) {
         out_groups.push_back(group_to_map(grp, attributes));
     }

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -95,7 +95,7 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
-    bool allow_erasing = key_value_map_get<bool>(options, "allow_erasing", false);
+    bool allow_erasing = dnfdaemon::key_value_map_get<bool>(options, "allow_erasing", false);
 
     session.fill_sack();
 
@@ -262,7 +262,7 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
 
     std::string comment;
     if (options.find("comment") != options.end()) {
-        comment = key_value_map_get<std::string>(options, "comment");
+        comment = dnfdaemon::key_value_map_get<std::string>(options, "comment");
     }
 
     transaction->set_callbacks(std::make_unique<dnf5daemon::DbusTransactionCB>(session));

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -253,7 +253,8 @@ dnfdaemon::KeyValueMap repo_to_map(
 }
 
 bool keyval_repo_compare(const dnfdaemon::KeyValueMap & first, const dnfdaemon::KeyValueMap & second) {
-    return key_value_map_get<std::string>(first, "id") < key_value_map_get<std::string>(second, "id");
+    return dnfdaemon::key_value_map_get<std::string>(first, "id") <
+           dnfdaemon::key_value_map_get<std::string>(second, "id");
 }
 
 }  // namespace
@@ -310,11 +311,12 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall & call) {
     const std::vector<std::string> empty_list{};
 
     // read options from dbus call
-    std::string enable_disable = key_value_map_get<std::string>(options, "enable_disable", "enabled");
-    std::vector<std::string> patterns = key_value_map_get<std::vector<std::string>>(options, "patterns", empty_list);
+    std::string enable_disable = dnfdaemon::key_value_map_get<std::string>(options, "enable_disable", "enabled");
+    std::vector<std::string> patterns =
+        dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "patterns", empty_list);
     // check demanded attributes
     std::vector<std::string> repo_attrs =
-        key_value_map_get<std::vector<std::string>>(options, "repo_attrs", empty_list);
+        dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "repo_attrs", empty_list);
     bool fill_sack_needed = false;
     for (auto & attr_str : repo_attrs) {
         if (repo_attributes.count(attr_str) == 0) {

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -168,7 +168,7 @@ void Rpm::dbus_register() {
 }
 
 std::vector<std::string> get_filter_patterns(dnfdaemon::KeyValueMap options, const std::string & option) {
-    auto filter_patterns = key_value_map_get<std::vector<std::string>>(options, option);
+    auto filter_patterns = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, option);
     if (filter_patterns.empty()) {
         throw sdbus::Error(dnfdaemon::ERROR, fmt::format("\"{}\" option expected an argument.", option));
     }
@@ -422,7 +422,7 @@ sdbus::MethodReply Rpm::downgrade(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
-    std::vector<std::string> repo_ids = key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
+    std::vector<std::string> repo_ids = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
     // fill the goal
     auto & goal = session.get_goal();
@@ -446,19 +446,20 @@ sdbus::MethodReply Rpm::install(sdbus::MethodCall & call) {
 
     libdnf5::GoalSetting skip_broken;
     if (options.find("skip_broken") != options.end()) {
-        skip_broken = key_value_map_get<bool>(options, "skip_broken") ? libdnf5::GoalSetting::SET_TRUE
-                                                                      : libdnf5::GoalSetting::SET_FALSE;
+        skip_broken = dnfdaemon::key_value_map_get<bool>(options, "skip_broken") ? libdnf5::GoalSetting::SET_TRUE
+                                                                                 : libdnf5::GoalSetting::SET_FALSE;
     } else {
         skip_broken = libdnf5::GoalSetting::AUTO;
     }
     libdnf5::GoalSetting skip_unavailable;
     if (options.find("skip_unavailable") != options.end()) {
-        skip_unavailable = key_value_map_get<bool>(options, "skip_unavailable") ? libdnf5::GoalSetting::SET_TRUE
-                                                                                : libdnf5::GoalSetting::SET_FALSE;
+        skip_unavailable = dnfdaemon::key_value_map_get<bool>(options, "skip_unavailable")
+                               ? libdnf5::GoalSetting::SET_TRUE
+                               : libdnf5::GoalSetting::SET_FALSE;
     } else {
         skip_unavailable = libdnf5::GoalSetting::AUTO;
     }
-    std::vector<std::string> repo_ids = key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
+    std::vector<std::string> repo_ids = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
     // fill the goal
     auto & goal = session.get_goal();
@@ -482,7 +483,7 @@ sdbus::MethodReply Rpm::upgrade(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
-    std::vector<std::string> repo_ids = key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
+    std::vector<std::string> repo_ids = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
     // fill the goal
     auto & goal = session.get_goal();
@@ -507,7 +508,7 @@ sdbus::MethodReply Rpm::reinstall(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
-    std::vector<std::string> repo_ids = key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
+    std::vector<std::string> repo_ids = dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
     // fill the goal
     auto & goal = session.get_goal();

--- a/dnf5daemon-server/services/rpm/rpm.hpp
+++ b/dnf5daemon-server/services/rpm/rpm.hpp
@@ -20,8 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5DAEMON_SERVER_SERVICES_RPM_RPM_HPP
 #define DNF5DAEMON_SERVER_SERVICES_RPM_RPM_HPP
 
+#include "dbus.hpp"
 #include "session.hpp"
 
+#include <libdnf5/rpm/package_query.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 class Rpm : public IDbusSessionService {
@@ -32,6 +34,8 @@ public:
     void dbus_deregister();
 
 private:
+    libdnf5::rpm::PackageQuery filter_packages(const dnfdaemon::KeyValueMap & options);
+
     sdbus::MethodReply list(sdbus::MethodCall & call);
     sdbus::MethodReply install(sdbus::MethodCall & call);
     sdbus::MethodReply upgrade(sdbus::MethodCall & call);
@@ -39,6 +43,8 @@ private:
     sdbus::MethodReply distro_sync(sdbus::MethodCall & call);
     sdbus::MethodReply downgrade(sdbus::MethodCall & call);
     sdbus::MethodReply reinstall(sdbus::MethodCall & call);
+
+    void list_fd(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -62,11 +62,11 @@ public:
 
     template <typename ItemType>
     ItemType session_configuration_value(const std::string & key, const ItemType & default_value) {
-        return key_value_map_get(session_configuration, key, default_value);
+        return dnfdaemon::key_value_map_get(session_configuration, key, default_value);
     }
     template <typename ItemType>
     ItemType session_configuration_value(const std::string & key) {
-        return key_value_map_get<ItemType>(session_configuration, key);
+        return dnfdaemon::key_value_map_get<ItemType>(session_configuration, key);
     }
 
     std::string get_object_path() { return object_path; };

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -44,6 +44,8 @@ public:
     virtual ~IDbusSessionService() = default;
     virtual void dbus_register() = 0;
 
+    Session & get_session() const noexcept { return session; }
+
 protected:
     Session & session;
 };

--- a/dnf5daemon-server/utils.cpp
+++ b/dnf5daemon-server/utils.cpp
@@ -1,0 +1,84 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "utils.hpp"
+
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+
+#include <array>
+#include <string>
+
+namespace dnfdaemon {
+
+bool write_to_fd(const std::string & message, int out_fd, std::string & error_msg) {
+    const size_t fd_buffer_size = fcntl(out_fd, F_GETPIPE_SZ);
+    // TODO(mblaha): make the timeout configurable
+    const int timeout = 30000;
+
+    std::array<pollfd, 1> pfds{};
+    pfds[0].fd = out_fd;
+    pfds[0].events = POLLOUT;
+
+    ssize_t total_bytes_written = 0;
+    ssize_t bytes_written = -1;
+    size_t bytes_remaining = message.size();
+
+    int ready = -1;
+    bool success = true;
+    while (bytes_remaining > 0 && success) {
+        ready = poll(pfds.data(), pfds.size(), timeout);
+        switch (ready) {
+            case -1:
+                // poll call failed
+                error_msg = "poll() call failed.";
+                success = false;
+                break;
+            case 0:
+                // timeout was reached
+                error_msg = "Timeout reached.";
+                success = false;
+                break;
+            default:
+                if ((pfds[0].revents & POLLOUT) != 0) {
+                    // file descriptor is ready for writing
+                    bytes_written =
+                        write(out_fd, message.data() + total_bytes_written, std::min(fd_buffer_size, bytes_remaining));
+                    if (bytes_written == -1) {
+                        if ((errno != EAGAIN && errno != EWOULDBLOCK)) {
+                            // error writing
+                            // e.g. the client has closed the read end of the pipe
+                            success = false;
+                            error_msg = "Error writing to the file descriptor.";
+                        }
+                    } else {
+                        total_bytes_written += bytes_written;
+                        bytes_remaining -= bytes_written;
+                    }
+                } else {
+                    success = false;
+                    error_msg = "File descriptor not ready for writing.";
+                }
+        }
+    }
+    return success;
+}
+
+}  // namespace dnfdaemon

--- a/dnf5daemon-server/utils.hpp
+++ b/dnf5daemon-server/utils.hpp
@@ -57,6 +57,13 @@ ItemType key_value_map_get(
     }
 }
 
+/// Write the message to the file descriptor opened for writing.
+/// @param Message
+/// @param out_fd Open file descriptor
+/// @param error_msg In case of error this string contains error description
+/// @return True in case the write succeeded, False otherwise.
+bool write_to_fd(const std::string & message, int out_fd, std::string & error_msg);
+
 }  // namespace dnfdaemon
 
 #endif

--- a/dnf5daemon-server/utils.hpp
+++ b/dnf5daemon-server/utils.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <string>
 
+namespace dnfdaemon {
 
 template <typename ItemType>
 ItemType key_value_map_get(const dnfdaemon::KeyValueMap & map, const std::string & key) {
@@ -55,5 +56,7 @@ ItemType key_value_map_get(
         throw sdbus::Error(dnfdaemon::ERROR, fmt::format("Map item \"{}\" has incorrect type.", key));
     }
 }
+
+}  // namespace dnfdaemon
 
 #endif

--- a/doc/dnf_daemon/examples/rpm_list_fd.py
+++ b/doc/dnf_daemon/examples/rpm_list_fd.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python3
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+This is an example how to use `list_fd()` method of dnf5daemon-server Rpm interface.
+"""
+
+import dbus
+import json
+import os
+import select
+import time
+
+DNFDAEMON_BUS_NAME = 'org.rpm.dnf.v0'
+DNFDAEMON_OBJECT_PATH = '/' + DNFDAEMON_BUS_NAME.replace('.', '/')
+
+IFACE_SESSION_MANAGER = '{}.SessionManager'.format(DNFDAEMON_BUS_NAME)
+IFACE_RPM = '{}.rpm.Rpm'.format(DNFDAEMON_BUS_NAME)
+
+
+def repoquery(iface_rpm, options):
+    """Generator function that yields packages as they arrive from the server."""
+
+    # create a pipe and pass the write end to the server
+    pipe_r, pipe_w = os.pipe()
+    # transfer id serves as an identifier of the pipe transfer for a signal emitted
+    # after server finish. This example does not use it.
+    iface_rpm.list_fd(options, pipe_w, "the_transfer_id")
+    # close the write end - otherwise poll cannot detect the end of transmission
+    os.close(pipe_w)
+
+    # decoder that will be used to parse incomming data
+    parser = json.JSONDecoder()
+
+    # prepare for polling
+    poller = select.poll()
+    poller.register(pipe_r, select.POLLIN)
+    # wait for data 10 secs at most
+    timeout = 10000
+    # 64k is a typical size of a pipe
+    buffer_size = 65536
+
+    # remaining string to parse (can contain unfinished json from previous run)
+    to_parse = ""
+    # remaining raw data (i.e. data before UTF decoding)
+    raw_data = b""
+    while True:
+        # wait for data
+        polled_event = poller.poll(timeout)
+        if not polled_event:
+            print("Timeout reached.")
+            break
+
+        # we know there is only one fd registered in poller
+        descriptor, event = polled_event[0]
+        # read a chunk of data
+        buffer = os.read(descriptor, buffer_size)
+        if not buffer:
+            # end of file
+            break
+
+        raw_data += buffer
+        try:
+            to_parse += raw_data.decode()
+            # decode successful, clear remaining raw data
+            raw_data = b""
+        except UnicodeDecodeError:
+            # Buffer size split data in the middle of multibyte UTF character.
+            # Need to read another chunk of data.
+            continue
+
+        # parse JSON objects from the string
+        while to_parse:
+            try:
+                # skip all chars till begin of next JSON objects (new lines mostly)
+                json_obj_start = to_parse.find('{')
+                obj, end = parser.raw_decode(to_parse[json_obj_start:])
+                yield obj
+                to_parse = to_parse[(json_obj_start+end):]
+            except json.decoder.JSONDecodeError as e:
+                # this is just example which assumes that every decode error
+                # means the data are incomplete (buffer size split the json
+                # object in the middle). So the handler does not do anything
+                # just break the parsing cycle and continue polling.
+                break
+
+    # finally close read end of the pipe
+    os.close(pipe_r)
+
+    # non-empty raw_data here means the raw_data.decode() failed
+    if raw_data:
+        raise Exception("Failed to decode part of received data.")
+
+    # non-empty to_parse here means there are some unfinished (or generally unparsable)
+    # JSON objects in the stream.
+    if to_parse:
+        raise Exception("Failed to parse part of received data.")
+
+
+bus = dbus.SystemBus()
+
+# open a new session with dnf5daemon-server
+iface_session = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, DNFDAEMON_OBJECT_PATH),
+    dbus_interface=IFACE_SESSION_MANAGER)
+session = iface_session.open_session(
+    dbus.Dictionary({}, signature=dbus.Signature('sv')))
+
+options = {
+    # retrieve all package attributes
+    "package_attrs": [
+        "name",
+        "epoch",
+        "version",
+        "release",
+        "arch",
+        "repo_id",
+        "from_repo_id",
+        "is_installed",
+        "install_size",
+        "download_size",
+        "sourcerpm",
+        "summary",
+        "url",
+        "license",
+        "description",
+        "files",
+        "changelogs",
+        "provides",
+        "requires",
+        "requires_pre",
+        "conflicts",
+        "obsoletes",
+        "recommends",
+        "suggests",
+        "enhances",
+        "supplements",
+        "evr",
+        "nevra",
+        "full_nevra",
+        "reason",
+        "vendor",
+    ],
+    # take all packages into account (other supported scopes are installed, available,
+    # upgrades, upgradable)
+    "scope": "all",
+    # get only packages with name starting with "a"
+    "patterns": ["a*"],
+    # return only the latest version for each name.arch
+    "latest-limit": 1,
+}
+iface_rpm = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, session),
+    dbus_interface=IFACE_RPM)
+
+
+i = 1
+for pkg in repoquery(iface_rpm, options):
+    print(i, pkg["nevra"])
+    i += 1


### PR DESCRIPTION
Adds new API `list_fd()` on `Rpm` interface.
This is an alternative to the original Rpm.list() method. It accepts the same 
input arguments and behaves the same way. The difference is that it uses a
file descriptor to transfer package data to the user.
It enables dnfdaemon to bypass D-Bus message size restrictions. The draw-back
is that the client has to implement reading from a pipe and parsing returned
JSON dictionaries with packages.

For: https://github.com/rpm-software-management/dnf5/issues/1139