### PR TITLE
API: no inline methods, add p_impl

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -244,30 +244,30 @@ void AutomaticCommand::set_argument_parser() {
     {
         auto conflicts =
             parser.add_conflict_args_group(std::make_unique<std::vector<libdnf5::cli::ArgumentParser::Argument *>>());
-        conflicts->push_back(nodownloadupdates->arg);
-        downloadupdates->arg->set_conflict_arguments(conflicts);
+        conflicts->push_back(nodownloadupdates->get_arg());
+        downloadupdates->get_arg()->set_conflict_arguments(conflicts);
     }
     // installupdates and no-installupdates options conflict with each other.
     // installupdates and no-downloadupdates options conflict with each other.
     {
         auto conflicts =
             parser.add_conflict_args_group(std::make_unique<std::vector<libdnf5::cli::ArgumentParser::Argument *>>());
-        conflicts->push_back(downloadupdates->arg);
-        conflicts->push_back(installupdates->arg);
-        nodownloadupdates->arg->set_conflict_arguments(conflicts);
+        conflicts->push_back(downloadupdates->get_arg());
+        conflicts->push_back(installupdates->get_arg());
+        nodownloadupdates->get_arg()->set_conflict_arguments(conflicts);
     }
     {
         auto conflicts =
             parser.add_conflict_args_group(std::make_unique<std::vector<libdnf5::cli::ArgumentParser::Argument *>>());
-        conflicts->push_back(noinstallupdates->arg);
-        conflicts->push_back(nodownloadupdates->arg);
-        installupdates->arg->set_conflict_arguments(conflicts);
+        conflicts->push_back(noinstallupdates->get_arg());
+        conflicts->push_back(nodownloadupdates->get_arg());
+        installupdates->get_arg()->set_conflict_arguments(conflicts);
     }
     {
         auto conflicts =
             parser.add_conflict_args_group(std::make_unique<std::vector<libdnf5::cli::ArgumentParser::Argument *>>());
-        conflicts->push_back(installupdates->arg);
-        noinstallupdates->arg->set_conflict_arguments(conflicts);
+        conflicts->push_back(installupdates->get_arg());
+        noinstallupdates->get_arg()->set_conflict_arguments(conflicts);
     }
 }
 

--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -106,7 +106,7 @@ void AutomaticCommand::wait_for_network() {
     }
 
     auto & context = get_context();
-    auto & base = context.base;
+    auto & base = context.get_base();
     auto & logger = *base.get_logger();
     logger.debug("Waiting for internet connection...");
 
@@ -273,7 +273,7 @@ void AutomaticCommand::set_argument_parser() {
 
 void AutomaticCommand::pre_configure() {
     auto & context = get_context();
-    auto & base = context.base;
+    auto & base = context.get_base();
 
     auto random_sleep = config_automatic.config_commands.random_sleep.get_value();
     if (timer->get_value() && random_sleep > 0) {
@@ -321,7 +321,7 @@ void AutomaticCommand::configure() {
 
 void AutomaticCommand::run() {
     auto & context = get_context();
-    auto & base = context.base;
+    auto & base = context.get_base();
     bool success = true;
 
     // setup upgrade transaction goal
@@ -455,7 +455,7 @@ AutomaticCommand::~AutomaticCommand() {
     // during ~Base, resulting in a segmentation fault. Therefore, we need to reset
     // download_callbacks manually.
     if (download_callbacks_set) {
-        context.base.set_download_callbacks(nullptr);
+        context.get_base().set_download_callbacks(nullptr);
     }
 }
 

--- a/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
+++ b/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
@@ -55,7 +55,7 @@ void TransactionCallbacksSimple::install_start(
         case libdnf5::transaction::TransactionItemAction::DISABLE:
         case libdnf5::transaction::TransactionItemAction::RESET:
         case libdnf5::transaction::TransactionItemAction::SWITCH:
-            auto & logger = *context.base.get_logger();
+            auto & logger = *context.get_base().get_logger();
             logger.warning(
                 "Unexpected action in TransactionPackage: {}",
                 static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(

--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -92,7 +92,7 @@ void BuildDepCommand::set_argument_parser() {
 
 void BuildDepCommand::configure() {
     if (!pkg_specs.empty()) {
-        get_context().base.get_repo_sack()->enable_source_repos();
+        get_context().get_base().get_repo_sack()->enable_source_repos();
     }
 
     auto & context = get_context();
@@ -187,7 +187,7 @@ bool BuildDepCommand::add_from_pkg(
     std::set<std::string> & install_specs, std::set<std::string> & conflicts_specs, const std::string & pkg_spec) {
     auto & ctx = get_context();
 
-    libdnf5::rpm::PackageQuery pkg_query(ctx.base);
+    libdnf5::rpm::PackageQuery pkg_query(ctx.get_base());
     libdnf5::ResolveSpecSettings settings;
     settings.set_with_provides(false);
     settings.set_with_filenames(false);
@@ -200,7 +200,7 @@ bool BuildDepCommand::add_from_pkg(
         source_names.emplace_back(pkg.get_source_name());
     }
 
-    libdnf5::rpm::PackageQuery source_pkgs(ctx.base);
+    libdnf5::rpm::PackageQuery source_pkgs(ctx.get_base());
     source_pkgs.filter_arch(std::vector<std::string>{"src", "nosrc"});
     source_pkgs.filter_name(source_names);
     if (source_pkgs.empty()) {
@@ -286,9 +286,9 @@ void BuildDepCommand::run() {
     if (conflicts_specs.size() > 0) {
         auto & ctx = get_context();
         // exclude available (not installed) conflicting packages
-        auto system_repo = ctx.base.get_repo_sack()->get_system_repo();
-        auto rpm_package_sack = ctx.base.get_rpm_package_sack();
-        libdnf5::rpm::PackageQuery conflicts_query_available(ctx.base);
+        auto system_repo = ctx.get_base().get_repo_sack()->get_system_repo();
+        auto rpm_package_sack = ctx.get_base().get_rpm_package_sack();
+        libdnf5::rpm::PackageQuery conflicts_query_available(ctx.get_base());
         conflicts_query_available.filter_name(std::vector<std::string>{conflicts_specs.begin(), conflicts_specs.end()});
         libdnf5::rpm::PackageQuery conflicts_query_installed(conflicts_query_available);
         conflicts_query_available.filter_repo_id({system_repo->get_id()}, libdnf5::sack::QueryCmp::NEQ);
@@ -305,7 +305,7 @@ void BuildDepCommand::goal_resolved() {
     auto & transaction = *ctx.get_transaction();
     auto transaction_problems = transaction.get_problems();
     if (transaction_problems != libdnf5::GoalProblem::NO_PROBLEM) {
-        auto skip_unavailable = ctx.base.get_config().get_skip_unavailable_option().get_value();
+        auto skip_unavailable = ctx.get_base().get_config().get_skip_unavailable_option().get_value();
         if (transaction_problems != libdnf5::GoalProblem::NOT_FOUND || !skip_unavailable) {
             throw GoalResolveError(transaction);
         }

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -110,7 +110,7 @@ void ChangelogCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add(
+    context.get_base().get_config().get_optional_metadata_types_option().add(
         libdnf5::Option::Priority::RUNTIME, libdnf5::OPTIONAL_METADATA_TYPES);
 }
 
@@ -119,7 +119,7 @@ void ChangelogCommand::run() {
 
     std::pair<libdnf5::cli::output::ChangelogFilterType, std::variant<libdnf5::rpm::PackageQuery, int64_t, int32_t>>
         filter = {libdnf5::cli::output::ChangelogFilterType::NONE, 0};
-    libdnf5::rpm::PackageQuery full_package_query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery full_package_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
 
     auto since = since_option->get_value();
     auto count = count_option->get_value();
@@ -140,7 +140,7 @@ void ChangelogCommand::run() {
     }
 
     //query
-    libdnf5::rpm::PackageQuery query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK, true);
+    libdnf5::rpm::PackageQuery query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK, true);
     libdnf5::ResolveSpecSettings settings;
     settings.set_ignore_case(true);
     settings.set_with_nevra(true);

--- a/dnf5-plugins/config-manager_plugin/addrepo.cpp
+++ b/dnf5-plugins/config-manager_plugin/addrepo.cpp
@@ -263,7 +263,7 @@ void ConfigManagerAddRepoCommand::set_argument_parser() {
 
 void ConfigManagerAddRepoCommand::configure() {
     auto & ctx = get_context();
-    auto & base = ctx.base;
+    auto & base = ctx.get_base();
 
     const auto & repo_dirs = base.get_config().get_reposdir_option().get_value();
     if (repo_dirs.empty()) {
@@ -283,7 +283,7 @@ void ConfigManagerAddRepoCommand::configure() {
 void ConfigManagerAddRepoCommand::add_repos_from_repofile(
     const SourceRepofile & source_repofile, const std::filesystem::path & dest_repo_dir) {
     auto & ctx = get_context();
-    auto & base = ctx.base;
+    auto & base = ctx.get_base();
     auto logger = base.get_logger();
 
     if (save_filename.empty()) {
@@ -375,7 +375,7 @@ void ConfigManagerAddRepoCommand::create_repo(
     const std::map<std::string, std::string> & repo_opts,
     const std::filesystem::path & dest_repo_dir) {
     auto & ctx = get_context();
-    auto & base = ctx.base;
+    auto & base = ctx.get_base();
     auto logger = base.get_logger();
 
     // Test for presence of required arguments.
@@ -472,7 +472,7 @@ void ConfigManagerAddRepoCommand::test_if_filepath_not_exist(
 void ConfigManagerAddRepoCommand::test_if_ids_not_already_exist(
     const std::vector<std::string> & repo_ids, const std::filesystem::path & ignore_path) const {
     auto & ctx = get_context();
-    auto & base = ctx.base;
+    auto & base = ctx.get_base();
     auto logger = base.get_logger();
 
     // The repository can also be defined in the main configuration file.

--- a/dnf5-plugins/config-manager_plugin/setopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/setopt.cpp
@@ -161,7 +161,7 @@ void ConfigManagerSetOptCommand::set_argument_parser() {
 
 void ConfigManagerSetOptCommand::configure() {
     auto & ctx = get_context();
-    const auto & config = ctx.base.get_config();
+    const auto & config = ctx.get_base().get_config();
 
     auto repo_ids = load_existing_repo_ids();
     for (auto & [in_repo_id, repo_setopts] : in_repos_setopts) {
@@ -236,7 +236,7 @@ void ConfigManagerSetOptCommand::configure() {
 
 std::set<std::string> ConfigManagerSetOptCommand::load_existing_repo_ids() const {
     auto & ctx = get_context();
-    auto & base = ctx.base;
+    auto & base = ctx.get_base();
     auto logger = base.get_logger();
 
     std::set<std::string> repo_ids;

--- a/dnf5-plugins/config-manager_plugin/setvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/setvar.cpp
@@ -54,7 +54,7 @@ void ConfigManagerSetVarCommand::set_argument_parser() {
                 check_variable_name(var_name);
 
                 // Test that the variable is not read-only.
-                auto vars = ctx.base.get_vars();
+                auto vars = ctx.get_base().get_vars();
                 if (vars->is_read_only(var_name)) {
                     throw ConfigManagerError(
                         M_("Cannot set \"{}\": Variable \"{}\" is read-only"), std::string{value}, var_name);
@@ -92,7 +92,7 @@ void ConfigManagerSetVarCommand::configure() {
     auto & ctx = get_context();
 
     if (!setvars.empty()) {
-        const auto & vars_dir = get_last_vars_dir_path(ctx.base.get_config());
+        const auto & vars_dir = get_last_vars_dir_path(ctx.get_base().get_config());
         if (vars_dir.empty()) {
             throw ConfigManagerError(M_("Missing path to vars directory"));
         }

--- a/dnf5-plugins/config-manager_plugin/unsetopt.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetopt.cpp
@@ -89,7 +89,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                         tmp_repo_conf.opt_binds().at(repo_key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
                         write_warning(
-                            *ctx.base.get_logger(),
+                            *ctx.get_base().get_logger(),
                             M_("config-manager: Request to remove unsupported repository option: {}"),
                             key);
                     }
@@ -101,7 +101,7 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
                         tmp_config.opt_binds().at(key);
                     } catch (const OptionBindsOptionNotFoundError & ex) {
                         write_warning(
-                            *ctx.base.get_logger(),
+                            *ctx.get_base().get_logger(),
                             M_("config-manager: Request to remove unsupported main option: {}"),
                             key);
                     }
@@ -118,11 +118,11 @@ void ConfigManagerUnsetOptCommand::set_argument_parser() {
 
 void ConfigManagerUnsetOptCommand::configure() {
     auto & ctx = get_context();
-    const auto & config = ctx.base.get_config();
+    const auto & config = ctx.get_base().get_config();
 
     // Remove options from main configuration file.
     if (!main_opts_to_remove.empty()) {
-        const auto & cfg_filepath = get_config_file_path(ctx.base.get_config());
+        const auto & cfg_filepath = get_config_file_path(ctx.get_base().get_config());
         if (std::filesystem::exists(cfg_filepath)) {
             ConfigParser parser;
             bool changed = false;
@@ -136,7 +136,7 @@ void ConfigManagerUnsetOptCommand::configure() {
             for (const auto & key : main_opts_to_remove) {
                 if (!used_keys.contains(key)) {
                     write_warning(
-                        *ctx.base.get_logger(),
+                        *ctx.get_base().get_logger(),
                         M_("config-manager: Request to remove main option but it is not present in the config file: "
                            "{}"),
                         key);
@@ -148,7 +148,7 @@ void ConfigManagerUnsetOptCommand::configure() {
             }
         } else {
             write_warning(
-                *ctx.base.get_logger(),
+                *ctx.get_base().get_logger(),
                 M_("config-manager: Request to remove main option but config file not found: {}"),
                 cfg_filepath.string());
         }
@@ -182,7 +182,7 @@ void ConfigManagerUnsetOptCommand::configure() {
                 if (const auto used_repoid_opts = used_repos_opts.find(in_repoid);
                     used_repoid_opts == used_repos_opts.end()) {
                     write_warning(
-                        *ctx.base.get_logger(),
+                        *ctx.get_base().get_logger(),
                         M_("config-manager: Request to remove repository option but repoid is not present "
                            "in the overrides: {}"),
                         in_repoid);
@@ -190,7 +190,7 @@ void ConfigManagerUnsetOptCommand::configure() {
                     for (const auto & key : keys) {
                         if (!used_repoid_opts->second.contains(key))
                             write_warning(
-                                *ctx.base.get_logger(),
+                                *ctx.get_base().get_logger(),
                                 M_("config-manager: Request to remove repository option but it is not present "
                                    "in the overrides: {}.{}"),
                                 in_repoid,
@@ -210,7 +210,7 @@ void ConfigManagerUnsetOptCommand::configure() {
             }
         } else {
             write_warning(
-                *ctx.base.get_logger(),
+                *ctx.get_base().get_logger(),
                 M_("config-manager: Request to remove repository option but file with overrides not found: {}"),
                 repos_override_file_path.string());
         }

--- a/dnf5-plugins/config-manager_plugin/unsetvar.cpp
+++ b/dnf5-plugins/config-manager_plugin/unsetvar.cpp
@@ -58,14 +58,14 @@ void ConfigManagerUnsetVarCommand::set_argument_parser() {
 void ConfigManagerUnsetVarCommand::configure() {
     auto & ctx = get_context();
     if (!vars_to_remove.empty()) {
-        const auto & vars_dir = get_last_vars_dir_path(ctx.base.get_config());
+        const auto & vars_dir = get_last_vars_dir_path(ctx.get_base().get_config());
         if (vars_dir.empty()) {
             throw ConfigManagerError(M_("Missing path to vars directory"));
         }
 
         if (!std::filesystem::exists(vars_dir)) {
             write_warning(
-                *ctx.base.get_logger(),
+                *ctx.get_base().get_logger(),
                 M_("config-manager: Request to remove variable but vars directory was not found: {}"),
                 vars_dir.string());
             return;
@@ -78,7 +78,7 @@ void ConfigManagerUnsetVarCommand::configure() {
                     std::filesystem::remove(filepath);
                 } else {
                     write_warning(
-                        *ctx.base.get_logger(),
+                        *ctx.get_base().get_logger(),
                         M_("config-manager: Request to remove variable but it is not present in the vars directory: "
                            "{}"),
                         name);

--- a/dnf5-plugins/copr_plugin/copr_debug.cpp
+++ b/dnf5-plugins/copr_plugin/copr_debug.cpp
@@ -34,7 +34,7 @@ void CoprDebugCommand::set_argument_parser() {
 
 
 void CoprDebugCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     std::unique_ptr<dnf5::CoprConfig> copr_config = std::make_unique<dnf5::CoprConfig>(base);
     auto name_version = copr_config->get_value("main", "name_version");
     auto arch = copr_config->get_value("main", "arch");

--- a/dnf5-plugins/copr_plugin/copr_disable.cpp
+++ b/dnf5-plugins/copr_plugin/copr_disable.cpp
@@ -39,7 +39,7 @@ void CoprDisableCommand::set_argument_parser() {
 
 
 void CoprDisableCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     copr_repo_disable(base, get_project_spec());
 }
 

--- a/dnf5-plugins/copr_plugin/copr_enable.cpp
+++ b/dnf5-plugins/copr_plugin/copr_enable.cpp
@@ -57,7 +57,7 @@ void CoprEnableCommand::set_argument_parser() {
 
 
 void CoprEnableCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     std::unique_ptr<dnf5::CoprConfig> config = std::make_unique<dnf5::CoprConfig>(base);
     auto repo = CoprRepo(base, config, get_project_spec(), opt_chroot);
     repo.save_interactive();

--- a/dnf5-plugins/copr_plugin/copr_list.cpp
+++ b/dnf5-plugins/copr_plugin/copr_list.cpp
@@ -64,7 +64,7 @@ void CoprListCommand::set_argument_parser() {
 
 
 void CoprListCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     std::unique_ptr<dnf5::CoprConfig> config = std::make_unique<dnf5::CoprConfig>(base);
     // empty string if no --hub is specified
     auto hostname = copr_cmd()->hub();

--- a/dnf5-plugins/copr_plugin/copr_remove.cpp
+++ b/dnf5-plugins/copr_plugin/copr_remove.cpp
@@ -39,7 +39,7 @@ void CoprRemoveCommand::set_argument_parser() {
 
 
 void CoprRemoveCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     copr_repo_remove(base, get_project_spec());
 }
 

--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
@@ -83,7 +83,7 @@ void NeedsRestartingCommand::configure() {
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 
     const std::set<std::string> metadata_types{libdnf5::METADATA_TYPE_FILELISTS, libdnf5::METADATA_TYPE_UPDATEINFO};
-    context.base.get_config().get_optional_metadata_types_option().add(
+    context.get_base().get_config().get_optional_metadata_types_option().add(
         libdnf5::Option::Priority::RUNTIME, metadata_types);
 }
 
@@ -109,7 +109,7 @@ time_t NeedsRestartingCommand::get_boot_time(Context & ctx) {
     //      correct. Does not work on containers which share their kernel with
     //      the host---there, the host kernel uptime is returned
 
-    const auto & logger = ctx.base.get_logger();
+    const auto & logger = ctx.get_base().get_logger();
 
     // First, ask systemd for the boot time. If systemd is available, this is
     // the best option.
@@ -189,7 +189,7 @@ libdnf5::rpm::PackageSet recursive_dependencies(
 void NeedsRestartingCommand::system_needs_restarting(Context & ctx) {
     const auto boot_time = get_boot_time(ctx);
 
-    libdnf5::rpm::PackageQuery reboot_suggested{ctx.base};
+    libdnf5::rpm::PackageQuery reboot_suggested{ctx.get_base()};
     reboot_suggested.filter_installed();
     reboot_suggested.filter_reboot_suggested();
 
@@ -285,7 +285,7 @@ void NeedsRestartingCommand::services_need_restarting(Context & ctx) {
     // Iterate over each file from each installed package and check whether it
     // is a unit file for a running service. This is much faster than running
     // filter_file on each unit file.
-    libdnf5::rpm::PackageQuery installed{ctx.base};
+    libdnf5::rpm::PackageQuery installed{ctx.get_base()};
     installed.filter_installed();
 
     std::vector<std::string> service_names;

--- a/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
@@ -99,7 +99,7 @@ void RepoclosureCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(false);
     // filelists needed because there are packages in repos with file requirements
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
@@ -111,13 +111,14 @@ void RepoclosureCommand::run() {
     // to_check_query is the set of packages we are checking the dependencies of
     // in case that `--newest` was used, start with an empty query
     bool newest_used = newest->get_value();
-    libdnf5::rpm::PackageQuery available_query(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, newest_used);
-    libdnf5::rpm::PackageQuery to_check_query(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, newest_used);
+    libdnf5::rpm::PackageQuery available_query(
+        ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, newest_used);
+    libdnf5::rpm::PackageQuery to_check_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, newest_used);
     if (newest_used) {
-        libdnf5::repo::RepoQuery repos(ctx.base);
+        libdnf5::repo::RepoQuery repos(ctx.get_base());
         repos.filter_enabled(true);
         for (const auto & repo : repos) {
-            libdnf5::rpm::PackageQuery repo_pkgs(ctx.base);
+            libdnf5::rpm::PackageQuery repo_pkgs(ctx.get_base());
             repo_pkgs.filter_repo_id({repo->get_id()});
             repo_pkgs.filter_latest_evr();
             available_query |= repo_pkgs;
@@ -133,12 +134,12 @@ void RepoclosureCommand::run() {
         to_check_query.filter_arch(arches);
     }
 
-    if (ctx.base.get_config().get_best_option().get_value()) {
+    if (ctx.get_base().get_config().get_best_option().get_value()) {
         available_query.filter_latest_evr();
     }
 
     if (!pkg_specs.empty()) {
-        libdnf5::rpm::PackageQuery to_check_pkgs(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
+        libdnf5::rpm::PackageQuery to_check_pkgs(ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
         libdnf5::ResolveSpecSettings settings;
         settings.set_with_nevra(true);
         settings.set_with_provides(false);

--- a/dnf5/cmdline_aliases.cpp
+++ b/dnf5/cmdline_aliases.cpp
@@ -95,7 +95,7 @@ bool attach_named_args(
 
 void load_aliases_from_toml_file(Context & context, const fs::path & config_file_path) {
     auto & arg_parser = context.get_argument_parser();
-    auto logger = context.base.get_logger();
+    auto logger = context.get_base().get_logger();
 
     try {
         const auto arg_parser_elements =
@@ -654,7 +654,7 @@ void load_aliases_from_toml_file(Context & context, const fs::path & config_file
 }  // namespace
 
 void load_cmdline_aliases(Context & context, const std::filesystem::path & config_dir_path) {
-    auto logger = context.base.get_logger();
+    auto logger = context.get_base().get_logger();
 
     std::vector<fs::path> config_paths;
     std::error_code ec;  // Do not report errors if config_dir_path refers to a non-existing file or not a directory

--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -31,14 +31,14 @@ using namespace libdnf5::cli;
 
 void AdvisoryInfoCommand::process_and_print_queries(
     Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, const std::vector<std::string> & package_specs) {
-    libdnf5::rpm::PackageQuery packages(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery packages(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
     if (package_specs.size() > 0) {
         packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);
     }
     if (all->get_value()) {
         packages.filter_installed();
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::LTE);
-        auto advisory_query_not_installed = libdnf5::advisory::AdvisoryQuery(ctx.base);
+        auto advisory_query_not_installed = libdnf5::advisory::AdvisoryQuery(ctx.get_base());
         advisory_query_not_installed.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
         advisories |= advisory_query_not_installed;
     } else if (installed->get_value()) {
@@ -48,11 +48,11 @@ void AdvisoryInfoCommand::process_and_print_queries(
         packages.filter_upgradable();
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
     } else {  // available is the default
-        libdnf5::rpm::PackageQuery installed_packages(ctx.base);
+        libdnf5::rpm::PackageQuery installed_packages(ctx.get_base());
         installed_packages.filter_installed();
         installed_packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, installed_packages);
+        add_running_kernel_packages(ctx.get_base(), installed_packages);
 
         if (package_specs.size() > 0) {
             installed_packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -33,7 +33,7 @@ void AdvisoryListCommand::process_and_print_queries(
     std::vector<libdnf5::advisory::AdvisoryPackage> installed_pkgs;
     std::vector<libdnf5::advisory::AdvisoryPackage> not_installed_pkgs;
 
-    libdnf5::rpm::PackageQuery packages(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery packages(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
     if (package_specs.size() > 0) {
         packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);
     }
@@ -51,11 +51,11 @@ void AdvisoryListCommand::process_and_print_queries(
         packages.filter_upgradable();
         not_installed_pkgs = advisories.get_advisory_packages_sorted(packages, libdnf5::sack::QueryCmp::GT);
     } else {  // available is the default
-        libdnf5::rpm::PackageQuery installed_packages(ctx.base);
+        libdnf5::rpm::PackageQuery installed_packages(ctx.get_base());
         installed_packages.filter_installed();
         installed_packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, installed_packages);
+        add_running_kernel_packages(ctx.get_base(), installed_packages);
 
         if (package_specs.size() > 0) {
             installed_packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -74,7 +74,7 @@ void AdvisorySubCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_UPDATEINFO);
 }
 
@@ -82,7 +82,7 @@ void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
     auto advisories_opt = advisory_query_from_cli_input(
-        ctx.base,
+        ctx.get_base(),
         advisory_specs->get_value(),
         advisory_security->get_value(),
         advisory_bugfix->get_value(),
@@ -92,7 +92,7 @@ void AdvisorySubCommand::run() {
         advisory_bz->get_value(),
         advisory_cve->get_value());
 
-    auto advisories = advisories_opt.value_or(libdnf5::advisory::AdvisoryQuery(ctx.base));
+    auto advisories = advisories_opt.value_or(libdnf5::advisory::AdvisoryQuery(ctx.get_base()));
 
     if (with_bz->get_value()) {
         advisories.filter_reference("*", {"bugzilla"}, libdnf5::sack::QueryCmp::IGLOB);

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -48,12 +48,12 @@ void AdvisorySubCommand::set_argument_parser() {
     with_bz = std::make_unique<AdvisoryWithBzOption>(*this);
     with_cve = std::make_unique<AdvisoryWithCveOption>(*this);
 
-    all->arg->add_conflict_argument(*available->arg);
-    all->arg->add_conflict_argument(*installed->arg);
-    all->arg->add_conflict_argument(*updates->arg);
-    available->arg->add_conflict_argument(*installed->arg);
-    available->arg->add_conflict_argument(*updates->arg);
-    installed->arg->add_conflict_argument(*updates->arg);
+    all->get_arg()->add_conflict_argument(*available->get_arg());
+    all->get_arg()->add_conflict_argument(*installed->get_arg());
+    all->get_arg()->add_conflict_argument(*updates->get_arg());
+    available->get_arg()->add_conflict_argument(*installed->get_arg());
+    available->get_arg()->add_conflict_argument(*updates->get_arg());
+    installed->get_arg()->add_conflict_argument(*updates->get_arg());
 }
 
 // There can be multiple versions of kernel installed at the same time.

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -30,7 +30,7 @@ void AdvisorySummaryCommand::process_and_print_queries(
     Context & ctx, libdnf5::advisory::AdvisoryQuery & advisories, const std::vector<std::string> & package_specs) {
     std::string mode;
 
-    libdnf5::rpm::PackageQuery packages(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery packages(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
     if (package_specs.size() > 0) {
         packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);
     }
@@ -38,7 +38,7 @@ void AdvisorySummaryCommand::process_and_print_queries(
     if (all->get_value()) {
         packages.filter_installed();
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::LTE);
-        auto advisory_query_not_installed = libdnf5::advisory::AdvisoryQuery(ctx.base);
+        auto advisory_query_not_installed = libdnf5::advisory::AdvisoryQuery(ctx.get_base());
         advisory_query_not_installed.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
         advisories |= advisory_query_not_installed;
         mode = _("All");
@@ -51,11 +51,11 @@ void AdvisorySummaryCommand::process_and_print_queries(
         advisories.filter_packages(packages, libdnf5::sack::QueryCmp::GT);
         mode = _("Updates");
     } else {  // available is the default
-        libdnf5::rpm::PackageQuery installed_packages(ctx.base);
+        libdnf5::rpm::PackageQuery installed_packages(ctx.get_base());
         installed_packages.filter_installed();
         installed_packages.filter_latest_evr();
 
-        add_running_kernel_packages(ctx.base, installed_packages);
+        add_running_kernel_packages(ctx.get_base(), installed_packages);
 
         if (package_specs.size() > 0) {
             installed_packages.filter_name(package_specs, libdnf5::sack::QueryCmp::IGLOB);

--- a/dnf5/commands/autoremove/autoremove.cpp
+++ b/dnf5/commands/autoremove/autoremove.cpp
@@ -48,7 +48,7 @@ void AutoremoveCommand::configure() {
 
 void AutoremoveCommand::run() {
     auto & ctx = get_context();
-    libdnf5::rpm::PackageQuery unneeded(ctx.base);
+    libdnf5::rpm::PackageQuery unneeded(ctx.get_base());
     unneeded.filter_unneeded();
     auto goal = get_context().get_goal();
     for (const auto & pkg : unneeded) {

--- a/dnf5/commands/check/check.cpp
+++ b/dnf5/commands/check/check.cpp
@@ -257,7 +257,7 @@ void CheckCommand::set_argument_parser() {
 
 
 void CheckCommand::configure() {
-    installonly_pkgs_provides = get_context().base.get_config().get_installonlypkgs_option().get_value();
+    installonly_pkgs_provides = get_context().get_base().get_config().get_installonlypkgs_option().get_value();
     if (!(dependencies || duplicates || obsoleted)) {
         dependencies = duplicates = obsoleted = true;
     }
@@ -268,7 +268,7 @@ void CheckCommand::run() {
     auto & ctx = get_context();
 
     auto ts = rpmtsCreate();
-    auto & config = ctx.base.get_config();
+    auto & config = ctx.get_base().get_config();
     rpmtsSetRootDir(ts, config.get_installroot_option().get_value().c_str());
 
     rpmdbMatchIterator mi = rpmtsInitIterator(ts, RPMDBI_PACKAGES, NULL, 0);

--- a/dnf5/commands/clean/clean.cpp
+++ b/dnf5/commands/clean/clean.cpp
@@ -132,7 +132,7 @@ void CleanCommand::set_argument_parser() {
 
 void CleanCommand::run() {
     auto & ctx = get_context();
-    fs::path cachedir{ctx.base.get_config().get_cachedir_option().get_value()};
+    fs::path cachedir{ctx.get_base().get_config().get_cachedir_option().get_value()};
 
     std::error_code ec;
     libdnf5::repo::RepoCache::RemoveStatistics statistics{};
@@ -140,7 +140,7 @@ void CleanCommand::run() {
         if (!dir_entry.is_directory()) {
             continue;
         }
-        libdnf5::repo::RepoCache cache(ctx.base.get_weak_ptr(), dir_entry.path());
+        libdnf5::repo::RepoCache cache(ctx.get_base().get_weak_ptr(), dir_entry.path());
 
         try {
             if (required_actions & CLEAN_ALL) {

--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -45,14 +45,14 @@ void EnvironmentInfoCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 
 void EnvironmentInfoCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::EnvironmentQuery query(ctx.base);
+    libdnf5::comps::EnvironmentQuery query(ctx.get_base());
     auto environment_specs_str = environment_specs->get_value();
 
     // Filter by patterns if given

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -43,14 +43,14 @@ void EnvironmentListCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 
 void EnvironmentListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::EnvironmentQuery query(ctx.base);
+    libdnf5::comps::EnvironmentQuery query(ctx.get_base());
     auto environment_specs_str = environment_specs->get_value();
 
     // Filter by patterns if given

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -51,7 +51,7 @@ void GroupInstallCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 
@@ -66,7 +66,7 @@ void GroupInstallCommand::run() {
     }
     if (with_optional->get_value()) {
         auto group_package_types = libdnf5::comps::package_type_from_string(
-            ctx.base.get_config().get_group_package_types_option().get_value());
+            ctx.get_base().get_config().get_group_package_types_option().get_value());
         settings.set_group_package_types(group_package_types | libdnf5::comps::PackageType::OPTIONAL);
     }
     for (const auto & spec : group_specs->get_value()) {

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -35,7 +35,7 @@ void GroupListCommand::set_argument_parser() {
 
     available = std::make_unique<GroupAvailableOption>(*this);
     installed = std::make_unique<GroupInstalledOption>(*this);
-    available->arg->add_conflict_argument(*installed->arg);
+    available->get_arg()->add_conflict_argument(*installed->get_arg());
     hidden = std::make_unique<GroupHiddenOption>(*this);
     group_specs = std::make_unique<GroupSpecArguments>(*this);
     group_pkg_contains = std::make_unique<GroupContainsPkgsOption>(*this);

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -45,14 +45,14 @@ void GroupListCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 
 void GroupListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::GroupQuery query(ctx.base);
+    libdnf5::comps::GroupQuery query(ctx.get_base());
     auto group_specs_str = group_specs->get_value();
 
     // Filter by patterns if given

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -42,7 +42,7 @@ void GroupRemoveCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -48,7 +48,7 @@ void GroupUpgradeCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
 }
 

--- a/dnf5/commands/history/history_info.cpp
+++ b/dnf5/commands/history/history_info.cpp
@@ -38,7 +38,7 @@ void HistoryInfoCommand::set_argument_parser() {
 
 void HistoryInfoCommand::run() {
     auto ts_specs = transaction_specs->get_value();
-    libdnf5::transaction::TransactionHistory history(get_context().base);
+    libdnf5::transaction::TransactionHistory history(get_context().get_base());
     std::vector<libdnf5::transaction::Transaction> transactions;
 
     if (ts_specs.empty()) {

--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -39,7 +39,7 @@ void HistoryListCommand::set_argument_parser() {
 
 void HistoryListCommand::run() {
     auto ts_specs = transaction_specs->get_value();
-    libdnf5::transaction::TransactionHistory history(get_context().base);
+    libdnf5::transaction::TransactionHistory history(get_context().get_base());
     std::vector<libdnf5::transaction::Transaction> transactions;
 
     if (ts_specs.empty()) {

--- a/dnf5/commands/history/history_store.cpp
+++ b/dnf5/commands/history/history_store.cpp
@@ -51,9 +51,9 @@ void HistoryStoreCommand::set_argument_parser() {
 
 void HistoryStoreCommand::run() {
     const auto ts_specs = transaction_specs->get_value();
-    libdnf5::transaction::TransactionHistory history(get_context().base);
+    libdnf5::transaction::TransactionHistory history(get_context().get_base());
     std::vector<libdnf5::transaction::Transaction> transactions;
-    auto logger = get_context().base.get_logger();
+    auto logger = get_context().get_base().get_logger();
 
     std::filesystem::path tmp_path(output_option->get_value());
 
@@ -61,7 +61,7 @@ void HistoryStoreCommand::run() {
         std::cout << libdnf5::utils::sformat(
             _("File \"{}\" already exists, it will be overwritten.\n"), tmp_path.string());
         // ask user for the file overwrite confirmation
-        if (!libdnf5::cli::utils::userconfirm::userconfirm(get_context().base.get_config())) {
+        if (!libdnf5::cli::utils::userconfirm::userconfirm(get_context().get_base().get_config())) {
             throw libdnf5::cli::AbortedByUserError();
         }
     }

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -93,7 +93,7 @@ void InstallCommand::run() {
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
     auto advisories = advisory_query_from_cli_input(
-        ctx.base,
+        ctx.get_base(),
         advisory_name->get_value(),
         advisory_security->get_value(),
         advisory_bugfix->get_value(),

--- a/dnf5/commands/leaves/leaves.cpp
+++ b/dnf5/commands/leaves/leaves.cpp
@@ -61,7 +61,7 @@ void LeavesCommand::configure() {
 void LeavesCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::rpm::PackageQuery leaves_package_query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery leaves_package_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
     auto leaves_package_groups = leaves_package_query.filter_leaves_groups();
 
     for (auto & package_group : leaves_package_groups) {

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -63,11 +63,11 @@ void ListCommand::set_argument_parser() {
 
     installed = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "installed", '\0', _("List installed packages."), false);
-    conflicts->push_back(installed->arg);
+    conflicts->push_back(installed->get_arg());
 
     available = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "available", '\0', _("List available packages."), false);
-    conflicts->push_back(available->arg);
+    conflicts->push_back(available->get_arg());
 
     extras = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this,
@@ -75,7 +75,7 @@ void ListCommand::set_argument_parser() {
         '\0',
         _("List extras, that is packages installed on the system that are not available in any known repository."),
         false);
-    conflicts->push_back(extras->arg);
+    conflicts->push_back(extras->get_arg());
 
     obsoletes = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this,
@@ -83,27 +83,27 @@ void ListCommand::set_argument_parser() {
         '\0',
         _("List packages installed on the system that are obsoleted by packages in any known repository."),
         false);
-    conflicts->push_back(obsoletes->arg);
+    conflicts->push_back(obsoletes->get_arg());
 
     recent = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "recent", '\0', _("List packages recently added into the repositories."), false);
-    conflicts->push_back(recent->arg);
+    conflicts->push_back(recent->get_arg());
 
     upgrades = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "upgrades", '\0', _("List upgrades available for the installed packages."), false);
-    conflicts->push_back(upgrades->arg);
+    conflicts->push_back(upgrades->get_arg());
 
     autoremove = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "autoremove", '\0', _("List packages which will be removed by the 'dnf autoremove' command."), false);
-    conflicts->push_back(autoremove->arg);
+    conflicts->push_back(autoremove->get_arg());
 
-    installed->arg->set_conflict_arguments(conflicts);
-    available->arg->set_conflict_arguments(conflicts);
-    extras->arg->set_conflict_arguments(conflicts);
-    obsoletes->arg->set_conflict_arguments(conflicts);
-    recent->arg->set_conflict_arguments(conflicts);
-    upgrades->arg->set_conflict_arguments(conflicts);
-    autoremove->arg->set_conflict_arguments(conflicts);
+    installed->get_arg()->set_conflict_arguments(conflicts);
+    available->get_arg()->set_conflict_arguments(conflicts);
+    extras->get_arg()->set_conflict_arguments(conflicts);
+    obsoletes->get_arg()->set_conflict_arguments(conflicts);
+    recent->get_arg()->set_conflict_arguments(conflicts);
+    upgrades->get_arg()->set_conflict_arguments(conflicts);
+    autoremove->get_arg()->set_conflict_arguments(conflicts);
 }
 
 void ListCommand::configure() {

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -140,14 +140,14 @@ std::unique_ptr<libdnf5::cli::output::PackageListSections> ListCommand::create_o
 
 void ListCommand::run() {
     auto & ctx = get_context();
-    auto & config = ctx.base.get_config();
+    auto & config = ctx.get_base().get_config();
 
-    libdnf5::rpm::PackageQuery full_package_query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
-    libdnf5::rpm::PackageQuery base_query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery full_package_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+    libdnf5::rpm::PackageQuery base_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
 
     // pre-select by patterns
     if (!pkg_specs.empty()) {
-        base_query = libdnf5::rpm::PackageQuery(ctx.base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
+        base_query = libdnf5::rpm::PackageQuery(ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
         libdnf5::ResolveSpecSettings settings;
         settings.set_ignore_case(true);
         settings.set_with_nevra(true);

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -41,12 +41,12 @@ void MakeCacheCommand::set_argument_parser() {
 void MakeCacheCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::repo::RepoQuery enabled_repos_query(ctx.base);
+    libdnf5::repo::RepoQuery enabled_repos_query(ctx.get_base());
     enabled_repos_query.filter_enabled(true);
     if (enabled_repos_query.empty()) {
         std::string repos_paths;
         bool first = true;
-        for (const auto & val : ctx.base.get_config().get_reposdir_option().get_value()) {
+        for (const auto & val : ctx.get_base().get_config().get_reposdir_option().get_value()) {
             if (!first) {
                 repos_paths += ", ";
             }

--- a/dnf5/commands/module/module_list.cpp
+++ b/dnf5/commands/module/module_list.cpp
@@ -46,7 +46,7 @@ void ModuleListCommand::configure() {
 }
 
 void ModuleListCommand::run() {
-    libdnf5::module::ModuleQuery query(get_context().base, true);
+    libdnf5::module::ModuleQuery query(get_context().get_base(), true);
     auto module_specs_str = module_specs->get_value();
     std::set<std::string> unmatched_module_spec;
 
@@ -54,7 +54,7 @@ void ModuleListCommand::run() {
         for (const auto & module_spec : module_specs_str) {
             bool module_spec_matched = false;
             for (const auto & nsvcap : libdnf5::module::Nsvcap::parse(module_spec)) {
-                libdnf5::module::ModuleQuery nsvcap_query(get_context().base, false);
+                libdnf5::module::ModuleQuery nsvcap_query(get_context().get_base(), false);
                 nsvcap_query.filter_nsvca(nsvcap, libdnf5::sack::QueryCmp::GLOB);
                 if (!nsvcap_query.empty()) {
                     query |= nsvcap_query;
@@ -66,7 +66,7 @@ void ModuleListCommand::run() {
             }
         }
     } else {
-        query = libdnf5::module::ModuleQuery(get_context().base, false);
+        query = libdnf5::module::ModuleQuery(get_context().get_base(), false);
     }
 
     if (enabled->get_value()) {

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -62,7 +62,7 @@ void ProvidesCommand::set_argument_parser() {
 void ProvidesCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
-    context.base.get_config().get_optional_metadata_types_option().add_item(
+    context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
@@ -111,7 +111,7 @@ void ProvidesCommand::run() {
     std::set<std::string> unmatched_specs;
 
     for (auto & spec : pkg_specs) {
-        libdnf5::rpm::PackageQuery full_package_query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+        libdnf5::rpm::PackageQuery full_package_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
         // get the matched query first and the type of match (no_match, provides, file, binary) second
         auto matched = filter_spec(spec, full_package_query);
         for (auto package : matched.first) {

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -43,7 +43,7 @@ void RemoveCommand::set_argument_parser() {
     noautoremove->set_long_name("no-autoremove");
     noautoremove->set_description("Disable removal of dependencies that are no longer used");
     noautoremove->set_const_value("false");
-    noautoremove->link_value(&ctx.base.get_config().get_clean_requirements_on_remove_option());
+    noautoremove->link_value(&ctx.get_base().get_config().get_clean_requirements_on_remove_option());
     cmd.register_named_arg(noautoremove);
 
     auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -108,10 +108,10 @@ void RepoInfoCommand::print(const libdnf5::repo::RepoQuery & query, [[maybe_unus
     std::sort(repos.begin(), repos.end(), [](const auto & l, const auto & r) { return l->get_id() < r->get_id(); });
 
     for (auto & repo : repos) {
-        libdnf5::rpm::PackageQuery pkgs(get_context().base, libdnf5::sack::ExcludeFlags::IGNORE_EXCLUDES);
+        libdnf5::rpm::PackageQuery pkgs(get_context().get_base(), libdnf5::sack::ExcludeFlags::IGNORE_EXCLUDES);
         pkgs.filter_repo_id({repo->get_id()});
 
-        libdnf5::rpm::PackageQuery available_pkgs(get_context().base);
+        libdnf5::rpm::PackageQuery available_pkgs(get_context().get_base());
         available_pkgs.filter_repo_id({repo->get_id()});
 
         uint64_t repo_size = 0;

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -36,9 +36,9 @@ void RepoListCommand::set_argument_parser() {
     disabled = std::make_unique<RepoDisabledOption>(*this);
     repo_specs = std::make_unique<RepoSpecArguments>(*this);
 
-    all->arg->add_conflict_argument(*enabled->arg);
-    all->arg->add_conflict_argument(*disabled->arg);
-    enabled->arg->add_conflict_argument(*disabled->arg);
+    all->get_arg()->add_conflict_argument(*enabled->get_arg());
+    all->get_arg()->add_conflict_argument(*disabled->get_arg());
+    enabled->get_arg()->add_conflict_argument(*disabled->get_arg());
 }
 
 void RepoListCommand::run() {

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -44,7 +44,7 @@ void RepoListCommand::set_argument_parser() {
 void RepoListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::repo::RepoQuery query(ctx.base);
+    libdnf5::repo::RepoQuery query(ctx.get_base());
     if (all->get_value()) {
         // don't filter anything
     } else if (disabled->get_value()) {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -164,7 +164,7 @@ void RepoqueryCommand::set_argument_parser() {
         "Limit to installed duplicate packages (i.e. more package versions for  the  same  name and "
         "architecture). Installonly packages are excluded from this set.",
         false);
-    only_outputs_installed->push_back(duplicates->arg);
+    only_outputs_installed->push_back(duplicates->get_arg());
 
     unneeded = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this,
@@ -173,17 +173,17 @@ void RepoqueryCommand::set_argument_parser() {
         "Limit to unneeded installed packages (i.e. packages that were installed as "
         "dependencies but are no longer needed).",
         false);
-    only_outputs_installed->push_back(unneeded->arg);
+    only_outputs_installed->push_back(unneeded->get_arg());
 
     installonly = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "installonly", '\0', "Limit to installed installonly packages.", false);
-    only_outputs_installed->push_back(installonly->arg);
+    only_outputs_installed->push_back(installonly->get_arg());
 
     // FILTERS THAT REQUIRE BOTH INSTALLED AND AVAILABLE PACKAGES TO BE LOADED:
 
     extras = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "extras", '\0', "Limit to installed packages that are not present in any available repository.", false);
-    only_outputs_installed->push_back(extras->arg);
+    only_outputs_installed->push_back(extras->get_arg());
 
     upgrades = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this,
@@ -406,8 +406,8 @@ void RepoqueryCommand::set_argument_parser() {
 
     changelogs = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "changelogs", '\0', "Display package changelogs.", false);
-    repoquery_formatting->register_argument(changelogs->arg);
-    formatting_conflicts->push_back(changelogs->arg);
+    repoquery_formatting->register_argument(changelogs->get_arg());
+    formatting_conflicts->push_back(changelogs->get_arg());
 
     // Add additional supported package attribute getters, all pkg_attrs_options get turned into options
     pkg_attrs_options.insert(pkg_attrs_options.begin(), {"files", "sourcerpm", "location"});
@@ -439,16 +439,16 @@ void RepoqueryCommand::set_argument_parser() {
     // Options that configure how repos should be loaded are incompatible
     // with --available and --installed options.
     available->set_conflict_arguments(only_outputs_installed);
-    available->add_conflict_argument(*upgrades->arg);
+    available->add_conflict_argument(*upgrades->get_arg());
     installed->set_conflict_arguments(only_outputs_installed);
-    installed->add_conflict_argument(*upgrades->arg);
+    installed->add_conflict_argument(*upgrades->get_arg());
 
     // --upgrades option returns only available packages, conflict with options
     // that return only installed packages
-    upgrades->arg->set_conflict_arguments(only_outputs_installed);
+    upgrades->get_arg()->set_conflict_arguments(only_outputs_installed);
 
     // recursive is not compatible with exactdeps
-    recursive->arg->add_conflict_argument(*exactdeps->arg);
+    recursive->get_arg()->add_conflict_argument(*exactdeps->get_arg());
 }
 
 void RepoqueryCommand::configure() {

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -57,7 +57,7 @@ void SearchCommand::configure() {
 }
 
 void SearchCommand::run() {
-    auto & base = get_context().base;
+    auto & base = get_context().get_base();
     SearchProcessor processor(base, patterns->get_value(), all->get_value(), show_duplicates->get_value());
     libdnf5::cli::output::print_search_results(processor.get_results());
 }

--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -84,11 +84,11 @@ void SystemUpgradeDownloadCommand::set_argument_parser() {
 void SystemUpgradeDownloadCommand::configure() {
     auto & ctx = get_context();
 
-    const std::filesystem::path installroot{ctx.base.get_config().get_installroot_option().get_value()};
+    const std::filesystem::path installroot{ctx.get_base().get_config().get_installroot_option().get_value()};
 
-    target_releasever = ctx.base.get_vars()->get_value("releasever");
+    target_releasever = ctx.get_base().get_vars()->get_value("releasever");
 
-    const auto & detected_releasever = libdnf5::Vars::detect_release(ctx.base.get_weak_ptr(), installroot);
+    const auto & detected_releasever = libdnf5::Vars::detect_release(ctx.get_base().get_weak_ptr(), installroot);
     if (detected_releasever != nullptr) {
         system_releasever = *detected_releasever;
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -98,8 +98,8 @@ void UpgradeCommand::configure() {
         advisory_cve->get_value());
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 
-    if (!context.base.get_config().get_destdir_option().empty()) {
-        context.base.get_config().get_downloadonly_option().set(true);
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
     }
 }
 
@@ -123,7 +123,7 @@ void UpgradeCommand::run() {
     }
 
     auto advisories = advisory_query_from_cli_input(
-        ctx.base,
+        ctx.get_base(),
         advisory_name->get_value(),
         advisory_security->get_value(),
         advisory_bugfix->get_value(),

--- a/dnf5/commands/versionlock/versionlock_add.cpp
+++ b/dnf5/commands/versionlock/versionlock_add.cpp
@@ -88,7 +88,7 @@ bool lock_version(
 
 void VersionlockAddCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
+    auto package_sack = ctx.get_base().get_rpm_package_sack();
     auto vl_config = package_sack->get_versionlock_config();
     auto orig_size = vl_config.get_packages().size();
 
@@ -100,7 +100,7 @@ void VersionlockAddCommand::run() {
     settings.set_with_filenames(false);
     settings.set_with_binaries(false);
     for (const auto & spec : pkg_specs) {
-        libdnf5::rpm::PackageQuery query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+        libdnf5::rpm::PackageQuery query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
         query.resolve_pkg_spec(spec, settings, false);
         if (query.empty()) {
             std::cerr << libdnf5::utils::sformat(_("No package found for \"{}\"."), spec) << std::endl;

--- a/dnf5/commands/versionlock/versionlock_clear.cpp
+++ b/dnf5/commands/versionlock/versionlock_clear.cpp
@@ -34,7 +34,7 @@ void VersionlockClearCommand::set_argument_parser() {
 
 void VersionlockClearCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
+    auto package_sack = ctx.get_base().get_rpm_package_sack();
     auto vl_config = package_sack->get_versionlock_config();
     vl_config.get_packages().clear();
     vl_config.save();

--- a/dnf5/commands/versionlock/versionlock_delete.cpp
+++ b/dnf5/commands/versionlock/versionlock_delete.cpp
@@ -65,7 +65,7 @@ void delete_package(libdnf5::rpm::VersionlockConfig & vl_config, std::string_vie
 
 void VersionlockDeleteCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
+    auto package_sack = ctx.get_base().get_rpm_package_sack();
     auto vl_config = package_sack->get_versionlock_config();
     auto orig_size = vl_config.get_packages().size();
 

--- a/dnf5/commands/versionlock/versionlock_exclude.cpp
+++ b/dnf5/commands/versionlock/versionlock_exclude.cpp
@@ -107,7 +107,7 @@ bool exclude_versions(
 
 void VersionlockExcludeCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
+    auto package_sack = ctx.get_base().get_rpm_package_sack();
     auto vl_config = package_sack->get_versionlock_config();
 
     const auto comment = format_comment("exclude");
@@ -119,7 +119,7 @@ void VersionlockExcludeCommand::run() {
     settings.set_with_filenames(false);
     settings.set_with_binaries(false);
     for (const auto & spec : pkg_specs) {
-        libdnf5::rpm::PackageQuery query(ctx.base, libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
+        libdnf5::rpm::PackageQuery query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
         query.resolve_pkg_spec(spec, settings, false);
         if (query.empty()) {
             std::cerr << libdnf5::utils::sformat(_("No package found for \"{}\"."), spec) << std::endl;

--- a/dnf5/commands/versionlock/versionlock_list.cpp
+++ b/dnf5/commands/versionlock/versionlock_list.cpp
@@ -32,7 +32,7 @@ void VersionlockListCommand::set_argument_parser() {
 
 void VersionlockListCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
+    auto package_sack = ctx.get_base().get_rpm_package_sack();
     auto vl_config = package_sack->get_versionlock_config();
 
     bool first = true;

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -619,6 +619,20 @@ const std::vector<std::pair<std::string, std::string>> & Context::get_repos_from
 }
 
 
+Command::~Command() = default;
+
+Context & Command::get_context() const noexcept {
+    return static_cast<Context &>(get_session());
+}
+
+void Command::goal_resolved() {
+    auto & transaction = *get_context().get_transaction();
+    if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
+        throw libdnf5::cli::GoalResolveError(transaction);
+    }
+}
+
+
 RpmTransCB::RpmTransCB(Context & context) : context(context) {
     multi_progress_bar.set_total_bar_visible_limit(libdnf5::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
 }
@@ -828,13 +842,6 @@ bool RpmTransCB::is_time_to_print() {
 
 std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time = std::chrono::steady_clock::now();
 
-
-void Command::goal_resolved() {
-    auto & transaction = *get_context().get_transaction();
-    if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
-        throw libdnf5::cli::GoalResolveError(transaction);
-    }
-}
 
 /// Returns file and directory paths that begins with `path_to_complete`.
 /// Files must match `regex_pattern`.

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -49,9 +49,14 @@ public:
     enum class LoadAvailableRepos { NONE, ENABLED, ALL };
 
     /// Constructs a new Context instance and sets the destination loggers.
-    Context(std::vector<std::unique_ptr<libdnf5::Logger>> && loggers);
+    explicit Context(std::vector<std::unique_ptr<libdnf5::Logger>> && loggers);
 
+    Context(const Context & src) = delete;
+    Context(Context && src) = delete;
     ~Context();
+
+    Context & operator=(const Context & src) = delete;
+    Context & operator=(Context && src) = delete;
 
     void apply_repository_setopts();
 
@@ -73,10 +78,6 @@ public:
     /// Sets callbacks for repositories and loads them, updating metadata if necessary.
     void load_repos(bool load_system);
 
-    libdnf5::Base base;
-    std::vector<std::pair<std::string, std::string>> setopts;
-    std::vector<std::pair<std::string, std::string>> repos_from_path;
-
     /// list of lists of libdnf5 plugin names (global patterns) that we want to enable (true) or disable (false)
     std::vector<std::pair<std::vector<std::string>, bool>> libdnf5_plugins_enablement;
 
@@ -87,97 +88,81 @@ public:
     std::filesystem::path transaction_store_path;
 
     /// Gets user comment.
-    const char * get_comment() const noexcept { return comment; }
+    const char * get_comment() const noexcept;
 
     /// Stores pointer to user comment.
-    void set_comment(const char * comment) noexcept { this->comment = comment; }
+    void set_comment(const char * comment) noexcept;
 
     /// Get command line used to run the dnf5 command
-    std::string get_cmdline() { return cmdline; }
+    std::string get_cmdline();
 
     /// Set command line used to run the dnf5 command
-    void set_cmdline(std::string & cmdline) { this->cmdline = cmdline; }
+    void set_cmdline(std::string & cmdline);
 
     /// Downloads transaction packages, creates the history DB transaction and
     /// rpm transaction and runs it.
     void download_and_run(libdnf5::base::Transaction & transaction);
 
     /// Set to true to suppresses messages notifying about the current state or actions of dnf5.
-    void set_quiet(bool quiet) { this->quiet = quiet; }
+    void set_quiet(bool quiet);
 
-    bool get_quiet() const { return quiet; }
+    bool get_quiet() const;
 
     /// Set to true to print information about main configuration
-    void set_dump_main_config(bool enable) { this->dump_main_config = enable; }
+    void set_dump_main_config(bool enable);
 
-    bool get_dump_main_config() const { return dump_main_config; }
+    bool get_dump_main_config() const;
 
     /// Set a list of repository IDs to print information about their configuration
-    void set_dump_repo_config_id_list(const std::vector<std::string> & repo_id_list) {
-        this->dump_repo_config_id_list = repo_id_list;
-    }
+    void set_dump_repo_config_id_list(const std::vector<std::string> & repo_id_list);
 
-    const std::vector<std::string> & get_dump_repo_config_id_list() const { return dump_repo_config_id_list; }
+    const std::vector<std::string> & get_dump_repo_config_id_list() const;
 
     /// Set to true to print information about variables
-    void set_dump_variables(bool enable) { this->dump_variables = enable; }
+    void set_dump_variables(bool enable);
 
-    bool get_dump_variables() const { return dump_variables; }
+    bool get_dump_variables() const;
 
     /// Set to true to show newly installed leaf packages and packages that became leaves after a transaction.
-    void set_show_new_leaves(bool show_new_leaves) { this->show_new_leaves = show_new_leaves; }
+    void set_show_new_leaves(bool show_new_leaves);
 
-    bool get_show_new_leaves() const { return show_new_leaves; }
+    bool get_show_new_leaves() const;
 
-    Plugins & get_plugins() { return *plugins; }
+    Plugins & get_plugins();
 
     libdnf5::Goal * get_goal(bool new_if_not_exist = true);
 
-    void set_transaction(libdnf5::base::Transaction && transaction) {
-        this->transaction = std::make_unique<libdnf5::base::Transaction>(std::move(transaction));
-    }
+    void set_transaction(libdnf5::base::Transaction && transaction);
 
-    libdnf5::base::Transaction * get_transaction() { return transaction.get(); }
+    libdnf5::base::Transaction * get_transaction();
 
-    void set_load_system_repo(bool on) { load_system_repo = on; }
-    bool get_load_system_repo() const noexcept { return load_system_repo; }
+    void set_load_system_repo(bool on);
+    bool get_load_system_repo() const noexcept;
 
-    void set_load_available_repos(LoadAvailableRepos which) { load_available_repos = which; }
-    LoadAvailableRepos get_load_available_repos() const noexcept { return load_available_repos; }
+    void set_load_available_repos(LoadAvailableRepos which);
+    LoadAvailableRepos get_load_available_repos() const noexcept;
 
     /// If quiet mode is not active, it will print `msg` to standard output.
     void print_info(std::string_view msg) const;
 
-    void set_output_stream(std::ostream & new_output_stream) { output_stream = new_output_stream; }
+    void set_output_stream(std::ostream & new_output_stream);
 
     // Store the transaction to be run later in a minimal boot environment,
     // using `dnf5 offline`
-    void set_should_store_offline(bool should_store_offline) { this->should_store_offline = should_store_offline; }
-    bool get_should_store_offline() const { return should_store_offline; }
+    void set_should_store_offline(bool should_store_offline);
+    bool get_should_store_offline() const;
+
+    libdnf5::Base & get_base();
+
+    std::vector<std::pair<std::string, std::string>> & get_setopts();
+    const std::vector<std::pair<std::string, std::string>> & get_setopts() const;
+
+    std::vector<std::pair<std::string, std::string>> & get_repos_from_path();
+    const std::vector<std::pair<std::string, std::string>> & get_repos_from_path() const;
 
 private:
-    std::string cmdline;
-
-    /// Points to user comment.
-    const char * comment{nullptr};
-
-    bool should_store_offline = false;
-
-    bool quiet{false};
-    bool dump_main_config{false};
-    std::vector<std::string> dump_repo_config_id_list;
-    bool dump_variables{false};
-    bool show_new_leaves{false};
-    std::string get_cmd_line();
-
-    std::reference_wrapper<std::ostream> output_stream = std::cout;
-
-    std::unique_ptr<Plugins> plugins;
-    std::unique_ptr<libdnf5::Goal> goal;
-    std::unique_ptr<libdnf5::base::Transaction> transaction;
-
-    bool load_system_repo{false};
-    LoadAvailableRepos load_available_repos{LoadAvailableRepos::NONE};
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -170,8 +170,11 @@ class Command : public libdnf5::cli::session::Command {
 public:
     using libdnf5::cli::session::Command::Command;
 
+    Command() = delete;
+    ~Command() override;
+
     /// @return Reference to the Context.
-    Context & get_context() const noexcept { return static_cast<Context &>(get_session()); }
+    Context & get_context() const noexcept;
 
     void goal_resolved() override;
 };

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -180,17 +180,6 @@ public:
 };
 
 
-class RpmTransactionItem : public libdnf5::rpm::TransactionItem {
-public:
-    enum class Actions { INSTALL, ERASE, UPGRADE, DOWNGRADE, REINSTALL };
-
-    RpmTransactionItem(const libdnf5::base::TransactionPackage & tspkg);
-    Actions get_action() const noexcept { return action; }
-
-private:
-    Actions action;
-};
-
 class RpmTransCB : public libdnf5::rpm::TransactionCallbacks {
 public:
     RpmTransCB(Context & context);

--- a/dnf5/include/dnf5/offline.cpp
+++ b/dnf5/include/dnf5/offline.cpp
@@ -63,7 +63,7 @@ void log_status(
     const auto & version = get_application_version();
     const std::string & version_string = fmt::format("{}.{}.{}", version.major, version.minor, version.micro);
 
-    auto logger = context.base.get_logger();
+    auto logger = context.get_base().get_logger();
     logger->info(message);
 
 #ifdef WITH_SYSTEMD

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -68,9 +68,9 @@ class OfflineTransactionState {
 public:
     void write();
     OfflineTransactionState(std::filesystem::path path);
-    OfflineTransactionStateData & get_data() { return data; };
-    const std::exception_ptr & get_read_exception() const { return read_exception; };
-    std::filesystem::path get_path() const { return path; };
+    OfflineTransactionStateData & get_data();
+    const std::exception_ptr & get_read_exception() const;
+    std::filesystem::path get_path() const;
 
 private:
     void read();

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -42,7 +42,7 @@ public:
               '\0',
               _("Allow resolving of depsolve problems by skipping packages"),
               false,
-              &command.get_context().base.get_config().get_skip_broken_option()) {}
+              &command.get_context().get_base().get_config().get_skip_broken_option()) {}
 };
 
 class SkipUnavailableOption : public libdnf5::cli::session::BoolOption {
@@ -54,7 +54,7 @@ public:
               '\0',
               _("Allow skipping unavailable packages"),
               false,
-              &command.get_context().base.get_config().get_skip_unavailable_option()) {}
+              &command.get_context().get_base().get_config().get_skip_unavailable_option()) {}
 };
 
 /// Create two options (`--allow-downgrade` and `--no-allow-downgrade`) for a command provided as an argument command.

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -28,34 +28,24 @@ namespace dnf5 {
 
 class AllowErasingOption : public libdnf5::cli::session::BoolOption {
 public:
-    explicit AllowErasingOption(libdnf5::cli::session::Command & command)
-        : BoolOption(
-              command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
+    explicit AllowErasingOption(libdnf5::cli::session::Command & command);
+    ~AllowErasingOption();
 };
+
 
 class SkipBrokenOption : public libdnf5::cli::session::BoolOption {
 public:
-    explicit SkipBrokenOption(dnf5::Command & command)
-        : BoolOption(
-              command,
-              "skip-broken",
-              '\0',
-              _("Allow resolving of depsolve problems by skipping packages"),
-              false,
-              &command.get_context().get_base().get_config().get_skip_broken_option()) {}
+    explicit SkipBrokenOption(dnf5::Command & command);
+    ~SkipBrokenOption();
 };
+
 
 class SkipUnavailableOption : public libdnf5::cli::session::BoolOption {
 public:
-    explicit SkipUnavailableOption(dnf5::Command & command)
-        : BoolOption(
-              command,
-              "skip-unavailable",
-              '\0',
-              _("Allow skipping unavailable packages"),
-              false,
-              &command.get_context().get_base().get_config().get_skip_unavailable_option()) {}
+    explicit SkipUnavailableOption(dnf5::Command & command);
+    ~SkipUnavailableOption();
 };
+
 
 /// Create two options (`--allow-downgrade` and `--no-allow-downgrade`) for a command provided as an argument command.
 /// The values are stored in the `allow_downgrade` configuration option

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -117,7 +117,7 @@ void RootCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();
-    auto & config = ctx.base.get_config();
+    auto & config = ctx.get_base().get_config();
 
     cmd.set_description(_("Utility for packages maintaining"));
     cmd.set_long_description(_("DNF5 is a program for maintaining packages."));
@@ -171,13 +171,13 @@ void RootCommand::set_argument_parser() {
                                      [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                      [[maybe_unused]] const char * option,
                                      [[maybe_unused]] const char * value) {
-        std::filesystem::path cachedir{ctx.base.get_config().get_cachedir_option().get_value()};
+        std::filesystem::path cachedir{ctx.get_base().get_config().get_cachedir_option().get_value()};
         std::error_code ec;
         for (const auto & dir_entry : std::filesystem::directory_iterator(cachedir, ec)) {
             if (!dir_entry.is_directory()) {
                 continue;
             }
-            libdnf5::repo::RepoCache cache(ctx.base.get_weak_ptr(), dir_entry.path());
+            libdnf5::repo::RepoCache cache(ctx.get_base().get_weak_ptr(), dir_entry.path());
             try {
                 cache.write_attribute(libdnf5::repo::RepoCache::ATTRIBUTE_EXPIRED);
             } catch (const std::exception & ex) {
@@ -209,7 +209,7 @@ void RootCommand::set_argument_parser() {
                 throw libdnf5::cli::ArgumentParserError(
                     M_("repofrompath: Incorrect repoid and path specification \"{}\""), std::string(value));
             }
-            ctx.repos_from_path.emplace_back(val.substr(0, comma), val.substr(comma + 1));
+            ctx.get_repos_from_path().emplace_back(val.substr(0, comma), val.substr(comma + 1));
             return true;
         });
     global_options_group->register_argument(repofrompath);
@@ -242,10 +242,10 @@ void RootCommand::set_argument_parser() {
                         std::string(value));
                 }
                 // Store repository option to vector. Use it later when repositories configuration will be loaded.
-                ctx.setopts.emplace_back(key, val + 1);
+                ctx.get_setopts().emplace_back(key, val + 1);
             } else {
                 // Apply global option immediately.
-                auto & conf = ctx.base.get_config();
+                auto & conf = ctx.get_base().get_config();
                 try {
                     conf.opt_binds().at(key).new_string(libdnf5::Option::Priority::COMMANDLINE, val + 1);
                 } catch (const std::exception & ex) {
@@ -273,7 +273,7 @@ void RootCommand::set_argument_parser() {
             }
             auto name = std::string(value, val);
             try {
-                ctx.base.get_vars()->set(name, val + 1, libdnf5::Vars::Priority::COMMANDLINE);
+                ctx.get_base().get_vars()->set(name, val + 1, libdnf5::Vars::Priority::COMMANDLINE);
             } catch (libdnf5::Error & ex) {
                 std::string message{ex.what()};
                 throw libdnf5::cli::ArgumentParserError(M_("setvar: {}"), message);
@@ -322,7 +322,7 @@ void RootCommand::set_argument_parser() {
                                          [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                          [[maybe_unused]] const char * option,
                                          [[maybe_unused]] const char * value) {
-            auto & conf = ctx.base.get_config();
+            auto & conf = ctx.get_base().get_config();
             conf.opt_binds().at("tsflags").new_string(libdnf5::Option::Priority::COMMANDLINE, "nodocs");
             return true;
         });
@@ -340,7 +340,7 @@ void RootCommand::set_argument_parser() {
                                          [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                          [[maybe_unused]] const char * option,
                                          const char * value) {
-            auto & conf = ctx.base.get_config();
+            auto & conf = ctx.get_base().get_config();
             conf.opt_binds().at("excludepkgs").new_string(libdnf5::Option::Priority::COMMANDLINE, value);
             return true;
         });
@@ -359,7 +359,7 @@ void RootCommand::set_argument_parser() {
             // Store the repositories enablement to vector. Use it later when repositories configuration will be loaded.
             libdnf5::OptionStringList repoid_patterns(value);
             for (auto & repoid_pattern : repoid_patterns.get_value()) {
-                ctx.setopts.emplace_back(repoid_pattern + ".enabled", "1");
+                ctx.get_setopts().emplace_back(repoid_pattern + ".enabled", "1");
             }
             return true;
         });
@@ -377,7 +377,7 @@ void RootCommand::set_argument_parser() {
             // Store the repositories disablement to vector. Use it later when repositories configuration will be loaded.
             libdnf5::OptionStringList repoid_patterns(value);
             for (auto & repoid_pattern : repoid_patterns.get_value()) {
-                ctx.setopts.emplace_back(repoid_pattern + ".enabled", "0");
+                ctx.get_setopts().emplace_back(repoid_pattern + ".enabled", "0");
             }
             return true;
         });
@@ -394,12 +394,12 @@ void RootCommand::set_argument_parser() {
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             // The first occurrence of the argument first disables all repositories.
             if (arg->get_parse_count() == 1) {
-                ctx.setopts.emplace_back("*.enabled", "0");
+                ctx.get_setopts().emplace_back("*.enabled", "0");
             }
             // Store repositories enablemend to vector. Use it later when repositories configuration will be loaded.
             libdnf5::OptionStringList repoid_patterns(value);
             for (auto & repoid_pattern : repoid_patterns.get_value()) {
-                ctx.setopts.emplace_back(repoid_pattern + ".enabled", "1");
+                ctx.get_setopts().emplace_back(repoid_pattern + ".enabled", "1");
             }
             return true;
         });
@@ -415,11 +415,11 @@ void RootCommand::set_argument_parser() {
                                           [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                           [[maybe_unused]] const char * option,
                                           [[maybe_unused]] const char * value) {
-        ctx.base.get_config().get_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
-        ctx.base.get_config().get_repo_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
+        ctx.get_base().get_config().get_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
+        ctx.get_base().get_config().get_repo_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         // Store to vector. Use it later when repositories configuration will be loaded.
-        ctx.setopts.emplace_back("*.gpgcheck", "0");
-        ctx.setopts.emplace_back("*.repo_gpgcheck", "0");
+        ctx.get_setopts().emplace_back("*.gpgcheck", "0");
+        ctx.get_setopts().emplace_back("*.repo_gpgcheck", "0");
         return true;
     });
     global_options_group->register_argument(no_gpgchecks);
@@ -503,7 +503,7 @@ void RootCommand::set_argument_parser() {
     releasever->set_parse_hook_func(
         [&ctx](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
-            ctx.base.get_vars()->set("releasever", value);
+            ctx.get_base().get_vars()->set("releasever", value);
             return true;
         });
     global_options_group->register_argument(releasever);
@@ -611,8 +611,8 @@ void RootCommand::set_argument_parser() {
                     std::string(value),
                     available_arches);
             }
-            ctx.base.get_config().get_ignorearch_option().set(libdnf5::Option::Priority::COMMANDLINE, true);
-            ctx.base.get_vars()->set("arch", value, libdnf5::Vars::Priority::COMMANDLINE);
+            ctx.get_base().get_config().get_ignorearch_option().set(libdnf5::Option::Priority::COMMANDLINE, true);
+            ctx.get_base().get_vars()->set("arch", value, libdnf5::Vars::Priority::COMMANDLINE);
             return true;
         });
         global_options_group->register_argument(forcearch);
@@ -824,7 +824,7 @@ static void print_transaction_size_stats(Context & context) {
 }
 
 static void dump_main_configuration(Context & context) {
-    libdnf5::Base & base = context.base;
+    libdnf5::Base & base = context.get_base();
     std::cout << _("======== Main configuration: ========") << std::endl;
     for (const auto & option : base.get_config().opt_binds()) {
         const auto & val = option.second;
@@ -844,7 +844,7 @@ static void dump_main_configuration(Context & context) {
 }
 
 static void dump_repository_configuration(Context & context, const std::vector<std::string> & repo_id_list) {
-    libdnf5::Base & base = context.base;
+    libdnf5::Base & base = context.get_base();
     auto & log_router = *base.get_logger();
 
     std::set<libdnf5::repo::RepoWeakPtr> matching_repos;
@@ -888,14 +888,14 @@ static void dump_repository_configuration(Context & context, const std::vector<s
 
 static void dump_variables(Context & context) {
     std::cout << _("======== Variables: ========") << std::endl;
-    for (const auto & var : context.base.get_vars()->get_variables()) {
+    for (const auto & var : context.get_base().get_vars()->get_variables()) {
         const auto & val = var.second;
         std::cout << fmt::format("{} = {}", var.first, val.value) << std::endl;
     }
 }
 
 static void print_new_leaves(Context & context) {
-    libdnf5::rpm::PackageQuery pkg_query(context.base);
+    libdnf5::rpm::PackageQuery pkg_query(context.get_base());
     pkg_query.filter_installed();
     libdnf5::rpm::PackageQuery pre_trans_leaves_query(pkg_query);
     pre_trans_leaves_query.filter_leaves();
@@ -960,7 +960,7 @@ static bool has_named_arg(libdnf5::cli::ArgumentParser::Command * command, std::
 }
 
 static void print_resolve_hints(dnf5::Context & context) {
-    auto & conf = context.base.get_config();
+    auto & conf = context.get_base().get_config();
     std::vector<std::string> hints;
     auto transaction_problems = context.get_transaction()->get_problems();
     auto * command = context.get_selected_command()->get_argument_parser_command();
@@ -1067,7 +1067,7 @@ int main(int argc, char * argv[]) try {
     // Creates a context and passes the loggers to it. We want to capture all messages from the context in the log.
     dnf5::Context context(std::move(loggers));
 
-    libdnf5::Base & base = context.base;
+    libdnf5::Base & base = context.get_base();
 
     auto & log_router = *base.get_logger();
 
@@ -1196,13 +1196,13 @@ int main(int argc, char * argv[]) try {
             any_repos_from_system_configuration = repo_sack->size() > 0;
 
             auto vars = base.get_vars();
-            for (auto & id_path_pair : context.repos_from_path) {
+            for (auto & id_path_pair : context.get_repos_from_path()) {
                 id_path_pair.first = vars->substitute(id_path_pair.first);
                 id_path_pair.second = vars->substitute(id_path_pair.second);
             }
-            repo_sack->create_repos_from_paths(context.repos_from_path, libdnf5::Option::Priority::COMMANDLINE);
-            for (const auto & [id, path] : context.repos_from_path) {
-                context.setopts.emplace_back(id + ".enabled", "1");
+            repo_sack->create_repos_from_paths(context.get_repos_from_path(), libdnf5::Option::Priority::COMMANDLINE);
+            for (const auto & [id, path] : context.get_repos_from_path()) {
+                context.get_setopts().emplace_back(id + ".enabled", "1");
             }
 
             context.apply_repository_setopts();
@@ -1270,7 +1270,7 @@ int main(int argc, char * argv[]) try {
                     }
                 }
 
-                if (!libdnf5::cli::utils::userconfirm::userconfirm(context.base.get_config())) {
+                if (!libdnf5::cli::utils::userconfirm::userconfirm(context.get_base().get_config())) {
                     throw libdnf5::cli::AbortedByUserError();
                 }
 

--- a/dnf5/offline.cpp
+++ b/dnf5/offline.cpp
@@ -17,9 +17,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "dnf5/offline.hpp"
+
 #include "libdnf5/common/exception.hpp"
 
-#include <dnf5/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
 
@@ -32,6 +33,20 @@ namespace dnf5::offline {
 OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : path(std::move(path)) {
     read();
 }
+
+OfflineTransactionStateData & OfflineTransactionState::get_data() {
+    return data;
+}
+
+const std::exception_ptr & OfflineTransactionState::get_read_exception() const {
+    return read_exception;
+}
+
+std::filesystem::path OfflineTransactionState::get_path() const {
+    return path;
+}
+
+
 void OfflineTransactionState::read() {
     try {
         const std::ifstream file{path};
@@ -48,6 +63,7 @@ void OfflineTransactionState::read() {
         data = OfflineTransactionStateData{};
     }
 }
+
 void OfflineTransactionState::write() {
     auto file = libdnf5::utils::fs::File(path, "w");
     file.write(toml::format(toml::value{{STATE_HEADER, data}}));

--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -91,7 +91,7 @@ Plugins::~Plugins() {
 }
 
 void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
-    auto logger = context->base.get_logger();
+    auto logger = context->get_base().get_logger();
     auto * iplugin = plugin->get_iplugin();
     plugins.emplace_back(std::move(plugin));
     auto name = iplugin->get_name();
@@ -100,7 +100,7 @@ void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
 }
 
 void Plugins::load_plugin(const std::string & file_path) {
-    auto logger = context->base.get_logger();
+    auto logger = context->get_base().get_logger();
     logger->debug("Loading plugin file=\"{}\"", file_path);
     auto plugin = std::make_unique<PluginLibrary>(*context, file_path);
     auto * iplugin = plugin->get_iplugin();
@@ -117,7 +117,7 @@ void Plugins::load_plugin(const std::string & file_path) {
 }
 
 void Plugins::load_plugins(const std::string & dir_path) {
-    auto logger = context->base.get_logger();
+    auto logger = context->get_base().get_logger();
 
     std::vector<std::filesystem::path> lib_paths;
     std::error_code ec;

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -40,14 +40,14 @@ void create_allow_downgrade_options(dnf5::Command & command) {
     allow_downgrade->set_long_name("allow-downgrade");
     allow_downgrade->set_description("Allow downgrade of dependencies for resolve of requested operation");
     allow_downgrade->set_const_value("true");
-    allow_downgrade->link_value(&command.get_context().base.get_config().get_allow_downgrade_option());
+    allow_downgrade->link_value(&command.get_context().get_base().get_config().get_allow_downgrade_option());
     parser_command->register_named_arg(allow_downgrade);
 
     auto no_allow_downgrade = parser.add_new_named_arg("no-allow-downgrade");
     no_allow_downgrade->set_long_name("no-allow-downgrade");
     no_allow_downgrade->set_description("Disable downgrade of dependencies for resolve of requested operation");
     no_allow_downgrade->set_const_value("false");
-    no_allow_downgrade->link_value(&command.get_context().base.get_config().get_allow_downgrade_option());
+    no_allow_downgrade->link_value(&command.get_context().get_base().get_config().get_allow_downgrade_option());
     parser_command->register_named_arg(no_allow_downgrade);
 
     allow_downgrade->add_conflict_argument(*no_allow_downgrade);
@@ -61,7 +61,7 @@ void create_destdir_option(dnf5::Command & command) {
         "Set directory used for downloading packages to. Default location is to the current working directory.");
     destdir->set_has_value(true);
     destdir->set_arg_value_help("DESTDIR");
-    destdir->link_value(&command.get_context().base.get_config().get_destdir_option());
+    destdir->link_value(&command.get_context().get_base().get_config().get_destdir_option());
     command.get_argument_parser_command()->register_named_arg(destdir);
 }
 
@@ -71,7 +71,7 @@ void create_downloadonly_option(dnf5::Command & command) {
     downloadonly->set_long_name("downloadonly");
     downloadonly->set_description("Only download packages for a transaction");
     downloadonly->set_const_value("true");
-    downloadonly->link_value(&command.get_context().base.get_config().get_downloadonly_option());
+    downloadonly->link_value(&command.get_context().get_base().get_config().get_downloadonly_option());
     command.get_argument_parser_command()->register_named_arg(downloadonly);
 }
 
@@ -88,8 +88,9 @@ void create_offline_option(dnf5::Command & command) {
                                      [[maybe_unused]] const char * value) {
         // The installroot will be prepended to the cachedir and system_cachedir later in Base.setup()
         const auto & offline_datadir = dnf5::offline::DEFAULT_DATADIR;
-        ctx.base.get_config().get_system_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
-        ctx.base.get_config().get_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
+        ctx.get_base().get_config().get_system_cachedir_option().set(
+            libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
+        ctx.get_base().get_config().get_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
         ctx.set_should_store_offline(true);
         return true;
     });

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -28,6 +28,35 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnf5 {
 
+AllowErasingOption::AllowErasingOption(libdnf5::cli::session::Command & command)
+    : BoolOption(command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
+
+AllowErasingOption::~AllowErasingOption() = default;
+
+
+SkipBrokenOption::SkipBrokenOption(dnf5::Command & command)
+    : BoolOption(
+          command,
+          "skip-broken",
+          '\0',
+          _("Allow resolving of depsolve problems by skipping packages"),
+          false,
+          &command.get_context().get_base().get_config().get_skip_broken_option()) {}
+
+SkipBrokenOption::~SkipBrokenOption() = default;
+
+
+SkipUnavailableOption::SkipUnavailableOption(dnf5::Command & command)
+    : BoolOption(
+          command,
+          "skip-unavailable",
+          '\0',
+          _("Allow skipping unavailable packages"),
+          false,
+          &command.get_context().get_base().get_config().get_skip_unavailable_option()) {}
+
+SkipUnavailableOption::~SkipUnavailableOption() = default;
+
 
 void create_allow_downgrade_options(dnf5::Command & command) {
     auto * solver_options = command.get_context().get_argument_parser().add_new_group("solver_options");

--- a/dnf5daemon-client/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5daemon-client/commands/advisory/advisory_subcommand.cpp
@@ -34,12 +34,12 @@ void AdvisorySubCommand::set_argument_parser() {
     available = std::make_unique<AdvisoryAvailableOption>(*this);
     installed = std::make_unique<AdvisoryInstalledOption>(*this);
     updates = std::make_unique<AdvisoryUpdatesOption>(*this);
-    all->arg->add_conflict_argument(*available->arg);
-    all->arg->add_conflict_argument(*installed->arg);
-    all->arg->add_conflict_argument(*updates->arg);
-    available->arg->add_conflict_argument(*installed->arg);
-    available->arg->add_conflict_argument(*updates->arg);
-    installed->arg->add_conflict_argument(*updates->arg);
+    all->get_arg()->add_conflict_argument(*available->get_arg());
+    all->get_arg()->add_conflict_argument(*installed->get_arg());
+    all->get_arg()->add_conflict_argument(*updates->get_arg());
+    available->get_arg()->add_conflict_argument(*installed->get_arg());
+    available->get_arg()->add_conflict_argument(*updates->get_arg());
+    installed->get_arg()->add_conflict_argument(*updates->get_arg());
 
     contains_pkgs = std::make_unique<AdvisoryContainsPkgsOption>(*this);
     advisory_security = std::make_unique<SecurityOption>(*this);

--- a/dnf5daemon-client/commands/group/group_list.cpp
+++ b/dnf5daemon-client/commands/group/group_list.cpp
@@ -44,7 +44,7 @@ GroupListCommand::GroupListCommand(Context & context, const char * command)
 
     available = std::make_unique<GroupAvailableOption>(*this);
     installed = std::make_unique<GroupInstalledOption>(*this);
-    available->arg->add_conflict_argument(*installed->arg);
+    available->get_arg()->add_conflict_argument(*installed->get_arg());
     hidden = std::make_unique<GroupHiddenOption>(*this);
     contains_pkgs = std::make_unique<GroupContainPkgsOption>(*this);
 

--- a/include/libdnf5-cli/session.hpp
+++ b/include/libdnf5-cli/session.hpp
@@ -161,7 +161,18 @@ private:
 };
 
 
-class Option {};
+class Option {
+public:
+    Option(const Option & src) = delete;
+    Option(Option && src) = delete;
+    ~Option();
+
+    Option & operator=(const Option & src) = delete;
+    Option & operator=(Option && src) = delete;
+
+protected:
+    Option();
+};
 
 
 class BoolOption : public Option {
@@ -174,18 +185,21 @@ public:
         bool default_value,
         libdnf5::OptionBool * linked_option = nullptr);
 
+    ~BoolOption();
+
     /// @return Parsed value.
     /// @since 5.0
-    bool get_value() const { return conf->get_value(); }
+    bool get_value() const;
 
     /// Set bool value with priority for the option
     /// @param priority Priority
     /// @param value Value
     /// @since 5.0
-    void set(libdnf5::Option::Priority priority, bool value) { return conf->set(priority, value); }
+    void set(libdnf5::Option::Priority priority, bool value);
 
-    // TODO(dmach): `arg` must be public, because it is used to define conflicting args
-    //protected:
+    libdnf5::cli::ArgumentParser::NamedArg * get_arg();
+
+protected:
     libdnf5::OptionBool * conf{nullptr};
     libdnf5::cli::ArgumentParser::NamedArg * arg{nullptr};
 };
@@ -213,10 +227,15 @@ public:
         const bool icase,
         const std::string & delimiters = libdnf5::OptionStringList::get_default_delimiters());
 
+    ~AppendStringListOption();
+
     /// @return Parsed value.
     /// @since 5.0
-    std::vector<std::string> get_value() const { return conf->get_value(); }
+    std::vector<std::string> get_value() const;
 
+    libdnf5::cli::ArgumentParser::NamedArg * get_arg();
+
+protected:
     libdnf5::OptionStringList * conf{nullptr};
     libdnf5::cli::ArgumentParser::NamedArg * arg{nullptr};
 };
@@ -226,12 +245,16 @@ class StringArgumentList : public Option {
 public:
     explicit StringArgumentList(
         libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc, int nargs);
-    StringArgumentList(libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc)
-        : StringArgumentList(command, name, desc, ArgumentParser::PositionalArg::UNLIMITED){};
+    explicit StringArgumentList(
+        libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc);
+
+    ~StringArgumentList();
 
     /// @return Parsed value.
     /// @since 5.0
     std::vector<std::string> get_value() const;
+
+    libdnf5::cli::ArgumentParser::PositionalArg * get_arg();
 
 protected:
     std::vector<std::unique_ptr<libdnf5::Option>> * conf{nullptr};

--- a/include/libdnf5-cli/session.hpp
+++ b/include/libdnf5-cli/session.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "argument_parser.hpp"
 
+#include <libdnf5/common/impl_ptr.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/conf/option_string_list.hpp>
@@ -37,7 +38,14 @@ class Command;
 
 class Session {
 public:
-    Session() : argument_parser(new libdnf5::cli::ArgumentParser) {}
+    explicit Session();
+    ~Session();
+
+    Session(const Session & src) = delete;
+    Session(Session && src);
+
+    Session & operator=(const Session & src) = delete;
+    Session & operator=(Session && src);
 
     /// Store the command to the session and initialize it.
     /// @since 5.0
@@ -55,12 +63,12 @@ public:
     /// @return Selected (sub)command that a user specified on the command line.
     ///         The returned pointer must **not** be freed manually.
     /// @since 5.0
-    Command * get_selected_command() { return selected_command; }
+    Command * get_selected_command();
 
     /// Set `command` as the selected (sub)command that a user specified on the command line.
     /// We're only pointing to a command that is owned by the Session already.
     /// @since 5.0
-    void set_selected_command(Command * command) { selected_command = command; }
+    void set_selected_command(Command * command);
 
     /// @return The underlying argument parser.
     /// @since 5.0
@@ -71,9 +79,8 @@ public:
     void clear();
 
 private:
-    Command * selected_command{nullptr};
-    std::vector<std::unique_ptr<Command>> commands;
-    std::unique_ptr<libdnf5::cli::ArgumentParser> argument_parser;
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 
@@ -152,12 +159,6 @@ private:
     Session & session;
     libdnf5::cli::ArgumentParser::Command * argument_parser_command;
 };
-
-
-inline Command * Session::get_root_command() {
-    auto * arg_parser_root_command = argument_parser->get_root_command();
-    return arg_parser_root_command ? static_cast<Command *>(arg_parser_root_command->get_user_data()) : nullptr;
-}
 
 
 class Option {};

--- a/include/libdnf5-cli/session.hpp
+++ b/include/libdnf5-cli/session.hpp
@@ -87,41 +87,48 @@ private:
 class Command : public libdnf5::cli::ArgumentParserUserData {
 public:
     explicit Command(Session & session, const std::string & name);
-    virtual ~Command() = default;
+    virtual ~Command();
+
+    Command() = delete;
+    Command(const Command & src) = delete;
+    Command(Command && src) = delete;
+
+    Command & operator=(const Command & src) = delete;
+    Command & operator=(Command && src) = delete;
 
     /// Sets a parent command and group. Can add a new group to the parent command.
     /// @since 5.0
-    virtual void set_parent_command() {}
+    virtual void set_parent_command();
 
     /// Set command arguments.
     /// @since 5.0
-    virtual void set_argument_parser() {}
+    virtual void set_argument_parser();
 
     /// Register subcommands.
     /// @since 5.0
-    virtual void register_subcommands() {}
+    virtual void register_subcommands();
 
     /// Adjust configuration.
     /// Called after parsing the command line and but before loading configuration files.
     /// @since 5.0
-    virtual void pre_configure() {}
+    virtual void pre_configure();
 
     /// Adjust configuration.
     /// Called after parsing the command line and loading configuration files.
     /// @since 5.0
-    virtual void configure() {}
+    virtual void configure();
 
     /// Loads additional packages that are not in the repositories.
     /// @since 5.0
-    virtual void load_additional_packages() {}
+    virtual void load_additional_packages();
 
     /// Run the command.
     /// @since 5.0
-    virtual void run() {}
+    virtual void run();
 
     /// Called immediately after the goal is resolved.
     /// @since 5.0
-    virtual void goal_resolved() {}
+    virtual void goal_resolved();
 
     /// Throw a ArgumentParserMissingCommandError exception with the command name in it
     void throw_missing_command() const;
@@ -129,24 +136,17 @@ public:
     /// @return Pointer to the Session.
     ///         The returned pointer must **not** be freed manually.
     /// @since 5.0
-    Session & get_session() const noexcept { return session; }
+    Session & get_session() const noexcept;
 
     /// @return Pointer to the parent Command. Root command returns null because it has no parent.
     ///         The returned pointer must **not** be freed manually.
     /// @since 5.0
-    Command * get_parent_command() const noexcept {
-        auto * parser_parent = argument_parser_command->get_parent();
-        if (!parser_parent)
-            return nullptr;
-        return static_cast<Command *>(parser_parent->get_user_data());
-    }
+    Command * get_parent_command() const noexcept;
 
     /// @return Pointer to the underlying argument parser command.
     ///         The returned pointer must **not** be freed manually.
     /// @since 5.0
-    libdnf5::cli::ArgumentParser::Command * get_argument_parser_command() const noexcept {
-        return argument_parser_command;
-    }
+    libdnf5::cli::ArgumentParser::Command * get_argument_parser_command() const noexcept;
 
 protected:
     /// Register a `subcommand` to the current command.

--- a/include/libdnf5/repo/repo_callbacks.hpp
+++ b/include/libdnf5/repo/repo_callbacks.hpp
@@ -34,25 +34,21 @@ namespace libdnf5::repo {
 /// To implement callbacks, inherit from this class and override virtual methods.
 class RepoCallbacks {
 public:
-    RepoCallbacks() = default;
+    explicit RepoCallbacks();
     RepoCallbacks(const RepoCallbacks &) = delete;
     RepoCallbacks(RepoCallbacks &&) = delete;
+    virtual ~RepoCallbacks();
+
     RepoCallbacks & operator=(const RepoCallbacks &) = delete;
     RepoCallbacks & operator=(RepoCallbacks &&) = delete;
-    virtual ~RepoCallbacks() = default;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 
     /// GPG key import callback. Allows to confirm or deny the import.
     /// @param key_info The key that is about to be imported
     /// @return `true` to import the key, `false` to not import
-    virtual bool repokey_import(const libdnf5::rpm::KeyInfo & key_info) { return true; }
+    virtual bool repokey_import(const libdnf5::rpm::KeyInfo & key_info);
     /// Called on successful repo key import.
     /// @param key_info The key that was successfully imported
-    virtual void repokey_imported(const libdnf5::rpm::KeyInfo & key_info) {}
-
-#pragma GCC diagnostic pop
+    virtual void repokey_imported(const libdnf5::rpm::KeyInfo & key_info);
 };
 
 }  // namespace libdnf5::repo

--- a/include/libdnf5/rpm/transaction_callbacks.hpp
+++ b/include/libdnf5/rpm/transaction_callbacks.hpp
@@ -27,7 +27,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::base {
 
-class TransactionGroup;
 class TransactionPackage;
 
 }  // namespace libdnf5::base
@@ -38,10 +37,6 @@ namespace libdnf5::rpm {
 /// Class represents one item in transaction set.
 using TransactionItem = base::TransactionPackage;
 
-
-// suppress "unused-parameter" warnings because TransactionCallbacks is a virtual class
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 
 /// Base class for Transaction callbacks
 /// User implements Transaction callbacks by inheriting this class and overriding its methods.
@@ -67,36 +62,40 @@ public:
     /// @return  string representation of the scriptlet type
     static const char * script_type_to_string(ScriptType type) noexcept;
 
-    virtual ~TransactionCallbacks() = default;
+    explicit TransactionCallbacks();
+    TransactionCallbacks(const TransactionCallbacks &) = delete;
+    TransactionCallbacks(TransactionCallbacks &&) = delete;
+    virtual ~TransactionCallbacks();
+
+    TransactionCallbacks & operator=(const TransactionCallbacks &) = delete;
+    TransactionCallbacks & operator=(TransactionCallbacks &&) = delete;
 
     /// Called right before the rpm transaction is run
     /// @param total Number of elements in the rpm transaction
-    virtual void before_begin(uint64_t total) {}
+    virtual void before_begin(uint64_t total);
     /// Called after the transaction run finished
     /// @param success Whether the rpm transaction was completed successfully
-    virtual void after_complete(bool success) {}
+    virtual void after_complete(bool success);
 
-    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void install_start(const TransactionItem & item, uint64_t total) {}
-    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void transaction_progress(uint64_t amount, uint64_t total) {}
-    virtual void transaction_start(uint64_t total) {}
-    virtual void transaction_stop(uint64_t total) {}
-    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void uninstall_start(const TransactionItem & item, uint64_t total) {}
-    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void unpack_error(const TransactionItem & item) {}
-    virtual void cpio_error(const TransactionItem & item) {}
-    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
-    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type) {}
-    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
-    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void verify_progress(uint64_t amount, uint64_t total) {}
-    virtual void verify_start(uint64_t total) {}
-    virtual void verify_stop(uint64_t total) {}
+    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void install_start(const TransactionItem & item, uint64_t total);
+    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void transaction_progress(uint64_t amount, uint64_t total);
+    virtual void transaction_start(uint64_t total);
+    virtual void transaction_stop(uint64_t total);
+    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void uninstall_start(const TransactionItem & item, uint64_t total);
+    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void unpack_error(const TransactionItem & item);
+    virtual void cpio_error(const TransactionItem & item);
+    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type);
+    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void verify_progress(uint64_t amount, uint64_t total);
+    virtual void verify_start(uint64_t total);
+    virtual void verify_stop(uint64_t total);
 };
-
-#pragma GCC diagnostic pop
 
 
 }  // namespace libdnf5::rpm

--- a/libdnf5-cli/session.cpp
+++ b/libdnf5-cli/session.cpp
@@ -127,11 +127,41 @@ Command::Command(Session & session, const std::string & name) : session{session}
     argument_parser_command->set_user_data(this);
 }
 
+Command::~Command() = default;
+
+void Command::set_parent_command() {}
+
+void Command::set_argument_parser() {}
+
+void Command::register_subcommands() {}
+
+void Command::pre_configure() {}
+
+void Command::configure() {}
+
+void Command::load_additional_packages() {}
+
+void Command::run() {}
+
+void Command::goal_resolved() {}
 
 void Command::throw_missing_command() const {
     throw ArgumentParserMissingCommandError(M_("Missing command"), get_argument_parser_command()->get_id());
 }
+Session & Command::get_session() const noexcept {
+    return session;
+}
 
+Command * Command::get_parent_command() const noexcept {
+    auto * parser_parent = argument_parser_command->get_parent();
+    if (!parser_parent)
+        return nullptr;
+    return static_cast<Command *>(parser_parent->get_user_data());
+}
+
+libdnf5::cli::ArgumentParser::Command * Command::get_argument_parser_command() const noexcept {
+    return argument_parser_command;
+}
 
 void Command::register_subcommand(std::unique_ptr<Command> subcommand, libdnf5::cli::ArgumentParser::Group * group) {
     auto * sub_arg_parser_command = subcommand->get_argument_parser_command();

--- a/libdnf5-cli/session.cpp
+++ b/libdnf5-cli/session.cpp
@@ -175,6 +175,11 @@ void Command::register_subcommand(std::unique_ptr<Command> subcommand, libdnf5::
 }
 
 
+Option::Option() = default;
+
+Option::~Option() = default;
+
+
 BoolOption::BoolOption(
     libdnf5::cli::session::Command & command,
     const std::string & long_name,
@@ -204,6 +209,20 @@ BoolOption::BoolOption(
     arg->link_value(conf);
 
     command.get_argument_parser_command()->register_named_arg(arg);
+}
+
+BoolOption::~BoolOption() = default;
+
+bool BoolOption::get_value() const {
+    return conf->get_value();
+}
+
+void BoolOption::set(libdnf5::Option::Priority priority, bool value) {
+    return conf->set(priority, value);
+}
+
+libdnf5::cli::ArgumentParser::NamedArg * BoolOption::get_arg() {
+    return arg;
 }
 
 
@@ -242,7 +261,6 @@ AppendStringListOption::AppendStringListOption(
     command.get_argument_parser_command()->register_named_arg(arg);
 }
 
-
 AppendStringListOption::AppendStringListOption(
     libdnf5::cli::session::Command & command,
     const std::string & long_name,
@@ -251,6 +269,15 @@ AppendStringListOption::AppendStringListOption(
     const std::string & help)
     : AppendStringListOption(command, long_name, short_name, desc, help, "", false) {}
 
+AppendStringListOption::~AppendStringListOption() = default;
+
+std::vector<std::string> AppendStringListOption::get_value() const {
+    return conf->get_value();
+}
+
+libdnf5::cli::ArgumentParser::NamedArg * AppendStringListOption::get_arg() {
+    return arg;
+}
 
 StringArgumentList::StringArgumentList(
     libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc, int nargs) {
@@ -264,6 +291,12 @@ StringArgumentList::StringArgumentList(
     command.get_argument_parser_command()->register_positional_arg(arg);
 }
 
+StringArgumentList::StringArgumentList(
+    libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc)
+    : StringArgumentList(command, name, desc, ArgumentParser::PositionalArg::UNLIMITED){};
+
+StringArgumentList::~StringArgumentList() = default;
+
 std::vector<std::string> StringArgumentList::get_value() const {
     std::vector<std::string> result;
 
@@ -273,6 +306,10 @@ std::vector<std::string> StringArgumentList::get_value() const {
     }
 
     return result;
+}
+
+libdnf5::cli::ArgumentParser::PositionalArg * StringArgumentList::get_arg() {
+    return arg;
 }
 
 

--- a/libdnf5/repo/repo_callbacks.cpp
+++ b/libdnf5/repo/repo_callbacks.cpp
@@ -1,0 +1,34 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/repo/repo_callbacks.hpp"
+
+namespace libdnf5::repo {
+
+RepoCallbacks::RepoCallbacks() = default;
+
+RepoCallbacks::~RepoCallbacks() = default;
+
+bool RepoCallbacks::repokey_import(const libdnf5::rpm::KeyInfo &) {
+    return true;
+}
+
+void RepoCallbacks::repokey_imported(const libdnf5::rpm::KeyInfo &) {}
+
+}  // namespace libdnf5::repo

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -477,33 +477,6 @@ TransactionCallbacks::ScriptType Transaction::rpm_tag_to_script_type(rpmTag_e ta
     }
 }
 
-const char * TransactionCallbacks::script_type_to_string(ScriptType type) noexcept {
-    switch (type) {
-        case ScriptType::PRE_INSTALL:
-            return "pre-install";
-        case ScriptType::POST_INSTALL:
-            return "post-install";
-        case ScriptType::PRE_UNINSTALL:
-            return "pre-uninstall";
-        case ScriptType::POST_UNINSTALL:
-            return "post-uninstall";
-        case ScriptType::PRE_TRANSACTION:
-            return "pre-transaction";
-        case ScriptType::POST_TRANSACTION:
-            return "post-transaction";
-        case ScriptType::TRIGGER_PRE_INSTALL:
-            return "trigger-pre-install";
-        case ScriptType::TRIGGER_INSTALL:
-            return "trigger-install";
-        case ScriptType::TRIGGER_UNINSTALL:
-            return "trigger-uninstall";
-        case ScriptType::TRIGGER_POST_UNINSTALL:
-            return "trigger-post-uninstall";
-        case ScriptType::UNKNOWN:
-            return "unknown";
-    }
-    return "unknown";
-}
 
 #define libdnf_assert_transaction_item_set() libdnf_assert(item != nullptr, "TransactionItem is not set")
 

--- a/libdnf5/rpm/transaction_callbacks.cpp
+++ b/libdnf5/rpm/transaction_callbacks.cpp
@@ -1,0 +1,96 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/rpm/transaction_callbacks.hpp"
+
+namespace libdnf5::rpm {
+
+const char * TransactionCallbacks::script_type_to_string(ScriptType type) noexcept {
+    switch (type) {
+        case ScriptType::PRE_INSTALL:
+            return "pre-install";
+        case ScriptType::POST_INSTALL:
+            return "post-install";
+        case ScriptType::PRE_UNINSTALL:
+            return "pre-uninstall";
+        case ScriptType::POST_UNINSTALL:
+            return "post-uninstall";
+        case ScriptType::PRE_TRANSACTION:
+            return "pre-transaction";
+        case ScriptType::POST_TRANSACTION:
+            return "post-transaction";
+        case ScriptType::TRIGGER_PRE_INSTALL:
+            return "trigger-pre-install";
+        case ScriptType::TRIGGER_INSTALL:
+            return "trigger-install";
+        case ScriptType::TRIGGER_UNINSTALL:
+            return "trigger-uninstall";
+        case ScriptType::TRIGGER_POST_UNINSTALL:
+            return "trigger-post-uninstall";
+        case ScriptType::UNKNOWN:
+            return "unknown";
+    }
+    return "unknown";
+}
+
+TransactionCallbacks::TransactionCallbacks() = default;
+
+TransactionCallbacks::~TransactionCallbacks() = default;
+
+void TransactionCallbacks::before_begin(uint64_t) {}
+
+void TransactionCallbacks::after_complete(bool) {}
+
+void TransactionCallbacks::install_progress(const TransactionItem &, uint64_t, uint64_t) {}
+
+void TransactionCallbacks::install_start(const TransactionItem &, uint64_t) {}
+
+void TransactionCallbacks::install_stop(const TransactionItem &, uint64_t, uint64_t) {}
+
+void TransactionCallbacks::transaction_progress(uint64_t, uint64_t) {}
+
+void TransactionCallbacks::transaction_start(uint64_t) {}
+
+void TransactionCallbacks::transaction_stop(uint64_t) {}
+
+void TransactionCallbacks::uninstall_progress(const TransactionItem &, uint64_t, uint64_t) {}
+
+void TransactionCallbacks::uninstall_start(const TransactionItem &, uint64_t) {}
+
+void TransactionCallbacks::uninstall_stop(const TransactionItem &, uint64_t, uint64_t) {}
+
+void TransactionCallbacks::unpack_error(const TransactionItem &) {}
+
+void TransactionCallbacks::cpio_error(const TransactionItem &) {}
+
+void TransactionCallbacks::script_error(const TransactionItem *, Nevra, ScriptType, uint64_t) {}
+
+void TransactionCallbacks::script_start(const TransactionItem *, Nevra, ScriptType) {}
+
+void TransactionCallbacks::script_stop(const TransactionItem *, Nevra, ScriptType, uint64_t) {}
+
+void TransactionCallbacks::elem_progress(const TransactionItem &, uint64_t, uint64_t) {}
+
+void TransactionCallbacks::verify_progress(uint64_t, uint64_t) {}
+
+void TransactionCallbacks::verify_start(uint64_t) {}
+
+void TransactionCallbacks::verify_stop(uint64_t) {}
+
+}  // namespace libdnf5::rpm


### PR DESCRIPTION
Converts inline methods to non-inline in several classes.
Adds p_impl to some classes.
Moves public class variables to the private/p_impl section.
Deletes some unwanted constructors and assigns operators.

Related https://github.com/rpm-software-management/dnf5/issues/1025