### PR TITLE
Add "Complete!" message after succesfull transaction

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1444,6 +1444,11 @@ int main(int argc, char * argv[]) try {
 
     log_router.info("DNF5 finished");
 
+    // Print Complete! message only when transaction is created to prevent poluting output from repoquery or other command
+    if (auto * transaction = context.get_transaction(); transaction && !transaction->empty()) {
+        context.print_info(_("Complete!"));
+    }
+
     return static_cast<int>(libdnf5::cli::ExitCode::SUCCESS);
 } catch (const libdnf5::Error & e) {
     std::cerr << libdnf5::format(e, libdnf5::FormatDetailLevel::WithName);


### PR DESCRIPTION
Keeping the last message something abou scriptlets is not clear message that everything passed correctly and program was terminated correctly. The commit uses the same message like DNF4. Contrary to DNF4, this commit does not add Complete! message when there is anything to perform - no transaction table.

Closes: https://github.com/rpm-software-management/dnf5/issues/613