### PR TITLE
Run transaction.test() before downloading and installing packages

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -395,6 +395,11 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
 }
 
 void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
+    if (transaction.test() != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
+      std::cerr << "Transaction has failed. Try to run it with superuser privileges (under the root user on most systems)"
+                << std::endl;
+      throw libdnf5::cli::SilentCommandExitError(1);
+    }
     if (!transaction_store_path.empty()) {
         auto transaction_location = transaction_store_path / "transaction.json";
         constexpr const char * packages_in_trans_dir{"./packages"};


### PR DESCRIPTION
Hi, 
I recently faced the issue described in https://github.com/rpm-software-management/dnf5/issues/849 and [here on bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2217842) about "too late" permissions check while installing/upgrading packages. 

I've solved it by calling `Transaction::test()` in the beginning of `Context::Impl::download_and_run()`.
It is clearly [stated](https://github.com/rpm-software-management/dnf5/blob/4a05cfb857ee4a6c732051833dab1065cf4ddedb/include/libdnf5/base/transaction.hpp#L118) in the `test()` definition that it is redundant to call `test()` before `run()` but without calling it we should wait for download process to finish. 

Another possible inconvenience is when `Transaction::test()` returns non `TransactionRunResult::SUCCESS` I do not customize the error message. Let me know if you think I should check for error types and maybe customize the error message based on that. 

Please let me know if you think it can/should be implemented in a different way and share your recommendations.
Thanks!