### PR TITLE
dnf5daemon: The buildtime attribute has been added to the package_attrs option

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -40,7 +40,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Following options and filters are supported:
 
             - package_attrs: list of strings
-                list of package attributes that are returned. Supported attributes are name, epoch, version, release, arch, repo_id, from_repo_id, is_installed, install_size, download_size, sourcerpm, summary, url, license, description, files, changelogs, provides, requires, requires_pre, conflicts, obsoletes, recommends, suggests, enhances, supplements, evr, nevra, full_nevra, reason, vendor, group.
+                list of package attributes that are returned. Supported attributes are name, epoch, version, release, arch, repo_id, from_repo_id, is_installed, install_size, download_size, buildtime, sourcerpm, summary, url, license, description, files, changelogs, provides, requires, requires_pre, conflicts, obsoletes, recommends, suggests, enhances, supplements, evr, nevra, full_nevra, reason, vendor, group.
             - with_nevra: bool (default true)
                 match patterns against available packages NEVRAs
             - with_provides: bool (default true)

--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -36,6 +36,7 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"is_installed", PackageAttribute::is_installed},
     {"install_size", PackageAttribute::install_size},
     {"download_size", PackageAttribute::download_size},
+    {"buildtime", PackageAttribute::buildtime},
     {"sourcerpm", PackageAttribute::sourcerpm},
     {"summary", PackageAttribute::summary},
     {"url", PackageAttribute::url},
@@ -118,6 +119,9 @@ dnfdaemon::KeyValueMap package_to_map(
                 break;
             case PackageAttribute::download_size:
                 dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_download_size()));
+                break;
+            case PackageAttribute::buildtime:
+                dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_build_time()));
                 break;
             case PackageAttribute::sourcerpm:
                 dbus_package.emplace(attr, libdnf_package.get_sourcerpm());
@@ -253,6 +257,10 @@ std::string package_to_json(const libdnf5::rpm::Package & libdnf_package, const 
             case PackageAttribute::download_size:
                 json_object_object_add(
                     json_pkg, cattr, json_object_new_int64(static_cast<int64_t>(libdnf_package.get_download_size())));
+                break;
+            case PackageAttribute::buildtime:
+                json_object_object_add(
+                    json_pkg, cattr, json_object_new_int64(static_cast<int64_t>(libdnf_package.get_build_time())));
                 break;
             case PackageAttribute::sourcerpm:
                 json_object_object_add(json_pkg, cattr, json_object_new_string(libdnf_package.get_sourcerpm().c_str()));

--- a/dnf5daemon-server/package.hpp
+++ b/dnf5daemon-server/package.hpp
@@ -40,6 +40,7 @@ enum class PackageAttribute {
     is_installed,
     install_size,
     download_size,
+    buildtime,
     sourcerpm,
     summary,
     url,

--- a/doc/dnf_daemon/examples/rpm_list_fd.py
+++ b/doc/dnf_daemon/examples/rpm_list_fd.py
@@ -134,6 +134,7 @@ options = {
         "is_installed",
         "install_size",
         "download_size",
+        "buildtime",
         "sourcerpm",
         "summary",
         "url",


### PR DESCRIPTION
Hello. I'm trying to develop a desktop application and using the capabilities of dnfdaemon, I came across the lack of a really useful buildtime attribute. Without it, I will not be able to correctly and quickly separate packages by date and recommend recent updates. I have added small changes that work on my stand. Now I can get this attribute by specifying it in package_attrs when accessing dbus methods, but I'm not completely sure that I won't need to change it somewhere else.