### PR TITLE
dnf5daemon: Introspection files revision

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -186,7 +186,7 @@ BuildRequires:  libcurl-devel >= 7.62.0
 
 %if %{with dnf5daemon_server}
 # required for dnf5daemon-server
-BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
+BuildRequires:  pkgconfig(sdbus-c++) >= 0.9.0
 BuildRequires:  systemd-rpm-macros
 %if %{with dnf5daemon_tests}
 BuildRequires:  dbus-daemon

--- a/dnf5daemon-client/CMakeLists.txt
+++ b/dnf5daemon-client/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(.)
 # TODO(mblaha) workaround for dnf5daemon-client using server's headers, fix
 include_directories(..)
 
-pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++)
+pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++>=0.9.0)
 
 add_executable(${DNF5DAEMON_CLIENT_BIN} ${DNF5DAEMON_CLIENT_SOURCES})
 

--- a/dnf5daemon-server/CMakeLists.txt
+++ b/dnf5daemon-server/CMakeLists.txt
@@ -11,7 +11,7 @@ add_definitions(-DGETTEXT_DOMAIN=\"${GETTEXT_DOMAIN}\")
 
 include_directories(.)
 
-pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++)
+pkg_check_modules(SDBUS_CPP REQUIRED sdbus-c++>=0.9.0)
 find_package(Threads)
 
 add_executable(${DNF5DAEMON_SERVER_BIN} ${DNF5DAEMON_SERVER_SOURCES})

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -81,7 +81,7 @@ int DownloadCB::progress(void * user_cb_data, double total_to_download, double d
 int DownloadCB::end(void * user_cb_data, TransferStatus status, const char * msg) {
     try {
         auto signal = create_signal_download(dnfdaemon::SIGNAL_DOWNLOAD_END, user_cb_data);
-        signal << static_cast<int>(status);
+        signal << static_cast<uint32_t>(status);
         signal << msg;
         dbus_object->emitSignal(signal);
     } catch (...) {
@@ -131,7 +131,7 @@ void DbusTransactionCB::install_start(const libdnf5::rpm::TransactionItem & item
         action = dnfdaemon::transaction_package_to_action(item);
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_START, item.get_package().get_full_nevra());
-        signal << static_cast<int>(action);
+        signal << static_cast<uint32_t>(action);
         signal << total;
         dbus_object->emitSignal(signal);
     } catch (...) {
@@ -171,7 +171,7 @@ void DbusTransactionCB::script_start(
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START, to_full_nevra_string(nevra));
-        signal << static_cast<int>(type);
+        signal << static_cast<uint32_t>(type);
         dbus_object->emitSignal(signal);
     } catch (...) {
     }
@@ -185,7 +185,7 @@ void DbusTransactionCB::script_stop(
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_STOP, to_full_nevra_string(nevra));
-        signal << static_cast<int>(type);
+        signal << static_cast<uint32_t>(type);
         signal << return_code;
         dbus_object->emitSignal(signal);
     } catch (...) {
@@ -211,7 +211,7 @@ void DbusTransactionCB::script_error(
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_ERROR, to_full_nevra_string(nevra));
-        signal << static_cast<int>(type);
+        signal << static_cast<uint32_t>(type);
         signal << return_code;
         dbus_object->emitSignal(signal);
     } catch (...) {

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -101,6 +101,26 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="message" type="s" />
     </signal>
 
+    <!--
+        repo_key_import_request:
+        @session_object_path: object path of the dnf5daemon session
+        @key_id: PGP key id
+        @user_ids: User id
+        @key_fingerprint: Fingerprint of the PGP key
+        @key_url: URL of the PGP key
+        @timestamp: timestamp when the key was created
+
+        Request for repository key import confirmation.
+    -->
+    <signal name="repo_key_import_request">
+        <arg name="session_object_path" type="o" />
+        <arg name="key_id" type="s" />
+        <arg name="user_ids" type="as" />
+        <arg name="key_fingerprint" type="s" />
+        <arg name="key_url" type="s" />
+        <arg name="timestamp" type="x" />
+    </signal>
+
 </interface>
 
 </node>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -27,12 +27,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 <interface name="org.rpm.dnf.v0.Base">
     <!--
         read_all_repos:
-        @retval: `true` if repositories were successfully loaded, `false` otherwise.
+        @success: `true` if repositories were successfully loaded, `false` otherwise.
 
         Explicitly ask for loading repositories metadata.
     -->
     <method name="read_all_repos">
-        <arg name="retval" type="b" direction="out"/>
+        <arg name="success" type="b" direction="out"/>
     </method>
 
     <!--
@@ -68,7 +68,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     </signal>
 
     <!--
-        mirror_failure:
+        download_mirror_failure:
         @session_object_path: object path of the dnf5daemon session
         @download_id: unique id of downloaded object (repo or package)
         @message: an error message
@@ -77,7 +77,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
         Mirror failure during the download.
     -->
-    <signal name="mirror_failure">
+    <signal name="download_mirror_failure">
         <arg name="session_object_path" type="o" />
         <arg name="download_id" type="s" />
         <arg name="message" type="s" />
@@ -89,7 +89,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         download_end:
         @session_object_path: object path of the dnf5daemon session
         @download_id: unique id of downloaded object (repo or package)
-        @status: libdnf5::repo::DownloadCallbacks::TransferStatus (0 - successful, 1 - already exists, 2 - error)
+        @transfer_status: libdnf5::repo::DownloadCallbacks::TransferStatus (0 - successful, 1 - already exists, 2 - error)
         @error: error message in case of failed download
 
         Downloading has ended.
@@ -97,28 +97,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <signal name="download_end">
         <arg name="session_object_path" type="o" />
         <arg name="download_id" type="s" />
-        <arg name="status" type="i" />
+        <arg name="transfer_status" type="u" />
         <arg name="message" type="s" />
-    </signal>
-
-    <!--
-        repo_key_import_request:
-        @session_object_path: object path of the dnf5daemon session
-        @key_id: PGP key id
-        @user_ids: User id
-        @key_fingerprint: Fingerprint of the PGP key
-        @key_url: URL of the PGP key
-        @timestamp: timestamp when the key was created
-
-        Request for repository key import confirmation.
-    -->
-    <signal name="repo_key_import_request">
-        <arg name="session_object_path" type="o" />
-        <arg name="key_id" type="s" />
-        <arg name="user_ids" type="as" />
-        <arg name="key_fingerprint" type="s" />
-        <arg name="key_url" type="s" />
-        <arg name="timestamp" type="x" />
     </signal>
 
 </interface>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -90,7 +90,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         @session_object_path: object path of the dnf5daemon session
         @download_id: unique id of downloaded object (repo or package)
         @transfer_status: libdnf5::repo::DownloadCallbacks::TransferStatus (0 - successful, 1 - already exists, 2 - error)
-        @error: error message in case of failed download
+        @message: error message in case of failed download
 
         Downloading has ended.
     -->

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -72,7 +72,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         solver_problems - problems reported by underlying libsolv
     -->
     <method name="get_transaction_problems">
-        <arg name="problems" type="a{sv}" direction="out" />
+        <arg name="problems" type="aa{sv}" direction="out" />
     </method>
 
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
@@ -27,7 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 <interface name="org.rpm.dnf.v0.SessionManager">
     <!--
         open_session:
-        @configuration: session configuration - an array of key/value pairs
+        @options: session configuration - an array of key/value pairs
         @session_object_path: object path to created Session object
 
         Opens a new session.

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
@@ -28,7 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <!--
         open_session:
         @configuration: session configuration - an array of key/value pairs
-        @path: object path to created Session object
+        @session_object_path: object path to created Session object
 
         Opens a new session.
 
@@ -49,19 +49,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     -->
     <method name="open_session">
         <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="path" type="o" direction="out"/>
+        <arg name="session_object_path" type="o" direction="out"/>
     </method>
 
     <!--
         close_session:
-        @path: object path of session to close
-        @result: bool whether the requested session was successfully closed
+        @session_object_path: object path of session to close
+        @success: bool whether the requested session was successfully closed
 
         Close session on given object path.
     -->
     <method name="close_session">
-        <arg name="path" type="o" direction="in" />
-        <arg name="result" type="b" direction="out" />
+        <arg name="session_object_path" type="o" direction="in" />
+        <arg name="success" type="b" direction="out" />
     </method>
 
 </interface>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
@@ -80,26 +80,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="repo_ids" type="as" direction="in"/>
     </method>
 
-    <!--
-        repo_key_import_request:
-        @session_object_path: object path of the dnf5daemon session
-        @key_id: PGP key id
-        @user_ids: User id
-        @key_fingerprint: Fingerprint of the PGP key
-        @key_url: URL of the PGP key
-        @timestamp: timestamp when the key was created
-
-        Request for repository key import confirmation.
-    -->
-    <signal name="repo_key_import_request">
-        <arg name="session_object_path" type="o" />
-        <arg name="key_id" type="s" />
-        <arg name="user_ids" type="as" />
-        <arg name="key_fingerprint" type="s" />
-        <arg name="key_url" type="s" />
-        <arg name="timestamp" type="x" />
-    </signal>
-
 </interface>
 
 </node>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
@@ -28,7 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <!--
         list:
         @options: an array of key/value pairs
-        @data: array of returned repositories with requested attributes
+        @repositories: array of returned repositories with requested attributes
 
         Get list of repositories that match to given filters.
 
@@ -45,7 +45,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     -->
     <method name="list">
         <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="data" type="aa{sv}" direction="out"/>
+        <arg name="repositories" type="aa{sv}" direction="out"/>
     </method>
 
     <!--
@@ -53,7 +53,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         @key_id: id of the key in question
         @confirmed: whether the key import is confirmed by user
 
-        Get list of repositories that match to given filters.
+        Confirm repository PGP key import.
     -->
     <method name="confirm_key">
         <arg name="key_id" type="s" direction="in"/>
@@ -62,23 +62,43 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
     <!--
         enable:
-        @ids: array of strings containing all repo ids to be enabled
+        @repo_ids: array of strings containing all repo ids to be enabled
 
         Enable repositories based on the list of given ids.
     -->
     <method name="enable">
-        <arg name="ids" type="as" direction="in"/>
+        <arg name="repo_ids" type="as" direction="in"/>
     </method>
 
     <!--
         disable:
-        @ids: array of strings containing all repo ids to be disabled
+        @repo_ids: array of strings containing all repo ids to be disabled
 
         Disable repositories based on the list of given ids.
     -->
     <method name="disable">
-        <arg name="ids" type="as" direction="in"/>
+        <arg name="repo_ids" type="as" direction="in"/>
     </method>
+
+    <!--
+        repo_key_import_request:
+        @session_object_path: object path of the dnf5daemon session
+        @key_id: PGP key id
+        @user_ids: User id
+        @key_fingerprint: Fingerprint of the PGP key
+        @key_url: URL of the PGP key
+        @timestamp: timestamp when the key was created
+
+        Request for repository key import confirmation.
+    -->
+    <signal name="repo_key_import_request">
+        <arg name="session_object_path" type="o" />
+        <arg name="key_id" type="s" />
+        <arg name="user_ids" type="as" />
+        <arg name="key_fingerprint" type="s" />
+        <arg name="key_url" type="s" />
+        <arg name="timestamp" type="x" />
+    </signal>
 
 </interface>
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -28,7 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <!--
         list:
         @options: an array of key/value pairs
-        @data: array of returned packages with requested attributes
+        @packages: array of returned packages with requested attributes
 
         Get list of packages that match to given filters.
 
@@ -83,15 +83,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     -->
     <method name="list">
         <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="data" type="aa{sv}" direction="out"/>
+        <arg name="packages" type="aa{sv}" direction="out"/>
     </method>
 
     <!--
         install:
-        @specs: an array of package specifications to be installed on the system
+        @pkg_specs: an array of package specifications to be installed on the system
         @options: an array of key/value pairs to modify install behavior
 
-        Mark packages specified by @specs for installation.
+        Mark packages specified by @pkg_specs for installation.
 
         Following @options are supported:
 
@@ -105,16 +105,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Unknown options are ignored.
     -->
     <method name="install">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
         upgrade:
-        @specs: an array of package specifications to be upgraded on the system
+        @pkg_specs: an array of package specifications to be upgraded on the system
         @options: an array of key/value pairs to modify upgrade behavior
 
-        Mark packages specified by @specs for upgrade.
+        Mark packages specified by @pkg_specs for upgrade.
 
         Following @options are supported:
 
@@ -124,27 +124,27 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Unknown options are ignored.
     -->
     <method name="upgrade">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
         remove:
-        @specs: an array of package specifications to be removed on the system
+        @pkg_specs: an array of package specifications to be removed on the system
         @options: an array of key/value pairs to modify remove behavior
 
-        Mark packages specified by @specs for removal.
+        Mark packages specified by @pkg_specs for removal.
 
         Unknown options are ignored.
     -->
     <method name="remove">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
         distro_sync:
-        @specs: array of package specifications to synchronize to the latest available versions
+        @pkg_specs: array of package specifications to synchronize to the latest available versions
         @options: an array of key/value pairs to modify distro_sync behavior
 
         Following @options are supported:
@@ -152,51 +152,69 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Unknown options are ignored.
     -->
     <method name="distro_sync">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
         downgrade:
-        @specs: an array of package specifications to be downgraded on the system
+        @pkg_specs: an array of package specifications to be downgraded on the system
         @options: an array of key/value pairs to modify downgrade behavior
 
-        Mark packages specified by @specs for downgrade.
+        Mark packages specified by @pkg_specs for downgrade.
 
         Following @options are supported:
 
         Unknown options are ignored.
     -->
     <method name="downgrade">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
         reinstall:
-        @specs: an array of package specifications to be reinstalled on the system
+        @pkg_specs: an array of package specifications to be reinstalled on the system
         @options: an array of key/value pairs to modify reinstall behavior
 
-        Mark packages specified by @specs for reinstall.
+        Mark packages specified by @pkg_specs for reinstall.
 
         Following @options are supported:
 
         Unknown options are ignored.
     -->
     <method name="reinstall">
-        <arg name="specs" type="as" direction="in" />
+        <arg name="pkg_specs" type="as" direction="in" />
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
     <!--
+        transaction_elem_progress:
+        @session_object_path: object path of the dnf5daemon session
+        @nevra: full NEVRA of the package
+        @processed: amount already processed
+        @total: total to process
+
+        Overall progress in transaction item processing. Called right before an item is processed.
+    -->
+    <signal name="transaction_elem_progress">
+        <arg name="session_object_path" type="o" />
+        <arg name="nevra" type="s" />
+        <arg name="processed" type="t" />
+        <arg name="total" type="t" />
+    </signal>
+
+    <!--
         transaction_action_start:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package
         @action: one of the dnfdaemon::RpmTransactionItem::Actions enum
         @total: total to process
 
-        Processing of the item has started.
+        Processing (installation or removal) of the package has started.
     -->
     <signal name="transaction_action_start">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
         <arg name="action" type="u" />
         <arg name="total" type="t" />
@@ -204,104 +222,165 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
     <!--
         transaction_action_progress:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package
-        @amount: amount already processed
+        @processed: amount already processed
         @total: total to process
 
         Progress in processing of the package.
     -->
     <signal name="transaction_action_progress">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
-        <arg name="amount" type="t" />
+        <arg name="processed" type="t" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_action_stop:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package
         @total: total processed
 
-        Processing of the item has finished.
+        Processing of the package has finished.
     -->
     <signal name="transaction_action_stop">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_script_start:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package script belongs to
+        @scriptlet_type: scriptlet type that started (pre, post,...)
 
         The scriptlet has started.
     -->
     <signal name="transaction_script_start">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
+        <arg name="scriptlet_type" type="u" />
     </signal>
 
     <!--
         transaction_script_stop:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package script belongs to
+        @scriptlet_type: scriptlet type that started (pre, post,...)
         @return_code: return value of the script
 
         The scriptlet has successfully finished.
     -->
     <signal name="transaction_script_stop">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
+        <arg name="scriptlet_type" type="u" />
         <arg name="return_code" type="t" />
     </signal>
 
     <!--
         transaction_script_error:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package script belongs to
+        @scriptlet_type: scriptlet type that started (pre, post,...)
         @return_code: return value of the script
 
         The scriptlet has finished with an error.
     -->
     <signal name="transaction_script_error">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
+        <arg name="scriptlet_type" type="u" />
         <arg name="return_code" type="t" />
     </signal>
 
     <!--
         transaction_verify_start:
+        @session_object_path: object path of the dnf5daemon session
         @total: total to process
 
         Package files verification has started.
     -->
     <signal name="transaction_verify_start">
+        <arg name="session_object_path" type="o" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_verify_progress:
-        @nevra: full NEVRA of the package
-        @amount: amount already processed
+        @session_object_path: object path of the dnf5daemon session
+        @processed: amount already processed
         @total: total to process
 
         Progress in processing of the package.
     -->
     <signal name="transaction_verify_progress">
-        <arg name="amount" type="t" />
+        <arg name="session_object_path" type="o" />
+        <arg name="processed" type="t" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_verify_stop:
-        @nevra: full NEVRA of the package
+        @session_object_path: object path of the dnf5daemon session
+        @total: total to process
 
         Package files verification has finished.
     -->
     <signal name="transaction_verify_stop">
+        <arg name="session_object_path" type="o" />
+        <arg name="total" type="t" />
+    </signal>
+
+    <!--
+        transaction_transaction_start:
+        @session_object_path: object path of the dnf5daemon session
+        @total: total to process
+
+        Preparation of transaction packages has started.
+    -->
+    <signal name="transaction_transaction_start">
+        <arg name="session_object_path" type="o" />
+        <arg name="total" type="t" />
+    </signal>
+
+    <!--
+        transaction_transaction_progress:
+        @session_object_path: object path of the dnf5daemon session
+        @processed: amount already processed
+        @total: total to process
+
+        Progress in preparation of transaction packages.
+    -->
+    <signal name="transaction_transaction_progress">
+        <arg name="session_object_path" type="o" />
+        <arg name="processed" type="t" />
+        <arg name="total" type="t" />
+    </signal>
+
+    <!--
+        transaction_transaction_stop:
+        @session_object_path: object path of the dnf5daemon session
+        @total: total to process
+
+        Preparation of transaction packages has finished.
+    -->
+    <signal name="transaction_transaction_stop">
+        <arg name="session_object_path" type="o" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_unpack_error:
+        @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package
 
         Error while unpacking the package.
     -->
     <signal name="transaction_unpack_error">
+        <arg name="session_object_path" type="o" />
         <arg name="nevra" type="s" />
     </signal>
 </interface>

--- a/dnf5daemon-server/services/advisory/advisory.cpp
+++ b/dnf5daemon-server/services/advisory/advisory.cpp
@@ -31,9 +31,16 @@ namespace dnfdaemon {
 
 void Advisory::dbus_register() {
     auto dbus_object = session.get_dbus_object();
-    dbus_object->registerMethod(INTERFACE_ADVISORY, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-        session.get_threads_manager().handle_method(*this, &Advisory::list, call, session.session_locale);
-    });
+    dbus_object->registerMethod(
+        INTERFACE_ADVISORY,
+        "list",
+        "a{sv}",
+        {"options"},
+        "aa{sv}",
+        {"advisories"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Advisory::list, call, session.session_locale);
+        });
 }
 
 libdnf5::advisory::AdvisoryQuery Advisory::advisory_query_from_options(

--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -34,7 +34,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 void Base::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_BASE, "read_all_repos", "", {}, "b", {"result"}, [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_BASE, "read_all_repos", "", {}, "b", {"success"}, [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Base::read_all_repos, call, session.session_locale);
         });
 
@@ -51,7 +51,7 @@ void Base::dbus_register() {
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_DOWNLOAD_END,
-        "osis",
+        "osus",
         {"session_object_path", "download_id", "transfer_status", "message"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,

--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -58,6 +58,11 @@ void Base::dbus_register() {
         dnfdaemon::SIGNAL_DOWNLOAD_MIRROR_FAILURE,
         "ossss",
         {"session_object_path", "download_id", "message", "url", "metadata"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_BASE,
+        dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST,
+        "osasssx",
+        {"session_object_path", "key_id", "user_ids", "key_fingerprint", "key_url", "timestamp"});
 }
 
 sdbus::MethodReply Base::read_all_repos(sdbus::MethodCall & call) {

--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -34,14 +34,30 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 void Base::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_BASE, "read_all_repos", "", "b", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_BASE, "read_all_repos", "", {}, "b", {"result"}, [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Base::read_all_repos, call, session.session_locale);
         });
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_REPO, dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST, "ossssx");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_ADD_NEW, "os");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_PROGRESS, "ott");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_END, "o");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_DOWNLOAD_MIRROR_FAILURE, "o");
+
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_BASE,
+        dnfdaemon::SIGNAL_DOWNLOAD_ADD_NEW,
+        "ossx",
+        {"session_object_path", "download_id", "description", "total_to_download"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_BASE,
+        dnfdaemon::SIGNAL_DOWNLOAD_PROGRESS,
+        "osxx",
+        {"session_object_path", "download_id", "total_to_download", "downloaded"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_BASE,
+        dnfdaemon::SIGNAL_DOWNLOAD_END,
+        "osis",
+        {"session_object_path", "download_id", "transfer_status", "message"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_BASE,
+        dnfdaemon::SIGNAL_DOWNLOAD_MIRROR_FAILURE,
+        "ossss",
+        {"session_object_path", "download_id", "message", "url", "metadata"});
 }
 
 sdbus::MethodReply Base::read_all_repos(sdbus::MethodCall & call) {

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -48,21 +48,45 @@ void Goal::dbus_register() {
     // TODO(mblaha) Adjust resolve method to accommodate also groups, environments,
     // and modules as part of the transaction
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_GOAL, "resolve", "a{sv}", "a(sssa{sv}a{sv})u", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_GOAL,
+        "resolve",
+        "a{sv}",
+        {"options"},
+        "a(sssa{sv}a{sv})u",
+        {"transaction_items", "result"},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Goal::resolve, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_GOAL, "get_transaction_problems_string", "", "as", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_GOAL,
+        "get_transaction_problems_string",
+        "",
+        {},
+        "as",
+        {"problems"},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(
                 *this, &Goal::get_transaction_problems_string, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_GOAL, "get_transaction_problems", "", "a{sv}", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_GOAL,
+        "get_transaction_problems",
+        "",
+        {},
+        "aa{sv}",
+        {"problems"},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(
                 *this, &Goal::get_transaction_problems, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_GOAL, "do_transaction", "a{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_GOAL,
+        "do_transaction",
+        "a{sv}",
+        {"options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Goal::do_transaction, call, session.session_locale);
         });
 }

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -288,12 +288,6 @@ void Repo::dbus_register() {
         dnfdaemon::INTERFACE_REPO, "disable", "as", {"repo_ids"}, "", {}, [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Repo::disable, call, session.session_locale);
         });
-
-    dbus_object->registerSignal(
-        dnfdaemon::INTERFACE_REPO,
-        dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST,
-        "osasssx",
-        {"session_object_path", "key_id", "user_ids", "key_fingerprint", "key_url", "timestamp"});
 }
 
 sdbus::MethodReply Repo::confirm_key(sdbus::MethodCall & call) {

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -261,19 +261,39 @@ bool keyval_repo_compare(const dnfdaemon::KeyValueMap & first, const dnfdaemon::
 void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_REPO, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_REPO,
+        "list",
+        "a{sv}",
+        {"options"},
+        "aa{sv}",
+        {"repositories"},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Repo::list, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_REPO, "confirm_key", "sb", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_REPO,
+        "confirm_key",
+        "sb",
+        {"key_id", "confirmed"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Repo::confirm_key, call);
         });
-    dbus_object->registerMethod(dnfdaemon::INTERFACE_REPO, "enable", "as", "", [this](sdbus::MethodCall call) -> void {
-        session.get_threads_manager().handle_method(*this, &Repo::enable, call, session.session_locale);
-    });
-    dbus_object->registerMethod(dnfdaemon::INTERFACE_REPO, "disable", "as", "", [this](sdbus::MethodCall call) -> void {
-        session.get_threads_manager().handle_method(*this, &Repo::disable, call, session.session_locale);
-    });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_REPO, "enable", "as", {"repo_ids"}, "", {}, [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Repo::enable, call, session.session_locale);
+        });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_REPO, "disable", "as", {"repo_ids"}, "", {}, [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Repo::disable, call, session.session_locale);
+        });
+
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_REPO,
+        dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST,
+        "osasssx",
+        {"session_object_path", "key_id", "user_ids", "key_fingerprint", "key_url", "timestamp"});
 }
 
 sdbus::MethodReply Repo::confirm_key(sdbus::MethodCall & call) {

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -34,42 +34,137 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 void Rpm::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "distro_sync", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "distro_sync",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::distro_sync, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "downgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "downgrade",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::downgrade, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "list",
+        "a{sv}",
+        {"options"},
+        "aa{sv}",
+        {"packages"},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::list, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "install", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "install",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::install, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "upgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "upgrade",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::upgrade, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "reinstall", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "reinstall",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::reinstall, call, session.session_locale);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_RPM, "remove", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_RPM,
+        "remove",
+        "asa{sv}",
+        {"pkg_specs", "options"},
+        "",
+        {},
+        [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Rpm::remove, call, session.session_locale);
         });
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_START, "osut");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_PROGRESS, "ostt");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_STOP, "ost");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START, "osu");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_STOP, "osut");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_ERROR, "osut");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_START, "ot");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_PROGRESS, "ott");
-    dbus_object->registerSignal(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_STOP, "ot");
+
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_ELEM_PROGRESS,
+        "ostt",
+        {"session_object_path", "nevra", "processed", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_ACTION_START,
+        "osut",
+        {"session_object_path", "nevra", "action", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_ACTION_PROGRESS,
+        "ostt",
+        {"session_object_path", "nevra", "processed", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_ACTION_STOP,
+        "ost",
+        {"session_object_path", "nevra", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START,
+        "osu",
+        {"session_object_path", "nevra", "scriptlet_type"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_STOP,
+        "osut",
+        {"session_object_path", "nevra", "scriptlet_type", "return_code"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_ERROR,
+        "osut",
+        {"session_object_path", "nevra", "scriptlet_type", "return_code"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_START, "ot", {"session_object_path", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_VERIFY_PROGRESS,
+        "ott",
+        {"session_object_path", "processed", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_STOP, "ot", {"session_object_path", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_START,
+        "ot",
+        {"session_object_path", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_PROGRESS,
+        "ott",
+        {"session_object_path", "processed", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_STOP,
+        "ot",
+        {"session_object_path", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_UNPACK_ERROR, "os", {"session_object_path", "nevra"});
 }
 
 std::vector<std::string> get_filter_patterns(dnfdaemon::KeyValueMap options, const std::string & option) {

--- a/dnf5daemon-server/session_manager.cpp
+++ b/dnf5daemon-server/session_manager.cpp
@@ -48,11 +48,23 @@ SessionManager::~SessionManager() {
 void SessionManager::dbus_register() {
     dbus_object = sdbus::createObject(*connection, dnfdaemon::DBUS_OBJECT_PATH);
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_SESSION_MANAGER, "open_session", "a{sv}", "o", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_SESSION_MANAGER,
+        "open_session",
+        "a{sv}",
+        {"options"},
+        "o",
+        {"session_object_path"},
+        [this](sdbus::MethodCall call) -> void {
             threads_manager.handle_method(*this, &SessionManager::open_session, call);
         });
     dbus_object->registerMethod(
-        dnfdaemon::INTERFACE_SESSION_MANAGER, "close_session", "o", "b", [this](sdbus::MethodCall call) -> void {
+        dnfdaemon::INTERFACE_SESSION_MANAGER,
+        "close_session",
+        "o",
+        {"session_object_path"},
+        "b",
+        {"success"},
+        [this](sdbus::MethodCall call) -> void {
             threads_manager.handle_method(*this, &SessionManager::close_session, call);
         });
     dbus_object->finishRegistration();


### PR DESCRIPTION
The change makes sure that all dnf5daemon-server methods and signals:
- are documented in <interface>.xml files
- have correct D-Bus signatures
- all their parameters have provided names for better introspection

Fixes: https://github.com/rpm-software-management/dnf5/issues/1246