### PR TITLE
system-upgrade: Fix + adapt to new transaction serialization format

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -406,7 +406,8 @@ void OfflineExecuteCommand::configure() {
     check_state(*state);
 
     ctx.set_load_system_repo(true);
-    ctx.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    // Stored transactions can be replayed without loading available repos
+    ctx.set_load_available_repos(Context::LoadAvailableRepos::NONE);
 
     // Get the cache from the cachedir specified in the state file
     ctx.get_base().get_config().get_system_cachedir_option().set(state->get_data().cachedir);
@@ -444,10 +445,10 @@ void OfflineExecuteCommand::run() {
     state->get_data().status = dnf5::offline::STATUS_TRANSACTION_INCOMPLETE;
     state->write();
 
-    const auto & installroot = ctx.base.get_config().get_installroot_option().get_value();
+    const auto & installroot = ctx.get_base().get_config().get_installroot_option().get_value();
     const auto & datadir = installroot / dnf5::offline::DEFAULT_DATADIR.relative_path();
     std::filesystem::create_directories(datadir);
-    const auto & transaction_json_path = datadir / dnf5::offline::TRANSACTION_JSON_FILENAME;
+    const auto & transaction_json_path = datadir / "transaction.json";
 
     const auto & goal = std::make_unique<libdnf5::Goal>(ctx.get_base());
 

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -228,7 +228,7 @@ void check_state(const dnf5::offline::OfflineTransactionState & state) {
     }
 }
 
-void reboot([[maybe_unused]] bool poweroff = false) {
+void reboot(bool poweroff = false) {
     if (std::getenv("DNF_SYSTEM_UPGRADE_NO_REBOOT")) {
         if (poweroff) {
             std::cerr << "DNF_SYSTEM_UPGRADE_NO_REBOOT is set, not powering off." << std::endl;

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -467,8 +467,19 @@ void OfflineExecuteCommand::run() {
 
     PlymouthOutput plymouth;
     auto callbacks = std::make_unique<PlymouthTransCB>(ctx, plymouth);
-    /* callbacks->get_multi_progress_bar()->set_total_num_of_bars(num_of_actions); */
+    const auto & trans_packages = transaction.get_transaction_packages();
+    auto num_of_actions = trans_packages.size() + 1;
+    for (auto & trans_pkg : trans_packages) {
+        if (libdnf5::transaction::transaction_item_action_is_inbound(trans_pkg.get_action())) {
+            ++num_of_actions;
+            break;
+        }
+    }
+
+    callbacks->get_multi_progress_bar()->set_total_num_of_bars(num_of_actions);
     transaction.set_callbacks(std::move(callbacks));
+
+    transaction.set_description(state->get_data().cmd_line);
 
     const auto result = transaction.run();
     std::cout << std::endl;

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -467,6 +467,12 @@ void OfflineExecuteCommand::run() {
 
     PlymouthOutput plymouth;
     auto callbacks = std::make_unique<PlymouthTransCB>(ctx, plymouth);
+
+    // Adapted from Context::Impl::download_and_run:
+    // Compute the total number of transaction actions (number of bars)
+    // Total number of actions = number of packages in the transaction +
+    //                           action of verifying package files if new package files are present in the transaction +
+    //                           action of preparing transaction
     const auto & trans_packages = transaction.get_transaction_packages();
     auto num_of_actions = trans_packages.size() + 1;
     for (auto & trans_pkg : trans_packages) {

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -49,14 +49,10 @@ protected:
     std::filesystem::path get_magic_symlink() const { return magic_symlink; };
     std::filesystem::path get_datadir() const { return datadir; };
     std::optional<dnf5::offline::OfflineTransactionState> state;
-    std::string get_system_releasever() const { return system_releasever; };
-    std::string get_target_releasever() const { return target_releasever; };
 
 private:
     std::filesystem::path magic_symlink;
     std::filesystem::path datadir;
-    std::string target_releasever;
-    std::string system_releasever;
 };
 
 class OfflineRebootCommand : public OfflineSubcommand {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -349,7 +349,7 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     }
     base.get_config().get_tsflags_option().set(libdnf5::Option::Priority::RUNTIME, "test");
 
-    print_info("\nTesting offline transaction");
+    print_info("Testing offline transaction");
     auto result = test_transaction.run();
     if (result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
         std::cerr << "Transaction failed: " << libdnf5::base::Transaction::transaction_result_to_string(result)
@@ -434,6 +434,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     if (base.get_config().get_downloadonly_option().get_value()) {
         return;
     }
+    print_info("");
 
     if (should_store_offline) {
         store_offline(transaction);
@@ -444,7 +445,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         return;
     }
 
-    print_info("\nRunning transaction");
+    print_info("Running transaction");
 
     // Compute the total number of transaction actions (number of bars)
     // Total number of actions = number of packages in the transaction +

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -43,12 +43,11 @@ const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
 const std::string STATUS_READY{"ready"};
 const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
 
-const int STATE_VERSION = 0;
+const int STATE_VERSION = 1;
 const std::string STATE_HEADER{"offline-transaction-state"};
 
 const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
 const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
-const std::filesystem::path TRANSACTION_JSON_FILENAME{"offline-transaction.json"};
 
 struct OfflineTransactionStateData {
     int state_version = STATE_VERSION;
@@ -59,8 +58,6 @@ struct OfflineTransactionStateData {
     std::string verb;
     std::string cmd_line;
     bool poweroff_after = false;
-    std::vector<std::string> enabled_repos;
-    std::vector<std::string> disabled_repos;
     std::string module_platform_id;
 };
 
@@ -98,8 +95,6 @@ TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
     verb,
     cmd_line,
     poweroff_after,
-    enabled_repos,
-    disabled_repos,
     module_platform_id)
 
 #endif  // DNF5_OFFLINE_HPP

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -115,11 +115,6 @@ void create_offline_option(dnf5::Command & command) {
                                      [[maybe_unused]] libdnf5::cli::ArgumentParser::NamedArg * arg,
                                      [[maybe_unused]] const char * option,
                                      [[maybe_unused]] const char * value) {
-        // The installroot will be prepended to the cachedir and system_cachedir later in Base.setup()
-        const auto & offline_datadir = dnf5::offline::DEFAULT_DATADIR;
-        ctx.get_base().get_config().get_system_cachedir_option().set(
-            libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
-        ctx.get_base().get_config().get_cachedir_option().set(libdnf5::Option::Priority::INSTALLROOT, offline_datadir);
         ctx.set_should_store_offline(true);
         return true;
     });


### PR DESCRIPTION
System-upgrade was broken by https://github.com/rpm-software-management/dnf5/commit/5f8b76ad7e0faa5c5b151e4301417f004bc4470e, since RPMs of serialized transactions are now expected to be stored in a single flat directory (like that created by `dnf5 download --destdir ./packages`) rather than the directory structure used by the DNF cache (in `/path/to/repository-cachedir/packages`).

We would like to set `destdir` to download the packages to a single flat directory, but then we can't test the transaction as usual because of the limitation described in https://github.com/rpm-software-management/dnf5/pull/1301. So instead, we serialize the transaction without testing it, then build a new "test transaction" from the serialized transaction and test that. This solution may seem like a hack, but it's actually quite nice, since we can a test the offline transaction exactly how it will be performed later by `dnf5 offline _execute`.

Due to the improvements from https://github.com/rpm-software-management/dnf5/pull/1264, we can now create the offline transaction without making a copy of the entire repository cache, and we can execute it without loading the repositories at all.

This PR also fixes the `--poweroff` flag which was not working correctly at all. The argument value was not stored correctly, and there was a typo in the D-Bus method name (should be `PowerOff` not `Poweroff`).

Resolves https://github.com/rpm-software-management/dnf5/issues/1446.