### PR TITLE
[libdnf5 API] Base::get_plugins_info

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -50,6 +50,15 @@
 %template(BaseWeakPtr) libdnf5::WeakPtr<libdnf5::Base, false>;
 %template(VarsWeakPtr) libdnf5::WeakPtr<libdnf5::Vars, false>;
 
+%ignore std::vector<libdnf5::plugin::PluginInfo>::insert;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::pop;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::pop_back;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::push;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::push_back;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::reserve;
+%ignore std::vector<libdnf5::plugin::PluginInfo>::resize;
+%template(VectorPluginInfo) std::vector<libdnf5::plugin::PluginInfo>;
+
 %include "libdnf5/base/base.hpp"
 
 %include "libdnf5/base/solver_problems.hpp"

--- a/bindings/libdnf5/plugin.i
+++ b/bindings/libdnf5/plugin.i
@@ -16,9 +16,19 @@
 
 %{
     #include "libdnf5/plugin/iplugin.hpp"
+    #include "libdnf5/plugin/plugin_info.hpp"
 %}
 
 #define CV __perl_CV
+
+%include "libdnf5/plugin/plugin_version.hpp"
+
+%extend libdnf5::plugin::Version {
+    Version(std::uint16_t major, std::uint16_t minor, std::uint16_t micro) {
+        libdnf5::plugin::Version * ver = new libdnf5::plugin::Version({major, minor, micro});
+        return ver;
+    }
+}
 
 %ignore PluginError;
 %ignore libdnf_plugin_get_api_version;
@@ -29,9 +39,4 @@
 %feature("director") IPlugin;
 %include "libdnf5/plugin/iplugin.hpp"
 
-%extend libdnf5::plugin::Version {
-    Version(std::uint16_t major, std::uint16_t minor, std::uint16_t micro) {
-        libdnf5::plugin::Version * ver = new libdnf5::plugin::Version({major, minor, micro});
-        return ver;
-    }
-}
+%include "libdnf5/plugin/plugin_info.hpp"

--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/conf/vars.hpp"
 #include "libdnf5/logger/log_router.hpp"
 #include "libdnf5/module/module_sack.hpp"
+#include "libdnf5/plugin/plugin_info.hpp"
 #include "libdnf5/repo/download_callbacks.hpp"
 #include "libdnf5/repo/repo_sack.hpp"
 #include "libdnf5/rpm/package_sack.hpp"
@@ -93,6 +94,10 @@ public:
     /// @param enable Request: true - enable plugins, false - disable plugins
     /// @exception libdnf5::UserAssertionError When called after Base::setup
     void enable_disable_plugins(const std::vector<std::string> & plugin_names, bool enable);
+
+    /// @return a list of information about plugins found during Base::setup
+    /// @exception libdnf5::UserAssertionError When called before Base::setup
+    const std::vector<plugin::PluginInfo> & get_plugins_info() const;
 
     /// Loads libdnf plugins, vars from environment, varsdirs and installroot (releasever, arch) and resolves
     /// configuration of protected_packages (glob:).

--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -28,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/conf/vars.hpp"
 #include "libdnf5/logger/log_router.hpp"
 #include "libdnf5/module/module_sack.hpp"
-#include "libdnf5/plugin/iplugin.hpp"
 #include "libdnf5/repo/download_callbacks.hpp"
 #include "libdnf5/repo/repo_sack.hpp"
 #include "libdnf5/rpm/package_sack.hpp"

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -20,10 +20,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_PLUGIN_IPLUGIN_HPP
 #define LIBDNF5_PLUGIN_IPLUGIN_HPP
 
+#include "plugin_version.hpp"
+
 #include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/version.hpp"
 
-#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -39,13 +40,6 @@ class Transaction;
 }  // namespace libdnf5
 
 namespace libdnf5::plugin {
-
-/// Plugin version
-struct Version {
-    std::uint16_t major;
-    std::uint16_t minor;
-    std::uint16_t micro;
-};
 
 class IPluginData;
 

--- a/include/libdnf5/plugin/plugin_info.hpp
+++ b/include/libdnf5/plugin/plugin_info.hpp
@@ -1,0 +1,75 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of li
+bdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_PLUGIN_PLUGIN_INFO_HPP
+#define LIBDNF5_PLUGIN_PLUGIN_INFO_HPP
+
+#include "plugin_version.hpp"
+
+#include "libdnf5/common/impl_ptr.hpp"
+#include "libdnf5/version.hpp"
+
+namespace libdnf5::plugin {
+
+class PluginInfo {
+public:
+    ~PluginInfo();
+
+    PluginInfo(const PluginInfo & src);
+    PluginInfo(PluginInfo && src) noexcept;
+    PluginInfo & operator=(const PluginInfo & src);
+    PluginInfo & operator=(PluginInfo && src) noexcept;
+
+    PluginInfo() = delete;
+
+    /// @return the real name of the plugin or derived from the configuration file if the plugin is not loaded
+    const std::string & get_name() const noexcept;
+
+    /// @return true if the plugin is loaded
+    bool is_loaded() const noexcept;
+
+    /// @return the version of the API supported by the plugin, or zeros if the plugin is not loaded
+    PluginAPIVersion get_api_version() const noexcept;
+
+    /// @return the real plugin name (returned from plugin) or nullptr if the plugin is not loaded
+    const char * get_real_name() const noexcept;
+
+    /// @return the version of the plugin, or zeros if the plugin is not loaded
+    Version get_version() const noexcept;
+
+    /// @return a nullptr terminated array of attributes supported by the plugin or nullptr if the plugin is not loaded
+    const char * const * get_attributes() const noexcept;
+
+    /// Gets the value of the attribute from the plugin.
+    /// Returns nullptr if the attribute does not exist or plugin is not loaded.
+    /// @return the value of the `name` attribute or nullptr
+    const char * get_attribute(const char * name) const noexcept;
+
+    class Impl;
+
+private:
+    explicit PluginInfo(Impl & p_impl);
+
+    ImplPtr<Impl> p_impl;
+};
+
+}  // namespace libdnf5::plugin
+
+#endif

--- a/include/libdnf5/plugin/plugin_version.hpp
+++ b/include/libdnf5/plugin/plugin_version.hpp
@@ -1,0 +1,36 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_PLUGIN_PLUGIN_VERSION_HPP
+#define LIBDNF5_PLUGIN_PLUGIN_VERSION_HPP
+
+#include <cstdint>
+
+namespace libdnf5::plugin {
+
+/// Plugin version
+struct Version {
+    std::uint16_t major;
+    std::uint16_t minor;
+    std::uint16_t micro;
+};
+
+}  // namespace libdnf5::plugin
+
+#endif

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/base/transaction.hpp>
 #include <libdnf5/common/exception.hpp>
+#include <libdnf5/plugin/iplugin.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <sys/wait.h>

--- a/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <Python.h>
 #include <fmt/format.h>
 #include <libdnf5/base/base.hpp>
+#include <libdnf5/plugin/iplugin.hpp>
 
 #include <cstdlib>
 #include <cstring>

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <fcntl.h>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/common/exception.hpp>
+#include <libdnf5/plugin/iplugin.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <rhsm/rhsm.h>
 #include <unistd.h>

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -157,6 +157,11 @@ void Base::enable_disable_plugins(const std::vector<std::string> & plugin_names,
     }
 }
 
+const std::vector<plugin::PluginInfo> & Base::get_plugins_info() const {
+    libdnf_user_assert(p_impl->pool, "Base::get_plugins_info must not be called before Base::setup");
+    return p_impl->get_plugins_info();
+}
+
 void Base::setup() {
     auto & pool = p_impl->pool;
     libdnf_user_assert(!pool, "Base was already initialized");

--- a/libdnf5/base/base_impl.hpp
+++ b/libdnf5/base/base_impl.hpp
@@ -56,6 +56,10 @@ public:
 
     plugin::Plugins & get_plugins() { return plugins; }
 
+    std::vector<plugin::PluginInfo> & get_plugins_info() { return plugins_info; }
+
+    const std::vector<plugin::PluginInfo> & get_plugins_info() const { return plugins_info; }
+
     /// Call a function that loads the config file, catching errors appropriately
     void with_config_file_path(std::function<void(const std::string &)> func);
 
@@ -94,6 +98,7 @@ private:
 
     /// map of plugin names (global patterns) that we want to enable (true) or disable (false)
     PreserveOrderMap<std::string, bool> plugins_enablement;
+    std::vector<plugin::PluginInfo> plugins_info;
 
     WeakPtrGuard<LogRouter, false> log_router_guard;
     WeakPtrGuard<Vars, false> vars_guard;
@@ -102,10 +107,13 @@ private:
 
 class InternalBaseUser {
 public:
-    static solv::RpmPool & get_rpm_pool(const libdnf5::BaseWeakPtr & base) { return base->p_impl->get_rpm_pool(); }
     static solv::CompsPool & get_comps_pool(const libdnf5::BaseWeakPtr & base) {
         return base->p_impl->get_comps_pool();
     }
+
+    static std::vector<plugin::PluginInfo> & get_plugins_info(Base * base) { return base->p_impl->get_plugins_info(); }
+
+    static solv::RpmPool & get_rpm_pool(const libdnf5::BaseWeakPtr & base) { return base->p_impl->get_rpm_pool(); }
 };
 
 }  // namespace libdnf5

--- a/libdnf5/plugin/plugin_info.cpp
+++ b/libdnf5/plugin/plugin_info.cpp
@@ -1,0 +1,64 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "plugin_info_impl.hpp"
+
+namespace libdnf5::plugin {
+
+PluginInfo::PluginInfo(Impl & p_impl) : p_impl{&p_impl} {}
+
+PluginInfo::~PluginInfo() = default;
+
+PluginInfo::PluginInfo(const PluginInfo & src) = default;
+
+PluginInfo::PluginInfo(PluginInfo && src) noexcept = default;
+
+PluginInfo & PluginInfo::operator=(const PluginInfo & src) = default;
+
+PluginInfo & PluginInfo::operator=(PluginInfo && src) noexcept = default;
+
+const std::string & PluginInfo::get_name() const noexcept {
+    return p_impl->get_name();
+}
+
+bool PluginInfo::is_loaded() const noexcept {
+    return p_impl->is_loaded();
+}
+
+PluginAPIVersion PluginInfo::get_api_version() const noexcept {
+    return p_impl->get_api_version();
+}
+
+const char * PluginInfo::get_real_name() const noexcept {
+    return p_impl->get_real_name();
+}
+
+Version PluginInfo::get_version() const noexcept {
+    return p_impl->get_version();
+}
+
+const char * const * PluginInfo::get_attributes() const noexcept {
+    return p_impl->get_attributes();
+}
+
+const char * PluginInfo::get_attribute(const char * name) const noexcept {
+    return p_impl->get_attribute(name);
+}
+
+}  // namespace libdnf5::plugin

--- a/libdnf5/plugin/plugin_info_impl.hpp
+++ b/libdnf5/plugin/plugin_info_impl.hpp
@@ -1,0 +1,70 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_PLUGIN_PLUGIN_INFO_IMPL_HPP
+#define LIBDNF5_PLUGIN_PLUGIN_INFO_IMPL_HPP
+
+#include "libdnf5/plugin/iplugin.hpp"
+#include "libdnf5/plugin/plugin_info.hpp"
+
+namespace libdnf5::plugin {
+
+class PluginInfo::Impl {
+public:
+    static PluginInfo create_plugin_info(std::string name_from_config, const IPlugin * iplugin) {
+        return PluginInfo(*new Impl(name_from_config, iplugin));
+    }
+
+    Impl() = delete;
+    Impl(const Impl & src) = default;
+    Impl(Impl && src) = delete;
+
+    ~Impl() = default;
+
+    Impl & operator=(const Impl & src) = default;
+    Impl & operator=(Impl &&) = delete;
+
+    const std::string & get_name() const noexcept { return name; }
+
+    bool is_loaded() const noexcept { return iplugin; }
+
+    PluginAPIVersion get_api_version() const noexcept {
+        return iplugin ? iplugin->get_api_version() : PluginAPIVersion{0, 0};
+    }
+
+    const char * get_real_name() const noexcept { return iplugin ? iplugin->get_name() : nullptr; }
+
+    Version get_version() const noexcept { return iplugin ? iplugin->get_version() : Version{0, 0, 0}; }
+
+    const char * const * get_attributes() const noexcept { return iplugin ? iplugin->get_attributes() : nullptr; }
+
+    const char * get_attribute(const char * name) const noexcept {
+        return iplugin ? iplugin->get_attribute(name) : nullptr;
+    }
+
+private:
+    explicit Impl(std::string name, const IPlugin * iplugin) : name{name}, iplugin{iplugin} {}
+
+    std::string name;
+    const IPlugin * iplugin;
+};
+
+}  // namespace libdnf5::plugin
+
+#endif


### PR DESCRIPTION
Introduces the `Base::get_plugins_info` method, which returns a list of information about plugins found during `Base::setup`.

It also introduces the `plugin::PluginInfo` class, which provides information about one libdnf5 plugin.

Closes #1429
Related to #1335 