### PR TITLE
Build libdnf5 static library, re-enable unit tests that use hidden (private) libdnf5 symbols

### DIFF
--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -157,7 +157,7 @@ enum class GoalAction {
 LIBDNF_API std::string goal_action_to_string(GoalAction action);
 
 /// Check whether the action is a replay action
-bool goal_action_is_replay(GoalAction action);
+LIBDNF_API bool goal_action_is_replay(GoalAction action);
 
 /// Settings for GoalJobSettings
 enum class GoalSetting { AUTO, SET_TRUE, SET_FALSE };

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -21,12 +21,24 @@ add_definitions(-DLIBSOLV_SOLVABLE_PREPEND_DEP)
 
 include_directories(.)
 
+# Creates an object library - a non-archival collection of object files that is the result
+# of compiling the given source files.
+# The collection of object files is used as source input for creating the libdnf5 static and shared library.
+add_library(libdnf5_obj OBJECT ${LIBDNF5_SOURCES})
+# libdnf5_obj is used to build libdnf5.so shared library - PIC needed
+set_property(TARGET libdnf5_obj PROPERTY POSITION_INDEPENDENT_CODE 1)
+set_target_properties(libdnf5_obj PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_PRESET hidden)
+
+# build libdnf5.a - static library is used by unit tests
+# Unit tests use private symbols that are not exported from libdnfř.so shared library.
+add_library(libdnf5_static STATIC $<TARGET_OBJECTS:libdnf5_obj>)
+set_target_properties(libdnf5_static PROPERTIES OUTPUT_NAME "dnf5_static")
+
 # build libdnf5.so
-add_library(libdnf5 SHARED ${LIBDNF5_SOURCES})
+add_library(libdnf5 SHARED $<TARGET_OBJECTS:libdnf5_obj>)
 set(DNF_SO_VERSION 2)
 set_target_properties(libdnf5 PROPERTIES OUTPUT_NAME "dnf5")
 set_target_properties(libdnf5 PROPERTIES SOVERSION ${DNF_SO_VERSION})
-set_target_properties(libdnf5 PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_PRESET hidden)
 # required to have dlopen symbol
 target_link_libraries(libdnf5 PUBLIC ${CMAKE_DL_LIBS})
 
@@ -37,6 +49,7 @@ target_link_libraries(libdnf5 PUBLIC stdc++)
 install(TARGETS libdnf5 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 target_link_libraries(libdnf5 PRIVATE common)
+target_link_libraries(libdnf5_static PRIVATE common)
 
 # link libraries and set pkg-config requires
 
@@ -45,32 +58,39 @@ find_package(toml11 REQUIRED)
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
 target_link_libraries(libdnf5 PUBLIC ${LIBFMT_LIBRARIES})
+target_link_libraries(libdnf5_static PUBLIC ${LIBFMT_LIBRARIES})
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})
 target_link_libraries(libdnf5 PRIVATE ${JSONC_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${JSONC_LIBRARIES})
 
 pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBMODULEMD_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBMODULEMD_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${LIBMODULEMD_LIBRARIES})
 
 pkg_check_modules(LIBSOLV REQUIRED libsolv>=0.7.25)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBSOLV_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLV_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${LIBSOLV_LIBRARIES})
 
 pkg_check_modules(LIBSOLVEXT REQUIRED libsolvext>=0.7.7)
 list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBSOLVEXT_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLVEXT_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${LIBSOLVEXT_LIBRARIES})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${RPM_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${RPM_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${RPM_LIBRARIES})
 
 if(WITH_COMPS)
     pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
     list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBXML2_MODULE_NAME}")
     include_directories(${LIBXML2_INCLUDE_DIRS})
     target_link_libraries(libdnf5 PRIVATE ${LIBXML2_LIBRARIES})
+    target_link_libraries(libdnf5_static PRIVATE ${LIBXML2_LIBRARIES})
 endif()
 
 if (WITH_ZCHUNK)
@@ -87,11 +107,13 @@ pkg_check_modules(LIBREPO REQUIRED librepo>=1.15.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
 target_include_directories(libdnf5 PUBLIC PRIVATE ${LIBREPO_INCLUDE_DIRS})
 target_link_libraries(libdnf5 PRIVATE ${LIBREPO_LDFLAGS})
+target_link_libraries(libdnf5_static PRIVATE ${LIBREPO_LDFLAGS})
 
 # SQLite3
 pkg_check_modules(SQLite3 REQUIRED sqlite3>=3.35.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${SQLite3_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${SQLite3_LIBRARIES})
+target_link_libraries(libdnf5_static PRIVATE ${SQLite3_LIBRARIES})
 
 
 # sort the pkg-config requires and concatenate them into a string

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 add_subdirectory(data)
 
 # libdnf5
-#add_subdirectory(libdnf5)
+add_subdirectory(libdnf5)
 
 # performance tests are available only for libdnf5
 if(WITH_PERFORMANCE_TESTS)
@@ -30,7 +30,7 @@ if(WITH_PERFORMANCE_TESTS)
 endif()
 
 # libdnf5-cli
-#add_subdirectory(libdnf5-cli)
+add_subdirectory(libdnf5-cli)
 
 # tutorial
 add_subdirectory(tutorial)
@@ -43,7 +43,7 @@ add_subdirectory(ruby)
 
 # components
 add_subdirectory(dnf5daemon-server)
-#add_subdirectory(dnf5-plugins)
+add_subdirectory(dnf5-plugins)
 
 # add shared
-#add_subdirectory(shared)
+add_subdirectory(shared)

--- a/test/libdnf5-cli/CMakeLists.txt
+++ b/test/libdnf5-cli/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 
 add_executable(run_tests_cli ${TEST_LIBDNF5_CLI_SOURCES})
 target_link_directories(run_tests_cli PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(run_tests_cli PRIVATE stdc++ libdnf5 libdnf5-cli cppunit test_shared)
+target_link_libraries(run_tests_cli PRIVATE stdc++ libdnf5_static libdnf5-cli cppunit test_shared)
 
 
 add_test(NAME test_libdnf_cli COMMAND run_tests_cli)

--- a/test/libdnf5/CMakeLists.txt
+++ b/test/libdnf5/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_options(run_tests PRIVATE "-Wno-self-assign-overloaded")
 target_compile_options(run_tests PRIVATE "-Wno-self-move")
 
 target_link_directories(run_tests PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(run_tests PRIVATE stdc++ libdnf5 cppunit test_shared)
+target_link_libraries(run_tests PRIVATE stdc++ libdnf5_static cppunit test_shared)
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -10,4 +10,4 @@ include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
 add_library(test_shared OBJECT ${TEST_SHARED_SOURCES})
 
 target_link_directories(test_shared PUBLIC ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(test_shared PUBLIC stdc++ libdnf5 cppunit)
+target_link_libraries(test_shared PUBLIC stdc++ libdnf5_static cppunit)


### PR DESCRIPTION
Some unit tests use private symbols that are not exported from libdnf5.so shared library.
Therefore, a static version of the libdnf5 library is built in which all symbols are available. Unit tests that need private symbols use the static library.

Please merge after https://github.com/rpm-software-management/dnf5/pull/1307 . 