### PR TITLE
copr: the dnf5 copr enable sets CoprRepoPart.enabled = true

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_repo.hpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.hpp
@@ -117,6 +117,12 @@ public:
         /// also the CoprRepoPart::load_raw_values() or
         /// CoprRepoPart::CoprRepoPart(dnfRepo) which are more about the
         /// 'disable' part.
+
+        // Copr Frontend API-responds to us with this particular CoprRepoPart
+        // included, so it _is_ supposed to be enabled (otherwise it would not
+        // be listed).
+        enabled = true;
+
         if (!json->has_key("opts"))
             return;
         auto opts = json->get_dict_item("opts");

--- a/test/dnf5-plugins/CMakeLists.txt
+++ b/test/dnf5-plugins/CMakeLists.txt
@@ -1,5 +1,1 @@
-# Temporarily disable Copr unit tests until the plugin is fixed.
-# The Copr dnf5 plug-in is broken. It uses an uninitialized variable. Because of the random value
-# of this variable, unit tests fail randomly (if it has a value of 0, which is always the case when we allow
-# the compiler to initialize memory to 0 or use clang).
-#add_subdirectory(copr_plugin)
+add_subdirectory(copr_plugin)


### PR DESCRIPTION
This was the last occurrence causing the attribute to remain uninitialized after calling any of the constructors.

This also reverts commit 2b6b53f7a2f71c86355b9f4d8cb2ae7f4e2ca02b.

Fixes: #1317