### PR TITLE
Move offline from dnf5 to libdnf5

### DIFF
--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -21,10 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_OFFLINE_HPP
 
 #include <dnf5/context.hpp>
-#include <dnf5/offline.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/conf/option_number.hpp>
+#include <libdnf5/transaction/offline.hpp>
 
 const std::filesystem::path PATH_TO_PLYMOUTH{"/usr/bin/plymouth"};
 const std::filesystem::path PATH_TO_JOURNALCTL{"/usr/bin/journalctl"};
@@ -48,7 +48,7 @@ public:
 protected:
     std::filesystem::path get_magic_symlink() const { return magic_symlink; };
     std::filesystem::path get_datadir() const { return datadir; };
-    std::optional<dnf5::offline::OfflineTransactionState> state;
+    std::optional<libdnf5::offline::OfflineTransactionState> state;
 
 private:
     std::filesystem::path magic_symlink;

--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -46,12 +46,10 @@ public:
     void configure() override;
 
 protected:
-    std::filesystem::path get_magic_symlink() const { return magic_symlink; };
     std::filesystem::path get_datadir() const { return datadir; };
     std::optional<libdnf5::offline::OfflineTransactionState> state;
 
 private:
-    std::filesystem::path magic_symlink;
     std::filesystem::path datadir;
 };
 

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_SYSTEM_UPGRADE_HPP
 
 #include <dnf5/context.hpp>
-#include <dnf5/offline.hpp>
+#include <libdnf5/transaction/offline.hpp>
 
 namespace dnf5 {
 
@@ -43,7 +43,7 @@ public:
 
 private:
     libdnf5::OptionBool * no_downgrade{nullptr};
-    std::filesystem::path datadir{dnf5::offline::DEFAULT_DATADIR};
+    std::filesystem::path datadir{libdnf5::offline::DEFAULT_DATADIR};
     std::string target_releasever;
     std::string system_releasever;
 };

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -317,7 +317,6 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     std::filesystem::create_directories(offline_datadir);
 
     constexpr const char * packages_in_trans_dir{"./packages"};
-    const auto & packages_location = offline_datadir / packages_in_trans_dir;
     constexpr const char * comps_in_trans_dir{"./comps"};
     const auto & comps_location = offline_datadir / comps_in_trans_dir;
 

--- a/dnf5/include/dnf5/offline.hpp
+++ b/dnf5/include/dnf5/offline.hpp
@@ -20,61 +20,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_OFFLINE_HPP
 #define DNF5_OFFLINE_HPP
 
-#include "dnf5/version.hpp"
-
 #include <dnf5/context.hpp>
-#include <libdnf5/conf/const.hpp>
-#include <libdnf5/conf/option_bool.hpp>
-#include <libdnf5/conf/option_number.hpp>
-#include <toml.hpp>
+
+#include <string>
 
 namespace dnf5::offline {
-
-// Unique identifiers used to mark and identify system-upgrade boots in
-// journald logs. These are the same as they are in `dnf4 system-upgrade`, so
-// `dnf5 offline log` will find offline transactions performed by DNF 4 and
-// vice-versa.
-const std::string REBOOT_REQUESTED_ID{"9348174c5cc74001a71ef26bd79d302e"};
-const std::string OFFLINE_STARTED_ID{"3e0a5636d16b4ca4bbe5321d06c6aa62"};
-const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
-
-const std::string STATUS_DOWNLOAD_INCOMPLETE{"download-incomplete"};
-const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
-const std::string STATUS_READY{"ready"};
-const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
-
-const int STATE_VERSION = 1;
-const std::string STATE_HEADER{"offline-transaction-state"};
-
-const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
-const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
-
-struct OfflineTransactionStateData {
-    int state_version = STATE_VERSION;
-    std::string status = STATUS_DOWNLOAD_INCOMPLETE;
-    std::string cachedir;
-    std::string target_releasever;
-    std::string system_releasever;
-    std::string verb;
-    std::string cmd_line;
-    bool poweroff_after = false;
-    std::string module_platform_id;
-};
-
-class OfflineTransactionState {
-public:
-    void write();
-    OfflineTransactionState(std::filesystem::path path);
-    OfflineTransactionStateData & get_data();
-    const std::exception_ptr & get_read_exception() const;
-    std::filesystem::path get_path() const;
-
-private:
-    void read();
-    std::exception_ptr read_exception;
-    std::filesystem::path path;
-    OfflineTransactionStateData data;
-};
 
 void log_status(
     Context & context,
@@ -84,17 +34,5 @@ void log_status(
     const std::string & target_releasever);
 
 }  // namespace dnf5::offline
-
-TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
-    dnf5::offline::OfflineTransactionStateData,
-    state_version,
-    status,
-    cachedir,
-    target_releasever,
-    system_releasever,
-    verb,
-    cmd_line,
-    poweroff_after,
-    module_platform_id)
 
 #endif  // DNF5_OFFLINE_HPP

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -51,27 +51,47 @@ const std::string STATE_HEADER{"offline-transaction-state"};
 const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
 const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
 
+/// Data of the initiated offline transaction state, by default stored in the
+/// /usr/lib/sysimage/libdnf5/offline/offline-transaction-state.toml file.
 struct OfflineTransactionStateData {
+    /// Version of the state file.
     int state_version = STATE_VERSION;
+    /// Current offline transaction status. One of download-incomplete, download-complete, ready, or transaction-incomplete.
     std::string status = STATUS_DOWNLOAD_INCOMPLETE;
+    /// Cachedir to be used for the offline transaction.
     std::string cachedir;
+    /// Target releasever for the offline transaction.
     std::string target_releasever;
+    /// Detected current releasever when the offline transaction was initialized.
     std::string system_releasever;
+    /// Dnf command used to initialize the offline transaction (e.g. "system-upgrade download").
     std::string verb;
+    /// Command line used to initialize the offline transaction.
     std::string cmd_line;
+    /// Power off the system after the operation is complete?
     bool poweroff_after = false;
+    /// module_platform_id for the offline transaction.
     std::string module_platform_id;
 };
 
+/// Class to handle offline transaction state.
 class OfflineTransactionState {
 public:
-    void write();
+    /// Constructs a new OfflineTransactionState instance based on the state file location.
+    /// @param path Path to the state file (default location is /usr/lib/sysimage/libdnf5/offline/offline-transaction-state.toml).
     OfflineTransactionState(std::filesystem::path path);
+
+    /// Returns offline transaction state data.
     OfflineTransactionStateData & get_data();
+    /// Write the current state to the file.
+    void write();
+    /// Returns any exception caught during the reading of the state file (or nullptr if no exception occurred).
     const std::exception_ptr & get_read_exception() const;
+    /// Returns path to the state file.
     std::filesystem::path get_path() const;
 
 private:
+    /// Read offline transaction state data from the file
     void read();
     std::exception_ptr read_exception;
     std::filesystem::path path;

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -40,6 +40,11 @@ const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
 const std::string STATUS_READY{"ready"};
 const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
 
+// This value comes from systemd, see
+// https://www.freedesktop.org/wiki/Software/systemd/SystemUpdates or
+// systemd.offline-updates(7).
+const std::filesystem::path MAGIC_SYMLINK{"/system-update"};
+
 const int STATE_VERSION = 1;
 const std::string STATE_HEADER{"offline-transaction-state"};
 

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2024 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TRANSACTION_OFFLINE_HPP
+#define LIBDNF5_TRANSACTION_OFFLINE_HPP
+
+#include <libdnf5/conf/const.hpp>
+#include <toml.hpp>
+
+#include <filesystem>
+
+namespace libdnf5::offline {
+
+// Unique identifiers used to mark and identify system-upgrade boots in
+// journald logs. These are the same as they are in `dnf4 system-upgrade`, so
+// `dnf5 offline log` will find offline transactions performed by DNF 4 and
+// vice-versa.
+const std::string REBOOT_REQUESTED_ID{"9348174c5cc74001a71ef26bd79d302e"};
+const std::string OFFLINE_STARTED_ID{"3e0a5636d16b4ca4bbe5321d06c6aa62"};
+const std::string OFFLINE_FINISHED_ID{"8cec00a1566f4d3594f116450395f06c"};
+
+const std::string STATUS_DOWNLOAD_INCOMPLETE{"download-incomplete"};
+const std::string STATUS_DOWNLOAD_COMPLETE{"download-complete"};
+const std::string STATUS_READY{"ready"};
+const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
+
+const int STATE_VERSION = 1;
+const std::string STATE_HEADER{"offline-transaction-state"};
+
+const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
+const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
+
+struct OfflineTransactionStateData {
+    int state_version = STATE_VERSION;
+    std::string status = STATUS_DOWNLOAD_INCOMPLETE;
+    std::string cachedir;
+    std::string target_releasever;
+    std::string system_releasever;
+    std::string verb;
+    std::string cmd_line;
+    bool poweroff_after = false;
+    std::string module_platform_id;
+};
+
+class OfflineTransactionState {
+public:
+    void write();
+    OfflineTransactionState(std::filesystem::path path);
+    OfflineTransactionStateData & get_data();
+    const std::exception_ptr & get_read_exception() const;
+    std::filesystem::path get_path() const;
+
+private:
+    void read();
+    std::exception_ptr read_exception;
+    std::filesystem::path path;
+    OfflineTransactionStateData data;
+};
+
+}  // namespace libdnf5::offline
+
+TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
+    libdnf5::offline::OfflineTransactionStateData,
+    state_version,
+    status,
+    cachedir,
+    target_releasever,
+    system_releasever,
+    verb,
+    cmd_line,
+    poweroff_after,
+    module_platform_id)
+
+#endif  // LIBDNF5_TRANSACTION_OFFLINE_HPP

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2024 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/common/exception.hpp"
+
+#include <libdnf5/transaction/offline.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/fs/file.hpp>
+
+
+namespace libdnf5::offline {
+
+OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : path(std::move(path)) {
+    read();
+}
+
+OfflineTransactionStateData & OfflineTransactionState::get_data() {
+    return data;
+}
+
+const std::exception_ptr & OfflineTransactionState::get_read_exception() const {
+    return read_exception;
+}
+
+std::filesystem::path OfflineTransactionState::get_path() const {
+    return path;
+}
+
+
+void OfflineTransactionState::read() {
+    try {
+        const std::ifstream file{path};
+        if (!file.good()) {
+            throw libdnf5::FileSystemError(errno, path, M_("error reading offline state file"));
+        }
+        const auto & value = toml::parse(path);
+        data = toml::find<OfflineTransactionStateData>(value, STATE_HEADER);
+        if (data.state_version != STATE_VERSION) {
+            throw libdnf5::RuntimeError(M_("incompatible version of state data"));
+        }
+    } catch (const std::exception & ex) {
+        read_exception = std::current_exception();
+        data = OfflineTransactionStateData{};
+    }
+}
+
+void OfflineTransactionState::write() {
+    auto file = libdnf5::utils::fs::File(path, "w");
+    file.write(toml::format(toml::value{{STATE_HEADER, data}}));
+    file.close();
+}
+
+}  // namespace libdnf5::offline

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -22,47 +22,192 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
+#include <toml.hpp>
 
+
+const int STATE_VERSION = 1;
+const std::string STATE_HEADER{"offline-transaction-state"};
+
+
+struct OfflineTransactionStateTomlData {
+    int state_version = STATE_VERSION;
+    std::string status = libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE;
+    std::string cachedir;
+    std::string target_releasever;
+    std::string system_releasever;
+    std::string verb;
+    std::string cmd_line;
+    bool poweroff_after = false;
+    std::string module_platform_id;
+};
+
+TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
+    OfflineTransactionStateTomlData,
+    state_version,
+    status,
+    cachedir,
+    target_releasever,
+    system_releasever,
+    verb,
+    cmd_line,
+    poweroff_after,
+    module_platform_id)
 
 namespace libdnf5::offline {
 
-OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : path(std::move(path)) {
-    read();
+class OfflineTransactionStateData::Impl {
+public:
+    friend OfflineTransactionStateData;
+    OfflineTransactionStateTomlData data;
+};
+
+
+OfflineTransactionStateData::~OfflineTransactionStateData() = default;
+
+OfflineTransactionStateData::OfflineTransactionStateData() : p_impl(std::make_unique<Impl>()){};
+OfflineTransactionStateData::OfflineTransactionStateData(const OfflineTransactionStateData & src)
+    : p_impl(new Impl(*src.p_impl)) {}
+OfflineTransactionStateData::OfflineTransactionStateData(OfflineTransactionStateData && src) noexcept = default;
+
+OfflineTransactionStateData & OfflineTransactionStateData::operator=(const OfflineTransactionStateData & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+    return *this;
 }
 
+OfflineTransactionStateData & OfflineTransactionStateData::operator=(OfflineTransactionStateData && src) noexcept =
+    default;
+
+void OfflineTransactionStateData::set_state_version(int state_version) {
+    p_impl->data.state_version = state_version;
+}
+int OfflineTransactionStateData::get_state_version() const {
+    return p_impl->data.state_version;
+}
+
+void OfflineTransactionStateData::set_status(const std::string & status) {
+    p_impl->data.status = status;
+}
+const std::string & OfflineTransactionStateData::get_status() const {
+    return p_impl->data.status;
+}
+
+void OfflineTransactionStateData::set_cachedir(const std::string & cachedir) {
+    p_impl->data.cachedir = cachedir;
+}
+const std::string & OfflineTransactionStateData::get_cachedir() const {
+    return p_impl->data.cachedir;
+}
+
+void OfflineTransactionStateData::set_target_releasever(const std::string & target_releasever) {
+    p_impl->data.target_releasever = target_releasever;
+}
+const std::string & OfflineTransactionStateData::get_target_releasever() const {
+    return p_impl->data.target_releasever;
+}
+
+void OfflineTransactionStateData::set_system_releasever(const std::string & system_releasever) {
+    p_impl->data.system_releasever = system_releasever;
+}
+const std::string & OfflineTransactionStateData::get_system_releasever() const {
+    return p_impl->data.system_releasever;
+}
+
+void OfflineTransactionStateData::set_verb(const std::string & verb) {
+    p_impl->data.verb = verb;
+}
+const std::string & OfflineTransactionStateData::get_verb() const {
+    return p_impl->data.verb;
+}
+
+void OfflineTransactionStateData::set_cmd_line(const std::string & cmd_line) {
+    p_impl->data.cmd_line = cmd_line;
+}
+const std::string & OfflineTransactionStateData::get_cmd_line() const {
+    return p_impl->data.cmd_line;
+}
+
+void OfflineTransactionStateData::set_poweroff_after(bool poweroff_after) {
+    p_impl->data.poweroff_after = poweroff_after;
+}
+bool OfflineTransactionStateData::get_poweroff_after() const {
+    return p_impl->data.poweroff_after;
+}
+
+void OfflineTransactionStateData::set_module_platform_id(const std::string & module_platform_id) {
+    p_impl->data.module_platform_id = module_platform_id;
+}
+const std::string & OfflineTransactionStateData::get_module_platform_id() const {
+    return p_impl->data.module_platform_id;
+}
+
+
+class OfflineTransactionState::Impl {
+    friend OfflineTransactionState;
+    std::exception_ptr read_exception;
+    std::filesystem::path path;
+    OfflineTransactionStateData data;
+};
+
+OfflineTransactionState::~OfflineTransactionState() = default;
+
+OfflineTransactionState::OfflineTransactionState(std::filesystem::path path) : p_impl(std::make_unique<Impl>()) {
+    p_impl->path = std::move(path);
+    read();
+}
+OfflineTransactionState::OfflineTransactionState(const OfflineTransactionState & src) : p_impl(new Impl(*src.p_impl)) {}
+OfflineTransactionState::OfflineTransactionState(OfflineTransactionState && src) noexcept = default;
+
+OfflineTransactionState & OfflineTransactionState::operator=(const OfflineTransactionState & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*src.p_impl);
+        }
+    }
+    return *this;
+}
+OfflineTransactionState & OfflineTransactionState::operator=(OfflineTransactionState && src) noexcept = default;
+
 OfflineTransactionStateData & OfflineTransactionState::get_data() {
-    return data;
+    return p_impl->data;
 }
 
 const std::exception_ptr & OfflineTransactionState::get_read_exception() const {
-    return read_exception;
+    return p_impl->read_exception;
 }
 
 std::filesystem::path OfflineTransactionState::get_path() const {
-    return path;
+    return p_impl->path;
 }
 
 
 void OfflineTransactionState::read() {
     try {
-        const std::ifstream file{path};
+        const std::ifstream file{p_impl->path};
         if (!file.good()) {
-            throw libdnf5::FileSystemError(errno, path, M_("error reading offline state file"));
+            throw libdnf5::FileSystemError(errno, p_impl->path, M_("error reading offline state file"));
         }
-        const auto & value = toml::parse(path);
-        data = toml::find<OfflineTransactionStateData>(value, STATE_HEADER);
-        if (data.state_version != STATE_VERSION) {
+        const auto & value = toml::parse(p_impl->path);
+        p_impl->data.p_impl->data = toml::find<OfflineTransactionStateTomlData>(value, STATE_HEADER);
+        if (p_impl->data.get_state_version() != STATE_VERSION) {
             throw libdnf5::RuntimeError(M_("incompatible version of state data"));
         }
     } catch (const std::exception & ex) {
-        read_exception = std::current_exception();
-        data = OfflineTransactionStateData{};
+        p_impl->read_exception = std::current_exception();
+        p_impl->data = OfflineTransactionStateData{};
     }
 }
 
 void OfflineTransactionState::write() {
-    auto file = libdnf5::utils::fs::File(path, "w");
-    file.write(toml::format(toml::value{{STATE_HEADER, data}}));
+    auto file = libdnf5::utils::fs::File(p_impl->path, "w");
+    file.write(toml::format(toml::value{{STATE_HEADER, p_impl->data.p_impl->data}}));
     file.close();
 }
 


### PR DESCRIPTION
We will need to share the code also with dnf5daemon-server to support
offline upgrades using D-Bus API.

For: https://bugzilla.redhat.com/show_bug.cgi?id=2124503