### PR TITLE
download: add `--source` alias for `--srpm`

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -352,3 +352,12 @@ long_name = 'list'
 short_name = 'l'
 source = 'repoquery.files'
 group_id = 'repoquery_formatting'
+
+########################################
+# Download aliases
+########################################
+
+['download.source']
+type = 'cloned_named_arg'
+long_name = 'source'
+source = 'download.srpm'


### PR DESCRIPTION
For compatibility with the download plugin in dnf4:

https://github.com/rpm-software-management/dnf-plugins-core/blob/a054dcbd64db7743b0af78ac8e06104c4bd6be6e/plugins/download.py#L52-L53