### PR TITLE
spec: Add conflict with the old provider of dnf.conf

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -342,7 +342,7 @@ Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
 Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
 %if %{with dnf5_obsoletes_dnf}
-Conflicts:      dnf-data < 4.16.0
+Conflicts:      dnf-data < 4.20.0
 %endif
 
 %description -n libdnf5


### PR DESCRIPTION
Another bit needed for switching dnf5 in Rawhide. We need to ensure there are no multiple providers of the dnf configuration on the system simultaneously.

Related: https://github.com/rpm-software-management/dnf5/pull/1444.