### PR TITLE
Add file search result for repoquery --whatprovides

### DIFF
--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -159,7 +159,7 @@ Options
     | This is a list option.
 
 ``--whatprovides=CAPABILITY,...``
-    | Limit to packages that provide any of <capabilities>.
+    | Limit to packages that provide any of <capabilities>. Capabilities :ref:`specifying a file provide <file_provides_ref-label>` are also matched against file provides.
     | This is a list option.
 
 ``--whatrecommends=CAPABILITY,...``

--- a/doc/misc/specs.7.rst
+++ b/doc/misc/specs.7.rst
@@ -153,6 +153,7 @@ packages providing the given spec. This can either be an explicit provide, an
 implicit provide (i.e. name of the package) or a file provide. The selection is
 case-sensitive and globbing is supported.
 
+.. _file_provides_ref-label:
 
 Specifying File Provides
 ------------------------


### PR DESCRIPTION
File provides are not only present in file provides, but also in normal provides. The code did not searched for file provides when filter_provide() already gained a result. It means that for some glob pattern, dnf5 provides incomplete results without the patch.

Closes: https://github.com/rpm-software-management/dnf5/issues/1153

CI-test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1491