### PR TITLE
Not handle compatibility.conf as configuration file

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -265,7 +265,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %doc %{_sysconfdir}/dnf/dnf5-aliases.d/README
 %dir %{_datadir}/dnf5
 %dir %{_datadir}/dnf5/aliases.d
-%config %{_datadir}/dnf5/aliases.d/compatibility.conf
+%{_datadir}/dnf5/aliases.d/compatibility.conf
 %dir %{_libdir}/dnf5
 %dir %{_libdir}/dnf5/plugins
 %dir %{_datadir}/dnf5/dnf5-plugins


### PR DESCRIPTION
Distribution configuration files in /usr/share/dnf5 are not supposed to be modified by user and should be always overriden by the next update. This behavior allows to modify distribution configuration without modifying DNF5 code.

Closes: https://github.com/rpm-software-management/dnf5/issues/1407