### PR TITLE
`undo` command man page and translations

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -201,6 +201,9 @@ Changes to individual commands
 ``help``
   * Dropped. The functionality is replaced by the ``--help`` option.
 
+``history``
+  * ``undo`` subcommand now accepts ``--ignore-extras`` and ``--ignore-installed`` like original ``history replay`` command.
+
 ``info``
   * Dropped ``--all`` option since this behavior is the default one.
   * Dropped ``--updates`` option, only ``--upgrades`` is available now.

--- a/doc/commands/history.8.rst
+++ b/doc/commands/history.8.rst
@@ -65,15 +65,55 @@ Subcommands
     | Replay the transaction that was previously stored into the file.
 
 
-Options
-=======
+Options for ``list`` and ``info``
+=================================
 
 ``--reverse``
     | Reverse the order of transactions in the output.
 
 
+Options for ``undo``
+====================
+
+``--skip-unavailable``
+    | Allow skipping packages actions that are not possible perform.
+
+``--ignore-extras``
+    | Don't consider extra packages pulled into the transaction as errors.
+    | They will still be reported as warnings.
+
+``--ignore-installed``
+    | Don't consider mismatches between installed and stored transaction packages as errors.
+    | They will still be reported as warnings.
+    | Using this option can result in an empty transaction.
+    | For install actions skip already installed packages.
+    | For upgrade actions skip groups or environments that are not installed.
+    | For remove actions skip not installed packages/groups/environments.
+
+
 Examples
 ========
+
+``dnf5 history list``
+    | List all transactions, where the most recent transaction is printed first.
+
+``dnf5 history info 4``
+    | Show detailed info about the fourth transaction.
+
+``dnf5 history info last``
+    | Show detailed info about the last transaction.
+
+``dnf5 history info last-1``
+    | Show detailed info about the second to last transaction.
+
+``dnf5 history list 4..8``
+    | List transactions with id in 4 to 8 range.
+
+``dnf5 history undo last``
+    | Undo the last transaction.
+
+``dnf5 history undo 4 --ignore-extras``
+    | Undo the fourth transaction ignoring extra packages pulled into the reverting transaction.
 
 
 See Also

--- a/libdnf5/base/goal_elements.cpp
+++ b/libdnf5/base/goal_elements.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/base/goal_elements.hpp"
 
 #include "libdnf5/common/exception.hpp"
+#include "libdnf5/utils/bgettext/bgettext-lib.h"
 
 namespace libdnf5 {
 
@@ -344,55 +345,55 @@ libdnf5::comps::PackageType GoalJobSettings::resolve_group_package_types(const l
 std::string goal_action_to_string(GoalAction action) {
     switch (action) {
         case GoalAction::INSTALL:
-            return "Install";
+            return _("Install");
         case GoalAction::INSTALL_VIA_PROVIDE:
-            return "Install via provide";
+            return _("Install via provide");
         case GoalAction::INSTALL_BY_COMPS:
-            return "Install by group";
+            return _("Install by group");
         case GoalAction::UPGRADE:
-            return "Upgrade";
+            return _("Upgrade");
         case GoalAction::UPGRADE_ALL:
-            return "Upgrade all";
+            return _("Upgrade all");
         case GoalAction::UPGRADE_MINIMAL:
-            return "Upgrade minimal";
+            return _("Upgrade minimal");
         case GoalAction::UPGRADE_ALL_MINIMAL:
-            return "Upgrade all minimal";
+            return _("Upgrade all minimal");
         case GoalAction::DOWNGRADE:
-            return "Downgrade";
+            return _("Downgrade");
         case GoalAction::REINSTALL:
-            return "Reinstall";
+            return _("Reinstall");
         case GoalAction::INSTALL_OR_REINSTALL:
-            return "Install or reinstall";
+            return _("Install or reinstall");
         case GoalAction::REMOVE:
-            return "Remove";
+            return _("Remove");
         case GoalAction::DISTRO_SYNC:
-            return "Distrosync";
+            return _("Distrosync");
         case GoalAction::DISTRO_SYNC_ALL:
-            return "Distrosync all";
+            return _("Distrosync all");
         case GoalAction::REASON_CHANGE:
-            return "Reason Change";
+            return _("Reason Change");
         case GoalAction::RESOLVE:
-            return "Resolve";
+            return _("Resolve");
         case GoalAction::ENABLE:
-            return "Enable";
+            return _("Enable");
         case GoalAction::DISABLE:
-            return "Disable";
+            return _("Disable");
         case GoalAction::RESET:
-            return "Reset";
+            return _("Reset");
         case GoalAction::REPLAY_INSTALL:
-            return "Install action";
+            return _("Install action");
         case GoalAction::REPLAY_REMOVE:
-            return "Remove action";
+            return _("Remove action");
         case GoalAction::REPLAY_UPGRADE:
-            return "Upgrade action";
+            return _("Upgrade action");
         case GoalAction::REPLAY_REINSTALL:
-            return "Reinstall action";
+            return _("Reinstall action");
         case GoalAction::REPLAY_REASON_CHANGE:
-            return "Reason change action";
+            return _("Reason change action");
         case GoalAction::REPLAY_REASON_OVERRIDE:
-            return "Reason override";
+            return _("Reason override");
         case GoalAction::REVERT_COMPS_UPGRADE:
-            return "Revert comps upgrade";
+            return _("Revert comps upgrade");
     }
     return "";
 }

--- a/libdnf5/base/log_event.cpp
+++ b/libdnf5/base/log_event.cpp
@@ -166,7 +166,7 @@ std::string LogEvent::to_string(
         case GoalProblem::NOT_INSTALLED: {
             if (goal_action_is_replay(action)) {
                 return ret.append(utils::sformat(
-                    _("Cannot perform {0} for {1} '{2}' becasue it is not installed."),
+                    _("Cannot perform {0} for {1} '{2}' because it is not installed."),
                     goal_action_to_string(action),
                     transaction_item_type_to_string(*spec_type),
                     *spec));


### PR DESCRIPTION
I chose not to add the context messages for translators for now (https://github.com/rpm-software-management/dnf5/issues/1544) but I can add them if required.