### PR TITLE
Switch off deltarpm support

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -661,7 +661,7 @@ configuration.
     files, rebuilding them to RPM locally. However, this is quite CPU and I/O
     intensive.
 
-    Default: ``True``.
+    Default: ``False``.
 
 .. _deltarpm_percentage_options-label:
 

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -273,7 +273,7 @@ class ConfigMain::Impl {
     OptionBool proxy_sslverify{true};
     OptionString proxy_sslclientcert{""};
     OptionString proxy_sslclientkey{""};
-    OptionBool deltarpm{true};
+    OptionBool deltarpm{false};
     OptionNumber<std::uint32_t> deltarpm_percentage{75};
     OptionBool skip_if_unavailable{false};
 };


### PR DESCRIPTION
Aligning upstream code with Fedora 40 changes, where deltarpm support was discontinued.

Fixes: https://github.com/rpm-software-management/dnf5/issues/1185.