### PR TITLE
Fix `DISTRO_SYNC_ALL` (distro-sync without arguments, system upgrade)

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -527,6 +527,10 @@ GoalProblem Goal::Impl::add_specs_to_goal(base::Transaction & transaction) {
             } break;
             case GoalAction::DISTRO_SYNC_ALL: {
                 rpm::PackageQuery query(base);
+                // Since distro-sync uses SOLVER_TARGETED mode we cannot pass in installed packages because if we did
+                // updating only a subset of packages would be a valid solution. However in a distro-sync we want to
+                // ensure ALL packages are synchronized with the target repository.
+                query.filter_available();
                 libdnf5::solv::IdQueue upgrade_ids;
                 for (auto package_id : *query.p_impl) {
                     upgrade_ids.push_back(package_id);


### PR DESCRIPTION
Since distro-sync uses `SOLVER_TARGETED` mode we cannot pass in installed packages because if we did updating only a subset of packages would be a valid solution. However in a distro-sync we want to ensure ALL packages are synchronized with the target repository.

This brings dnf5 behavior closer to dnf4.
There is still one difference in the transaction setup, dnf4 doesn't specify the transaction as targeted but thanks to libsolv's `auto-targeting` this should have the same behavior.

For: https://bugzilla.redhat.com/show_bug.cgi?id=2273749

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1482