### PR TITLE
dnfdaemon: Enhance comps.Group.list() method

### DIFF
--- a/dnf5daemon-client/commands/group/group_list.hpp
+++ b/dnf5daemon-client/commands/group/group_list.hpp
@@ -22,12 +22,44 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
+#include <libdnf5-cli/session.hpp>
 #include <libdnf5/conf/option_enum.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 #include <memory>
 #include <vector>
 
 namespace dnfdaemon::client {
+
+class GroupAvailableOption : public libdnf5::cli::session::BoolOption {
+public:
+    explicit GroupAvailableOption(libdnf5::cli::session::Command & command)
+        : BoolOption(command, "available", '\0', _("Show only available groups."), false) {}
+};
+
+class GroupInstalledOption : public libdnf5::cli::session::BoolOption {
+public:
+    explicit GroupInstalledOption(libdnf5::cli::session::Command & command)
+        : BoolOption(command, "installed", '\0', _("Show only installed groups."), false) {}
+};
+
+class GroupHiddenOption : public libdnf5::cli::session::BoolOption {
+public:
+    explicit GroupHiddenOption(libdnf5::cli::session::Command & command)
+        : BoolOption(command, "hidden", '\0', _("Show also hidden groups."), false) {}
+};
+
+class GroupContainPkgsOption : public libdnf5::cli::session::AppendStringListOption {
+public:
+    explicit GroupContainPkgsOption(libdnf5::cli::session::Command & command)
+        : AppendStringListOption(
+              command,
+              "contains-pkgs",
+              '\0',
+              _("Show only groups containing packages with specified names. List option, supports globs."),
+              "PACKAGE_NAME,...") {}
+};
+
 
 class GroupListCommand : public DaemonCommand {
 public:
@@ -36,6 +68,10 @@ public:
 
 private:
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_options{nullptr};
+    std::unique_ptr<GroupHiddenOption> hidden{nullptr};
+    std::unique_ptr<GroupAvailableOption> available{nullptr};
+    std::unique_ptr<GroupInstalledOption> installed{nullptr};
+    std::unique_ptr<GroupContainPkgsOption> contains_pkgs{nullptr};
     const std::string command;
 };
 

--- a/dnf5daemon-client/wrappers/dbus_group_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_group_wrapper.hpp
@@ -50,8 +50,7 @@ public:
     std::string get_description() const { return rawdata.at("description"); }
     std::string get_order() const { return rawdata.at("order"); }
     std::string get_langonly() const { return rawdata.at("langonly"); }
-    // TODO(mblaha) proper installed value
-    bool get_installed() const { return false; }
+    bool get_installed() const { return rawdata.at("installed"); }
     bool get_uservisible() const { return rawdata.at("uservisible"); }
     std::set<std::string> get_repos() const;
     std::vector<DbusGroupPackageWrapper> get_packages() const { return packages; }

--- a/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
+++ b/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
@@ -3,3 +3,4 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.SessionManager.xml ${C
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.rpm.Repo.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.rpm.Repo.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.rpm.Rpm.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.rpm.Rpm.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Advisory.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Advisory.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.comps.Group.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.comps.Group.xml COPYONLY)

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
@@ -1,0 +1,61 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<node>
+<!-- org.rpm.dnf.v0.comps.Group:
+   @short_description: Interface to comps groups
+-->
+<interface name="org.rpm.dnf.v0.comps.Group">
+    <!--
+        list:
+        @options: an array of key/value pairs
+        @groups: array of returned groups with requested attributes
+
+        Get list of groups that match to given filters.
+
+        Following options and filters are supported:
+
+            - attributes: list of strings
+                list of group attributes that are returned
+            - match_group_id: bool (default true)
+                match patterns against ids of the groups
+            - match_group_name: bool (default false)
+                match patterns against names of the groups
+            - scope: string (default "all")
+                limit groups to one of "all", "installed", "available"
+            - with_hidden: bool (default false)
+                include hidden groups into the result
+            - patterns: list of strings
+                any group matching to any of patterns is returned
+            - contains_pkgs: list of strings
+                include only groups containing given packages
+
+        Unknown options are ignored.
+    -->
+    <method name="list">
+        <arg name="options" type="a{sv}" direction="in"/>
+        <arg name="groups" type="aa{sv}" direction="out"/>
+    </method>
+
+</interface>
+
+</node>

--- a/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
@@ -98,6 +98,21 @@ Interfaces
 
 .. only:: sphinx4
 
+   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
+
+.. only:: not sphinx4
+
+   .. warning::
+      Sphinx 4 is required to build D-Bus documentation.
+
+      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml``:
+
+   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
+      :language: xml
+
+
+.. only:: sphinx4
+
    ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Advisory.xml
 
 .. only:: not sphinx4


### PR DESCRIPTION
New accepted options:

- with_hidden - boolean, defaults to false
  whether include hidden (uservisible=false) groups into output
- scope - string, accepted values "all" (default), "installed",
"available"
- group_with_id - boolean, defaults to true
  whether patterns should be matched against group ids
- group_with_name - boolean, defaults to false
  whether patterns should be matched against group names
- contains_pkgs - list of strings
  only return groups containing given packages

Change in behavior:

- in case the scope is "all" (default), duplicated groups are removed
from the output. Duplicities basically mean that the group is
installed and previously both installed and available groups were
returned.

Also adds comps.Groups interface to the D-Bus API documentation and adjusts dnf5daemon-client accordingly.

Tests: https://github.com/rpm-software-management/dnf5/pull/1352