### PR TITLE
dnf5daemon-server/dbus: Install config files into /usr

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -714,7 +714,7 @@ Package management service with a DBus interface.
 %files -n dnf5daemon-server -f dnf5daemon-server.lang
 %{_sbindir}/dnf5daemon-server
 %{_unitdir}/dnf5daemon-server.service
-%config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.rpm.dnf.v0.conf
+%{_datadir}/dbus-1/system.d/org.rpm.dnf.v0.conf
 %{_datadir}/dbus-1/system-services/org.rpm.dnf.v0.service
 %{_datadir}/dbus-1/interfaces/org.rpm.dnf.v0.*.xml
 %{_datadir}/polkit-1/actions/org.rpm.dnf.v0.policy

--- a/dnf5daemon-server/dbus/CMakeLists.txt
+++ b/dnf5daemon-server/dbus/CMakeLists.txt
@@ -1,7 +1,6 @@
-set(SYSCONFDIR /etc)
 set(SYSTEMD_UNIT_DIR /usr/lib/systemd/system)
 set(DBUS_SHARE_DIR /usr/share/dbus-1)
-set(DBUS_CONFIG_DIR ${SYSCONFDIR}/dbus-1/system.d)
+set(DBUS_CONFIG_DIR ${DBUS_SHARE_DIR}/system.d)
 
 install (
     FILES "dnf5daemon-server.service"


### PR DESCRIPTION
We should prefer to install DBUS policy configuration files into /usr rather than /etc.