### PR TITLE
Enable import data from DNF4 for systems without state dir

### DIFF
--- a/libdnf5/system/state.cpp
+++ b/libdnf5/system/state.cpp
@@ -250,6 +250,11 @@ State::State(const std::filesystem::path & path) : path(path) {
 
 bool State::packages_import_required() {
     // Importing will require write permission
+    std::error_code ec;
+    std::filesystem::create_directories(path, ec);
+    if (ec) {
+        return false;
+    }
     try {
         utils::fs::TempFile(path, "permissions-test");
     } catch (const FileSystemError & e) {


### PR DESCRIPTION
The original test for import failed because tmp file cannot be created when target directory is not present.

Closes: https://github.com/rpm-software-management/dnf5/issues/1379