### PR TITLE
Don't set obsoletes < 5 for ELN/RHEL yet

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -2,7 +2,7 @@
 %global project_version_minor 1
 %global project_version_patch 14
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 41 || 0%{?rhel} > 10]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 41 || 0%{?rhel} > 11]
 
 Name:           dnf5
 Version:        %{project_version_major}.%{project_version_minor}.%{project_version_patch}


### PR DESCRIPTION
The necessary pieces are not yet in place for RHEL 11 and this results in conflicts.

![screenshot](https://github.com/rpm-software-management/dnf5/assets/739555/fa416d73-8105-45dd-a5cf-d13b100cf0a2)
