### PR TITLE
spec: Fix files and directories ownership

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -277,8 +277,8 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/bash-completion/
 %dir %{_datadir}/bash-completion/completions/
 %{_datadir}/bash-completion/completions/dnf*
-%dir %{_prefix}/lib/sysimage/dnf
-%verify(not md5 size mtime) %ghost %{_prefix}/lib/sysimage/dnf/*
+%dir %{_prefix}/lib/sysimage/libdnf5
+%verify(not md5 size mtime) %ghost %{_prefix}/lib/sysimage/libdnf5/*
 %license COPYING.md
 %license gpl-2.0.txt
 %{_mandir}/man8/dnf5.8.*
@@ -358,6 +358,7 @@ Package management library.
 %else
 %exclude %{_sysconfdir}/dnf/dnf.conf
 %endif
+%ghost %{_sysconfdir}/dnf/versionlock.toml
 %dir %{_datadir}/dnf5/libdnf.conf.d
 %dir %{_sysconfdir}/dnf/libdnf5.conf.d
 %dir %{_datadir}/dnf5/repos.override.d
@@ -822,15 +823,18 @@ done
 %endif
 
 # own dirs and files that dnf5 creates on runtime
-mkdir -p %{buildroot}%{_prefix}/lib/sysimage/dnf
-for files in \
-    groups.toml modules.toml nevras.toml packages.toml \
-    system.toml transaction_history.sqlite \
-    transaction_history.sqlite-shm \
-    transaction_history.sqlite-wal userinstalled.toml
+mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5
+for file in \
+    environments.toml groups.toml modules.toml nevras.toml packages.toml \
+    system.toml \
+    transaction_history.sqlite transaction_history.sqlite-shm \
+    transaction_history.sqlite-wal
 do
-    touch %{buildroot}%{_prefix}/lib/sysimage/dnf/$files
+    touch %{buildroot}%{_prefix}/lib/sysimage/libdnf5/$file
 done
+mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/comps_groups
+mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/offline
+touch %{buildroot}%{_sysconfdir}/dnf/versionlock.toml
 
 # Remove if condition when Fedora 37 is EOL
 %if 0%{?fedora} > 37 || 0%{?rhel} > 10


### PR DESCRIPTION
- /usr/lib/sysimage/dnf was renamed to /usr/lib/sysimage/libdnf5
- added /usr/lib/sysimage/libdnf5/comps_groups directory
- added /usr/lib/sysimage/libdnf5/offline directory
- added /etc/dnf/versionlock.toml config file

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2284612