### PR TITLE
Give inline methods hidden visibility by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ find_package(PkgConfig REQUIRED)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Give inline methods hidden visibility by default
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 # remove PROJECT_SOURCE_DIR prefix from __FILE__ macro used in asserts (available since GCC 8 and Clang 10)
 add_compile_options("-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/=")
 


### PR DESCRIPTION
Hidden inline methods will not appear in the export table of a DSO (dynamic shared object) and will not require a PLT indirection when used within the DSO. 

According to the GCC man page:
Enabling  this  option  can have a dramatic effect on load and link times of a DSO as it massively reduces the size of the dynamic export table when the library  makes heavy use of templates.

So:
- it is optimization
- also hides our internal inline methos (Related to https://github.com/rpm-software-management/dnf5/issues/1304

And we can do this because we do not attempt to compare pointers to inline functions or methods where the  addresses  of  the two functions are taken in different shared objects.