### PR TITLE
automatic: Fix documentation and ship config file

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -274,12 +274,6 @@ void AutomaticCommand::set_argument_parser() {
 void AutomaticCommand::pre_configure() {
     auto & context = get_context();
     auto & base = context.get_base();
-
-    auto random_sleep = config_automatic.config_commands.random_sleep.get_value();
-    if (timer->get_value() && random_sleep > 0) {
-        random_wait(random_sleep);
-    }
-
     auto download_callbacks_uptr = std::make_unique<dnf5::DownloadCallbacksSimple>(output_stream);
     base.set_download_callbacks(std::move(download_callbacks_uptr));
     download_callbacks_set = true;
@@ -304,6 +298,11 @@ void AutomaticCommand::pre_configure() {
             config_automatic.load_from_parser(parser, *base.get_vars(), *base.get_logger());
             break;
         }
+    }
+
+    auto random_sleep = config_automatic.config_commands.random_sleep.get_value();
+    if (timer->get_value() && random_sleep > 0) {
+        random_wait(random_sleep);
     }
 
     context.set_output_stream(output_stream);

--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -278,13 +278,13 @@ void AutomaticCommand::pre_configure() {
     base.set_download_callbacks(std::move(download_callbacks_uptr));
     download_callbacks_set = true;
 
-    // read the config file, use the first existing file in following locations:
+    // read the config files in following order (/etc overrides /usr):
+    //      - [installroot]/usr/share/dnf5/dnf5-plugins/automatic.conf
     //      - [installroot]/etc/dnf/dnf5-plugins/automatic.conf
-    //      - [installroot]/usr/share/dnf5/d  nf5-plugins/automatic.conf
     auto & main_config = base.get_config();
     bool use_host_config{main_config.get_use_host_config_option().get_value()};
     std::filesystem::path installroot_path{main_config.get_installroot_option().get_value()};
-    std::vector<std::filesystem::path> possible_paths{"/etc/dnf/dnf5-plugins", "/usr/share/dnf5/dnf5-plugins"};
+    std::vector<std::filesystem::path> possible_paths{"/usr/share/dnf5/dnf5-plugins", "/etc/dnf/dnf5-plugins"};
     for (const auto & pth : possible_paths) {
         std::filesystem::path conf_file_path{pth / "automatic.conf"};
         if (!use_host_config) {
@@ -296,7 +296,6 @@ void AutomaticCommand::pre_configure() {
             base.get_config().load_from_parser(
                 parser, "base", *base.get_vars(), *base.get_logger(), libdnf5::Option::Priority::AUTOMATICCONFIG);
             config_automatic.load_from_parser(parser, *base.get_vars(), *base.get_logger());
-            break;
         }
     }
 

--- a/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
@@ -1,0 +1,105 @@
+# This configuration file is managed by the dnf5-plugin-automatic package.
+# Please do not edit it. To make changes in dnf5 automatic configuration
+# edit /etc/dnf/dnf5-plugins/automatic.conf and make your adjustments there.
+
+[commands]
+# Whether updates should be applied when they are available, by
+# dnf5 automatic.
+apply_updates = no
+
+# Whether updates should be downloaded when they are available, by
+# dnf5 automatic.
+download_updates = yes
+
+# Maximum time in seconds to wait until the system is on-line and able to
+# connect to remote repositories.
+# 0 means that network availability detection will be skipped.
+network_online_timeout = 60
+
+# Maximum random delay in seconds before downloading (only applied if
+# ``--timer`` option was used). Note that, by default, the ``systemd`` timers
+# also apply a random delay of up to 1 hour.
+random_sleep = 0
+
+# What kind of upgrade to perform:
+# default                            = all available upgrades
+# security                           = only the security upgrades
+upgrade_type = default
+
+# When the system should reboot following upgrades:
+# never                              = don't reboot after upgrades
+# when-changed                       = reboot after any changes
+# when-needed                        = reboot when necessary to apply changes
+reboot = never
+
+# The command that is run to trigger a system reboot.
+reboot_command = "shutdown -r +5 'Rebooting after applying package updates'"
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  Default is the
+# hostname.
+# system_name = my-host
+
+# How to send messages.  Valid options are stdio, command, command_email,
+# email, and motd. Multiple comma separated options can be specified.
+# stdio: messages will be sent to stdout; this is useful to have cron send the
+#   messages.
+# command: to send result to a custom command.
+# email: dnf5 automatic will send email itself according to the configured
+#   options.
+# motd: /etc/motd.d/dnf5-automatic file will have the messages.
+# command_email: then messages will be send via a shell command compatible with
+#   sendmail.
+# If emit_via is left blank, no messages will be sent.
+emit_via = stdio
+
+
+[command]
+# The shell command to execute.
+# command_format = "cat"
+
+# The contents of stdin to pass to the command. Variable `body` with the message
+# body is usable.
+# stdin_format = "{body}"
+
+
+[command_email]
+# The shell command to use to send email. Variables `subject`, `email_from`,
+# and `email_to` are available.
+# command_format = "mail -Ssendwait -s {subject} -r {email_from} {email_to}"
+
+# The contents of stdin to pass to the command. It is a format string with the
+# same arguments as `command_format`.
+# stdin_format = "{body}"
+
+# The address to send email messages from.
+email_from = root
+
+# List of addresses to send messages to.
+email_to = root
+
+
+[email]
+# The address to send email messages from.
+email_from = root
+
+# List of addresses to send messages to.
+email_to = root
+
+# Name of the host to connect to to send email messages.
+email_host = localhost
+
+# Port number to connect to at the email host.
+email_port = 25
+
+# Use TLS or STARTTLS to connect to the email host.
+# Available values are "no", "yes", and "starttls"
+email_tls = no
+
+# Credentials to use for SMTP server authentication are taken from .netrc file
+
+
+[base]
+# This section overrides config values from the dnf.conf (see man dnf.conf for
+# available options).

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -739,6 +739,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %files plugin-automatic -f dnf5-plugin-automatic.lang
 %ghost %{_sysconfdir}/motd.d/dnf5-automatic
 %{_libdir}/dnf5/plugins/automatic_cmd_plugin.so
+%{_datadir}/dnf5/dnf5-plugins/automatic.conf
 %{_mandir}/man8/dnf*-automatic.8.*
 %{_unitdir}/dnf5-automatic.service
 %{_unitdir}/dnf5-automatic.timer

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -149,7 +149,8 @@ Changes to individual commands
 
 ``automatic``
   * Now a DNF5 plugin.
-  * Different configuration file locations and some changes in format.
+  * Configuration file has been moved from ``/etc/dnf/automatic.conf`` to ``/etc/dnf/dnf5-plugins/automatic.conf``. However, its contents remain compatible.
+  * The specific systemd units, ``dnf-automatic-download``, ``dnf-automatic-install``, and ``dnf-automatic-notifyonly``, have been dropped. Only one ``dnf5-automatic`` timer is shipped.
   * See the :ref:`Automatic command <automatic_plugin_ref-label>` for more information.
 
 ``autoremove``

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -18,8 +18,6 @@
 
 .. _automatic_plugin_ref-label:
 
-.. TODO(jkolarik): Fix references to configuration files to correct locations
-
 ##################
  Automatic Command
 ##################
@@ -35,17 +33,11 @@ Description
 
 Alternative CLI to ``dnf upgrade`` with specific facilities to make it suitable to be executed automatically and regularly from systemd timers, cron jobs and similar.
 
-The operation of the tool is usually controlled by the configuration file or the function-specific timer units (see below). The command only accepts a single optional argument pointing to the config file, and some control arguments intended for use by the services that back the timer units. If no configuration file is passed from the command line, ``/etc/dnf/automatic.conf`` is used.
+The operation of the tool is controlled by configuration files. Default values are set from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` config file. Host-specific overrides from ``/etc/dnf/dnf5-plugins/automatic.conf`` are then applied.
 
 The tool synchronizes package metadata as needed and then checks for updates available for the given system and then either exits, downloads the packages or downloads and applies the updates. The outcome of the operation is then reported by a selected mechanism, for instance via the standard output, email or MOTD messages.
 
-The systemd timer unit ``dnf-automatic.timer`` will behave as the configuration file specifies (see below) with regard to whether to download and apply updates. Some other timer units are provided which override the configuration file with some standard behaviours:
-
-- dnf-automatic-notifyonly
-- dnf-automatic-download
-- dnf-automatic-install
-
-Regardless of the configuration file settings, the first will only notify of available updates. The second will download, but not install them. The third will download and install them.
+The systemd timer unit ``dnf5-automatic.timer`` will behave as the configuration file specifies (see below) with regard to whether to download and apply updates.
 
 
 Options
@@ -53,6 +45,8 @@ Options
 
 ``--timer``
     | Apply random delay before execution.
+
+The following options can be used to override values from the configuration file.
 
 ``--downloadupdates``
     | Automatically download updated packages.
@@ -67,12 +61,15 @@ Options
     | Do not automatically install downloaded updates.
 
 
-Run dnf-automatic
-=================
 
-You can select one that most closely fits your needs, customize ``/etc/dnf/automatic.conf`` for any specific behaviors, and enable the timer unit.
+Run dnf5 automatic service
+==========================
 
-For example: ``systemctl enable --now dnf-automatic-notifyonly.timer``
+The service is typically executed using the systemd timer ``dnf5-automatic.timer``. To configure the service, customize the ``/etc/dnf/dnf5-plugins/automatic.conf`` file. You can either copy the distribution config file from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` and use it as a baseline, or create your own configuration file from scratch with only the required overrides.
+
+Then enable the timer unit:
+
+``systemctl enable --now dnf5-automatic.timer``
 
 
 Configuration File Format
@@ -90,22 +87,22 @@ Setting the mode of operation of the program.
 ``apply_updates``
     boolean, default: False
 
-    Whether packages comprising the available updates should be applied by ``dnf-automatic.timer``, i.e. installed via RPM. Implies ``download_updates``. Note that if this is set to ``False``, downloaded packages will be left in the cache till the next successful DNF transaction. Note that the other timer units override this setting.
+    Whether packages comprising the available updates should be applied by ``dnf5-automatic.timer``, i.e. installed via RPM. Implies ``download_updates``. Note that if this is set to ``False``, downloaded packages will be left in the cache till the next successful DNF transaction.
 
 ``download_updates``
     boolean, default: True
 
-    Whether packages comprising the available updates should be downloaded by ``dnf-automatic.timer``. Note that the other timer units override this setting.
+    Whether packages comprising the available updates should be downloaded by ``dnf5-automatic.timer``.
 
 ``network_online_timeout``
     time in seconds, default: 60
 
-    Maximal time dnf-automatic will wait until the system is online. 0 means that network availability detection will be skipped.
+    Maximal time ``dnf5 automatic`` will wait until the system is online. 0 means that network availability detection will be skipped.
 
 ``random_sleep``
     time in seconds, default: 0
 
-    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 1 hour.
+    Maximal random delay before downloading (only applied if ``--timer`` option was used).  Note that, by default, the ``systemd`` timers also apply a random delay of up to 1 hour.
 
 .. _upgrade_type_automatic-label:
 
@@ -218,16 +215,6 @@ The email emitter configuration.
     either one of ``no``, ``yes``, ``starttls``, default: ``no``
 
     Whether to use TLS, STARTTLS or no encryption to connect to the SMTP server.
-
-``email_username``
-    string, default empty.
-
-    Username to use for SMTP server authentication.
-
-``email_password``
-    string, default empty.
-
-    Password to use for SMTP server authentication.
 
 
 ------------------


### PR DESCRIPTION
- changes the config files reading behavior - /usr/share/dnf5/dnf5-plugins/automatic.conf is always read to set the defaults, /etc/dnf/dnf5-plugins/automatic.conf is then used for host-specific overrides
- fixes errors in the documentation
- enhances documentation of changes between dnf4 and dnf5
- ship default configuration file in /usr/share/dnf5/dnf5-plugins/automatic.conf

Resolves: https://github.com/rpm-software-management/dnf5/issues/1289
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2279257
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2279258