### PR TITLE
Enhance warning about RPMs that were not validate by RPM

### DIFF
--- a/test/libdnf5/base/test_transaction.cpp
+++ b/test/libdnf5/base/test_transaction.cpp
@@ -38,7 +38,8 @@ void BaseTransactionTest::test_check_gpg_signatures_no_gpgcheck() {
     CPPUNIT_ASSERT(transaction.check_gpg_signatures());
     CPPUNIT_ASSERT_EQUAL((size_t)1, transaction.get_gpg_signature_problems().size());
     CPPUNIT_ASSERT_EQUAL(
-        std::string("Warning: skipped PGP checks for 1 package(s)."), transaction.get_gpg_signature_problems()[0]);
+        std::string("Warning: skipped PGP checks for 1 package from repository: repomd-repo1"),
+        transaction.get_gpg_signature_problems()[0]);
 }
 
 void BaseTransactionTest::test_check_gpg_signatures_fail() {

--- a/test/python3/libdnf5/base/test_transaction.py
+++ b/test/python3/libdnf5/base/test_transaction.py
@@ -32,7 +32,7 @@ class TestTransaction(base_test_case.BaseTestCase):
 
         self.assertEqual(1, transaction.get_transaction_packages_count())
         self.assertTrue(transaction.check_gpg_signatures())
-        self.assertEqual(('Warning: skipped PGP checks for 1 package(s).',),
+        self.assertEqual(('Warning: skipped PGP checks for 1 package from repository: repomd-repo1',),
                          transaction.get_gpg_signature_problems())
 
     def test_check_gpg_signatures_fail(self):


### PR DESCRIPTION
DNF5 informs about number of packages that signature was not verified, but without any additional detail. The ID of repository provides a good hint for user why the check was skipped.

Closes: https://github.com/rpm-software-management/dnf5/issues/1311

Requires CI modification: https://github.com/rpm-software-management/ci-dnf-stack/pull/1498