### PR TITLE
Fix: dnf5 builddep plugin: Link with "common"

### DIFF
--- a/dnf5-plugins/builddep_plugin/CMakeLists.txt
+++ b/dnf5-plugins/builddep_plugin/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(builddep_cmd_plugin PRIVATE ${RPMBUILD})
 pkg_check_modules(RPM REQUIRED rpm)
 target_link_libraries(builddep_cmd_plugin PRIVATE ${RPM_LIBRARIES})
 
+target_link_libraries(builddep_cmd_plugin PRIVATE common)
 target_link_libraries(builddep_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(builddep_cmd_plugin PRIVATE dnf5)
 


### PR DESCRIPTION
The plugin uses "libdnf5::utils::string::split" function.