### PR TITLE
spec: Add conflict with the former provider of plugin man pages

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -33,6 +33,8 @@ Obsoletes:      dnf < 5
 
 Provides:       yum = %{version}-%{release}
 Obsoletes:      yum < 5
+
+Conflicts:      python3-dnf-plugins-core < 4.7.0
 %endif
 
 Provides:       dnf5-command(advisory)


### PR DESCRIPTION
We relocated the plugin man pages provided by `dnf-plugins-core` to a different location, avoiding conflicts with `dnf5`, starting with `dnf-plugins-core` version 4.7.0. As a result, we need to require this upgrade; otherwise, the man page files will conflict.

Closes https://github.com/rpm-software-management/dnf5/issues/1383.