### PR TITLE
conf: Fix append options overrides

### DIFF
--- a/libdnf5/conf/config_utils.hpp
+++ b/libdnf5/conf/config_utils.hpp
@@ -28,11 +28,13 @@ namespace libdnf5 {
 
 template <typename T>
 static void option_T_list_append(T & option, Option::Priority priority, const std::string & value) {
+    if (priority < option.get_priority()) {
+        return;
+    }
     if (value.empty()) {
         option.set(priority, value);
         return;
     }
-    auto add_priority = priority < option.get_priority() ? option.get_priority() : priority;
     auto val = option.from_string(value);
     bool first = true;
     for (auto & item : val) {
@@ -43,7 +45,7 @@ static void option_T_list_append(T & option, Option::Priority priority, const st
         } else {
             auto orig_value = option.get_value();
             orig_value.insert(orig_value.end(), item);
-            option.set(add_priority, orig_value);
+            option.set(priority, orig_value);
         }
         first = false;
     }


### PR DESCRIPTION
Fixes the use case when an append option is initialized with higher
priority, and user tries to change it with lower priority. This should
not be allowed.

Example of incorrect behavior without this patch:

$ cat /etc/dnf/dnf.conf:
[main]
excludepkgs=kernel-core,acpi

$ dnf5 install acpi --exclude=
Updating and loading repositories:
Repositories loaded.
Failed to resolve the transaction:
Argument 'acpi' matches only excluded packages.

For: https://github.com/rpm-software-management/dnf5/issues/1331