### PR TITLE
system-upgrade: backwards-compat offline-{upgrade,distrosync}

### DIFF
--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -56,9 +56,10 @@ void SystemUpgradeCommand::set_argument_parser() {
 
 void SystemUpgradeCommand::register_subcommands() {
     register_subcommand(std::make_unique<OfflineCleanCommand>(get_context()));
-    register_subcommand(std::make_unique<SystemUpgradeDownloadCommand>(get_context()));
     register_subcommand(std::make_unique<OfflineLogCommand>(get_context()));
     register_subcommand(std::make_unique<OfflineRebootCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineStatusCommand>(get_context()));
+    register_subcommand(std::make_unique<SystemUpgradeDownloadCommand>(get_context()));
 }
 
 void SystemUpgradeDownloadCommand::set_argument_parser() {
@@ -113,6 +114,50 @@ void SystemUpgradeDownloadCommand::run() {
     }
 
     ctx.set_should_store_offline(true);
+}
+
+void OfflineDistroSyncCommand::pre_configure() {
+    throw_missing_command();
+}
+
+void OfflineDistroSyncCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("subcommands").register_argument(arg_parser_this_cmd);
+}
+
+void OfflineDistroSyncCommand::set_argument_parser() {
+    get_argument_parser_command()->set_description(_("Store a distro-sync transaction to be performed offline"));
+}
+
+void OfflineDistroSyncCommand::register_subcommands() {
+    register_subcommand(std::make_unique<OfflineCleanCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineRebootCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineLogCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineStatusCommand>(get_context()));
+}
+
+void OfflineUpgradeCommand::pre_configure() {
+    throw_missing_command();
+}
+
+void OfflineUpgradeCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("subcommands").register_argument(arg_parser_this_cmd);
+}
+
+void OfflineUpgradeCommand::set_argument_parser() {
+    get_argument_parser_command()->set_description(_("Store an upgrade transaction to be performed offline"));
+}
+
+void OfflineUpgradeCommand::register_subcommands() {
+    register_subcommand(std::make_unique<OfflineCleanCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineRebootCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineLogCommand>(get_context()));
+    register_subcommand(std::make_unique<OfflineStatusCommand>(get_context()));
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -48,6 +48,24 @@ private:
     std::string system_releasever;
 };
 
+class OfflineDistroSyncCommand : public Command {
+public:
+    explicit OfflineDistroSyncCommand(Context & context) : Command(context, "offline-distrosync") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
+};
+
+class OfflineUpgradeCommand : public Command {
+public:
+    explicit OfflineUpgradeCommand(Context & context) : Command(context, "offline-upgrade") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
+};
+
 }  // namespace dnf5
 
 #endif  // DNF5_COMMANDS_SYSTEM_UPGRADE_HPP

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -131,19 +131,17 @@ descr = "Alias for 'makecache'"
 group_id = 'commands-compatibility-aliases'
 complete = false
 
-['offline-distrosync']
+['offline-distrosync.download']
 type = 'command'
 attached_command = 'distro-sync'
-group_id = 'commands-compatibility-aliases'
 complete = true
 attached_named_args = [
   { id_path = 'distro-sync.offline' }
 ]
 
-['offline-upgrade']
+['offline-upgrade.download']
 type = 'command'
 attached_command = 'upgrade'
-group_id = 'commands-compatibility-aliases'
 complete = true
 attached_named_args = [
   { id_path = 'upgrade.offline' }

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -134,6 +134,7 @@ complete = false
 ['offline-distrosync.download']
 type = 'command'
 attached_command = 'distro-sync'
+descr = "Alias for 'distro-sync --offline'"
 complete = true
 attached_named_args = [
   { id_path = 'distro-sync.offline' }
@@ -142,6 +143,7 @@ attached_named_args = [
 ['offline-upgrade.download']
 type = 'command'
 attached_command = 'upgrade'
+descr = "Alias for 'upgrade --offline'"
 complete = true
 attached_named_args = [
   { id_path = 'upgrade.offline' }

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -694,6 +694,8 @@ static void add_commands(Context & context) {
     context.add_and_initialize_command(std::make_unique<MakeCacheCommand>(context));
     context.add_and_initialize_command(std::make_unique<VersionlockCommand>(context));
     context.add_and_initialize_command(std::make_unique<SystemUpgradeCommand>(context));
+    context.add_and_initialize_command(std::make_unique<OfflineDistroSyncCommand>(context));
+    context.add_and_initialize_command(std::make_unique<OfflineUpgradeCommand>(context));
     context.add_and_initialize_command(std::make_unique<OfflineCommand>(context));
 }
 


### PR DESCRIPTION
Make `dnf5 offline-distrosync` and `dnf5 offline-upgrade` backwards-compatible with DNF 4. There didn't seem to be a way to do this with aliases alone since we need `dnf5 offline-distrosync` and `dnf5 offline-distrosync download` to be aliased to different commands (`dnf5 offline` and `dnf5 distro-sync`, respectively). We also want `dnf5 offline-distrosync --help` to show the help for `dnf5 offline`.

Resolves https://github.com/rpm-software-management/dnf5/issues/1343.

Marked draft until I have a ci-dnf-stack PR ready.