### PR TITLE
Re-enable clang builds after API changes

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false  # don't fail all matrix jobs if one of them fails
       matrix:
-        compiler: [gcc]  # gcc is the default
+        compiler: [gcc, clang]  # gcc is the default
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Related: #1257 and #1091.