### PR TITLE
Add --minimal option for check-ugrade command

### DIFF
--- a/dnf5/commands/check-upgrade/check-upgrade.hpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.hpp
@@ -45,6 +45,7 @@ public:
     void run() override;
 
 protected:
+    libdnf5::OptionBool * minimal{nullptr};
     libdnf5::OptionBool * changelogs{nullptr};
     std::vector<std::string> pkg_specs;
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -44,9 +44,10 @@ void UpgradeCommand::set_argument_parser() {
         parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));
     auto minimal_opt = parser.add_new_named_arg("minimal");
     minimal_opt->set_long_name("minimal");
-    // TODO(dmach): Explain how this relates to options such as --security, --enhancement etc.
     minimal_opt->set_description(
-        "Upgrade packages only to the lowest versions of packages that fix the problems affecting the system.");
+        _("Upgrade packages only to the lowest versions that fix advisories of type bugfix, enhancement, security, or "
+          "newpackage. In case that any option limiting advisories is used it upgrades packages only to the lowest "
+          "versions that fix advisories that matching selected advisory property"));
     minimal_opt->set_const_value("true");
     minimal_opt->link_value(minimal);
     cmd.register_named_arg(minimal_opt);

--- a/doc/commands/check-upgrade.8.rst
+++ b/doc/commands/check-upgrade.8.rst
@@ -76,6 +76,11 @@ Options
 ``--newpackage``
     | Consider only content contained in newpackage advisories.
 
+``--minimal``
+    | Reports the lowest versions of packages that fix advisories of type bugfix, enhancement, security, or
+    | newpackage. In case that any option limiting advisories is used it reports the lowest versions of packages
+    | that fix advisories matching selected advisory properties"
+
 
 Examples
 ========

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -39,7 +39,9 @@ Options
 =======
 
 ``--minimal``
-    | Update packages only to the lowest available version that provides bug fixes, enhancements, or security fixes.
+    | Upgrade packages only to the lowest available versions that fix advisories of type bugfix, enhancement, security, or
+    | newpackage. In case that any option limiting advisories is used it upgrades packages only to the lowest versions
+    | that fix advisories matching selected advisory properties
 
 ``--allowerasing``
     | Allow erasing of installed packages to resolve any potential dependency problems.


### PR DESCRIPTION
It is required for a feature parity with upgrade command where the option is already available.

Related: https://issues.redhat.com/browse/RHEL-38804

CI: https://github.com/rpm-software-management/ci-dnf-stack/pull/1511