### PR TITLE
dnfdaemon: Support to run transactions offline

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -206,7 +206,8 @@ void OfflineSubcommand::configure() {
     const std::filesystem::path installroot = ctx.get_base().get_config().get_installroot_option().get_value();
     datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
     std::filesystem::create_directories(datadir);
-    state = std::make_optional<libdnf5::offline::OfflineTransactionState>(datadir / "offline-transaction-state.toml");
+    state = std::make_optional<libdnf5::offline::OfflineTransactionState>(
+        datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME);
 }
 
 void check_state(const libdnf5::offline::OfflineTransactionState & state) {

--- a/dnf5daemon-client/commands/command.cpp
+++ b/dnf5daemon-client/commands/command.cpp
@@ -37,7 +37,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-void TransactionCommand::run_transaction() {
+void TransactionCommand::run_transaction(bool offline) {
     auto & ctx = get_context();
     dnfdaemon::KeyValueMap options = {};
 
@@ -80,6 +80,7 @@ void TransactionCommand::run_transaction() {
 
     // do the transaction
     options.clear();
+    options["offline"] = offline;
     ctx.session_proxy->callMethod("do_transaction")
         .onInterface(dnfdaemon::INTERFACE_GOAL)
         .withTimeout(static_cast<uint64_t>(-1))

--- a/dnf5daemon-client/commands/command.hpp
+++ b/dnf5daemon-client/commands/command.hpp
@@ -42,7 +42,7 @@ public:
 class TransactionCommand : public DaemonCommand {
 public:
     explicit TransactionCommand(Context & context, const std::string & name) : DaemonCommand(context, name){};
-    void run_transaction();
+    void run_transaction(bool offline = false);
 };
 
 

--- a/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
+++ b/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
@@ -49,6 +49,9 @@ void DistroSyncCommand::set_argument_parser() {
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::UNLIMITED, pkg_specs);
     specs_arg->set_description("Patterns");
     cmd.register_positional_arg(specs_arg);
+
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
 }
 
 void DistroSyncCommand::run() {
@@ -65,7 +68,7 @@ void DistroSyncCommand::run() {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/distro-sync/distro-sync.hpp
+++ b/dnf5daemon-client/commands/distro-sync/distro-sync.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
@@ -35,6 +35,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs;
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/downgrade/downgrade.cpp
+++ b/dnf5daemon-client/commands/downgrade/downgrade.cpp
@@ -49,6 +49,9 @@ void DowngradeCommand::set_argument_parser() {
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::AT_LEAST_ONE, pkg_specs);
     specs_arg->set_description("List of packages to downgrade");
     cmd.register_positional_arg(specs_arg);
+
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
 }
 
 void DowngradeCommand::run() {
@@ -65,7 +68,7 @@ void DowngradeCommand::run() {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/downgrade/downgrade.hpp
+++ b/dnf5daemon-client/commands/downgrade/downgrade.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
@@ -35,6 +35,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs{};
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/install/install.cpp
+++ b/dnf5daemon-client/commands/install/install.cpp
@@ -62,6 +62,9 @@ void InstallCommand::set_argument_parser() {
     skip_unavailable->link_value(&skip_unavailable_option);
     cmd.register_named_arg(skip_unavailable);
 
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
+
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::AT_LEAST_ONE, pkg_specs);
     specs_arg->set_description("List of packages to install");
     cmd.register_positional_arg(specs_arg);
@@ -88,7 +91,7 @@ void InstallCommand::run() {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/install/install.hpp
+++ b/dnf5daemon-client/commands/install/install.hpp
@@ -22,7 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
 #include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
@@ -35,9 +34,10 @@ public:
     void run() override;
 
 private:
+    std::vector<std::string> pkg_specs{};
     libdnf5::OptionBool skip_broken_option{false};
     libdnf5::OptionBool skip_unavailable_option{false};
-    std::vector<std::string> pkg_specs{};
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/reinstall/reinstall.cpp
+++ b/dnf5daemon-client/commands/reinstall/reinstall.cpp
@@ -49,6 +49,9 @@ void ReinstallCommand::set_argument_parser() {
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::AT_LEAST_ONE, pkg_specs);
     specs_arg->set_description("List of packages to reinstall");
     cmd.register_positional_arg(specs_arg);
+
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
 }
 
 void ReinstallCommand::run() {
@@ -65,7 +68,7 @@ void ReinstallCommand::run() {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/reinstall/reinstall.hpp
+++ b/dnf5daemon-client/commands/reinstall/reinstall.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
@@ -35,6 +35,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs{};
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/remove/remove.cpp
+++ b/dnf5daemon-client/commands/remove/remove.cpp
@@ -51,6 +51,9 @@ void RemoveCommand::set_argument_parser() {
     specs_arg->set_description("List of packages to remove");
     cmd.register_positional_arg(specs_arg);
 
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
+
     // run remove command always with allow_erasing on
     context.allow_erasing.set(libdnf5::Option::Priority::RUNTIME, true);
 }
@@ -69,7 +72,7 @@ void RemoveCommand::run() {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/remove/remove.hpp
+++ b/dnf5daemon-client/commands/remove/remove.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
@@ -35,6 +35,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs{};
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/shared_options.cpp
+++ b/dnf5daemon-client/commands/shared_options.cpp
@@ -21,7 +21,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils/url.hpp"
 
+#include <libdnf5-cli/argument_parser.hpp>
+
 #include <filesystem>
+
+namespace {
 
 static void normalize_paths(int specs_count, const char * const specs[], std::vector<std::string> & pkg_specs) {
     const std::string_view ext(".rpm");
@@ -39,6 +43,10 @@ static void normalize_paths(int specs_count, const char * const specs[], std::ve
     }
 }
 
+}  // anonymous namespace
+
+namespace dnfdaemon::client {
+
 libdnf5::cli::ArgumentParser::PositionalArg * pkg_specs_argument(
     libdnf5::cli::ArgumentParser & parser, int nargs, std::vector<std::string> & pkg_specs) {
     auto specs = parser.add_new_positional_arg("pkg_specs", nargs, nullptr, nullptr);
@@ -49,3 +57,15 @@ libdnf5::cli::ArgumentParser::PositionalArg * pkg_specs_argument(
         });
     return specs;
 }
+
+libdnf5::cli::ArgumentParser::NamedArg * create_offline_option(
+    libdnf5::cli::ArgumentParser & parser, libdnf5::Option * value) {
+    auto offline = parser.add_new_named_arg("offline");
+    offline->set_long_name("offline");
+    offline->set_description("Store the transaction to be performed offline");
+    offline->set_const_value("true");
+    offline->link_value(value);
+    return offline;
+}
+
+}  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/shared_options.hpp
+++ b/dnf5daemon-client/commands/shared_options.hpp
@@ -22,7 +22,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf5-cli/argument_parser.hpp>
 
+namespace dnfdaemon::client {
+
 libdnf5::cli::ArgumentParser::PositionalArg * pkg_specs_argument(
     libdnf5::cli::ArgumentParser & parser, int nargs, std::vector<std::string> & pkg_specs);
 
+/// Create the `--offline` named arg bound to the given option
+libdnf5::cli::ArgumentParser::NamedArg * create_offline_option(
+    libdnf5::cli::ArgumentParser & parser, libdnf5::Option * value);
+
+}  // namespace dnfdaemon::client
 #endif

--- a/dnf5daemon-client/commands/upgrade/upgrade.cpp
+++ b/dnf5daemon-client/commands/upgrade/upgrade.cpp
@@ -49,6 +49,9 @@ void UpgradeCommand::set_argument_parser() {
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::UNLIMITED, pkg_specs);
     specs_arg->set_description("List of packages to upgrade");
     cmd.register_positional_arg(specs_arg);
+
+    auto offline_arg = create_offline_option(parser, &offline_option);
+    cmd.register_named_arg(offline_arg);
 }
 
 void UpgradeCommand::run() {
@@ -59,13 +62,12 @@ void UpgradeCommand::run() {
     }
 
     dnfdaemon::KeyValueMap options = {};
-
     ctx.session_proxy->callMethod("upgrade")
         .onInterface(dnfdaemon::INTERFACE_RPM)
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(pkg_specs, options);
 
-    run_transaction();
+    run_transaction(offline_option.get_value());
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/upgrade/upgrade.hpp
+++ b/dnf5daemon-client/commands/upgrade/upgrade.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands/command.hpp"
 
-#include <libdnf5/conf/option.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
@@ -35,6 +35,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs{};
+    libdnf5::OptionBool offline_option{false};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -61,6 +61,7 @@ const char * const INTERFACE_RPM = "org.rpm.dnf.v0.rpm.Rpm";
 const char * const INTERFACE_GOAL = "org.rpm.dnf.v0.Goal";
 const char * const INTERFACE_GROUP = "org.rpm.dnf.v0.comps.Group";
 const char * const INTERFACE_ADVISORY = "org.rpm.dnf.v0.Advisory";
+const char * const INTERFACE_OFFLINE = "org.rpm.dnf.v0.Offline";
 const char * const INTERFACE_SESSION_MANAGER = "org.rpm.dnf.v0.SessionManager";
 
 // signals

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -85,6 +85,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Following @options are supported:
             - comment: string
                 Adds a comment to a transaction.
+            - offline: boolean, default false
+                If true, the transaction will be prepared to run during the next reboot. Otherwise, it will run immediately.
 
         Unknown options are ignored.
     -->

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
@@ -1,0 +1,80 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<node>
+<!-- org.rpm.dnf.v0.Offline:
+   @short_description: Interface to offline transactions
+-->
+<interface name="org.rpm.dnf.v0.Offline">
+    <!--
+        check_pending:
+        @pending: boolean, true if there is a pending offline transaction
+
+        Check whether there is an offline transaction configured for the next reboot initiated by dnf5.
+    -->
+    <method name="check_pending">
+        <arg name="pending" type="b" direction="out" />
+    </method>
+
+
+    <!--
+        cancel:
+        @success: boolean, returns `false` if there was an error during the transaction cancellation, or if the offline transaction was initiated by another tool than dnf5. Returns `true` if the offline transaction was successfully cancelled or if no offline transaction was configured.
+        @error_msg: string, contains error encountered while cancelling the transaction
+
+        Cancel the dnf5 offline transaction configured for the next reboot. Offline updates scheduled by another tool are not cancelled.
+    -->
+    <method name="cancel">
+        <arg name="success" type="b" direction="out" />
+        <arg name="error_msg" type="s" direction="out" />
+    </method>
+
+    <!--
+        clean:
+        @success: boolean, returns `false` if there was an error during the transaction cleanup. Returns `true` if the offline transaction was successfully cleaned or if no offline transaction was configured.
+        @error_msg: string, contains error encountered while cleaning the transaction
+
+        Cancel the dnf5 offline transaction configured for the next reboot and remove all stored offline transaction data, including downloaded packages. Offline updates scheduled by another tool are not affected.
+    -->
+    <method name="clean">
+        <arg name="success" type="b" direction="out" />
+        <arg name="error_msg" type="s" direction="out" />
+    </method>
+
+    <!--
+        set_finish_action:
+        @action: string, if set to "poweroff", the system will be powered off after applying the offline transaction. Otherwise the system will reboot.
+        @success: boolean, true if the action was successfully set
+        @error_msg: string, contains error encountered while setting the action
+
+        Set the action that should be performed after the offline transaction is applied. If the `action` is "poweroff", the system will be powered off, otherwise it will be rebooted (which is default).
+        The call might fail in case there is no scheduled offline transaction, or the transaction was not scheduled using libdnf5.
+    -->
+    <method name="set_finish_action">
+        <arg name="action" type="s" direction="in" />
+        <arg name="success" type="b" direction="out" />
+        <arg name="error_msg" type="s" direction="out" />
+    </method>
+
+</interface>
+
+</node>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
@@ -26,13 +26,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <interface name="org.rpm.dnf.v0.Offline">
     <!--
-        check_pending:
+        get_status:
         @pending: boolean, true if there is a pending offline transaction
+        @transaction_status: the status of the current offline dnf5 transaction
 
-        Check whether there is an offline transaction configured for the next reboot initiated by dnf5.
+        Check whether there is an offline transaction configured for the next reboot initiated by dnf5 and return its status.
     -->
-    <method name="check_pending">
+    <method name="get_status">
         <arg name="pending" type="b" direction="out" />
+        <arg name="transaction_status" type="a{sv}" direction="out" />
     </method>
 
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
@@ -62,7 +62,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
     <!--
         set_finish_action:
-        @action: string, if set to "poweroff", the system will be powered off after applying the offline transaction. Otherwise the system will reboot.
+        @action: string, one of "poweroff", or "reboot". If set to "poweroff", the system will be powered off after applying the offline transaction. Otherwise the system will reboot.
         @success: boolean, true if the action was successfully set
         @error_msg: string, contains error encountered while setting the action
 

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -28,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 
 #include <fmt/format.h>
-#include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/transaction/transaction_item.hpp>
 #include <libdnf5/transaction/transaction_item_action.hpp>
 #include <sdbus-c++/sdbus-c++.h>

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -1,0 +1,190 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "offline.hpp"
+
+#include "dbus.hpp"
+#include "utils/string.hpp"
+
+#include <libdnf5/transaction/offline.hpp>
+#include <sdbus-c++/sdbus-c++.h>
+
+#include <exception>
+#include <filesystem>
+
+const char * const ERR_ANOTHER_TOOL = "Offline transaction was initiated by another tool.";
+
+std::filesystem::path Offline::get_datadir() {
+    auto base = session.get_base();
+    const auto & installroot = base->get_config().get_installroot_option().get_value();
+    return installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
+}
+
+Offline::Scheduled Offline::offline_transaction_scheduled() {
+    std::error_code ec;
+    // magic symlink exists
+    if (std::filesystem::exists(libdnf5::offline::MAGIC_SYMLINK, ec)) {
+        // and points to dnf5 location
+        if (std::filesystem::equivalent(libdnf5::offline::MAGIC_SYMLINK, get_datadir())) {
+            return Scheduled::SCHEDULED;
+        } else {
+            return Scheduled::ANOTHER_TOOL;
+        }
+    }
+    return Scheduled::NOT_SCHEDULED;
+}
+
+void Offline::dbus_register() {
+    auto dbus_object = session.get_dbus_object();
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_OFFLINE,
+        "cancel",
+        {},
+        {},
+        "bs",
+        {"success", "error_msg"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Offline::cancel, call, session.session_locale);
+        });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_OFFLINE,
+        "check_pending",
+        {},
+        {},
+        "b",
+        {"pending"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Offline::check_pending, call, session.session_locale);
+        });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_OFFLINE,
+        "clean",
+        {},
+        {},
+        "bs",
+        {"success", "error_msg"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Offline::clean, call, session.session_locale);
+        });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_OFFLINE,
+        "set_finish_action",
+        "s",
+        {"action"},
+        "bs",
+        {"success", "error_msg"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(
+                *this, &Offline::set_finish_action, call, session.session_locale);
+        });
+}
+
+sdbus::MethodReply Offline::check_pending(sdbus::MethodCall & call) {
+    auto reply = call.createReply();
+    reply << (offline_transaction_scheduled() == Scheduled::SCHEDULED);
+    return reply;
+}
+
+sdbus::MethodReply Offline::cancel(sdbus::MethodCall & call) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+        throw std::runtime_error("Not authorized");
+    }
+    bool success = true;
+    std::string error_msg;
+    switch (offline_transaction_scheduled()) {
+        case Scheduled::SCHEDULED: {
+            std::error_code ec;
+            if (!std::filesystem::remove(libdnf5::offline::MAGIC_SYMLINK, ec) && ec) {
+                success = false;
+                error_msg = ec.message();
+            }
+        } break;
+        case Scheduled::ANOTHER_TOOL:
+            success = false;
+            error_msg = ERR_ANOTHER_TOOL;
+            break;
+        case Scheduled::NOT_SCHEDULED:
+            break;
+    }
+    auto reply = call.createReply();
+    reply << success;
+    reply << error_msg;
+    return reply;
+}
+
+sdbus::MethodReply Offline::clean(sdbus::MethodCall & call) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+        throw std::runtime_error("Not authorized");
+    }
+    std::vector<std::string> error_msgs;
+    bool success = true;
+    if (offline_transaction_scheduled() == Scheduled::SCHEDULED) {
+        // remove the magic symlink if it was created by dnf5
+        std::error_code ec;
+        if (!std::filesystem::remove(libdnf5::offline::MAGIC_SYMLINK, ec) && ec) {
+            success = false;
+            error_msgs.push_back(ec.message());
+        }
+    }
+    // clean dnf5 offline transaction files
+    for (const auto & entry : std::filesystem::directory_iterator(get_datadir())) {
+        std::error_code ec;
+        std::filesystem::remove_all(entry.path(), ec);
+        if (ec) {
+            success = false;
+            error_msgs.push_back(ec.message());
+        }
+    }
+    auto reply = call.createReply();
+    reply << success;
+    reply << libdnf5::utils::string::join(error_msgs, ", ");
+    return reply;
+}
+
+sdbus::MethodReply Offline::set_finish_action(sdbus::MethodCall & call) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+        throw std::runtime_error("Not authorized");
+    }
+    bool success{false};
+    std::string error_msg{};
+    // try load the offline transaction state
+    const std::filesystem::path state_path{
+        libdnf5::offline::MAGIC_SYMLINK / libdnf5::offline::TRANSACTION_STATE_FILENAME};
+    libdnf5::offline::OfflineTransactionState state{state_path};
+    const auto & read_exception = state.get_read_exception();
+    if (read_exception == nullptr) {
+        // set the poweroff_after item accordingly
+        std::string finish_action;
+        call >> finish_action;
+        state.get_data().set_poweroff_after(finish_action == "poweroff");
+        // write the new state
+        state.write();
+        success = true;
+    } else {
+        try {
+            std::rethrow_exception(read_exception);
+        } catch (const std::exception & ex) {
+            error_msg = ex.what();
+        }
+    }
+    auto reply = call.createReply();
+    reply << success;
+    reply << error_msg;
+    return reply;
+}

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -64,13 +64,13 @@ void Offline::dbus_register() {
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_OFFLINE,
-        "check_pending",
+        "get_status",
         {},
         {},
-        "b",
-        {"pending"},
+        "ba{sv}",
+        {"is_pending", "transaction_status"},
         [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Offline::check_pending, call, session.session_locale);
+            session.get_threads_manager().handle_method(*this, &Offline::get_status, call, session.session_locale);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_OFFLINE,
@@ -95,9 +95,27 @@ void Offline::dbus_register() {
         });
 }
 
-sdbus::MethodReply Offline::check_pending(sdbus::MethodCall & call) {
+sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
+    dnfdaemon::KeyValueMap transaction_state;
+
+    const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
+    // try load the offline transaction state
+    libdnf5::offline::OfflineTransactionState state{state_path};
+    if (!state.get_read_exception()) {
+        const auto & state_data = state.get_data();
+        transaction_state["status"] = state_data.get_status();
+        transaction_state["cachedir"] = state_data.get_cachedir();
+        transaction_state["target_releasever"] = state_data.get_target_releasever();
+        transaction_state["system_releasever"] = state_data.get_system_releasever();
+        transaction_state["verb"] = state_data.get_verb();
+        transaction_state["cmd_line"] = state_data.get_cmd_line();
+        transaction_state["poweroff_after"] = state_data.get_poweroff_after();
+        transaction_state["module_platform_id"] = state_data.get_module_platform_id();
+    }
+
     auto reply = call.createReply();
     reply << (offline_transaction_scheduled() == Scheduled::SCHEDULED);
+    reply << transaction_state;
     return reply;
 }
 

--- a/dnf5daemon-server/services/offline/offline.hpp
+++ b/dnf5daemon-server/services/offline/offline.hpp
@@ -35,8 +35,8 @@ public:
 
 private:
     sdbus::MethodReply cancel(sdbus::MethodCall & call);
-    sdbus::MethodReply check_pending(sdbus::MethodCall & call);
     sdbus::MethodReply clean(sdbus::MethodCall & call);
+    sdbus::MethodReply get_status(sdbus::MethodCall & call);
     sdbus::MethodReply set_finish_action(sdbus::MethodCall & call);
 
     enum class Scheduled { NOT_SCHEDULED, ANOTHER_TOOL, SCHEDULED };

--- a/dnf5daemon-server/services/offline/offline.hpp
+++ b/dnf5daemon-server/services/offline/offline.hpp
@@ -1,0 +1,47 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5DAEMON_SERVER_SERVICES_OFFLINE_OFFLINE_HPP
+#define DNF5DAEMON_SERVER_SERVICES_OFFLINE_OFFLINE_HPP
+
+#include "session.hpp"
+
+#include <sdbus-c++/sdbus-c++.h>
+
+#include <filesystem>
+
+class Offline : public IDbusSessionService {
+public:
+    using IDbusSessionService::IDbusSessionService;
+    ~Offline() = default;
+    void dbus_register();
+    void dbus_deregister();
+
+private:
+    sdbus::MethodReply cancel(sdbus::MethodCall & call);
+    sdbus::MethodReply check_pending(sdbus::MethodCall & call);
+    sdbus::MethodReply clean(sdbus::MethodCall & call);
+    sdbus::MethodReply set_finish_action(sdbus::MethodCall & call);
+
+    enum class Scheduled { NOT_SCHEDULED, ANOTHER_TOOL, SCHEDULED };
+    Scheduled offline_transaction_scheduled();
+    std::filesystem::path get_datadir();
+};
+
+#endif

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "services/base/base.hpp"
 #include "services/comps/group.hpp"
 #include "services/goal/goal.hpp"
+#include "services/offline/offline.hpp"
 #include "services/repo/repo.hpp"
 #include "services/rpm/rpm.hpp"
 #include "utils.hpp"
@@ -135,6 +136,7 @@ Session::Session(
     services.emplace_back(std::make_unique<Repo>(*this));
     services.emplace_back(std::make_unique<Rpm>(*this));
     services.emplace_back(std::make_unique<Goal>(*this));
+    services.emplace_back(std::make_unique<Offline>(*this));
     services.emplace_back(std::make_unique<Group>(*this));
     services.emplace_back(std::make_unique<dnfdaemon::Advisory>(*this));
 

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -88,6 +88,10 @@ public:
     std::optional<std::string> session_locale;
     void confirm_key(const std::string & key_id, const bool confirmed);
     bool wait_for_key_confirmation(const std::string & key_id, sdbus::Signal & signal);
+    /// download packages for the current transaction
+    void download_transaction_packages();
+    /// prepare the current transaction to run during the next reboot
+    void store_transaction_offline();
 
 private:
     sdbus::IConnection & connection;


### PR DESCRIPTION
Adds support for "offline" option to Goal::do_transaction() dbus API method.