### PR TITLE
daemon: Generate transfer_id on server side

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -107,7 +107,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <method name="list_fd">
         <arg name="options" type="a{sv}" direction="in"/>
         <arg name="file_descriptor" type="h" direction="in"/>
-        <arg name="transfer_id" type="s" direction="in"/>
+        <arg name="transfer_id" type="s" direction="out"/>
     </method>
 
     <!--

--- a/dnf5daemon-server/services/rpm/rpm.hpp
+++ b/dnf5daemon-server/services/rpm/rpm.hpp
@@ -44,7 +44,7 @@ private:
     sdbus::MethodReply downgrade(sdbus::MethodCall & call);
     sdbus::MethodReply reinstall(sdbus::MethodCall & call);
 
-    void list_fd(sdbus::MethodCall & call);
+    void list_fd(sdbus::MethodCall & call, const std::string & transfer_id);
 };
 
 #endif

--- a/doc/dnf_daemon/examples/rpm_list_fd.py
+++ b/doc/dnf_daemon/examples/rpm_list_fd.py
@@ -40,7 +40,8 @@ def repoquery(iface_rpm, options):
     pipe_r, pipe_w = os.pipe()
     # transfer id serves as an identifier of the pipe transfer for a signal emitted
     # after server finish. This example does not use it.
-    iface_rpm.list_fd(options, pipe_w, "the_transfer_id")
+    transfer_id = iface_rpm.list_fd(options, pipe_w)
+    print("transfer_id: ", transfer_id)
     # close the write end - otherwise poll cannot detect the end of transmission
     os.close(pipe_w)
 
@@ -89,6 +90,8 @@ def repoquery(iface_rpm, options):
             try:
                 # skip all chars till begin of next JSON objects (new lines mostly)
                 json_obj_start = to_parse.find('{')
+                if json_obj_start < 0:
+                    break
                 obj, end = parser.raw_decode(to_parse[json_obj_start:])
                 yield obj
                 to_parse = to_parse[(json_obj_start+end):]
@@ -108,7 +111,7 @@ def repoquery(iface_rpm, options):
 
     # non-empty to_parse here means there are some unfinished (or generally unparsable)
     # JSON objects in the stream.
-    if to_parse:
+    if to_parse.strip():
         raise Exception("Failed to parse part of received data.")
 
 


### PR DESCRIPTION
The list_fd() method of the Rpm interface uses a unique transfer_id to
identify which particular file descriptor transfer has finished.
Previously, it was the client's responsibility to pass this unique
identifier to the server in the list_fd() method call. With this patch,
the identifier is generated on the server side, simplifying the method's
usage for clients.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1493