### PR TITLE
Raise an exception when `=` is used with short option

### DIFF
--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -553,15 +553,18 @@ int ArgumentParser::NamedArg::parse_short(const char * option, int argc, const c
     const char * arg_value;
     int consumed_args;
     if (has_value) {
-        if (option[1] != '\0') {
-            arg_value = option + 1;
-            consumed_args = 1;
-        } else {
+        if (option[1] == '\0') {
             if (argc < 2) {
                 throw ArgumentParserNamedArgMissingValueError(M_("Missing value for named argument \"-{}\""), *option);
             }
             arg_value = argv[1];
             consumed_args = 2;
+        } else if (option[1] == '=') {
+            throw ArgumentParserInvalidValueError(
+                M_("'=' is not supported delimiter for short option \"-{}\""), std::string(option));
+        } else {
+            arg_value = option + 1;
+            consumed_args = 1;
         }
     } else {
         arg_value = const_val.c_str();


### PR DESCRIPTION
It prevents silently skipping  the change in behavior between DNF4 and DNF5 Where `-x=dnf` excluded `dnf` but in DNF5 it excludes `=dnf`. Without the exception it would be hard to detect that something might work differently then expected.

Closes: https://github.com/rpm-software-management/dnf5/issues/1353