### PR TITLE
conf: New classes for append options

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -66,8 +66,10 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %include "libdnf5/conf/option_seconds.hpp"
 %include "libdnf5/conf/option_string.hpp"
 %include "libdnf5/conf/option_string_list.hpp"
-%template(OptionStringSet) libdnf5::OptionStringContainer<std::set<std::string>>;
-%template(OptionStringList) libdnf5::OptionStringContainer<std::vector<std::string>>;
+%template(OptionStringSet) libdnf5::OptionStringContainer<std::set<std::string>, false>;
+%template(OptionStringList) libdnf5::OptionStringContainer<std::vector<std::string>, false>;
+%template(OptionStringAppendSet) libdnf5::OptionStringContainer<std::set<std::string>, true>;
+%template(OptionStringAppendList) libdnf5::OptionStringContainer<std::vector<std::string>, true>;
 
 %ignore libdnf5::OptionPathNotFoundError;
 %include "libdnf5/conf/option_path.hpp"
@@ -77,6 +79,8 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %template(OptionChildString) libdnf5::OptionChild<libdnf5::OptionString>;
 %template(OptionChildStringList) libdnf5::OptionChild<libdnf5::OptionStringList>;
 %template(OptionChildStringSet) libdnf5::OptionChild<libdnf5::OptionStringSet>;
+%template(OptionChildStringAppendList) libdnf5::OptionChild<libdnf5::OptionStringAppendList>;
+%template(OptionChildStringAppendSet) libdnf5::OptionChild<libdnf5::OptionStringAppendSet>;
 %template(OptionChildNumberInt32) libdnf5::OptionChild<libdnf5::OptionNumber<std::int32_t>>;
 %template(OptionChildNumberUInt32) libdnf5::OptionChild<libdnf5::OptionNumber<std::uint32_t>>;
 %template(OptionChildNumberFloat) libdnf5::OptionChild<libdnf5::OptionNumber<float>>;

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -66,7 +66,6 @@ public:
     }
     std::vector<std::string> get_includepkgs() const override {
         return repo->get_config().get_includepkgs_option().get_value();
-        ;
     }
     bool get_skip_if_unavailable() const override {
         return repo->get_config().get_skip_if_unavailable_option().get_value();

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -88,12 +88,12 @@ public:
     const OptionStringList & get_reposdir_option() const;
     OptionBool & get_debug_solver_option();
     const OptionBool & get_debug_solver_option() const;
-    OptionStringList & get_installonlypkgs_option();
-    const OptionStringList & get_installonlypkgs_option() const;
+    OptionStringAppendList & get_installonlypkgs_option();
+    const OptionStringAppendList & get_installonlypkgs_option() const;
     OptionStringList & get_group_package_types_option();
     const OptionStringList & get_group_package_types_option() const;
-    OptionStringSet & get_optional_metadata_types_option();
-    const OptionStringSet & get_optional_metadata_types_option() const;
+    OptionStringAppendSet & get_optional_metadata_types_option();
+    const OptionStringAppendSet & get_optional_metadata_types_option() const;
     OptionBool & get_use_host_config_option();
     const OptionBool & get_use_host_config_option() const;
 
@@ -104,8 +104,8 @@ public:
     OptionNumber<std::uint32_t> & get_installonly_limit_option();
     const OptionNumber<std::uint32_t> & get_installonly_limit_option() const;
 
-    OptionStringList & get_tsflags_option();
-    const OptionStringList & get_tsflags_option() const;
+    OptionStringAppendList & get_tsflags_option();
+    const OptionStringAppendList & get_tsflags_option() const;
     OptionBool & get_assumeyes_option();
     const OptionBool & get_assumeyes_option() const;
     OptionBool & get_assumeno_option();
@@ -222,12 +222,12 @@ public:
     const OptionPath & get_cachedir_option() const;
     OptionBool & get_fastestmirror_option();
     const OptionBool & get_fastestmirror_option() const;
-    OptionStringList & get_excludepkgs_option();
-    const OptionStringList & get_excludepkgs_option() const;
-    OptionStringList & get_includepkgs_option();
-    const OptionStringList & get_includepkgs_option() const;
-    OptionStringList & get_exclude_from_weak_option();
-    const OptionStringList & get_exclude_from_weak_option() const;
+    OptionStringAppendList & get_excludepkgs_option();
+    const OptionStringAppendList & get_excludepkgs_option() const;
+    OptionStringAppendList & get_includepkgs_option();
+    const OptionStringAppendList & get_includepkgs_option() const;
+    OptionStringAppendList & get_exclude_from_weak_option();
+    const OptionStringAppendList & get_exclude_from_weak_option() const;
     OptionBool & get_exclude_from_weak_autodetect_option();
     const OptionBool & get_exclude_from_weak_autodetect_option() const;
     OptionString & get_proxy_option();
@@ -238,8 +238,8 @@ public:
     const OptionString & get_proxy_password_option() const;
     OptionStringSet & get_proxy_auth_method_option();
     const OptionStringSet & get_proxy_auth_method_option() const;
-    OptionStringList & get_protected_packages_option();
-    const OptionStringList & get_protected_packages_option() const;
+    OptionStringAppendList & get_protected_packages_option();
+    const OptionStringAppendList & get_protected_packages_option() const;
     OptionString & get_username_option();
     const OptionString & get_username_option() const;
     OptionString & get_password_option();

--- a/include/libdnf5/conf/option_string_list.hpp
+++ b/include/libdnf5/conf/option_string_list.hpp
@@ -28,10 +28,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
-/// Option that stores a container of strings. The type of the container is a template parameter.
-/// Support default value, and check of an input value using the regular expression
+/// Option that stores a container of strings. The type of the container is a
+/// template parameter. Non-type IsAppend template parameter is used to
+/// distinguish between regular list-like options (e.g. OptionStringList,
+/// OptionStringSet) and append options (e.g. OptionStringAppendList,
+/// OptionStringAppendSet).
+/// Support default value, and check of an input value using the regular expression.
 // @replaces libdnf:conf/OptionStringList.hpp:class:OptionStringList
-template <typename T>
+template <typename T, bool IsAppend = false>
 class OptionStringContainer : public Option {
 public:
     using ValueType = T;
@@ -121,6 +125,9 @@ private:
 
 using OptionStringList = OptionStringContainer<std::vector<std::string>>;
 using OptionStringSet = OptionStringContainer<std::set<std::string>>;
+
+using OptionStringAppendList = OptionStringContainer<std::vector<std::string>, true>;
+using OptionStringAppendSet = OptionStringContainer<std::set<std::string>, true>;
 
 }  // namespace libdnf5
 

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -58,10 +58,10 @@ public:
     const OptionString & get_mediaid_option() const;
     OptionStringList & get_gpgkey_option();
     const OptionStringList & get_gpgkey_option() const;
-    OptionStringList & get_excludepkgs_option();
-    const OptionStringList & get_excludepkgs_option() const;
-    OptionStringList & get_includepkgs_option();
-    const OptionStringList & get_includepkgs_option() const;
+    OptionStringAppendList & get_excludepkgs_option();
+    const OptionStringAppendList & get_excludepkgs_option() const;
+    OptionStringAppendList & get_includepkgs_option();
+    const OptionStringAppendList & get_includepkgs_option() const;
     OptionChild<OptionBool> & get_fastestmirror_option();
     const OptionChild<OptionBool> & get_fastestmirror_option() const;
     OptionChild<OptionString> & get_proxy_option();
@@ -76,8 +76,8 @@ public:
     const OptionChild<OptionString> & get_username_option() const;
     OptionChild<OptionString> & get_password_option();
     const OptionChild<OptionString> & get_password_option() const;
-    OptionChild<OptionStringList> & get_protected_packages_option();
-    const OptionChild<OptionStringList> & get_protected_packages_option() const;
+    OptionChild<OptionStringAppendList> & get_protected_packages_option();
+    const OptionChild<OptionStringAppendList> & get_protected_packages_option() const;
     OptionChild<OptionBool> & get_gpgcheck_option();
     const OptionChild<OptionBool> & get_gpgcheck_option() const;
     OptionChild<OptionBool> & get_repo_gpgcheck_option();

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -116,10 +116,10 @@ class ConfigMain::Impl {
     OptionStringList varsdir{VARS_DIRS};
     OptionStringList reposdir{REPOSITORY_CONF_DIRS};
     OptionBool debug_solver{false};
-    OptionStringList installonlypkgs{INSTALLONLYPKGS};
+    OptionStringAppendList installonlypkgs{INSTALLONLYPKGS};
     OptionStringList group_package_types{GROUP_PACKAGE_TYPES};
-    OptionStringSet optional_metadata_types{
-        OptionStringSet::ValueType{libdnf5::METADATA_TYPE_COMPS, libdnf5::METADATA_TYPE_UPDATEINFO}};
+    OptionStringAppendSet optional_metadata_types{
+        OptionStringAppendSet::ValueType{libdnf5::METADATA_TYPE_COMPS, libdnf5::METADATA_TYPE_UPDATEINFO}};
     OptionNumber<std::uint32_t> installonly_limit{3, 0, [](const std::string & value) -> std::uint32_t {
                                                       if (value == "<off>") {
                                                           return 0;
@@ -131,7 +131,7 @@ class ConfigMain::Impl {
                                                       }
                                                   }};
 
-    OptionStringList tsflags{std::vector<std::string>{}};
+    OptionStringAppendList tsflags{std::vector<std::string>{}};
     OptionBool assumeyes{false};
     OptionBool assumeno{false};
     OptionBool check_config_file_age{true};
@@ -216,15 +216,15 @@ class ConfigMain::Impl {
     OptionNumber<std::uint32_t> retries{10};
     OptionPath cachedir{geteuid() == 0 ? SYSTEM_CACHEDIR : libdnf5::xdg::get_user_cache_dir() / "libdnf5"};
     OptionBool fastestmirror{false};
-    OptionStringList excludepkgs{std::vector<std::string>{}};
-    OptionStringList includepkgs{std::vector<std::string>{}};
-    OptionStringList exclude_from_weak{std::vector<std::string>{}};
+    OptionStringAppendList excludepkgs{std::vector<std::string>{}};
+    OptionStringAppendList includepkgs{std::vector<std::string>{}};
+    OptionStringAppendList exclude_from_weak{std::vector<std::string>{}};
     OptionBool exclude_from_weak_autodetect{true};
     OptionString proxy{""};
     OptionString proxy_username{nullptr};
     OptionString proxy_password{nullptr};
     OptionStringSet proxy_auth_method{"any", "any|none|basic|digest|negotiate|ntlm|digest_ie|ntlm_wb", false};
-    OptionStringList protected_packages{std::vector<std::string>{"dnf5", "glob:/etc/dnf/protected.d/*.conf"}};
+    OptionStringAppendList protected_packages{std::vector<std::string>{"dnf5", "glob:/etc/dnf/protected.d/*.conf"}};
     OptionString username{""};
     OptionString password{""};
     OptionBool gpgcheck{false};
@@ -315,26 +315,10 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("varsdir", varsdir);
     owner.opt_binds().add("reposdir", reposdir);
     owner.opt_binds().add("debug_solver", debug_solver);
-
-    owner.opt_binds().add(
-        "installonlypkgs",
-        installonlypkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(installonlypkgs, priority, value);
-        },
-        nullptr,
-        true);
-
+    owner.opt_binds().add("installonlypkgs", installonlypkgs);
     owner.opt_binds().add("group_package_types", group_package_types);
     owner.opt_binds().add("installonly_limit", installonly_limit);
-
-    owner.opt_binds().add(
-        "tsflags",
-        tsflags,
-        [&](Option::Priority priority, const std::string & value) { option_T_list_append(tsflags, priority, value); },
-        nullptr,
-        true);
-
+    owner.opt_binds().add("tsflags", tsflags);
     owner.opt_binds().add("assumeyes", assumeyes);
     owner.opt_binds().add("assumeno", assumeno);
     owner.opt_binds().add("check_config_file_age", check_config_file_age);
@@ -406,43 +390,10 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("retries", retries);
     owner.opt_binds().add("cachedir", cachedir);
     owner.opt_binds().add("fastestmirror", fastestmirror);
-
-    owner.opt_binds().add(
-        "excludepkgs",
-        excludepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(excludepkgs, priority, value);
-        },
-        nullptr,
-        true);
-    //compatibility with yum
-    owner.opt_binds().add(
-        "exclude",
-        excludepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(excludepkgs, priority, value);
-        },
-        nullptr,
-        true);
-
-    owner.opt_binds().add(
-        "includepkgs",
-        includepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(includepkgs, priority, value);
-        },
-        nullptr,
-        true);
-
-    owner.opt_binds().add(
-        "exclude_from_weak",
-        exclude_from_weak,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(exclude_from_weak, priority, value);
-        },
-        nullptr,
-        true);
-
+    owner.opt_binds().add("excludepkgs", excludepkgs);
+    owner.opt_binds().add("exclude", excludepkgs);  //compatibility with yum
+    owner.opt_binds().add("includepkgs", includepkgs);
+    owner.opt_binds().add("exclude_from_weak", exclude_from_weak);
     owner.opt_binds().add("exclude_from_weak_autodetect", exclude_from_weak_autodetect);
     owner.opt_binds().add("proxy", proxy);
     owner.opt_binds().add("proxy_username", proxy_username);
@@ -461,15 +412,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
         nullptr,
         false);
 
-    owner.opt_binds().add(
-        "protected_packages",
-        protected_packages,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(protected_packages, priority, value);
-        },
-        nullptr,
-        false);
-
+    owner.opt_binds().add("protected_packages", protected_packages);
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
     owner.opt_binds().add("gpgcheck", gpgcheck);
@@ -494,15 +437,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("deltarpm", deltarpm);
     owner.opt_binds().add("deltarpm_percentage", deltarpm_percentage);
     owner.opt_binds().add("skip_if_unavailable", skip_if_unavailable);
-
-    owner.opt_binds().add(
-        "optional_metadata_types",
-        optional_metadata_types,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(optional_metadata_types, priority, value);
-        },
-        nullptr,
-        true);
+    owner.opt_binds().add("optional_metadata_types", optional_metadata_types);
 }
 
 ConfigMain::ConfigMain() {
@@ -681,10 +616,10 @@ const OptionBool & ConfigMain::get_debug_solver_option() const {
     return p_impl->debug_solver;
 }
 
-OptionStringList & ConfigMain::get_installonlypkgs_option() {
+OptionStringAppendList & ConfigMain::get_installonlypkgs_option() {
     return p_impl->installonlypkgs;
 }
-const OptionStringList & ConfigMain::get_installonlypkgs_option() const {
+const OptionStringAppendList & ConfigMain::get_installonlypkgs_option() const {
     return p_impl->installonlypkgs;
 }
 
@@ -695,10 +630,10 @@ const OptionStringList & ConfigMain::get_group_package_types_option() const {
     return p_impl->group_package_types;
 }
 
-OptionStringSet & ConfigMain::get_optional_metadata_types_option() {
+OptionStringAppendSet & ConfigMain::get_optional_metadata_types_option() {
     return p_impl->optional_metadata_types;
 }
-const OptionStringSet & ConfigMain::get_optional_metadata_types_option() const {
+const OptionStringAppendSet & ConfigMain::get_optional_metadata_types_option() const {
     return p_impl->optional_metadata_types;
 }
 
@@ -709,10 +644,10 @@ const OptionNumber<std::uint32_t> & ConfigMain::get_installonly_limit_option() c
     return p_impl->installonly_limit;
 }
 
-OptionStringList & ConfigMain::get_tsflags_option() {
+OptionStringAppendList & ConfigMain::get_tsflags_option() {
     return p_impl->tsflags;
 }
-const OptionStringList & ConfigMain::get_tsflags_option() const {
+const OptionStringAppendList & ConfigMain::get_tsflags_option() const {
     return p_impl->tsflags;
 }
 
@@ -1105,25 +1040,25 @@ const OptionBool & ConfigMain::get_fastestmirror_option() const {
     return p_impl->fastestmirror;
 }
 
-OptionStringList & ConfigMain::get_excludepkgs_option() {
+OptionStringAppendList & ConfigMain::get_excludepkgs_option() {
     return p_impl->excludepkgs;
 }
-const OptionStringList & ConfigMain::get_excludepkgs_option() const {
+const OptionStringAppendList & ConfigMain::get_excludepkgs_option() const {
     return p_impl->excludepkgs;
 }
 
-OptionStringList & ConfigMain::get_includepkgs_option() {
+OptionStringAppendList & ConfigMain::get_includepkgs_option() {
     return p_impl->includepkgs;
 }
-const OptionStringList & ConfigMain::get_includepkgs_option() const {
+const OptionStringAppendList & ConfigMain::get_includepkgs_option() const {
     return p_impl->includepkgs;
 }
 
-OptionStringList & ConfigMain::get_exclude_from_weak_option() {
+OptionStringAppendList & ConfigMain::get_exclude_from_weak_option() {
     return p_impl->exclude_from_weak;
 }
 
-const OptionStringList & ConfigMain::get_exclude_from_weak_option() const {
+const OptionStringAppendList & ConfigMain::get_exclude_from_weak_option() const {
     return p_impl->exclude_from_weak;
 }
 
@@ -1163,10 +1098,10 @@ const OptionStringSet & ConfigMain::get_proxy_auth_method_option() const {
     return p_impl->proxy_auth_method;
 }
 
-OptionStringList & ConfigMain::get_protected_packages_option() {
+OptionStringAppendList & ConfigMain::get_protected_packages_option() {
     return p_impl->protected_packages;
 }
-const OptionStringList & ConfigMain::get_protected_packages_option() const {
+const OptionStringAppendList & ConfigMain::get_protected_packages_option() const {
     return p_impl->protected_packages;
 }
 

--- a/libdnf5/conf/config_utils.hpp
+++ b/libdnf5/conf/config_utils.hpp
@@ -26,30 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5 {
 
 
-template <typename T>
-static void option_T_list_append(T & option, Option::Priority priority, const std::string & value) {
-    if (value.empty()) {
-        option.set(priority, value);
-        return;
-    }
-    auto add_priority = priority < option.get_priority() ? option.get_priority() : priority;
-    auto val = option.from_string(value);
-    bool first = true;
-    for (auto & item : val) {
-        if (item.empty()) {
-            if (first) {
-                option.set(priority, item);
-            }
-        } else {
-            auto orig_value = option.get_value();
-            orig_value.insert(orig_value.end(), item);
-            option.set(add_priority, orig_value);
-        }
-        first = false;
-    }
-}
-
-
 /// @brief Replaces globs (like /etc/foo.d/\\*.foo) by content of matching files.
 ///
 /// Ignores comment lines (start with '#') and blank lines in files.

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -48,8 +48,8 @@ class ConfigRepo::Impl {
     OptionString type{""};
     OptionString mediaid{""};
     OptionStringList gpgkey{std::vector<std::string>{}};
-    OptionStringList excludepkgs{std::vector<std::string>{}};
-    OptionStringList includepkgs{std::vector<std::string>{}};
+    OptionStringAppendList excludepkgs{std::vector<std::string>{}};
+    OptionStringAppendList includepkgs{std::vector<std::string>{}};
     OptionChild<OptionBool> fastestmirror{main_config.get_fastestmirror_option()};
     OptionChild<OptionString> proxy{main_config.get_proxy_option()};
     OptionChild<OptionString> proxy_username{main_config.get_proxy_username_option()};
@@ -57,7 +57,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionStringSet> proxy_auth_method{main_config.get_proxy_auth_method_option()};
     OptionChild<OptionString> username{main_config.get_username_option()};
     OptionChild<OptionString> password{main_config.get_password_option()};
-    OptionChild<OptionStringList> protected_packages{main_config.get_protected_packages_option()};
+    OptionChild<OptionStringAppendList> protected_packages{main_config.get_protected_packages_option()};
     OptionChild<OptionBool> gpgcheck{main_config.get_gpgcheck_option()};
     OptionChild<OptionBool> repo_gpgcheck{main_config.get_repo_gpgcheck_option()};
     OptionChild<OptionBool> enablegroups{main_config.get_enablegroups_option()};
@@ -102,34 +102,9 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
     owner.opt_binds().add("type", type);
     owner.opt_binds().add("mediaid", mediaid);
     owner.opt_binds().add("gpgkey", gpgkey);
-
-    owner.opt_binds().add(
-        "excludepkgs",
-        excludepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(excludepkgs, priority, value);
-        },
-        nullptr,
-        true);
-    //compatibility with yum
-    owner.opt_binds().add(
-        "exclude",
-        excludepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(excludepkgs, priority, value);
-        },
-        nullptr,
-        true);
-
-    owner.opt_binds().add(
-        "includepkgs",
-        includepkgs,
-        [&](Option::Priority priority, const std::string & value) {
-            option_T_list_append(includepkgs, priority, value);
-        },
-        nullptr,
-        true);
-
+    owner.opt_binds().add("excludepkgs", excludepkgs);
+    owner.opt_binds().add("exclude", excludepkgs);  //compatibility with yum
+    owner.opt_binds().add("includepkgs", includepkgs);
     owner.opt_binds().add("fastestmirror", fastestmirror);
 
     owner.opt_binds().add(
@@ -276,17 +251,17 @@ const OptionStringList & ConfigRepo::get_gpgkey_option() const {
     return p_impl->gpgkey;
 }
 
-OptionStringList & ConfigRepo::get_excludepkgs_option() {
+OptionStringAppendList & ConfigRepo::get_excludepkgs_option() {
     return p_impl->excludepkgs;
 }
-const OptionStringList & ConfigRepo::get_excludepkgs_option() const {
+const OptionStringAppendList & ConfigRepo::get_excludepkgs_option() const {
     return p_impl->excludepkgs;
 }
 
-OptionStringList & ConfigRepo::get_includepkgs_option() {
+OptionStringAppendList & ConfigRepo::get_includepkgs_option() {
     return p_impl->includepkgs;
 }
-const OptionStringList & ConfigRepo::get_includepkgs_option() const {
+const OptionStringAppendList & ConfigRepo::get_includepkgs_option() const {
     return p_impl->includepkgs;
 }
 
@@ -339,10 +314,10 @@ const OptionChild<OptionString> & ConfigRepo::get_password_option() const {
     return p_impl->password;
 }
 
-OptionChild<OptionStringList> & ConfigRepo::get_protected_packages_option() {
+OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_option() {
     return p_impl->protected_packages;
 }
-const OptionChild<OptionStringList> & ConfigRepo::get_protected_packages_option() const {
+const OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_option() const {
     return p_impl->protected_packages;
 }
 

--- a/test/libdnf5/conf/test_option.cpp
+++ b/test/libdnf5/conf/test_option.cpp
@@ -530,3 +530,24 @@ void OptionTest::test_options_list_add_item() {
     option.add_item(libdnf5::Option::Priority::RUNTIME, "item1");
     CPPUNIT_ASSERT((OptionStringSet::ValueType{"item1", "item2"}) == option.get_value());
 }
+
+void OptionTest::test_options_string_append_list() {
+    OptionStringAppendList option("Pkg1, Pkg2");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg1", "Pkg2"}), option.get_value());
+    // setting a new value will append to current value
+    option.set(Option::Priority::COMMANDLINE, "Pkg3");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg1", "Pkg2", "Pkg3"}), option.get_value());
+    // values are evaluated ordered by the priority
+    option.set(Option::Priority::MAINCONFIG, "Pkg4");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg3"}), option.get_value());
+    // I can clear the option using an empty first item (values with higher priority
+    // are also appended)
+    option.set(Option::Priority::MAINCONFIG, ",Pkg5");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3"}), option.get_value());
+    // emty item on other than first place is skipped and does not clear the value
+    option.set(Option::Priority::COMMANDLINE, "Pkg6, ,Pkg7");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3", "Pkg6", "Pkg7"}), option.get_value());
+    // I can clear the option an using empty value
+    option.set(Option::Priority::COMMANDLINE, "");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{}), option.get_value());
+}

--- a/test/libdnf5/conf/test_option.hpp
+++ b/test/libdnf5/conf/test_option.hpp
@@ -40,6 +40,7 @@ class OptionTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_options_string_set);
     CPPUNIT_TEST(test_options_list_add);
     CPPUNIT_TEST(test_options_list_add_item);
+    CPPUNIT_TEST(test_options_string_append_list);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -56,6 +57,7 @@ public:
     void test_options_string_set();
     void test_options_list_add();
     void test_options_list_add_item();
+    void test_options_string_append_list();
 };
 
 

--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -39,6 +39,9 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
 
     def test_container_add(self):
         types_config = self.base.get_config().get_optional_metadata_types_option()
+        # optional_metadata_types is an append option with non-empty default.
+        # To test anything, clear it first
+        types_config.set(())
         types_config.set((libdnf5.conf.METADATA_TYPE_FILELISTS,))
         types_config.add(libdnf5.conf.Option.Priority_RUNTIME, (libdnf5.conf.METADATA_TYPE_COMPS,
                          libdnf5.conf.METADATA_TYPE_UPDATEINFO))


### PR DESCRIPTION
Introducing `OptionStringAppendList` and `OptionStringAppendSet` classes
for append options.

The current implementation of append options is flawed because it requires
the options to be set in ascending order of priority for proper 
functionality. This is necessary for the resetting mechanism using an empty
item to work correctly. However, in dnf5, options are not processed
strictly in priority order. For instance, command line options like
`--exclude` are processed before the configuration files, despite having a
higher priority than config files.

The new classes accumulate all setting attempts and only process them in 
priority order when the option value is needed.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1331