### PR TITLE
dnfdaemon: Missing signal registration

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -230,21 +230,25 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
     <!--
         transaction_before_begin:
+        @session_object_path: object path of the dnf5daemon session
         @total: number of elements in the rpm transaction
 
         Send right before the rpm transaction is run.
     -->
     <signal name="transaction_before_begin">
+        <arg name="session_object_path" type="o" />
         <arg name="total" type="t" />
     </signal>
 
     <!--
         transaction_after_complete:
+        @session_object_path: object path of the dnf5daemon session
         @success: true if the rpm transaction was completed successfully
 
         Send right after the rpm transaction run finished.
     -->
     <signal name="transaction_after_complete">
+        <arg name="session_object_path" type="o" />
         <arg name="success" type="b" />
     </signal>
 

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -115,6 +115,13 @@ void Rpm::dbus_register() {
         });
 
     dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_BEFORE_BEGIN, "ot", {"session_object_path", "total"});
+    dbus_object->registerSignal(
+        dnfdaemon::INTERFACE_RPM,
+        dnfdaemon::SIGNAL_TRANSACTION_AFTER_COMPLETE,
+        "ob",
+        {"session_object_path", "success"});
+    dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_ELEM_PROGRESS,
         "ostt",


### PR DESCRIPTION
- correctly register "transaction_before_begin" and
  "transaction_after_complete" signals on Rpm interface
- add missing argument to the signals in introspection file