### PR TITLE
repoinfo: Implement JSON output

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -173,7 +173,12 @@ public:
     void set_should_store_offline(bool should_store_offline) { this->should_store_offline = should_store_offline; }
     bool get_should_store_offline() const { return should_store_offline; }
 
-    void set_json_output_requested(bool json_output) { this->json_output = json_output; }
+    void set_json_output_requested(bool json_output) {
+        this->json_output = json_output;
+        if (json_output) {
+            set_quiet(true);
+        }
+    }
     bool get_json_output_requested() const { return json_output; }
 
     libdnf5::Base & get_base() { return base; };

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1186,13 +1186,6 @@ int main(int argc, char * argv[]) try {
             return 0;
         }
 
-        auto download_callbacks_uptr = std::make_unique<dnf5::DownloadCallbacks>();
-        auto * download_callbacks = download_callbacks_uptr.get();
-        download_callbacks->set_show_total_bar_limit(static_cast<std::size_t>(-1));
-        if (!context.get_quiet()) {
-            base.set_download_callbacks(std::move(download_callbacks_uptr));
-        }
-
         // Parse command line arguments
         {
             auto & arg_parser = context.get_argument_parser();
@@ -1243,6 +1236,13 @@ int main(int argc, char * argv[]) try {
                 dnf5::print_versions(context);
                 return static_cast<int>(libdnf5::cli::ExitCode::SUCCESS);
             }
+        }
+
+        auto download_callbacks_uptr = std::make_unique<dnf5::DownloadCallbacks>();
+        auto * download_callbacks = download_callbacks_uptr.get();
+        download_callbacks->set_show_total_bar_limit(static_cast<std::size_t>(-1));
+        if (!context.get_quiet()) {
+            base.set_download_callbacks(std::move(download_callbacks_uptr));
         }
 
         auto command = context.get_selected_command();

--- a/include/libdnf5-cli/output/repo_info.hpp
+++ b/include/libdnf5-cli/output/repo_info.hpp
@@ -40,6 +40,8 @@ private:
     std::unique_ptr<Impl> p_impl;
 };
 
+void print_repoinfo_json(const std::vector<std::unique_ptr<IRepoInfo>> & repos);
+
 }  // namespace libdnf5::cli::output
 
 #endif  // LIBDNF5_CLI_OUTPUT_REPO_INFO_HPP


### PR DESCRIPTION
Turn on `quiet` mode when `--json` is requested. Also fixed suppressing repository download progress when `quiet` mode is turned on.

For: #867.