### PR TITLE
[DNF5] Implement `--enable-plugin` and `--disable-pluin`

### DIFF
--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -76,8 +76,9 @@ public:
     libdnf5::Base base;
     std::vector<std::pair<std::string, std::string>> setopts;
     std::vector<std::pair<std::string, std::string>> repos_from_path;
-    std::vector<std::string> enable_plugins_patterns;
-    std::vector<std::string> disable_plugins_patterns;
+
+    /// list of lists of libdnf5 plugin names (global patterns) that we want to enable (true) or disable (false)
+    std::vector<std::pair<std::vector<std::string>, bool>> libdnf5_plugins_enablement;
 
     void store_offline(libdnf5::base::Transaction & transaction);
 


### PR DESCRIPTION
These command line arguments were added some time ago, but the handler logic has not been implemented.

Now these arguments enable/disable loading of listed libdnf5 library plugins.

Closes #1422.