### PR TITLE
docs: Update nightly copr repo name

### DIFF
--- a/doc/tutorial/install-build-deps.rst
+++ b/doc/tutorial/install-build-deps.rst
@@ -7,7 +7,7 @@ On Fedora, we run one of the following commands according to our needs.
 
 Enable COPR repo with the DNF 5 nightly builds::
 
-    $ dnf copr enable rpmsoftwaremanagement/dnf5-unstable
+    $ dnf copr enable rpmsoftwaremanagement/dnf5-testing-nightly
 
 C++::
 


### PR DESCRIPTION
The dnf5-testing-nightly is the official nightly now, dnf5-unstable is not maintained anymore.