### PR TITLE
builddep: Add build-dep alias

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -716,6 +716,7 @@ config-manager, copr, and repoclosure commands.
 %{_mandir}/man8/dnf*-copr.8.*
 %{_mandir}/man8/dnf*-needs-restarting.8.*
 %{_mandir}/man8/dnf*-repoclosure.8.*
+%{_datadir}/dnf5/aliases.d/compatibility-plugins.conf
 
 
 # ========== dnf5-automatic plugin ==========

--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility-plugins.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility-plugins.conf
@@ -1,0 +1,7 @@
+version = '1.0'
+
+['build-dep']
+type = 'command'
+attached_command = 'builddep'
+descr = "Compatibility alias for 'builddep'"
+complete = false


### PR DESCRIPTION
Since the `build-dep` alias has been present in dnf4 and is still used by some teams, let's keep it in dnf5 as well.

Closes: #1528.