### PR TITLE
Prevent loading plugins for unittests

### DIFF
--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -133,6 +133,11 @@ void Base::Impl::with_config_file_path(std::function<void(const std::string &)> 
 }
 
 void Base::load_plugins() {
+    // load plugins according to configuration
+    if (!p_impl->config.get_plugins_option().get_value()) {
+        return;
+    }
+
     const char * plugins_config_dir = std::getenv("LIBDNF_PLUGINS_CONFIG_DIR");
     if (plugins_config_dir &&
         p_impl->config.get_pluginconfpath_option().get_priority() < Option::Priority::COMMANDLINE) {

--- a/test/dnf5daemon-server/support.py
+++ b/test/dnf5daemon-server/support.py
@@ -70,10 +70,12 @@ class InstallrootCase(unittest.TestCase):
         self.iface_session = dbus.Interface(
             self.bus.get_object(DNFDAEMON_BUS_NAME, DNFDAEMON_OBJECT_PATH),
             dbus_interface=IFACE_SESSION_MANAGER)
+        # Prevent loading plugins from host by setting "plugins" to False
         self.session = self.iface_session.open_session({
             "config": {
                 "config_file_path": self.config_file_path,
                 "installroot": self.installroot,
+                "plugins": False,
                 "cachedir": os.path.join(self.installroot, "var/cache/dnf"),
                 "reposdir": self.reposdir,
             }

--- a/test/perl5/libdnf5/rpm/test_package_query.t
+++ b/test/perl5/libdnf5/rpm/test_package_query.t
@@ -34,6 +34,9 @@ my $tmpdir = tempdir("libdnf5_perl5_unittest.XXXX", TMPDIR => 1, CLEANUP => 1);
 $base->get_config()->get_installroot_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $tmpdir."/installroot");
 $base->get_config()->get_cachedir_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $tmpdir."/cache");
 
+# Prevent loading plugins from host
+$base->get_config()->get_plugins_option()->set("False");
+
 # Sets base internals according to configuration
 $base->setup();
 

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -39,6 +39,9 @@ class BaseTestCase(unittest.TestCase):
         config.cachedir = os.path.join(self.temp_dir, "cache")
         config.optional_metadata_types = libdnf5.conf.OPTIONAL_METADATA_TYPES
 
+        # Prevent loading plugins from the host
+        config.plugins = False
+
         vars = self.base.get_vars().get()
         vars.set("arch", "x86_64")
 

--- a/test/python3/libdnf5/tutorial/session/create_base.py
+++ b/test/python3/libdnf5/tutorial/session/create_base.py
@@ -11,6 +11,9 @@ base = libdnf5.base.Base()
 base_config = base.get_config()
 base_config.installroot = installroot
 
+# Optionally prevent of loading of plugins. Plugins are loaded by default from the host
+base_config.plugins = False
+
 # Optionally load configuration from the config files.
 #
 # The Base's config is initialized with default values, one of which is

--- a/test/ruby/libdnf5/base_test_case.rb
+++ b/test/ruby/libdnf5/base_test_case.rb
@@ -37,6 +37,9 @@ class BaseTestCase < Test::Unit::TestCase
         @base.get_config().get_installroot_option().set(File.join(@temp_dir, "installroot"))
         @base.get_config().get_cachedir_option().set(File.join(@temp_dir, "cache"))
 
+        # Prevent loading of plugins from host
+        @base.get_config().get_plugins_option().set(false)
+
         # Sets Base internals according to configuration
         @base.setup()
 

--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -233,6 +233,9 @@ void BaseTestCase::setUp() {
     base.get_config().get_cachedir_option().set(temp->get_path() / "cache");
     base.get_config().get_optional_metadata_types_option().set(libdnf5::OPTIONAL_METADATA_TYPES);
 
+    // Prevent loading libdnf5 plugins
+    base.get_config().get_plugins_option().set(false);
+
     base.get_vars()->set("arch", "x86_64");
 
     base.setup();

--- a/test/shared/test_case_fixture.cpp
+++ b/test/shared/test_case_fixture.cpp
@@ -86,5 +86,8 @@ std::unique_ptr<libdnf5::Base> TestCaseFixture::get_preconfigured_base() {
     base->get_config().get_installroot_option().set(temp->get_path() / "installroot");
     base->get_config().get_cachedir_option().set(temp->get_path() / "cache");
 
+    // Prevent loading libdnf5 plugins
+    base->get_config().get_plugins_option().set(false);
+
     return base;
 }

--- a/test/tutorial/session/create_base.cpp
+++ b/test/tutorial/session/create_base.cpp
@@ -12,6 +12,10 @@ libdnf5::Base base;
 // installroot directory tree as its root for the rest of its lifetime.
 base.get_config().get_installroot_option().set(installroot);
 
+// Optionally - Prevent loading libdnf5 plugins.
+// Plugins are loaded by default from the host
+base.get_config().get_plugins_option().set(false);
+
 // Optionally load configuration from the config files.
 //
 // The Base's config is initialized with default values, one of which is


### PR DESCRIPTION
Loading plugins from host system is risky for both sides.

Closes: https://github.com/rpm-software-management/dnf5/issues/1316