### PR TITLE
dnfdaemon: Catch timeout during CheckAuthorization

### DIFF
--- a/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
@@ -31,6 +31,7 @@ Dbus methods and arguments. Generated from dbus XMLs.
 Description
 ===========
 
+Note: While most of the following methods can be invoked successfully by a regular user, authentication by an administrative user is required for some of them (e.g. `Goal.do_transaction()`, `Repo.confirm_key()`, `Repo.enable()`, `Repo.disable()`). This authentication is managed by calling `CheckAuthorization()` method of the `org.freedesktop.PolicyKit1.Authority` Polkit D-Bus interface. The `AllowUserInteraction` flag is set for this call, indicating that if an authentication agent is available, the call is blocked while the user is prompted to authenticate. A hardcoded timeout of 2 minutes is set for the user interaction.
 
 Interfaces
 ==========


### PR DESCRIPTION
- set a timeout for the user to enter the password (default 25 seconds
  seems to be too short)
- catch timeout error - otherwise the error is returned to the client
  causing the original call to fail with timeout

For example:

The user invokes the do_transaction() method on the Goal interface. The
first action of the do_transaction handler is to verify that the user is
authorized to run an RPM transaction. If an authentication agent is
available, this may result in prompting the user to enter their
password. If the user ignores the prompt, after a timeout period, the
result should be a "Not authorized" error.

However, without this patch, the result would be a "Method call timed
out," which is misleading. While the user called do_transaction(), the
timeout did not occur at this stage.

For: https://github.com/rpm-software-management/dnf5/issues/1187