### PR TITLE
config: add search (se) and info (if) aliases

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -110,6 +110,13 @@ descr = "Alias for 'group'"
 group_id = 'commands-compatibility-aliases'
 complete = true
 
+['if']
+type = 'command'
+attached_command = 'info'
+descr = "Alias for 'info'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
 ['in']
 type = 'command'
 attached_command = 'install'
@@ -181,6 +188,13 @@ complete = false
 type = 'command'
 attached_command = 'repoquery'
 descr = "Alias for 'repoquery'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
+['se']
+type = 'command'
+attached_command = 'search'
+descr = "Alias for 'search'"
 group_id = 'commands-compatibility-aliases'
 complete = false
 


### PR DESCRIPTION
Adds two command aliases present in dnf4:

- `se` for the `search` command
- `if` for the `info` command