### PR TITLE
Base: `notify_repos_configured` and `are_repos_configured methods`, libdnf5 plugins `post_repos_configured` hook

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1212,6 +1212,8 @@ int main(int argc, char * argv[]) try {
                 dump_main_configuration(context);
             }
 
+            base.notify_repos_configured();
+
             if (const auto & repo_id_list = context.get_dump_repo_config_id_list(); !repo_id_list.empty()) {
                 dump_repository_configuration(context, repo_id_list);
             }

--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -101,6 +101,15 @@ public:
     /// Returns true when setup() (mandatory method in many workflows) was already called
     bool is_initialized();
 
+    /// Notifies the libdnf5 library that the repositories are configured.  It can be called before `load_repos`.
+    /// The libdnf5 library can then call plugins that can make final adjustments to the repositories configuration.
+    /// In the case that it has not been called, it is called automatically at the beginning of the load_repos method.
+    /// Calling the method for the second time result in throwing an exception.
+    void notify_repos_configured();
+
+    /// Returns true when notify_repos_configured() was already called (by user or automatically)
+    bool are_repos_configured() const noexcept;
+
     // TODO(jmracek) Remove from public API due to unstability of the code
     transaction::TransactionHistoryWeakPtr get_transaction_history();
     libdnf5::module::ModuleSackWeakPtr get_module_sack();

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -91,6 +91,10 @@ public:
     /// It is called in `Base::notify_repos_configured` method.
     virtual void repos_configured() {}
 
+    /// The repos_loaded hook.
+    /// It is called at the end of the `RepoSack::load_repos` method (in Impl).
+    virtual void repos_loaded() {}
+
     /// The pre_transaction hook.
     /// It is called just before the actual transaction starts.
     virtual void pre_transaction(const libdnf5::base::Transaction &) {}

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -87,6 +87,10 @@ public:
     /// It is called at the end of the `Base::setup` method.
     virtual void post_base_setup() {}
 
+    /// The repos_configured hook.
+    /// It is called in `Base::notify_repos_configured` method.
+    virtual void repos_configured() {}
+
     /// The pre_transaction hook.
     /// It is called just before the actual transaction starts.
     virtual void pre_transaction(const libdnf5::base::Transaction &) {}

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -23,6 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/version.hpp"
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace libdnf5 {
 
@@ -94,6 +96,15 @@ public:
     /// The repos_loaded hook.
     /// It is called at the end of the `RepoSack::load_repos` method (in Impl).
     virtual void repos_loaded() {}
+
+    /// The pre_add_cmdline_packages hook.
+    /// It is called at the beginning of the `RepoSack::add_cmdline_packages` method.
+    /// @param paths Vector of paths (local files or URLs) to package files to be inserted into cmdline repo.
+    virtual void pre_add_cmdline_packages([[maybe_unused]] const std::vector<std::string> & paths) {}
+
+    /// The post_add_cmdline_packages hook.
+    /// It is called at the end of the `RepoSack::add_cmdline_packages` method.
+    virtual void post_add_cmdline_packages() {}
 
     /// The pre_transaction hook.
     /// It is called just before the actual transaction starts.

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -108,11 +108,13 @@ public:
 
     /// The pre_transaction hook.
     /// It is called just before the actual transaction starts.
-    virtual void pre_transaction(const libdnf5::base::Transaction &) {}
+    /// @param transaction Contains the transaction that will be started.
+    virtual void pre_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
 
     /// The post_transaction hook.
     /// It is called after transactions.
-    virtual void post_transaction(const libdnf5::base::Transaction &) {}
+    /// @param transaction Contains the completed transaction.
+    virtual void post_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
 
     /// Finish the plugin and release all resources obtained by the init method and in hooks.
     virtual void finish() noexcept {}

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -262,6 +262,8 @@ void Base::notify_repos_configured() {
     auto & repos_configured = p_impl->repos_configured;
     libdnf_user_assert(!repos_configured, "The `notify_repos_configured` notification has already been called");
 
+    p_impl->plugins.repos_configured();
+
     repos_configured = true;
 }
 

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -255,6 +255,20 @@ bool Base::is_initialized() {
     return p_impl->pool.get() != nullptr;
 }
 
+void Base::notify_repos_configured() {
+    auto & pool = p_impl->pool;
+    libdnf_user_assert(pool, "Base has not been initialized");
+
+    auto & repos_configured = p_impl->repos_configured;
+    libdnf_user_assert(!repos_configured, "The `notify_repos_configured` notification has already been called");
+
+    repos_configured = true;
+}
+
+bool Base::are_repos_configured() const noexcept {
+    return p_impl->repos_configured;
+}
+
 ConfigMain & Base::get_config() {
     return p_impl->config;
 }

--- a/libdnf5/base/base_impl.hpp
+++ b/libdnf5/base/base_impl.hpp
@@ -63,6 +63,8 @@ private:
     friend class Base;
     Impl(const libdnf5::BaseWeakPtr & base, std::vector<std::unique_ptr<Logger>> && loggers);
 
+    bool repos_configured{false};
+
     // RpmPool as the owner of underlying libsolv data, has to be the first member so that it is destroyed last.
     std::unique_ptr<solv::RpmPool> pool;
 

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -246,6 +246,14 @@ void Plugins::repos_configured() {
     }
 }
 
+void Plugins::repos_loaded() {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->repos_loaded();
+        }
+    }
+}
+
 void Plugins::pre_transaction(const libdnf5::base::Transaction & transaction) {
     for (auto & plugin : plugins) {
         if (plugin->get_enabled()) {

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -238,6 +238,14 @@ void Plugins::post_base_setup() {
     }
 }
 
+void Plugins::repos_configured() {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->repos_configured();
+        }
+    }
+}
+
 void Plugins::pre_transaction(const libdnf5::base::Transaction & transaction) {
     for (auto & plugin : plugins) {
         if (plugin->get_enabled()) {

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -254,6 +254,22 @@ void Plugins::repos_loaded() {
     }
 }
 
+void Plugins::pre_add_cmdline_packages(const std::vector<std::string> & paths) {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->pre_add_cmdline_packages(paths);
+        }
+    }
+}
+
+void Plugins::post_add_cmdline_packages() {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->post_add_cmdline_packages();
+        }
+    }
+}
+
 void Plugins::pre_transaction(const libdnf5::base::Transaction & transaction) {
     for (auto & plugin : plugins) {
         if (plugin->get_enabled()) {

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -58,6 +58,7 @@ public:
     void init();
     void pre_base_setup();
     void post_base_setup();
+    void repos_configured();
     void pre_transaction(const libdnf5::base::Transaction & transaction);
     void post_transaction(const libdnf5::base::Transaction & transaction);
     void finish() noexcept;
@@ -95,6 +96,8 @@ public:
     void pre_base_setup();
 
     void post_base_setup();
+
+    void repos_configured();
 
     void pre_transaction(const libdnf5::base::Transaction & transaction);
 
@@ -151,6 +154,12 @@ inline void Plugin::pre_base_setup() {
 inline void Plugin::post_base_setup() {
     if (iplugin_instance) {
         iplugin_instance->post_base_setup();
+    }
+}
+
+inline void Plugin::repos_configured() {
+    if (iplugin_instance) {
+        iplugin_instance->repos_configured();
     }
 }
 

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -60,6 +60,8 @@ public:
     void post_base_setup();
     void repos_configured();
     void repos_loaded();
+    void pre_add_cmdline_packages(const std::vector<std::string> & paths);
+    void post_add_cmdline_packages();
     void pre_transaction(const libdnf5::base::Transaction & transaction);
     void post_transaction(const libdnf5::base::Transaction & transaction);
     void finish() noexcept;
@@ -101,6 +103,10 @@ public:
     void repos_configured();
 
     void repos_loaded();
+
+    void pre_add_cmdline_packages(const std::vector<std::string> & paths);
+
+    void post_add_cmdline_packages();
 
     void pre_transaction(const libdnf5::base::Transaction & transaction);
 
@@ -169,6 +175,18 @@ inline void Plugin::repos_configured() {
 inline void Plugin::repos_loaded() {
     if (iplugin_instance) {
         iplugin_instance->repos_loaded();
+    }
+}
+
+inline void Plugin::pre_add_cmdline_packages(const std::vector<std::string> & paths) {
+    if (iplugin_instance) {
+        iplugin_instance->pre_add_cmdline_packages(paths);
+    }
+}
+
+inline void Plugin::post_add_cmdline_packages() {
+    if (iplugin_instance) {
+        iplugin_instance->post_add_cmdline_packages();
     }
 }
 

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -59,6 +59,7 @@ public:
     void pre_base_setup();
     void post_base_setup();
     void repos_configured();
+    void repos_loaded();
     void pre_transaction(const libdnf5::base::Transaction & transaction);
     void post_transaction(const libdnf5::base::Transaction & transaction);
     void finish() noexcept;
@@ -98,6 +99,8 @@ public:
     void post_base_setup();
 
     void repos_configured();
+
+    void repos_loaded();
 
     void pre_transaction(const libdnf5::base::Transaction & transaction);
 
@@ -160,6 +163,12 @@ inline void Plugin::post_base_setup() {
 inline void Plugin::repos_configured() {
     if (iplugin_instance) {
         iplugin_instance->repos_configured();
+    }
+}
+
+inline void Plugin::repos_loaded() {
+    if (iplugin_instance) {
+        iplugin_instance->repos_loaded();
     }
 }
 

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -541,6 +541,8 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
     base->get_rpm_package_sack()->load_config_excludes_includes();
     base->get_module_sack()->p_impl->module_filtering();
     repos_updated_and_loaded = true;
+
+    base->p_impl->get_plugins().repos_loaded();
 }
 
 

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -149,6 +149,8 @@ RepoWeakPtr RepoSack::get_cmdline_repo() {
 
 std::map<std::string, libdnf5::rpm::Package> RepoSack::add_cmdline_packages(
     const std::vector<std::string> & paths, bool calculate_checksum) {
+    p_impl->base->p_impl->get_plugins().pre_add_cmdline_packages(paths);
+
     // find remote URLs and local file paths in the input
     std::vector<std::string> rpm_urls;
     std::vector<std::string> rpm_filepaths;
@@ -230,6 +232,8 @@ std::map<std::string, libdnf5::rpm::Package> RepoSack::add_cmdline_packages(
     if (!path_to_package.empty()) {
         p_impl->base->get_rpm_package_sack()->load_config_excludes_includes();
     }
+
+    p_impl->base->p_impl->get_plugins().post_add_cmdline_packages();
 
     return path_to_package;
 }

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -553,14 +553,26 @@ void RepoSack::update_and_load_enabled_repos(bool load_system) {
 }
 
 void RepoSack::load_repos() {
+    auto & base = p_impl->base;
+
+    if (!base->are_repos_configured()) {
+        base->notify_repos_configured();
+    }
+
     // create the system repository if it does not exist
-    p_impl->base->get_repo_sack()->get_system_repo();
+    base->get_repo_sack()->get_system_repo();
     libdnf5::repo::RepoQuery repos(p_impl->base);
     repos.filter_enabled(true);
     p_impl->update_and_load_repos(repos);
 }
 
 void RepoSack::load_repos(Repo::Type type) {
+    auto & base = p_impl->base;
+
+    if (!base->are_repos_configured()) {
+        base->notify_repos_configured();
+    }
+
     libdnf_user_assert(
         (type == libdnf5::repo::Repo::Type::AVAILABLE) || (type == libdnf5::repo::Repo::Type::SYSTEM),
         "RepoSack::load_repos has to be used with libdnf5::repo::Repo::Type::SYSTEM, "
@@ -568,7 +580,7 @@ void RepoSack::load_repos(Repo::Type type) {
 
     if (type == Repo::Type::SYSTEM) {
         // create the system repository if it does not exist
-        p_impl->base->get_repo_sack()->get_system_repo();
+        base->get_repo_sack()->get_system_repo();
     }
 
     libdnf5::repo::RepoQuery repos(p_impl->base);


### PR DESCRIPTION
`notify_repos_configured` notifies the libdnf5 library that the repositories are configured.  It can be called before `load_repos`. The libdnf5 library can then call plugins `post_repos_configured` hook that can make final adjustments to the repositories configuration. In case the `notify_repos_configured` method was not explicitly called, it is called automatically at the beginning of the `load_repos` method.

Closes #1404 

Also adds hooks:
`repos_loaded`, `pre_add_cmdline_packages`, and `post_add_cmdline_packages`