### PR TITLE
dnf5daemon: Remove reposdir from allowed config overrides

### DIFF
--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -60,7 +60,6 @@ static const std::unordered_set<std::string> ALLOWED_MAIN_CONF_OVERRIDES = {
     "obsoletes",
     "optional_metadata_types",
     "protect_running_kernel",
-    "reposdir",
     "skip_broken",
     "skip_if_unavailable",
     "skip_unavailable",


### PR DESCRIPTION
The option is potentially dangerous and can cause dnf5daemon-server to
block on malicious reposdir.