### PR TITLE
spec: Add missing dnf-config-manager.8.gz file

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -762,6 +762,7 @@ config-manager, copr, and repoclosure commands.
 %if %{with dnf5_obsoletes_dnf}
 %{_mandir}/man8/dnf-builddep.8.*
 %{_mandir}/man8/dnf-changelog.8.*
+%{_mandir}/man8/dnf-config-manager.8.*
 %{_mandir}/man8/dnf-copr.8.*
 %{_mandir}/man8/dnf-needs-restarting.8.*
 %{_mandir}/man8/dnf-repoclosure.8.*


### PR DESCRIPTION
Should fix failing nightly testing builds.