### PR TITLE
PackageQuery: Source rpms do not upgrade binary ones

### DIFF
--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -129,11 +129,6 @@ void CheckUpgradeCommand::run() {
 
     upgrades_query.filter_upgrades();
 
-    // Source RPMs should not be reported as upgrades, e.g. when the binary
-    // package is marked exclude and only the source package is left in the
-    // repo
-    upgrades_query.filter_arch({"src", "nosrc"}, libdnf5::sack::QueryCmp::NOT_EXACT);
-
     libdnf5::rpm::PackageQuery installed_query(ctx.base);
     installed_query.filter_installed();
 

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -214,7 +214,6 @@ void ListCommand::run() {
         case PkgNarrow::UPGRADES:
             base_query.filter_priority();
             base_query.filter_upgrades();
-            base_query.filter_arch({"src", "nosrc"}, libdnf5::sack::QueryCmp::NEQ);
             base_query.filter_latest_evr();
             package_matched |= sections->add_section("Available upgrades", base_query, colorizer);
             break;


### PR DESCRIPTION
Noarch packages can be used to upgrade any binary packages, but not source
packages. Fixes incorrect filter_upgrades() behaviour where src packages
were returned as upgrade candidates for noarch packages.

Tests adjustment: https://github.com/rpm-software-management/ci-dnf-stack/pull/1472