### PR TITLE
[DNF5] --enable-plugin and --disable-pluin: no match found message 

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -113,8 +113,6 @@ public:
 
     void load_repos(bool load_system);
 
-    std::vector<std::pair<std::vector<std::string>, bool>> libdnf5_plugins_enablement;
-
     void store_offline(libdnf5::base::Transaction & transaction);
 
     std::filesystem::path transaction_store_path;
@@ -182,12 +180,22 @@ public:
     std::vector<std::pair<std::string, std::string>> & get_repos_from_path() { return repos_from_path; }
     const std::vector<std::pair<std::string, std::string>> & get_repos_from_path() const { return repos_from_path; }
 
+    std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement() {
+        return libdnf_plugins_enablement;
+    }
+    const std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement() const {
+        return libdnf_plugins_enablement;
+    }
+
 private:
     Context & owner;
 
     libdnf5::Base base;
     std::vector<std::pair<std::string, std::string>> setopts;
     std::vector<std::pair<std::string, std::string>> repos_from_path;
+
+    /// list of lists of libdnf plugin names (global patterns) that we want to enable (true) or disable (false)
+    std::vector<std::pair<std::vector<std::string>, bool>> libdnf_plugins_enablement;
 
     std::string cmdline;
 
@@ -616,6 +624,14 @@ std::vector<std::pair<std::string, std::string>> & Context::get_repos_from_path(
 
 const std::vector<std::pair<std::string, std::string>> & Context::get_repos_from_path() const {
     return p_impl->get_repos_from_path();
+}
+
+std::vector<std::pair<std::vector<std::string>, bool>> & Context::get_libdnf_plugins_enablement() {
+    return p_impl->get_libdnf_plugins_enablement();
+}
+
+const std::vector<std::pair<std::vector<std::string>, bool>> & Context::get_libdnf_plugins_enablement() const {
+    return p_impl->get_libdnf_plugins_enablement();
 }
 
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -78,9 +78,6 @@ public:
     /// Sets callbacks for repositories and loads them, updating metadata if necessary.
     void load_repos(bool load_system);
 
-    /// list of lists of libdnf5 plugin names (global patterns) that we want to enable (true) or disable (false)
-    std::vector<std::pair<std::vector<std::string>, bool>> libdnf5_plugins_enablement;
-
     void store_offline(libdnf5::base::Transaction & transaction);
 
     // When set current transaction is not executed but rather stored to
@@ -159,6 +156,9 @@ public:
 
     std::vector<std::pair<std::string, std::string>> & get_repos_from_path();
     const std::vector<std::pair<std::string, std::string>> & get_repos_from_path() const;
+
+    std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement();
+    const std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement() const;
 
 private:
     class Impl;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -441,7 +441,7 @@ void RootCommand::set_argument_parser() {
         [&ctx](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             libdnf5::OptionStringList plugin_name_patterns(value);
-            ctx.libdnf5_plugins_enablement.emplace_back(plugin_name_patterns.get_value(), true);
+            ctx.get_libdnf_plugins_enablement().emplace_back(plugin_name_patterns.get_value(), true);
             return true;
         });
     global_options_group->register_argument(enable_plugins_names);
@@ -456,7 +456,7 @@ void RootCommand::set_argument_parser() {
         [&ctx](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             libdnf5::OptionStringList plugin_name_patterns(value);
-            ctx.libdnf5_plugins_enablement.emplace_back(plugin_name_patterns.get_value(), false);
+            ctx.get_libdnf_plugins_enablement().emplace_back(plugin_name_patterns.get_value(), false);
             return true;
         });
     global_options_group->register_argument(disable_plugins_names);
@@ -1175,7 +1175,7 @@ int main(int argc, char * argv[]) try {
 
             // Enable/disable libdnf5 plugins according to the list created by
             // the --enable-plugin and --disable-plugin commandline arguments
-            for (const auto & [plugin_name_pattern, enable] : context.libdnf5_plugins_enablement) {
+            for (const auto & [plugin_name_pattern, enable] : context.get_libdnf_plugins_enablement()) {
                 base.enable_disable_plugins(plugin_name_pattern, enable);
             }
 


### PR DESCRIPTION
Print a warning if no libdnf plugin with a matching name is found.

Also moves `Context::libdnf5_plugins_enablement` to `Impl` and adds getters `Context::get_libdnf_plugins_enablement()`. I overlooked it when I created the Impl.

Closes #1431
Depends on issue #1429. PR #1430 needs to be merged first, then I'll rebase this PR.