### PR TITLE
Resolve goal according to strict setting first

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2428,7 +2428,7 @@ base::Transaction Goal::resolve() {
         }
     }
 
-    ret |= p_impl->rpm_goal.resolve();
+    transaction.p_impl->resolve_and_set_transaction(p_impl->rpm_goal, module_sack, ret);
 
     // Write debug solver data
     // Note: Modules debug data are handled separately when resolving module goal in ModuleSack::Impl::module_solve()
@@ -2455,8 +2455,6 @@ base::Transaction Goal::resolve() {
     }
 
     //TODO(amatej): Add conditional check that no extra packages were added by the solver
-
-    transaction.p_impl->set_transaction(p_impl->rpm_goal, module_sack, ret);
 
     return transaction;
 }

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -47,8 +47,10 @@ public:
 
     Impl & operator=(const Impl & other);
 
-    /// Set transaction according resolved goal and problems to EventLog
-    void set_transaction(rpm::solv::GoalPrivate & solved_goal, module::ModuleSack & module_sack, GoalProblem problems);
+    /// Resolve goal_to_resolve first using strict setting and then user defined setting,
+    /// then set transaction according the resolved goal and report problems to EventLog
+    void resolve_and_set_transaction(
+        rpm::solv::GoalPrivate & goal_to_resolve, module::ModuleSack & module_sack, GoalProblem problems);
 
     TransactionPackage make_transaction_package(
         Id id,


### PR DESCRIPTION
It should help to force solver to prefer latest solution rather then minimalistic solution skipping something.

Performance improvement for operation that does not generate any problem, because transaction is resolved only once with strict setting.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2272257