### PR TITLE
Prepare bash-completion for switch to dnf5 as the default package manager

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -18,6 +18,7 @@ Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Requires:       dnf-data
 %endif
 Recommends:     bash-completion
+Requires:       coreutils
 
 # Remove if condition when Fedora 37 is EOL
 %if 0%{?fedora} > 37 || 0%{?rhel} > 10

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -276,6 +276,9 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/bash-completion/
 %dir %{_datadir}/bash-completion/completions/
 %{_datadir}/bash-completion/completions/dnf5
+%if %{with dnf5_obsoletes_dnf}
+%{_datadir}/bash-completion/completions/dnf
+%endif
 %dir %{_prefix}/lib/sysimage/dnf
 %verify(not md5 size mtime) %ghost %{_prefix}/lib/sysimage/dnf/*
 %license COPYING.md
@@ -799,6 +802,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %if %{with dnf5_obsoletes_dnf}
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/dnf
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/yum
+ln -sr %{buildroot}%{_datadir}/bash-completion/completions/dnf5 %{buildroot}%{_datadir}/bash-completion/completions/dnf
 %endif
 
 # own dirs and files that dnf5 creates on runtime

--- a/dnf5/bash-completion/dnf5
+++ b/dnf5/bash-completion/dnf5
@@ -7,4 +7,11 @@ _do_dnf5_completion()
     mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
 }
 
-complete -F _do_dnf5_completion -o nosort -o nospace dnf5
+complete_cmds="dnf5"
+dnf_target=$(readlink -f "/usr/bin/dnf")
+
+if [ "$dnf_target" = "/usr/bin/dnf5" ]; then
+    complete_cmds+=" dnf"
+fi
+
+complete -F _do_dnf5_completion -o nosort -o nospace $complete_cmds


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=2223324.

Connected with:
- https://github.com/rpm-software-management/dnf/pull/2070

Related:
- https://github.com/rpm-software-management/dnf5/issues/1057