### PR TITLE
upgrade: check that `--destdir` is used only with `--downloadonly`

### DIFF
--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -68,6 +68,8 @@ void UpgradeCommand::set_argument_parser() {
     create_allow_downgrade_options(*this);
     create_downloadonly_option(*this);
     create_destdir_option(*this);
+    auto & destdir = parser.get_named_arg("upgrade.destdir", false);
+    destdir.set_description(destdir.get_description() + " Automatically sets the --downloadonly option.");
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);
@@ -93,6 +95,10 @@ void UpgradeCommand::configure() {
         advisory_bz->get_value(),
         advisory_cve->get_value());
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    if (!context.base.get_config().get_destdir_option().empty()) {
+        context.base.get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void UpgradeCommand::run() {

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -56,7 +56,7 @@ void create_destdir_option(dnf5::Command & command) {
     auto destdir = parser.add_new_named_arg("destdir");
     destdir->set_long_name("destdir");
     destdir->set_description(
-        "Set directory used for downloading packages to. Default location is to the current working directory");
+        "Set directory used for downloading packages to. Default location is to the current working directory.");
     destdir->set_has_value(true);
     destdir->set_arg_value_help("DESTDIR");
     destdir->link_value(&command.get_context().base.get_config().get_destdir_option());

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -45,8 +45,12 @@ Options
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
+``--downloadonly``
+    | Only download packages for transaction.
+
 ``--destdir=<path>``
-    Set directory used for downloading packages to. Default location is to the current working directory.
+    | Set directory used for downloading packages to. Default location is to the current working directory.
+    | Automatically sets the ``downloadonly`` option.
 
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to upgrade. All remaining packages will be upgraded.


### PR DESCRIPTION
If only `--destdir` is specified the command will download the pkgs to specified directory and then fail because transaction cannot find them (they are not in cache).