### PR TITLE
bindings: Add Python attributes for structs

### DIFF
--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -75,3 +75,12 @@
 
 %include "libdnf5/base/goal.hpp"
 %include "libdnf5/base/goal_elements.hpp"
+
+// Add attributes for getters/setters in Python.
+// See 'common.i' for more info.
+#if defined(SWIGPYTHON)
+%pythoncode %{
+common.create_attributes_from_getters_and_setters(ResolveSpecSettings)
+common.create_attributes_from_getters_and_setters(GoalJobSettings)
+%}
+#endif

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -282,6 +282,27 @@ del ClassName##__iter__
 %template(PreserveOrderMapStringString) libdnf5::PreserveOrderMap<std::string, std::string>;
 %template(PreserveOrderMapStringPreserveOrderMapStringString) libdnf5::PreserveOrderMap<std::string, libdnf5::PreserveOrderMap<std::string, std::string>>;
 
+// The following adds Python attribute shortcuts for getters and setters
+// from C++ structures that act as plain data objects.
+//
+// E.g. object.get_value() -> object.value
+//
+#if defined(SWIGPYTHON)
+%pythoncode %{
+def create_attributes_from_getters_and_setters(cls):
+    getter_prefix = 'get_'
+    setter_prefix = 'set_'
+    attrs = {method[len(getter_prefix):] for method in dir(cls) if method.startswith(getter_prefix) or method.startswith(setter_prefix)}
+    for attr in attrs:
+        getter_name = getter_prefix + attr
+        setter_name = setter_prefix + attr
+        setattr(cls, attr, property(
+            lambda self, getter_name=getter_name: getattr(self, getter_name)() if getter_name in dir(cls) else None,
+            lambda self, value, setter_name=setter_name: getattr(self, setter_name)(value) if setter_name in dir(cls) else None
+        ))
+%}
+#endif
+
 %exception;  // beware this resets all exception handlers if you import this file after defining any
 
 // Base weak ptr is used across the codebase

--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -91,3 +91,11 @@ add_iterator(SetRepoWeakPtr)
 conf.create_config_option_attributes(ConfigRepo)
 %}
 #endif
+
+// Add attributes for getters/setters in Python.
+// See 'common.i' for more info.
+#if defined(SWIGPYTHON)
+%pythoncode %{
+common.create_attributes_from_getters_and_setters(RepoCacheRemoveStatistics)
+%}
+#endif

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -108,3 +108,11 @@ wrap_unique_ptr(TransactionCallbacksUniquePtr, libdnf5::rpm::TransactionCallback
 %include "libdnf5/rpm/rpm_signature.hpp"
 
 %template(VectorKeyInfo) std::vector<libdnf5::rpm::KeyInfo>;
+
+// Add attributes for getters/setters in Python.
+// See 'common.i' for more info.
+#if defined(SWIGPYTHON)
+%pythoncode %{
+common.create_attributes_from_getters_and_setters(Changelog)
+%}
+#endif

--- a/test/python3/libdnf5/common/test_struct_attributes.py
+++ b/test/python3/libdnf5/common/test_struct_attributes.py
@@ -1,0 +1,47 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import libdnf5
+
+
+# Test using attributes instead of getters/setters
+class TestStructAttributes(unittest.TestCase):
+    def test_resolvespecsettings(self):
+        settings = libdnf5.base.ResolveSpecSettings()
+        settings.ignore_case = True
+        settings.with_provides = False
+        settings.with_filenames = False
+        self.assertEqual(True, settings.ignore_case)
+        self.assertEqual(False, settings.with_provides)
+        self.assertEqual(False, settings.with_filenames)
+
+    def test_goaljobsettings(self):
+        settings = libdnf5.base.GoalJobSettings()
+        settings.best = libdnf5.base.GoalSetting_SET_TRUE
+        settings.skip_unavailable = False
+        settings.to_repo_ids = ('repo1', 'repo2')
+        self.assertEqual(libdnf5.base.GoalSetting_SET_TRUE, settings.best)
+        self.assertEqual(False, settings.skip_unavailable)
+        self.assertEqual(('repo1', 'repo2'), settings.to_repo_ids)
+
+    def test_rpmchangelog(self):
+        changelog = libdnf5.rpm.Changelog(1234, 'Jo Anne', 'Version bump')
+        self.assertEqual(1234, changelog.timestamp)
+        self.assertEqual('Jo Anne', changelog.author)
+        self.assertEqual('Version bump', changelog.text)


### PR DESCRIPTION
This aligns with existing attributes for options in the configuration classes.

It should also resolve the issues breaking our libdnf5 clients, as the struct wrappers change was the only thing removed from the Python public API without prior deprecation.