### PR TITLE
dnf5 IPlugin: Do not use inline methods on API

### DIFF
--- a/dnf5/include/dnf5/iplugin.hpp
+++ b/dnf5/include/dnf5/iplugin.hpp
@@ -37,9 +37,10 @@ struct PluginVersion {
 /// @brief A base class for implementing DNF5 plugins that provide one or more commands to users.
 class IPlugin {
 public:
-    IPlugin(Context & context) : context(&context) {}
-    virtual ~IPlugin() = default;
+    explicit IPlugin(Context & context);
+    virtual ~IPlugin();
 
+    IPlugin() = delete;
     IPlugin(const IPlugin &) = delete;
     IPlugin(IPlugin &&) = delete;
     IPlugin & operator=(const IPlugin &) = delete;
@@ -62,14 +63,14 @@ public:
     virtual const char * get_attribute(const char * name) const noexcept = 0;
 
     /// Plugin initialization.
-    virtual void init() {}
+    virtual void init();
 
     virtual std::vector<std::unique_ptr<Command>> create_commands() = 0;
 
     /// Finish the plugin and release all resources obtained by the init method and in hooks.
     virtual void finish() noexcept = 0;
 
-    Context & get_context() noexcept { return *context; }
+    Context & get_context() const noexcept;
 
 private:
     Context * context;

--- a/dnf5/include/dnf5/version.hpp
+++ b/dnf5/include/dnf5/version.hpp
@@ -44,7 +44,7 @@ struct PluginAPIVersion {
     std::uint16_t minor;  // plugin must implement the `minor` version >= than the dnf5 to work together
 };
 
-static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 1, .minor = 0};
+static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 
 /// @return Application version

--- a/dnf5/iplugin.cpp
+++ b/dnf5/iplugin.cpp
@@ -1,0 +1,35 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "dnf5/iplugin.hpp"
+
+namespace dnf5 {
+
+IPlugin::IPlugin(Context & context) : context(&context) {}
+
+IPlugin::~IPlugin() = default;
+
+void IPlugin::init() {}
+
+Context & IPlugin::get_context() const noexcept {
+    return *context;
+}
+
+}  // namespace dnf5


### PR DESCRIPTION
Related https://github.com/rpm-software-management/dnf5/issues/1025

And increases the dnf5 plugin API version to 2.0.