### PR TITLE
Libdnf5 plugins: API and ABI stability improve, pImpl, IPluginData

### DIFF
--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_PLUGIN_IPLUGIN_HPP
 #define LIBDNF5_PLUGIN_IPLUGIN_HPP
 
+#include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/version.hpp"
 
 #include <cstdint>
@@ -123,7 +124,8 @@ public:
     Base & get_base() noexcept;
 
 private:
-    Base * base;
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf5::plugin

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -47,10 +47,12 @@ struct Version {
     std::uint16_t micro;
 };
 
+class IPluginData;
+
 /// @brief A base class for implementing LIBDNF5 plugins that introduce additional logic into the library using hooks.
 class IPlugin {
 public:
-    explicit IPlugin(Base & base);
+    explicit IPlugin(IPluginData & data);
     virtual ~IPlugin();
 
     IPlugin() = delete;
@@ -121,7 +123,7 @@ public:
     /// Finish the plugin and release all resources obtained by the init method and in hooks.
     virtual void finish() noexcept;
 
-    Base & get_base() noexcept;
+    Base & get_base() const noexcept;
 
 private:
     class Impl;
@@ -147,7 +149,7 @@ libdnf5::plugin::Version libdnf_plugin_get_version(void);
 
 /// Creates a new plugin instance. Passes the API version to the plugin.
 libdnf5::plugin::IPlugin * libdnf_plugin_new_instance(
-    libdnf5::LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser);
+    libdnf5::LibraryVersion library_version, libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser & parser);
 
 /// Deletes plugin instance.
 void libdnf_plugin_delete_instance(libdnf5::plugin::IPlugin * plugin_instance);

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -49,9 +49,10 @@ struct Version {
 /// @brief A base class for implementing LIBDNF5 plugins that introduce additional logic into the library using hooks.
 class IPlugin {
 public:
-    IPlugin(Base & base) : base(&base) {}
-    virtual ~IPlugin() = default;
+    explicit IPlugin(Base & base);
+    virtual ~IPlugin();
 
+    IPlugin() = delete;
     IPlugin(const IPlugin &) = delete;
     IPlugin(IPlugin &&) = delete;
     IPlugin & operator=(const IPlugin &) = delete;
@@ -75,51 +76,51 @@ public:
 
     /// The plugin can load additional plugins. E.g. C++ plugin for loading Python plugins.
     /// Called before init.
-    virtual void load_plugins() {}
+    virtual void load_plugins();
 
     /// Plugin initialization.
     /// Called before hooks.
-    virtual void init() {}
+    virtual void init();
 
     /// The pre_base_setup hook.
     /// It is called at the beginning of the `Base::setup` method (after the `init` hook).
-    virtual void pre_base_setup() {}
+    virtual void pre_base_setup();
 
     /// The post_base_setup hook.
     /// It is called at the end of the `Base::setup` method.
-    virtual void post_base_setup() {}
+    virtual void post_base_setup();
 
     /// The repos_configured hook.
     /// It is called in `Base::notify_repos_configured` method.
-    virtual void repos_configured() {}
+    virtual void repos_configured();
 
     /// The repos_loaded hook.
     /// It is called at the end of the `RepoSack::load_repos` method (in Impl).
-    virtual void repos_loaded() {}
+    virtual void repos_loaded();
 
     /// The pre_add_cmdline_packages hook.
     /// It is called at the beginning of the `RepoSack::add_cmdline_packages` method.
     /// @param paths Vector of paths (local files or URLs) to package files to be inserted into cmdline repo.
-    virtual void pre_add_cmdline_packages([[maybe_unused]] const std::vector<std::string> & paths) {}
+    virtual void pre_add_cmdline_packages(const std::vector<std::string> & paths);
 
     /// The post_add_cmdline_packages hook.
     /// It is called at the end of the `RepoSack::add_cmdline_packages` method.
-    virtual void post_add_cmdline_packages() {}
+    virtual void post_add_cmdline_packages();
 
     /// The pre_transaction hook.
     /// It is called just before the actual transaction starts.
     /// @param transaction Contains the transaction that will be started.
-    virtual void pre_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
+    virtual void pre_transaction(const libdnf5::base::Transaction & transaction);
 
     /// The post_transaction hook.
     /// It is called after transactions.
     /// @param transaction Contains the completed transaction.
-    virtual void post_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
+    virtual void post_transaction(const libdnf5::base::Transaction & transaction);
 
     /// Finish the plugin and release all resources obtained by the init method and in hooks.
-    virtual void finish() noexcept {}
+    virtual void finish() noexcept;
 
-    Base & get_base() noexcept { return *base; }
+    Base & get_base() noexcept;
 
 private:
     Base * base;

--- a/include/libdnf5/version.hpp
+++ b/include/libdnf5/version.hpp
@@ -44,7 +44,7 @@ struct PluginAPIVersion {
     std::uint16_t minor;  // plugin must implement the `minor` version >= than the libdnf5 to work together
 };
 
-static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 1, .minor = 0};
+static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 /// @return Library version
 /// @since 5.0

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -67,7 +67,7 @@ struct CommandToRun {
 
 class Actions : public plugin::IPlugin {
 public:
-    Actions(libdnf5::Base & base, libdnf5::ConfigParser &) : IPlugin(base) {}
+    Actions(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~Actions() = default;
 
     PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
@@ -777,8 +777,10 @@ plugin::Version libdnf_plugin_get_version(void) {
 }
 
 plugin::IPlugin * libdnf_plugin_new_instance(
-    [[maybe_unused]] LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser) try {
-    return new Actions(base, parser);
+    [[maybe_unused]] LibraryVersion library_version,
+    libdnf5::plugin::IPluginData & data,
+    libdnf5::ConfigParser & parser) try {
+    return new Actions(data, parser);
 } catch (...) {
     return nullptr;
 }

--- a/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -40,7 +40,7 @@ constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "Plu
 
 class PythonPluginLoader : public plugin::IPlugin {
 public:
-    PythonPluginLoader(libdnf5::Base & base, libdnf5::ConfigParser &) : IPlugin(base) {}
+    PythonPluginLoader(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~PythonPluginLoader();
 
     PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
@@ -327,8 +327,10 @@ plugin::Version libdnf_plugin_get_version(void) {
 }
 
 plugin::IPlugin * libdnf_plugin_new_instance(
-    [[maybe_unused]] LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser) try {
-    return new PythonPluginLoader(base, parser);
+    [[maybe_unused]] LibraryVersion library_version,
+    libdnf5::plugin::IPluginData & data,
+    libdnf5::ConfigParser & parser) try {
+    return new PythonPluginLoader(data, parser);
 } catch (...) {
     return nullptr;
 }

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -39,7 +39,7 @@ constexpr const char * attrs_value[]{
 
 class Rhsm : public plugin::IPlugin {
 public:
-    Rhsm(libdnf5::Base & base, libdnf5::ConfigParser &) : IPlugin(base) {}
+    Rhsm(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~Rhsm() = default;
 
     PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
@@ -153,8 +153,10 @@ plugin::Version libdnf_plugin_get_version(void) {
 }
 
 plugin::IPlugin * libdnf_plugin_new_instance(
-    [[maybe_unused]] LibraryVersion library_version, libdnf5::Base & base, libdnf5::ConfigParser & parser) try {
-    return new Rhsm(base, parser);
+    [[maybe_unused]] LibraryVersion library_version,
+    libdnf5::plugin::IPluginData & data,
+    libdnf5::ConfigParser & parser) try {
+    return new Rhsm(data, parser);
 } catch (...) {
     return nullptr;
 }

--- a/libdnf5/plugin/iplugin.cpp
+++ b/libdnf5/plugin/iplugin.cpp
@@ -21,7 +21,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::plugin {
 
-IPlugin::IPlugin(Base & base) : base(&base) {}
+
+class IPlugin::Impl {
+public:
+    explicit Impl(Base & base) : base(&base) {}
+
+    Base & get_base() const noexcept { return *base; }
+
+private:
+    Base * base;
+};
+
+
+IPlugin::IPlugin(Base & base) : p_impl(new Impl(base)) {}
 
 IPlugin::~IPlugin() = default;
 
@@ -48,7 +60,7 @@ void IPlugin::post_transaction([[maybe_unused]] const libdnf5::base::Transaction
 void IPlugin::finish() noexcept {}
 
 Base & IPlugin::get_base() noexcept {
-    return *base;
+    return p_impl->get_base();
 }
 
 }  // namespace libdnf5::plugin

--- a/libdnf5/plugin/iplugin.cpp
+++ b/libdnf5/plugin/iplugin.cpp
@@ -17,23 +17,23 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "libdnf5/plugin/iplugin.hpp"
+#include "iplugin_private.hpp"
 
 namespace libdnf5::plugin {
 
 
 class IPlugin::Impl {
 public:
-    explicit Impl(Base & base) : base(&base) {}
+    explicit Impl(IPluginData & data) : data(&data) {}
 
-    Base & get_base() const noexcept { return *base; }
+    Base & get_base() const noexcept { return plugin::get_base(*data); }
 
 private:
-    Base * base;
+    IPluginData * data;
 };
 
 
-IPlugin::IPlugin(Base & base) : p_impl(new Impl(base)) {}
+IPlugin::IPlugin(IPluginData & data) : p_impl(new Impl(data)) {}
 
 IPlugin::~IPlugin() = default;
 
@@ -59,7 +59,7 @@ void IPlugin::post_transaction([[maybe_unused]] const libdnf5::base::Transaction
 
 void IPlugin::finish() noexcept {}
 
-Base & IPlugin::get_base() noexcept {
+Base & IPlugin::get_base() const noexcept {
     return p_impl->get_base();
 }
 

--- a/libdnf5/plugin/iplugin.cpp
+++ b/libdnf5/plugin/iplugin.cpp
@@ -1,0 +1,54 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/plugin/iplugin.hpp"
+
+namespace libdnf5::plugin {
+
+IPlugin::IPlugin(Base & base) : base(&base) {}
+
+IPlugin::~IPlugin() = default;
+
+void IPlugin::load_plugins() {}
+
+void IPlugin::init() {}
+
+void IPlugin::pre_base_setup() {}
+
+void IPlugin::post_base_setup() {}
+
+void IPlugin::repos_configured() {}
+
+void IPlugin::repos_loaded() {}
+
+void IPlugin::pre_add_cmdline_packages([[maybe_unused]] const std::vector<std::string> & paths) {}
+
+void IPlugin::post_add_cmdline_packages() {}
+
+void IPlugin::pre_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
+
+void IPlugin::post_transaction([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
+
+void IPlugin::finish() noexcept {}
+
+Base & IPlugin::get_base() noexcept {
+    return *base;
+}
+
+}  // namespace libdnf5::plugin

--- a/libdnf5/plugin/iplugin_private.hpp
+++ b/libdnf5/plugin/iplugin_private.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_PLUGIN_IPLUGIN_PRIVATE_HPP
+#define LIBDNF5_PLUGIN_IPLUGIN_PRIVATE_HPP
+
+#include "libdnf5/plugin/iplugin.hpp"
+
+namespace libdnf5::plugin {
+
+// IPluginData exists to allow the set of passed data to be changed in the future without changing the API and ABI.
+// IPluginData now represents Base. But in the future it may be a struct/class.
+
+inline IPluginData & get_iplugin_data(Base & base) noexcept {
+    return *reinterpret_cast<IPluginData *>(&base);
+}
+
+inline Base & get_base(IPluginData & data) noexcept {
+    return *reinterpret_cast<Base *>(&data);
+}
+
+}  // namespace libdnf5::plugin
+
+#endif

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "plugins.hpp"
 
+#include "iplugin_private.hpp"
 #include "utils/library.hpp"
 
 #include "libdnf5/base/base.hpp"
@@ -74,7 +75,7 @@ PluginLibrary::PluginLibrary(Base & base, ConfigParser && parser, const std::str
     get_version = reinterpret_cast<TGetVersionFunc>(library.get_address("libdnf_plugin_get_version"));
     new_instance = reinterpret_cast<TNewInstanceFunc>(library.get_address("libdnf_plugin_new_instance"));
     delete_instance = reinterpret_cast<TDeleteInstanceFunc>(library.get_address("libdnf_plugin_delete_instance"));
-    iplugin_instance = new_instance(libdnf5::get_library_version(), base, get_config_parser());
+    iplugin_instance = new_instance(libdnf5::get_library_version(), get_iplugin_data(base), get_config_parser());
 }
 
 PluginLibrary::~PluginLibrary() {


### PR DESCRIPTION
Related https://github.com/rpm-software-management/dnf5/issues/1025

Please merge PR https://github.com/rpm-software-management/dnf5/pull/1405 first.

PR introduces pImpl and IPluginData.

IPluginData was introduced to allow future changes to the passed dataset without changing the API and ABI.
IPluginData now represents Base. But in the future it may be a struct/class.

And increases the libdnf5 plugin API version to 2.0.