### PR TITLE
Implementation of unified privileges checking for CLI commands

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -88,6 +88,7 @@ void BuildDepCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_store_option(*this);
 }
 
 void BuildDepCommand::configure() {

--- a/dnf5/commands/clean/clean.cpp
+++ b/dnf5/commands/clean/clean.cpp
@@ -127,7 +127,6 @@ void CleanCommand::set_argument_parser() {
     });
 
     cmd.register_positional_arg(cache_types);
-    create_store_option(*this);
 }
 
 void CleanCommand::run() {

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -52,6 +52,7 @@ void DistroSyncCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
 }

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -63,6 +63,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/common/xdg.hpp>
+#include <libdnf5/conf/const.hpp>
 #include <libdnf5/logger/factory.hpp>
 #include <libdnf5/logger/global_logger.hpp>
 #include <libdnf5/logger/memory_buffer_logger.hpp>
@@ -1125,7 +1126,8 @@ static bool cmd_requires_privileges(dnf5::Context & context) {
 
 static bool user_has_privileges(dnf5::Context & context) {
     std::filesystem::path lock_file_path = context.get_base().get_config().get_installroot_option().get_value();
-    lock_file_path /= "run/dnf/rpm.transaction.lock.tmp";
+    lock_file_path /= std::filesystem::path(libdnf5::TRANSACTION_LOCK_FILEPATH).relative_path();
+    lock_file_path += ".tmp";
 
     try {
         std::filesystem::create_directories(lock_file_path.parent_path());

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -50,6 +50,9 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to synchronize. All remaining packages will be synchronized.
 
+``--downloadonly``
+    | Download the resolved package set without executing an RPM transaction.
+
 ``--offline``
     | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
 

--- a/include/libdnf5-cli/exception.hpp
+++ b/include/libdnf5-cli/exception.hpp
@@ -44,6 +44,14 @@ public:
 };
 
 
+/// Exception is thrown when the user does not have enough privileges to perform requested operation.
+class InsufficientPrivilegesError : public Error {
+public:
+    using Error::Error;
+    const char * get_name() const noexcept override { return "InsufficientPrivilegesError"; }
+};
+
+
 /// Exception is thrown when libdnf5 fails to resolve the transaction.
 class GoalResolveError : public Error {
 public:

--- a/include/libdnf5/conf/const.hpp
+++ b/include/libdnf5/conf/const.hpp
@@ -42,6 +42,8 @@ const std::vector<std::string> REPOSITORY_CONF_DIRS{
     "/etc/yum.repos.d", "/etc/distro.repos.d", "/usr/share/dnf5/repos.d"};
 constexpr const char * REPOS_OVERRIDE_DIR = "/etc/dnf/repos.override.d";
 
+constexpr const char * TRANSACTION_LOCK_FILEPATH = "/run/dnf/rpmtransaction.lock";
+
 // More important varsdirs must be on the end of vector
 const std::vector<std::string> VARS_DIRS{"/usr/share/dnf5/vars.d", "/etc/dnf/vars"};
 

--- a/include/libdnf5/utils/locker.hpp
+++ b/include/libdnf5/utils/locker.hpp
@@ -24,12 +24,26 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::utils {
 
+/// Object for implementing a simple file mutex mechanism
+/// or checking read/write access on a given path.
 class Locker {
 public:
-    explicit Locker(const std::string & path) : path(path){};
+    /// Create a Locker object at a given path
+    explicit Locker(const std::string & path);
     ~Locker();
+
+    /// @brief Try to acquire read lock on a given file path
+    /// @return True if lock acquisition was successful, otherwise false
+    /// @throws libdnf5::SystemError if an unexpected error occurs when checking the lock state, like insufficient privileges
     bool read_lock();
+
+    /// @brief Try to acquire write lock on a given file path
+    /// @return True if lock acquisition was successful, otherwise false
+    /// @throws libdnf5::SystemError if an unexpected error occurs when checking the lock state, like insufficient privileges
     bool write_lock();
+
+    /// @brief Unlock the existing lock and remove the underlying lock file
+    /// @throws libdnf5::SystemError if an unexpected error occurs when unlocking
     void unlock();
 
 private:

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -38,6 +38,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/common/sack/exclude_flags.hpp"
 #include "libdnf5/common/sack/query_cmp.hpp"
 #include "libdnf5/comps/group/query.hpp"
+#include "libdnf5/conf/const.hpp"
 #include "libdnf5/repo/package_downloader.hpp"
 #include "libdnf5/rpm/package_query.hpp"
 #include "libdnf5/utils/bgettext/bgettext-lib.h"
@@ -853,7 +854,7 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
 
     // acquire the lock
     std::filesystem::path lock_file_path = config.get_installroot_option().get_value();
-    lock_file_path /= "run/dnf/rpmtransaction.lock";
+    lock_file_path /= std::filesystem::path(libdnf5::TRANSACTION_LOCK_FILEPATH).relative_path();
     std::filesystem::create_directories(lock_file_path.parent_path());
 
     libdnf5::utils::Locker locker(lock_file_path);

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -31,7 +31,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "transaction_impl.hpp"
 #include "transaction_module_impl.hpp"
 #include "transaction_package_impl.hpp"
-#include "utils/locker.hpp"
 #include "utils/string.hpp"
 
 #include "libdnf5/base/base.hpp"
@@ -44,6 +43,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/utils/bgettext/bgettext-lib.h"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 #include "libdnf5/utils/format.hpp"
+#include "libdnf5/utils/locker.hpp"
 
 #include <fmt/format.h>
 #include <unistd.h>

--- a/libdnf5/utils/locker.cpp
+++ b/libdnf5/utils/locker.cpp
@@ -18,7 +18,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#include "locker.hpp"
+#include "libdnf5/utils/locker.hpp"
 
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
@@ -28,6 +28,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 
 namespace libdnf5::utils {
+
+Locker::Locker(const std::string & path) : path(path){};
 
 bool Locker::read_lock() {
     return lock(F_RDLCK);


### PR DESCRIPTION
Using the existing RPM lock file functionality.

There are a hard-coded list of commands that are not allowed to run without superuser privileges. Then `assumeno` and `downloadonly` options are taken into account. Lastly, we check if provided command has defined the `store` option which should be defined for all transactional commands and therefore it should mean a need for elevated privileges.

For: #849.
Successor of: #1504.