### PR TITLE
Hide/Remove deprecated methods

### DIFF
--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -69,9 +69,6 @@ void create_destdir_option(dnf5::Command & command);
 /// The values are stored in the `downloadonly` configuration option
 void create_downloadonly_option(dnf5::Command & command);
 
-/// Create the `--forcearch` option for a command provided as an argument.
-/// The values are stored in the `forcearch` configuration option
-[[deprecated("--forcearch is now a global argument")]] void create_forcearch_option(dnf5::Command & command);
 
 }  // namespace dnf5
 

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -63,41 +63,6 @@ void create_destdir_option(dnf5::Command & command) {
     command.get_argument_parser_command()->register_named_arg(destdir);
 }
 
-void create_forcearch_option(dnf5::Command & command) {
-    auto & ctx = command.get_context();
-    auto & parser = ctx.get_argument_parser();
-    auto forcearch = parser.add_new_named_arg("forcearch");
-    forcearch->set_long_name("forcearch");
-    forcearch->set_description("Force the use of a different architecture.");
-    forcearch->set_has_value(true);
-    forcearch->set_arg_value_help("FORCEARCH");
-    forcearch->set_parse_hook_func([&ctx](
-                                       [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
-                                       [[maybe_unused]] const char * option,
-                                       const char * value) {
-        auto supported_arches = libdnf5::rpm::get_supported_arches();
-        if (std::find(supported_arches.begin(), supported_arches.end(), value) == supported_arches.end()) {
-            std::string available_arches{};
-            auto it = supported_arches.begin();
-            if (it != supported_arches.end()) {
-                available_arches.append("\"" + *it + "\"");
-                ++it;
-                for (; it != supported_arches.end(); ++it) {
-                    available_arches.append(", \"" + *it + "\"");
-                }
-            }
-            throw libdnf5::cli::ArgumentParserInvalidValueError(
-                M_("Unsupported architecture \"{0}\". Please choose one from {1}"),
-                std::string(value),
-                available_arches);
-        }
-        ctx.base.get_config().get_ignorearch_option().set(libdnf5::Option::Priority::COMMANDLINE, true);
-        ctx.base.get_vars()->set("arch", value, libdnf5::Vars::Priority::COMMANDLINE);
-        return true;
-    });
-    command.get_argument_parser_command()->register_named_arg(forcearch);
-}
-
 void create_downloadonly_option(dnf5::Command & command) {
     auto & parser = command.get_context().get_argument_parser();
     auto downloadonly = parser.add_new_named_arg("downloadonly");

--- a/include/libdnf5/logger/factory.hpp
+++ b/include/libdnf5/logger/factory.hpp
@@ -27,16 +27,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
-// File logger destination filename.
-/// @deprecated The filename should be set by API user.
-constexpr const char * FILE_LOGGER_FILENAME = "dnf5.log";
-
-/// @deprecated It is going to be removed.
-/// @brief Helper method for creating a file logger.
-/// @param base Reference to Base for loading the configured logger path.
-/// @return Instance of a new file logger.
-std::unique_ptr<libdnf5::Logger> create_file_logger(libdnf5::Base & base);
-
 /// @brief Helper method for creating a file logger in `logdir` location with given file name.
 /// @param base Reference to Base for loading the configured logger path.
 /// @param filename Name of the log file.

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -150,20 +150,10 @@ public:
     bool is_in_sync();
 
     /// @deprecated It is going to be removed without a warning
-    /// Downloads repository metadata.
-    // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
-    void download_metadata(const std::string & destdir);
-
-    /// @deprecated It is going to be removed without a warning
     /// Loads the repository objects into sacks.
     ///
     /// Also writes the libsolv's solv/solvx cache files.
     void load();
-
-    /// Not API, unsupported
-    /// Append a rpm database into the system repository. The type of the repo must be Type::SYSTEM.
-    // TODO(jrohel) this will add packages with conflicting rpmdb ids, which will break some operations
-    void load_extra_system_repo(const std::string & rootdir);
 
     /// Returns whether the using of "includes" is enabled
     /// If enabled, only packages listed in the "includepkgs" will be used from the repository.
@@ -318,29 +308,6 @@ public:
     // @replaces libdnf:repo/Repo.hpp:method:Repo.getMirrors()
     std::vector<std::string> get_mirrors() const;
 
-    /// @deprecated It is redundant because repo class has direct access to Base and Vars
-    /// Sets substitutions. Substitutions are used to substitute variables in repository configuration.
-    // @replaces libdnf:repo/Repo.hpp:method:Repo.setSubstitutions(const std::map<std::string, std::string> & substitutions)
-    void set_substitutions(const std::map<std::string, std::string> & substitutions);
-
-    /// @deprecated It is going to be removed without a warning
-    /// Not API, unsupported
-    void add_libsolv_testcase(const std::string & path);
-
-    /// @deprecated It is going to be removed without a warning
-    /// Not API, unsupported
-    /// Adds an RPM package at `path` to the repository.
-    ///
-    /// If `with_hdrid` is `true`, the RPM is loaded with the
-    /// `RPM_ADD_WITH_HDRID | RPM_ADD_WITH_SHA256SUM` flags, meaning libsolv will
-    /// calculate the SHA256 checksum of the RPM header and store it. This adds
-    /// overhead but has the advantage of TODO(lukash) describe the advantage.
-    /// @param path The path to the RPM file.
-    /// @param with_hdrid If true, libsolv calculates header checksum and stores it.
-    /// @throws RepoRpmError if the RPM file can't be read or is corrupted.
-    /// @return PackageId of the added package.
-    libdnf5::rpm::Package add_rpm_package(const std::string & path, bool with_hdrid);
-
     libdnf5::repo::RepoWeakPtr get_weak_ptr();
 
     /// @return The `Base` object to which this object belongs.
@@ -358,6 +325,24 @@ private:
     friend class FileDownloader;
     friend class PackageDownloader;
     friend class solv::Pool;
+
+    /// Downloads repository metadata.
+    // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
+    void download_metadata(const std::string & destdir);
+
+    void add_libsolv_testcase(const std::string & path);
+
+    /// Adds an RPM package at `path` to the repository.
+    ///
+    /// If `with_hdrid` is `true`, the RPM is loaded with the
+    /// `RPM_ADD_WITH_HDRID | RPM_ADD_WITH_SHA256SUM` flags, meaning libsolv will
+    /// calculate the SHA256 checksum of the RPM header and store it. This adds
+    /// overhead but has the advantage of TODO(lukash) describe the advantage.
+    /// @param path The path to the RPM file.
+    /// @param with_hdrid If true, libsolv calculates header checksum and stores it.
+    /// @throws RepoRpmError if the RPM file can't be read or is corrupted.
+    /// @return PackageId of the added package.
+    libdnf5::rpm::Package add_rpm_package(const std::string & path, bool with_hdrid);
 
     void make_solv_repo();
 

--- a/libdnf5/logger/factory.cpp
+++ b/libdnf5/logger/factory.cpp
@@ -58,8 +58,4 @@ std::unique_ptr<libdnf5::Logger> create_rotating_file_logger(Base & base, const 
 }
 
 
-std::unique_ptr<libdnf5::Logger> create_file_logger(Base & base) {
-    return create_file_logger(base, FILE_LOGGER_FILENAME);
-}
-
 }  // namespace libdnf5

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -237,12 +237,6 @@ void Repo::load() {
     p_impl->loaded = true;
 }
 
-void Repo::load_extra_system_repo(const std::string & rootdir) {
-    libdnf_user_assert(p_impl->type == Type::SYSTEM, "repo type must be SYSTEM to load an extra system repo");
-    libdnf_user_assert(p_impl->solv_repo, "repo must be loaded to load an extra system repo");
-    p_impl->solv_repo->load_system_repo(rootdir);
-}
-
 void Repo::add_libsolv_testcase(const std::string & path) {
     make_solv_repo();
 
@@ -304,10 +298,6 @@ bool Repo::is_expired() const {
 
 int Repo::get_expires_in() const {
     return p_impl->config.get_metadata_expire_option().get_value() - static_cast<int>(get_age());
-}
-
-void Repo::set_substitutions(const std::map<std::string, std::string> & substitutions) {
-    p_impl->downloader->substitutions = substitutions;
 }
 
 std::string Repo::get_metadata_path(const std::string & metadata_type) {

--- a/test/libdnf5/logger/test_file_logger.cpp
+++ b/test/libdnf5/logger/test_file_logger.cpp
@@ -28,6 +28,7 @@ using namespace std::filesystem;
 
 CPPUNIT_TEST_SUITE_REGISTRATION(FileLoggerTest);
 
+constexpr const char * FILE_LOGGER_FILENAME = "dnf5.log";
 
 void FileLoggerTest::setUp() {
     BaseTestCase::setUp();
@@ -37,7 +38,7 @@ void FileLoggerTest::setUp() {
     auto temp_logdir = path("/var/log/FileLoggerTestLogDir");
     config.get_logdir_option().set(installroot / temp_logdir.relative_path());
 
-    full_log_path = installroot / temp_logdir.relative_path() / libdnf5::FILE_LOGGER_FILENAME;
+    full_log_path = installroot / temp_logdir.relative_path() / FILE_LOGGER_FILENAME;
 }
 
 
@@ -47,16 +48,9 @@ void FileLoggerTest::tearDown() {
 }
 
 
-void FileLoggerTest::test_file_logger_create() {
-    CPPUNIT_ASSERT(!exists(full_log_path));
-    auto file_logger = libdnf5::create_file_logger(base);
-    CPPUNIT_ASSERT(exists(full_log_path));
-}
-
-
 void FileLoggerTest::test_file_logger_create_name() {
     CPPUNIT_ASSERT(!exists(full_log_path));
-    auto file_logger = libdnf5::create_file_logger(base, libdnf5::FILE_LOGGER_FILENAME);
+    auto file_logger = libdnf5::create_file_logger(base, FILE_LOGGER_FILENAME);
     CPPUNIT_ASSERT(exists(full_log_path));
 }
 
@@ -64,7 +58,7 @@ void FileLoggerTest::test_file_logger_create_name() {
 void FileLoggerTest::test_file_logger_add() {
     auto log_router = base.get_logger();
     auto loggers_count_before = log_router->get_loggers_count();
-    auto file_logger = libdnf5::create_file_logger(base);
+    auto file_logger = libdnf5::create_file_logger(base, FILE_LOGGER_FILENAME);
     log_router->add_logger(std::move(file_logger));
     CPPUNIT_ASSERT_EQUAL(loggers_count_before + 1, log_router->get_loggers_count());
 }

--- a/test/libdnf5/logger/test_file_logger.hpp
+++ b/test/libdnf5/logger/test_file_logger.hpp
@@ -29,14 +29,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 class FileLoggerTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(FileLoggerTest);
-    CPPUNIT_TEST(test_file_logger_create);
     CPPUNIT_TEST(test_file_logger_add);
+    CPPUNIT_TEST(test_file_logger_create_name);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void setUp() override;
     void tearDown() override;
-    void test_file_logger_create();
     void test_file_logger_create_name();
     void test_file_logger_add();
 

--- a/test/libdnf5/rpm/test_package_query.cpp
+++ b/test/libdnf5/rpm/test_package_query.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_package_query.hpp"
 
+#include "../shared/private_accessor.hpp"
 #include "../shared/utils.hpp"
 
 #include <libdnf5/rpm/package_query.hpp>
@@ -35,6 +36,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageQueryTest);
 using namespace libdnf5::rpm;
 
 namespace {
+
+create_private_getter_template;
+create_getter(add_rpm_package, &libdnf5::repo::Repo::add_rpm_package);
 
 // make constructor public so we can create Package instances in the tests
 class TestPackage : public Package {
@@ -347,7 +351,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     add_repo_solv("solv-repo1");
 
     std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    repo_sack->get_system_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
+    (*(repo_sack->get_system_repo()).*get(add_rpm_package{}))(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
     add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);
@@ -447,7 +451,7 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
     add_repo_solv("solv-repo1");
 
     std::string rpm_path = "cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    repo_sack->get_system_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
+    (*(repo_sack->get_system_repo()).*get(add_rpm_package{}))(PROJECT_BINARY_DIR "/test/data/" + rpm_path, false);
     add_cmdline_pkg(rpm_path);
 
     PackageQuery query1(base);

--- a/test/python3/libdnf5/logger/test_file_logger.py
+++ b/test/python3/libdnf5/logger/test_file_logger.py
@@ -22,6 +22,8 @@ import base_test_case
 import os
 import shutil
 
+FILE_LOGGER_FILENAME = "dnf5.log"
+
 
 class TestFileLogger(base_test_case.BaseTestCase):
     def setUp(self):
@@ -29,28 +31,23 @@ class TestFileLogger(base_test_case.BaseTestCase):
         config = self.base.get_config()
         config.logdir = os.path.join(
             config.installroot, "FileLoggerTestLogDir")
-        self.full_log_path = os.path.join(
-            config.logdir, libdnf5.logger.FILE_LOGGER_FILENAME)
+        self.full_log_path = os.path.join(config.logdir, FILE_LOGGER_FILENAME)
 
     def tearDown(self):
         super().tearDown()
         shutil.rmtree(os.path.dirname(self.full_log_path), ignore_errors=True)
 
-    def test_file_logger_create(self):
-        self.assertFalse(os.path.exists(self.full_log_path))
-        _ = libdnf5.logger.create_file_logger(self.base)
-        self.assertTrue(os.path.exists(self.full_log_path))
-
     def test_file_logger_create_name(self):
         self.assertFalse(os.path.exists(self.full_log_path))
         _ = libdnf5.logger.create_file_logger(
-            self.base, libdnf5.logger.FILE_LOGGER_FILENAME)
+            self.base, FILE_LOGGER_FILENAME)
         self.assertTrue(os.path.exists(self.full_log_path))
 
     def test_file_logger_add(self):
         log_router = self.base.get_logger()
         loggers_count_before = log_router.get_loggers_count()
-        logger = libdnf5.logger.create_file_logger(self.base)
+        logger = libdnf5.logger.create_file_logger(self.base,
+                                                   FILE_LOGGER_FILENAME)
         log_router.add_logger(logger)
         self.assertEqual(loggers_count_before + 1,
                          log_router.get_loggers_count())
@@ -59,7 +56,8 @@ class TestFileLogger(base_test_case.BaseTestCase):
         log_router = self.base.get_logger()
         global_logger = libdnf5.logger.GlobalLogger()
         global_logger.set(log_router.get(), libdnf5.logger.Logger.Level_DEBUG)
-        logger = libdnf5.logger.create_file_logger(self.base)
+        logger = libdnf5.logger.create_file_logger(self.base,
+                                                   FILE_LOGGER_FILENAME)
         log_router.add_logger(logger)
 
         # Run an action including librepo logging

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -93,13 +93,3 @@ class TestRepo(base_test_case.BaseTestCase):
         self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
         self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)
-
-    def test_load_extra_system_repo_incorrectly(self):
-        # Try to load extra system repo on non-system repo
-        repo = self.repo_sack.create_repo('test')
-        self.assertRaises(
-            RuntimeError, repo.load_extra_system_repo, 'some-root-dir')
-
-        # Try to load extra system repo on non-loaded repo
-        repo = self.repo_sack.get_system_repo()
-        self.assertRaises(RuntimeError, repo.load_extra_system_repo, 'dir')

--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -183,6 +183,7 @@ namespace {
 // Accessor of private Base::p_impl, see private_accessor.hpp
 create_private_getter_template;
 create_getter(priv_impl, &libdnf5::Base::p_impl);
+create_getter(add_rpm_package, &libdnf5::repo::Repo::add_rpm_package);
 
 }  // namespace
 
@@ -197,7 +198,8 @@ libdnf5::rpm::Package BaseTestCase::add_system_pkg(
 
     (base.*get(priv_impl()))->get_system_state().set_package_reason(na, reason);
 
-    return repo_sack->get_system_repo()->add_rpm_package(PROJECT_BINARY_DIR "/test/data/" + relative_path, false);
+    return (*(repo_sack->get_system_repo()).*get(add_rpm_package{}))(
+        PROJECT_BINARY_DIR "/test/data/" + relative_path, false);
 }
 
 


### PR DESCRIPTION
There is still public `libdnf5::repo::Repo::load()` which is marked as deprecated but it
cannot be easily hidden because dnfdaemon uses it as well.

@j-mracek since you originally marked it as deprecated do we want to keep the `load()` method or do we need to do some bigger changes to hide it?

For: https://github.com/rpm-software-management/dnf5/issues/1091