### PR TITLE
needs_restarting: Fix invalid reference usage

### DIFF
--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
@@ -168,12 +168,9 @@ libdnf5::rpm::PackageSet recursive_dependencies(
     stack.emplace_back(package);
 
     while (!stack.empty()) {
-        const auto & current = stack.back();
-        stack.pop_back();
-
         libdnf5::rpm::PackageQuery query{installed};
-        query.filter_provides(current.get_requires());
-
+        query.filter_provides(stack.back().get_requires());
+        stack.pop_back();
         for (const auto & dependency : query) {
             if (!dependencies.contains(dependency)) {
                 stack.emplace_back(dependency);


### PR DESCRIPTION
`current` is a reference to the last item of the `stack` vector, which
is being used after being invalidated by the `stack.pop_back()` call.

Resolves: https://github.com/rpm-software-management/dnf5/pull/1477