### PR TITLE
automatic: Skip network availability check without remote repo

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -175,6 +175,11 @@ void AutomaticCommand::wait_for_network() {
     }
     curl_url_cleanup(url);
 
+    if (addresses.size() == 0) {
+        // do not have any address to check availability for
+        return;
+    }
+
     while (std::chrono::system_clock::now() < time_end) {
         for (auto const & [host, service] : addresses) {
             if (server_available(host, service)) {


### PR DESCRIPTION
Network availability check uses remote repository URLs. If there is no
remote repository, skip the check.
This speeds up `dnf5 automatic` CI tests greatly because it skips
default 60 seconds timeout.