### PR TITLE
Add some docs about environments

### DIFF
--- a/doc/commands/environment.8.rst
+++ b/doc/commands/environment.8.rst
@@ -35,7 +35,8 @@ Description
 ===========
 
 The ``environment`` command in ``DNF5`` offers several queries for getting information
-about environments and groups related to them.
+about environments and groups related to them. You can install environments
+with the ``install`` command as ``install @environment-id``.
 
 Optional ``environment-spec`` arguments could be passed to filter only environments with given names.
 

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -34,8 +34,9 @@ Description
 ===========
 
 The ``group`` command in ``DNF5`` offers several queries for getting information about groups, packages
-related to them and it is also used for groups installation. Note that some
-things dnf-4 listed as groups are now listed with ``environment list``.
+related to them and it is also used for groups installation.
+To query environments use separate ``environment`` command.
+Note: ``dnf-4`` listed both environments and groups with the ``group`` command.
 
 Optional ``group-spec`` arguments could be passed to filter only groups with given names.
 

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -34,7 +34,8 @@ Description
 ===========
 
 The ``group`` command in ``DNF5`` offers several queries for getting information about groups, packages
-related to them and it is also used for groups installation.
+related to them and it is also used for groups installation. Note that some
+things dnf-4 listed as groups are now listed with ``environment list``.
 
 Optional ``group-spec`` arguments could be passed to filter only groups with given names.
 

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -33,7 +33,7 @@ Description
 
 The ``install`` command in ``DNF5`` is used for installing packages. It makes sure that
 all given packages defined in ``package-spec`` arguments and their dependencies are installed
-on the system.
+on the system. Environments can be installed with ``@environment-id`` as ``<package-spec>``.
 
 
 Options


### PR DESCRIPTION
This is not meant to stop implementing a nicer solution, but at least add some documentation on how it currently is.
I would be very happy to get the dnf-4 behaviour back, where `group` meant both env and group.

Related to #724 and #1559