### PR TITLE
builddep: Support the --with/--without options to toggle bconds

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -85,6 +85,36 @@ void BuildDepCommand::set_argument_parser() {
         });
     cmd.register_named_arg(defs);
 
+    auto with_bconds = parser.add_new_named_arg("with_bconds");
+    with_bconds->set_long_name("with");
+    with_bconds->set_has_value(true);
+    with_bconds->set_arg_value_help("OPTION");
+    with_bconds->set_description(
+        "Enable conditional build OPTION when parsing spec files. "
+        "Does not apply for source rpm files.");
+    with_bconds->set_parse_hook_func(
+        [this](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            rpm_macros.emplace_back("_with_" + std::string(value), "--with-" + std::string(value));
+            return true;
+        });
+    cmd.register_named_arg(with_bconds);
+
+    auto without_bconds = parser.add_new_named_arg("without_bconds");
+    without_bconds->set_long_name("without");
+    without_bconds->set_has_value(true);
+    without_bconds->set_arg_value_help("OPTION");
+    without_bconds->set_description(
+        "Disable conditional build OPTION when parsing spec files. "
+        "Does not apply for source rpm files.");
+    without_bconds->set_parse_hook_func(
+        [this](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            rpm_macros.emplace_back("_without_" + std::string(value), "--without-" + std::string(value));
+            return true;
+        });
+    cmd.register_named_arg(without_bconds);
+
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
@@ -240,7 +270,8 @@ void BuildDepCommand::run() {
         }
     } else {
         if (srpm_file_paths.size() > 0 && rpm_macros.size() > 0) {
-            std::cerr << "Warning: -D or --define arguments have no meaning for source rpm packages." << std::endl;
+            std::cerr << "Warning: -D/--define/--with/--without arguments have no effect on source rpm packages."
+                      << std::endl;
         }
     }
 

--- a/doc/dnf5_plugins/builddep.8.rst
+++ b/doc/dnf5_plugins/builddep.8.rst
@@ -44,6 +44,9 @@ Options
 ``-D "macro expr", --define="macro expr"``
     | Define a rpm macro. Set the value "expr" to the macro "macro" when parsing spec files. Does not apply for source rpm files.
 
+``--with=OPTION, --without=OPTION``
+    | Enable or disable conditional build OPTION when parsing spec files. Does not apply for source rpm files.
+
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.
 
@@ -78,3 +81,6 @@ Examples
 
 ``dnf builddep -D 'scl python27' python-foobar.spec``
     | Install the needed build requirements for the python27 SCL version of python-foobar.
+
+``dnf builddep --without=selinux foobar.spec``
+    | Install the needed build requirements except those for optional SELinux support.


### PR DESCRIPTION
This adds the same options used by `rpmbuild`, `mock`, etc. for setting macros to flip build-time conditional switches when parsing spec files.  It provides a consistent interface across related tools.

They are aliases in `rpmbuild`, I'm not sure if there is a better way to accomplish something like that here:
```
rpmbuild alias --with           --define "_with_!#:+     --with-!#:+" \
        --POPTdesc=$"enable configure <option> for build" \
        --POPTargs=$"<option>"
rpmbuild alias --without        --define "_without_!#:+  --without-!#:+" \
        --POPTdesc=$"disable configure <option> for build" \
        --POPTargs=$"<option>"
```