### PR TITLE
libdnf5::OptionEnum: remove template, add pImpl

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -55,7 +55,6 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %include "libdnf5/conf/option.hpp"
 %include "libdnf5/conf/option_bool.hpp"
 %include "libdnf5/conf/option_enum.hpp"
-%template(OptionEnumString) libdnf5::OptionEnum<std::string>;
 
 %include "libdnf5/conf/option_number.hpp"
 %template(OptionNumberInt32) libdnf5::OptionNumber<std::int32_t>;
@@ -81,7 +80,7 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %template(OptionChildNumberInt32) libdnf5::OptionChild<libdnf5::OptionNumber<std::int32_t>>;
 %template(OptionChildNumberUInt32) libdnf5::OptionChild<libdnf5::OptionNumber<std::uint32_t>>;
 %template(OptionChildNumberFloat) libdnf5::OptionChild<libdnf5::OptionNumber<float>>;
-%template(OptionChildEnumString) libdnf5::OptionChild<libdnf5::OptionEnum<std::string>>;
+%template(OptionChildEnum) libdnf5::OptionChild<libdnf5::OptionEnum>;
 %template(OptionChildSeconds) libdnf5::OptionChild<libdnf5::OptionSeconds>;
 
 

--- a/dnf5-plugins/automatic_plugin/config_automatic.hpp
+++ b/dnf5-plugins/automatic_plugin/config_automatic.hpp
@@ -39,12 +39,12 @@ public:
     ConfigAutomaticCommands();
     ~ConfigAutomaticCommands() = default;
 
-    libdnf5::OptionEnum<std::string> upgrade_type{"default", {"default", "security"}};
+    libdnf5::OptionEnum upgrade_type{"default", {"default", "security"}};
     libdnf5::OptionNumber<std::int32_t> random_sleep{0};
     libdnf5::OptionNumber<std::int32_t> network_online_timeout{60};
     libdnf5::OptionBool download_updates{true};
     libdnf5::OptionBool apply_updates{false};
-    libdnf5::OptionEnum<std::string> reboot{"never", {"never", "when-changed", "when-needed"}};
+    libdnf5::OptionEnum reboot{"never", {"never", "when-changed", "when-needed"}};
     libdnf5::OptionString reboot_command{"shutdown -r +5 'Rebooting after applying package updates'"};
 };
 
@@ -73,7 +73,7 @@ public:
     libdnf5::OptionString email_from{"root"};
     libdnf5::OptionString email_host{"localhost"};
     libdnf5::OptionNumber<std::int32_t> email_port{25};
-    libdnf5::OptionEnum<std::string> email_tls{"no", {"no", "yes", "starttls"}};
+    libdnf5::OptionEnum email_tls{"no", {"no", "yes", "starttls"}};
 };
 
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -343,8 +343,8 @@ void RepoqueryCommand::set_argument_parser() {
         "supplements",
         "",  // empty when option is not used
     };
-    providers_of_option = dynamic_cast<libdnf5::OptionEnum<std::string> *>(
-        parser.add_init_value(std::make_unique<libdnf5::OptionEnum<std::string>>("", pkg_attrs_options)));
+    providers_of_option = dynamic_cast<libdnf5::OptionEnum *>(
+        parser.add_init_value(std::make_unique<libdnf5::OptionEnum>("", pkg_attrs_options)));
     auto * providers_of = parser.add_new_named_arg("providersof");
     std::string allowed_values = libdnf5::utils::string::join(pkg_attrs_options, ", ");
     // Drop the empty option from the description of supported values
@@ -412,8 +412,8 @@ void RepoqueryCommand::set_argument_parser() {
     // Add additional supported package attribute getters, all pkg_attrs_options get turned into options
     pkg_attrs_options.insert(pkg_attrs_options.begin(), {"files", "sourcerpm", "location"});
 
-    pkg_attr_option = dynamic_cast<libdnf5::OptionEnum<std::string> *>(
-        parser.add_init_value(std::make_unique<libdnf5::OptionEnum<std::string>>("", pkg_attrs_options)));
+    pkg_attr_option = dynamic_cast<libdnf5::OptionEnum *>(
+        parser.add_init_value(std::make_unique<libdnf5::OptionEnum>("", pkg_attrs_options)));
     // remove the last empty ("") option, it should not be an arg
     pkg_attrs_options.pop_back();
     for (auto & pkg_attr : pkg_attrs_options) {

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -80,8 +80,8 @@ private:
 
     libdnf5::OptionBool * querytags_option{nullptr};
     libdnf5::OptionString * query_format_option{nullptr};
-    libdnf5::OptionEnum<std::string> * pkg_attr_option{nullptr};
-    libdnf5::OptionEnum<std::string> * providers_of_option{nullptr};
+    libdnf5::OptionEnum * pkg_attr_option{nullptr};
+    libdnf5::OptionEnum * providers_of_option{nullptr};
 
     std::unique_ptr<AdvisoryOption> advisory_name{nullptr};
     std::unique_ptr<SecurityOption> advisory_security{nullptr};

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -46,9 +46,8 @@ void RepolistCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
 
 
-    enable_disable_option = dynamic_cast<libdnf5::OptionEnum<std::string> *>(
-        parser.add_init_value(std::unique_ptr<libdnf5::OptionEnum<std::string>>(
-            new libdnf5::OptionEnum<std::string>("enabled", {"all", "enabled", "disabled"}))));
+    enable_disable_option = dynamic_cast<libdnf5::OptionEnum *>(parser.add_init_value(
+        std::unique_ptr<libdnf5::OptionEnum>(new libdnf5::OptionEnum("enabled", {"all", "enabled", "disabled"}))));
 
     auto all = parser.add_new_named_arg("all");
     all->set_long_name("all");

--- a/dnf5daemon-client/commands/repolist/repolist.hpp
+++ b/dnf5daemon-client/commands/repolist/repolist.hpp
@@ -41,7 +41,7 @@ public:
     void run() override;
 
 private:
-    libdnf5::OptionEnum<std::string> * enable_disable_option{nullptr};
+    libdnf5::OptionEnum * enable_disable_option{nullptr};
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_options{nullptr};
     const std::string command;
 };

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -70,8 +70,8 @@ public:
     const OptionBool & get_reset_nice_option() const;
     OptionPath & get_system_cachedir_option();
     const OptionPath & get_system_cachedir_option() const;
-    OptionEnum<std::string> & get_cacheonly_option();
-    const OptionEnum<std::string> & get_cacheonly_option() const;
+    OptionEnum & get_cacheonly_option();
+    const OptionEnum & get_cacheonly_option() const;
     OptionBool & get_keepcache_option();
     const OptionBool & get_keepcache_option() const;
     OptionPath & get_logdir_option();
@@ -130,8 +130,8 @@ public:
     const OptionSeconds & get_metadata_timer_sync_option() const;
     OptionStringList & get_disable_excludes_option();
     const OptionStringList & get_disable_excludes_option() const;
-    OptionEnum<std::string> & get_multilib_policy_option();  // :api
-    const OptionEnum<std::string> & get_multilib_policy_option() const;
+    OptionEnum & get_multilib_policy_option();  // :api
+    const OptionEnum & get_multilib_policy_option() const;
     OptionBool & get_best_option();  // :api
     const OptionBool & get_best_option() const;
     OptionBool & get_install_weak_deps_option();
@@ -142,8 +142,8 @@ public:
     const OptionString & get_bugtracker_url_option() const;
     OptionBool & get_zchunk_option();
     const OptionBool & get_zchunk_option() const;
-    OptionEnum<std::string> & get_color_option();
-    const OptionEnum<std::string> & get_color_option() const;
+    OptionEnum & get_color_option();
+    const OptionEnum & get_color_option() const;
     OptionString & get_color_list_installed_older_option();
     const OptionString & get_color_list_installed_older_option() const;
     OptionString & get_color_list_installed_newer_option();
@@ -187,8 +187,8 @@ public:
     const OptionBool & get_autocheck_running_kernel_option() const;
     OptionBool & get_clean_requirements_on_remove_option();
     const OptionBool & get_clean_requirements_on_remove_option() const;
-    OptionEnum<std::string> & get_history_list_view_option();
-    const OptionEnum<std::string> & get_history_list_view_option() const;
+    OptionEnum & get_history_list_view_option();
+    const OptionEnum & get_history_list_view_option() const;
     OptionBool & get_upgrade_group_objects_upgrade_option();
     const OptionBool & get_upgrade_group_objects_upgrade_option() const;
     OptionPath & get_destdir_option();
@@ -256,8 +256,8 @@ public:
     const OptionNumber<std::uint32_t> & get_bandwidth_option() const;
     OptionNumber<std::uint32_t> & get_minrate_option();
     const OptionNumber<std::uint32_t> & get_minrate_option() const;
-    OptionEnum<std::string> & get_ip_resolve_option();
-    const OptionEnum<std::string> & get_ip_resolve_option() const;
+    OptionEnum & get_ip_resolve_option();
+    const OptionEnum & get_ip_resolve_option() const;
     OptionNumber<float> & get_throttle_option();
     const OptionNumber<float> & get_throttle_option() const;
     OptionSeconds & get_timeout_option();

--- a/include/libdnf5/conf/option.hpp
+++ b/include/libdnf5/conf/option.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_CONF_OPTION_HPP
 
 #include "libdnf5/common/exception.hpp"
+#include "libdnf5/common/impl_ptr.hpp"
 
 #include <string>
 
@@ -77,8 +78,8 @@ public:
     };
 
     explicit Option(Priority priority = Priority::EMPTY);
-    Option(const Option & src) = default;
-    virtual ~Option() = default;
+    Option(const Option & src);
+    virtual ~Option();
 
     /// Makes copy (clone) of this object.
     // @replaces libdnf:conf/Option.hpp:method:Option.clone()
@@ -127,43 +128,10 @@ protected:
     const std::string & get_lock_comment() const noexcept;
 
 private:
-    Priority priority;
-    bool locked{false};
-    std::string lock_comment;
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
-inline Option::Option(Priority priority) : priority(priority) {}
-
-inline Option::Priority Option::get_priority() const {
-    return priority;
-}
-
-inline bool Option::empty() const noexcept {
-    return priority == Priority::EMPTY;
-}
-
-inline void Option::set_priority(Priority priority) {
-    this->priority = priority;
-}
-
-inline void Option::lock(const std::string & first_comment) {
-    if (!locked) {
-        lock_comment = first_comment;
-        locked = true;
-    }
-}
-
-inline bool Option::is_locked() const noexcept {
-    return locked;
-}
-
-inline void Option::assert_not_locked() const {
-    libdnf_user_assert(!locked, "Attempting to write to a locked option: {}", get_lock_comment());
-}
-
-inline const std::string & Option::get_lock_comment() const noexcept {
-    return lock_comment;
-}
 
 }  // namespace libdnf5
 

--- a/include/libdnf5/conf/option_enum.hpp
+++ b/include/libdnf5/conf/option_enum.hpp
@@ -28,84 +28,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
-/// Option that stores value from enumeration. The type of value is template parameter.
-/// Support default value and user defined function for conversion from string.
-// @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<T>
-template <typename T>
-class OptionEnum : public Option {
-public:
-    using ValueType = T;
-    using FromStringFunc = std::function<ValueType(const std::string &)>;
-
-    OptionEnum(ValueType default_value, const std::vector<ValueType> & enum_vals);
-    OptionEnum(ValueType default_value, std::vector<ValueType> && enum_vals);
-    OptionEnum(ValueType default_value, const std::vector<ValueType> & enum_vals, FromStringFunc && from_string_func);
-    OptionEnum(ValueType default_value, std::vector<ValueType> && enum_vals, FromStringFunc && from_string_func);
-
-    /// Makes copy (clone) of this object.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.clone()
-    OptionEnum * clone() const override;
-
-    /// Sets new value and priority (source).
-    /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, bool value)
-    void set(Priority priority, ValueType value);
-
-    /// Sets new value and runtime priority.
-    void set(ValueType value);
-
-    /// Parses input string and sets new value and priority.
-    /// The value and priority are stored only if the new priority is equal to or higher than the stored priority.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.set(Priority priority, const std::string & value)
-    void set(Priority priority, const std::string & value) override;
-
-    /// Parses input string and sets new value and runtime priority.
-    void set(const std::string & value) override;
-
-    /// Gets the stored value.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValue()
-    T get_value() const;
-
-    /// Gets the default value. Default value is used until it is replaced by set() method.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
-    T get_default_value() const;
-
-    /// Gets a string representation of the stored value.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.getValueString()
-    std::string get_value_string() const override;
-
-    /// Tests input value and throws exception if the value is not allowed.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.test(ValueType value)
-    void test(ValueType value) const;
-
-    /// Parses input string and returns result.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.fromString(const std::string & value)
-    ValueType from_string(const std::string & value) const;
-
-    /// Converts input value to the string.
-    // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<T>.toString(ValueType value)
-    std::string to_string(ValueType value) const;
-
-private:
-    FromStringFunc from_string_user;
-    std::vector<ValueType> enum_vals;
-    ValueType default_value;
-    ValueType value;
-};
-
-
-/// Option that stores value from enumeration. Specialized template for enumeration of strings.
+/// Option that stores value from enumeration of strings.
 /// It supports default value.
 /// It supports user defined function for conversion from string.
 // @replaces libdnf:conf/OptionEnum.hpp:class:OptionEnum<std::string>
-template <>
-class OptionEnum<std::string> : public Option {
+class OptionEnum : public Option {
 public:
     using ValueType = std::string;
-    using FromStringFunc = std::function<ValueType(const std::string &)>;
+    using FromStringFunc = std::function<std::string(const std::string &)>;
 
-    OptionEnum(const std::string & default_value, std::vector<ValueType> enum_vals);
-    OptionEnum(const std::string & default_value, std::vector<ValueType> enum_vals, FromStringFunc && from_string_func);
+    OptionEnum(std::string default_value, std::vector<std::string> enum_vals);
+    OptionEnum(std::string default_value, std::vector<std::string> enum_vals, FromStringFunc && from_string_func);
+
+    ~OptionEnum() override;
 
     /// Makes copy (clone) of this object.
     // @replaces libdnf:conf/OptionEnum.hpp:method:OptionEnum<std::string>.clone()
@@ -140,32 +75,10 @@ public:
     std::string from_string(const std::string & value) const;
 
 private:
-    FromStringFunc from_string_user;
-    std::vector<ValueType> enum_vals;
-    ValueType default_value;
-    ValueType value;
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
-template <typename T>
-inline OptionEnum<T> * OptionEnum<T>::clone() const {
-    return new OptionEnum<T>(*this);
-}
-
-inline OptionEnum<std::string> * OptionEnum<std::string>::clone() const {
-    return new OptionEnum<std::string>(*this);
-}
-
-inline const std::string & OptionEnum<std::string>::get_value() const {
-    return value;
-}
-
-inline const std::string & OptionEnum<std::string>::get_default_value() const {
-    return default_value;
-}
-
-inline std::string OptionEnum<std::string>::get_value_string() const {
-    return value;
-}
 
 }  // namespace libdnf5
 

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -90,8 +90,8 @@ public:
     const OptionChild<OptionNumber<std::uint32_t>> & get_bandwidth_option() const;
     OptionChild<OptionNumber<std::uint32_t>> & get_minrate_option();
     const OptionChild<OptionNumber<std::uint32_t>> & get_minrate_option() const;
-    OptionChild<OptionEnum<std::string>> & get_ip_resolve_option();
-    const OptionChild<OptionEnum<std::string>> & get_ip_resolve_option() const;
+    OptionChild<OptionEnum> & get_ip_resolve_option();
+    const OptionChild<OptionEnum> & get_ip_resolve_option() const;
     OptionChild<OptionNumber<float>> & get_throttle_option();
     const OptionChild<OptionNumber<float>> & get_throttle_option() const;
     OptionChild<OptionSeconds> & get_timeout_option();
@@ -141,8 +141,8 @@ public:
     OptionChild<OptionBool> & get_countme_option();
     const OptionChild<OptionBool> & get_countme_option() const;
     // yum compatibility options
-    OptionEnum<std::string> & get_failovermethod_option();
-    const OptionEnum<std::string> & get_failovermethod_option() const;
+    OptionEnum & get_failovermethod_option();
+    const OptionEnum & get_failovermethod_option() const;
 
     /// @return A unique ID of the repository, consisting of its id and a hash
     /// computed from its source URLs (metalink, mirrorlist or baseurl, first

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -107,7 +107,7 @@ class ConfigMain::Impl {
     OptionNumber<std::int32_t> recent{7, 0};
     OptionBool reset_nice{true};
     OptionPath system_cachedir{SYSTEM_CACHEDIR};
-    OptionEnum<std::string> cacheonly{"none", {"all", "metadata", "none"}};
+    OptionEnum cacheonly{"none", {"all", "metadata", "none"}};
     OptionBool keepcache{false};
     OptionPath logdir{geteuid() == 0 ? "/var/log" : libdnf5::xdg::get_user_state_dir()};
     OptionNumber<std::int32_t> log_size{1024 * 1024, str_to_bytes};
@@ -144,29 +144,29 @@ class ConfigMain::Impl {
     OptionBool allow_vendor_change{true};
     OptionSeconds metadata_timer_sync{60 * 60 * 3};  // 3 hours
     OptionStringList disable_excludes{std::vector<std::string>{}};
-    OptionEnum<std::string> multilib_policy{"best", {"best", "all"}};  // :api
-    OptionBool best{true};                                             // :api
+    OptionEnum multilib_policy{"best", {"best", "all"}};  // :api
+    OptionBool best{true};                                // :api
     OptionBool install_weak_deps{true};
     OptionBool allow_downgrade{true};
     OptionString bugtracker_url{BUGTRACKER};
     OptionBool zchunk{true};
 
-    OptionEnum<std::string> color{"auto", {"auto", "never", "always"}, [](const std::string & value) {
-                                      const std::array<const char *, 4> always{{"on", "yes", "1", "true"}};
-                                      const std::array<const char *, 4> never{{"off", "no", "0", "false"}};
-                                      const std::array<const char *, 2> aut{{"tty", "if-tty"}};
-                                      std::string tmp;
-                                      if (std::find(always.begin(), always.end(), value) != always.end()) {
-                                          tmp = "always";
-                                      } else if (std::find(never.begin(), never.end(), value) != never.end()) {
-                                          tmp = "never";
-                                      } else if (std::find(aut.begin(), aut.end(), value) != aut.end()) {
-                                          tmp = "auto";
-                                      } else {
-                                          tmp = value;
-                                      }
-                                      return tmp;
-                                  }};
+    OptionEnum color{"auto", {"auto", "never", "always"}, [](const std::string & value) {
+                         const std::array<const char *, 4> always{{"on", "yes", "1", "true"}};
+                         const std::array<const char *, 4> never{{"off", "no", "0", "false"}};
+                         const std::array<const char *, 2> aut{{"tty", "if-tty"}};
+                         std::string tmp;
+                         if (std::find(always.begin(), always.end(), value) != always.end()) {
+                             tmp = "always";
+                         } else if (std::find(never.begin(), never.end(), value) != never.end()) {
+                             tmp = "never";
+                         } else if (std::find(aut.begin(), aut.end(), value) != aut.end()) {
+                             tmp = "auto";
+                         } else {
+                             tmp = value;
+                         }
+                         return tmp;
+                     }};
 
     OptionString color_list_installed_older{"yellow"};
     OptionString color_list_installed_newer{"bold,yellow"};
@@ -189,7 +189,7 @@ class ConfigMain::Impl {
     OptionBool autocheck_running_kernel{true};  // :yum-compatibility
     OptionBool clean_requirements_on_remove{true};
 
-    OptionEnum<std::string> history_list_view{
+    OptionEnum history_list_view{
         "commands", {"single-user-commands", "users", "commands"}, [](const std::string & value) {
             if (value == "cmds" || value == "default") {
                 return std::string("commands");
@@ -234,17 +234,17 @@ class ConfigMain::Impl {
     OptionNumber<std::uint32_t> bandwidth{0, str_to_bytes};
     OptionNumber<std::uint32_t> minrate{1000, str_to_bytes};
 
-    OptionEnum<std::string> ip_resolve{"whatever", {"ipv4", "ipv6", "whatever"}, [](const std::string & value) {
-                                           auto tmp = value;
-                                           if (value == "4") {
-                                               tmp = "ipv4";
-                                           } else if (value == "6") {
-                                               tmp = "ipv6";
-                                           } else {
-                                               std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
-                                           }
-                                           return tmp;
-                                       }};
+    OptionEnum ip_resolve{"whatever", {"ipv4", "ipv6", "whatever"}, [](const std::string & value) {
+                              auto tmp = value;
+                              if (value == "4") {
+                                  tmp = "ipv4";
+                              } else if (value == "6") {
+                                  tmp = "ipv6";
+                              } else {
+                                  std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+                              }
+                              return tmp;
+                          }};
 
     OptionNumber<float> throttle{
         0, 0, [](const std::string & value) {
@@ -618,10 +618,10 @@ const OptionPath & ConfigMain::get_system_cachedir_option() const {
     return p_impl->system_cachedir;
 }
 
-OptionEnum<std::string> & ConfigMain::get_cacheonly_option() {
+OptionEnum & ConfigMain::get_cacheonly_option() {
     return p_impl->cacheonly;
 }
-const OptionEnum<std::string> & ConfigMain::get_cacheonly_option() const {
+const OptionEnum & ConfigMain::get_cacheonly_option() const {
     return p_impl->cacheonly;
 }
 
@@ -800,10 +800,10 @@ const OptionStringList & ConfigMain::get_disable_excludes_option() const {
     return p_impl->disable_excludes;
 }
 
-OptionEnum<std::string> & ConfigMain::get_multilib_policy_option() {
+OptionEnum & ConfigMain::get_multilib_policy_option() {
     return p_impl->multilib_policy;
 }
-const OptionEnum<std::string> & ConfigMain::get_multilib_policy_option() const {
+const OptionEnum & ConfigMain::get_multilib_policy_option() const {
     return p_impl->multilib_policy;
 }
 
@@ -842,10 +842,10 @@ const OptionBool & ConfigMain::get_zchunk_option() const {
     return p_impl->zchunk;
 }
 
-OptionEnum<std::string> & ConfigMain::get_color_option() {
+OptionEnum & ConfigMain::get_color_option() {
     return p_impl->color;
 }
-const OptionEnum<std::string> & ConfigMain::get_color_option() const {
+const OptionEnum & ConfigMain::get_color_option() const {
     return p_impl->color;
 }
 
@@ -989,10 +989,10 @@ const OptionBool & ConfigMain::get_clean_requirements_on_remove_option() const {
     return p_impl->clean_requirements_on_remove;
 }
 
-OptionEnum<std::string> & ConfigMain::get_history_list_view_option() {
+OptionEnum & ConfigMain::get_history_list_view_option() {
     return p_impl->history_list_view;
 }
-const OptionEnum<std::string> & ConfigMain::get_history_list_view_option() const {
+const OptionEnum & ConfigMain::get_history_list_view_option() const {
     return p_impl->history_list_view;
 }
 
@@ -1226,10 +1226,10 @@ const OptionNumber<std::uint32_t> & ConfigMain::get_minrate_option() const {
     return p_impl->minrate;
 }
 
-OptionEnum<std::string> & ConfigMain::get_ip_resolve_option() {
+OptionEnum & ConfigMain::get_ip_resolve_option() {
     return p_impl->ip_resolve;
 }
-const OptionEnum<std::string> & ConfigMain::get_ip_resolve_option() const {
+const OptionEnum & ConfigMain::get_ip_resolve_option() const {
     return p_impl->ip_resolve;
 }
 

--- a/libdnf5/conf/option.cpp
+++ b/libdnf5/conf/option.cpp
@@ -1,0 +1,73 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/conf/option.hpp"
+
+namespace libdnf5 {
+
+class Option::Impl {
+public:
+    Impl(Priority priority) : priority(priority){};
+
+private:
+    friend Option;
+
+    Priority priority;
+    bool locked{false};
+    std::string lock_comment;
+};
+
+Option::Option(Priority priority) : p_impl(new Impl(priority)) {}
+
+Option::~Option() = default;
+
+Option::Option(const Option & src) = default;
+
+Option::Priority Option::get_priority() const {
+    return p_impl->priority;
+}
+
+bool Option::empty() const noexcept {
+    return p_impl->priority == Priority::EMPTY;
+}
+
+void Option::set_priority(Priority priority) {
+    p_impl->priority = priority;
+}
+
+void Option::lock(const std::string & first_comment) {
+    if (!p_impl->locked) {
+        p_impl->lock_comment = first_comment;
+        p_impl->locked = true;
+    }
+}
+
+bool Option::is_locked() const noexcept {
+    return p_impl->locked;
+}
+
+void Option::assert_not_locked() const {
+    libdnf_user_assert(!p_impl->locked, "Attempting to write to a locked option: {}", get_lock_comment());
+}
+
+const std::string & Option::get_lock_comment() const noexcept {
+    return p_impl->lock_comment;
+}
+
+}  // namespace libdnf5

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -64,7 +64,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionNumber<std::uint32_t>> retries{main_config.get_retries_option()};
     OptionChild<OptionNumber<std::uint32_t>> bandwidth{main_config.get_bandwidth_option()};
     OptionChild<OptionNumber<std::uint32_t>> minrate{main_config.get_minrate_option()};
-    OptionChild<OptionEnum<std::string>> ip_resolve{main_config.get_ip_resolve_option()};
+    OptionChild<OptionEnum> ip_resolve{main_config.get_ip_resolve_option()};
     OptionChild<OptionNumber<float>> throttle{main_config.get_throttle_option()};
     OptionChild<OptionSeconds> timeout{main_config.get_timeout_option()};
     OptionChild<OptionNumber<std::uint32_t>> max_parallel_downloads{main_config.get_max_parallel_downloads_option()};
@@ -86,7 +86,7 @@ class ConfigRepo::Impl {
     OptionString enabled_metadata{""};
     OptionChild<OptionString> user_agent{main_config.get_user_agent_option()};
     OptionChild<OptionBool> countme{main_config.get_countme_option()};
-    OptionEnum<std::string> failovermethod{"priority", {"priority", "roundrobin"}};
+    OptionEnum failovermethod{"priority", {"priority", "roundrobin"}};
     OptionChild<OptionBool> build_cache{main_config.get_build_cache_option()};
 };
 
@@ -388,10 +388,10 @@ const OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_minrate_option(
     return p_impl->minrate;
 }
 
-OptionChild<OptionEnum<std::string>> & ConfigRepo::get_ip_resolve_option() {
+OptionChild<OptionEnum> & ConfigRepo::get_ip_resolve_option() {
     return p_impl->ip_resolve;
 }
-const OptionChild<OptionEnum<std::string>> & ConfigRepo::get_ip_resolve_option() const {
+const OptionChild<OptionEnum> & ConfigRepo::get_ip_resolve_option() const {
     return p_impl->ip_resolve;
 }
 
@@ -546,10 +546,10 @@ const OptionChild<OptionBool> & ConfigRepo::get_countme_option() const {
     return p_impl->countme;
 }
 
-OptionEnum<std::string> & ConfigRepo::get_failovermethod_option() {
+OptionEnum & ConfigRepo::get_failovermethod_option() {
     return p_impl->failovermethod;
 }
-const OptionEnum<std::string> & ConfigRepo::get_failovermethod_option() const {
+const OptionEnum & ConfigRepo::get_failovermethod_option() const {
     return p_impl->failovermethod;
 }
 

--- a/libdnf5/utils/dnf4convert/config_module.hpp
+++ b/libdnf5/utils/dnf4convert/config_module.hpp
@@ -39,7 +39,7 @@ public:
     OptionString name{""};
     OptionString stream{""};
     OptionStringList profiles{std::vector<std::string>{}};
-    OptionEnum<std::string> state{"", {"enabled", "disabled", ""}};
+    OptionEnum state{"", {"enabled", "disabled", ""}};
 
     void load_from_parser(
         const libdnf5::ConfigParser & parser,

--- a/test/libdnf5/conf/test_option.cpp
+++ b/test/libdnf5/conf/test_option.cpp
@@ -156,7 +156,7 @@ void OptionTest::test_options_child() {
 void OptionTest::test_options_enum() {
     const std::vector<std::string> ENUM_VALS{"aa", "bb", "cc", "dd", "ee"};
 
-    OptionEnum<std::string> option("bb", ENUM_VALS);
+    OptionEnum option("bb", ENUM_VALS);
     CPPUNIT_ASSERT_EQUAL(std::string("bb"), option.get_default_value());
     CPPUNIT_ASSERT_EQUAL(std::string("bb"), option.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::DEFAULT, option.get_priority());


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/1025

In next PRs I would like to add pImpl also to other `Option`* classes.