### PR TITLE
Set `group` reason for packages removed by a group removal

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1741,7 +1741,7 @@ void Goal::Impl::install_group_package(base::Transaction & transaction, libdnf5:
         auto [pkg_problem, pkg_queue] =
             // TODO(mblaha): add_install_to_goal needs group spec for better problems reporting
             add_install_to_goal(transaction, GoalAction::INSTALL_BY_COMPS, pkg_name, pkg_settings);
-        rpm_goal.add_transaction_group_installed(pkg_queue);
+        rpm_goal.add_transaction_group_reason(pkg_queue);
     } else {
         // check whether condition can even be met
         rpm::PackageQuery condition_query(base);
@@ -1753,7 +1753,7 @@ void Goal::Impl::install_group_package(base::Transaction & transaction, libdnf5:
             // TODO(mblaha): log absence of pkg in case the query is empty
             if (!query.empty()) {
                 add_provide_install_to_goal(fmt::format("({} if {})", pkg_name, pkg_condition), pkg_settings);
-                rpm_goal.add_transaction_group_installed(*query.p_impl);
+                rpm_goal.add_transaction_group_reason(*query.p_impl);
             }
         }
     }
@@ -1792,6 +1792,7 @@ void Goal::Impl::remove_group_packages(const rpm::PackageSet & remove_candidates
 
     auto & cfg_main = base->get_config();
     rpm_goal.add_remove(packages_to_remove_ids, cfg_main.get_clean_requirements_on_remove_option().get_value());
+    rpm_goal.add_transaction_group_reason(packages_to_remove_ids);
 }
 
 void Goal::Impl::add_group_install_to_goal(

--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -682,21 +682,21 @@ void GoalPrivate::add_transaction_user_installed(const libdnf5::solv::IdQueue & 
     }
 }
 
-void GoalPrivate::add_transaction_group_installed(const libdnf5::solv::IdQueue & idqueue) {
-    if (!transaction_group_installed) {
+void GoalPrivate::add_transaction_group_reason(const libdnf5::solv::IdQueue & idqueue) {
+    if (!transaction_group_reason) {
         auto & pool = get_rpm_pool();
-        transaction_group_installed.reset(new libdnf5::solv::SolvMap(pool->nsolvables));
+        transaction_group_reason.reset(new libdnf5::solv::SolvMap(pool->nsolvables));
     }
     for (const auto & id : idqueue) {
-        transaction_group_installed->add(id);
+        transaction_group_reason->add(id);
     }
 }
 
-void GoalPrivate::add_transaction_group_installed(const libdnf5::solv::SolvMap & solvmap) {
-    if (!transaction_group_installed) {
-        transaction_group_installed.reset(new libdnf5::solv::SolvMap(solvmap));
+void GoalPrivate::add_transaction_group_reason(const libdnf5::solv::SolvMap & solvmap) {
+    if (!transaction_group_reason) {
+        transaction_group_reason.reset(new libdnf5::solv::SolvMap(solvmap));
     } else {
-        *transaction_group_installed |= solvmap;
+        *transaction_group_reason |= solvmap;
     }
 }
 
@@ -722,7 +722,7 @@ transaction::TransactionItemReason GoalPrivate::get_reason(Id id) {
             return transaction::TransactionItemReason::USER;
         }
         // explicitly group-installed
-        if (transaction_group_installed && transaction_group_installed->contains(id)) {
+        if (transaction_group_reason && transaction_group_reason->contains(id)) {
             return transaction::TransactionItemReason::GROUP;
         }
         // for some packages (e.g. installed by provide) we cannot decide the reason, resort to USER

--- a/libdnf5/rpm/solv/goal_private.hpp
+++ b/libdnf5/rpm/solv/goal_private.hpp
@@ -170,8 +170,8 @@ public:
     bool is_clean_deps_present() { return clean_deps_present; }
 
     void add_transaction_user_installed(const libdnf5::solv::IdQueue & idqueue);
-    void add_transaction_group_installed(const libdnf5::solv::IdQueue & idqueue);
-    void add_transaction_group_installed(const libdnf5::solv::SolvMap & solvmap);
+    void add_transaction_group_reason(const libdnf5::solv::IdQueue & idqueue);
+    void add_transaction_group_reason(const libdnf5::solv::SolvMap & solvmap);
 
     /// Add packages that should not be used by solver to satisfy weak dependencies
     void add_exclude_from_weak(const libdnf5::solv::SolvMap & solvmap);
@@ -188,7 +188,7 @@ private:
     unsigned int installonly_limit{0};
 
     // packages potentially installed by any group in this transaction
-    std::unique_ptr<libdnf5::solv::SolvMap> transaction_group_installed;
+    std::unique_ptr<libdnf5::solv::SolvMap> transaction_group_reason;
     // packages explicitly user-installed in this transaction
     std::unique_ptr<libdnf5::solv::SolvMap> transaction_user_installed;
 


### PR DESCRIPTION
It also renames `add_transaction_group_installed` since it is now used to store removed packages as well.

I have discovered this while working on `undo` command, when undoing a `group remove` transaction the packages need to have a `group` reason.