### PR TITLE
Debuginfo-install command

### DIFF
--- a/dnf5/commands/debuginfo-install/debuginfo-install.cpp
+++ b/dnf5/commands/debuginfo-install/debuginfo-install.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "debuginfo-install.hpp"
+
+#include <libdnf5/conf/option_string.hpp>
+
+#include <memory>
+
+
+namespace dnf5 {
+
+
+using namespace libdnf5::cli;
+
+
+void DebuginfoInstallCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("software_management_commands").register_argument(arg_parser_this_cmd);
+}
+
+void DebuginfoInstallCommand::set_argument_parser() {
+    auto & ctx = get_context();
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    get_argument_parser_command()->set_description("Install debuginfo packages.");
+
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
+    auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
+    auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+
+    patterns_to_debuginfo_install_options = parser.add_new_values();
+    auto patterns_arg = parser.add_new_positional_arg(
+        "patterns",
+        ArgumentParser::PositionalArg::AT_LEAST_ONE,
+        parser.add_init_value(std::unique_ptr<libdnf5::Option>(new libdnf5::OptionString(nullptr))),
+        patterns_to_debuginfo_install_options);
+    patterns_arg->set_description("Patterns");
+    cmd.register_positional_arg(patterns_arg);
+}
+
+void DebuginfoInstallCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.get_base().get_repo_sack()->enable_debug_repos();
+}
+
+void DebuginfoInstallCommand::run() {
+    auto goal = get_context().get_goal();
+    auto settings = libdnf5::GoalJobSettings();
+    goal->set_allow_erasing(allow_erasing->get_value());
+
+    for (const auto & pattern : *patterns_to_debuginfo_install_options) {
+        auto option = dynamic_cast<libdnf5::OptionString *>(pattern.get());
+        goal->add_debug_install(option->get_value(), settings);
+    }
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/debuginfo-install/debuginfo-install.hpp
+++ b/dnf5/commands/debuginfo-install/debuginfo-install.hpp
@@ -1,0 +1,47 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef DNF5_COMMANDS_DEBUGINFO_INSTALL_DEBUGINFO_INSTALL_HPP
+#define DNF5_COMMANDS_DEBUGINFO_INSTALL_DEBUGINFO_INSTALL_HPP
+
+#include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
+
+namespace dnf5 {
+
+
+class DebuginfoInstallCommand : public Command {
+public:
+    explicit DebuginfoInstallCommand(Context & context) : Command(context, "debuginfo-install") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void configure() override;
+    void run() override;
+
+    std::vector<std::unique_ptr<libdnf5::Option>> * patterns_to_debuginfo_install_options{nullptr};
+
+    std::unique_ptr<AllowErasingOption> allow_erasing;
+};
+
+
+}  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_DEBUGINFO_INSTALL_DEBUGINFO_INSTALL_HPP

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/check-upgrade/check-upgrade.hpp"
 #include "commands/check/check.hpp"
 #include "commands/clean/clean.hpp"
+#include "commands/debuginfo-install/debuginfo-install.hpp"
 #include "commands/distro-sync/distro-sync.hpp"
 #include "commands/downgrade/downgrade.hpp"
 #include "commands/download/download.hpp"
@@ -671,6 +672,7 @@ static void add_commands(Context & context) {
     context.add_and_initialize_command(std::make_unique<DistroSyncCommand>(context));
     context.add_and_initialize_command(std::make_unique<DowngradeCommand>(context));
     context.add_and_initialize_command(std::make_unique<ReinstallCommand>(context));
+    context.add_and_initialize_command(std::make_unique<DebuginfoInstallCommand>(context));
     context.add_and_initialize_command(std::make_unique<SwapCommand>(context));
     context.add_and_initialize_command(std::make_unique<MarkCommand>(context));
     context.add_and_initialize_command(std::make_unique<AutoremoveCommand>(context));

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -172,6 +172,9 @@ Changes to individual commands
   * Existing repository files are not modified; drop-in override files are created instead.
   * See the :ref:`config-manager documentation <config_manager_plugin_ref-label>` for more information.
 
+``debuginfo-install``
+  * Now does not support `autoupdate` functionality. The permanent enablement of debug repositories can be achieved
+    using `config-manager` command.
 ``distro-sync``
   * Now when any argument doesn't match an installed package, DNF5 fails. The behavior can be modified by the ``--skip-unavailable`` option.
   * Dropped ``distrosync`` and ``distribution-synchronization`` aliases.

--- a/doc/commands/debuginfo-install.rst
+++ b/doc/commands/debuginfo-install.rst
@@ -1,0 +1,72 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _debuginfo_install_command_ref-label:
+
+##########################
+ Debuginfo-install Command
+##########################
+
+Synopsis
+========
+
+``dnf5 debuginfo-install [options] <patterns>...``
+
+
+Description
+===========
+
+Install the associated debuginfo packages for a given package specification.
+The command temporary enables corresponding debug repository for each enabled
+repository using following algorithm. When enabled repository ID has suffix `-rpm`
+then it enables <ID>-debug-rpms. When enabled repository does not have suffix `-rpm`
+it enables repository using pattern <ID>-debuginfo.
+
+When regular upgrade of debuginfo packages is expected, then it requires enabling
+of debug repository permanently using `config-manager` command.
+
+Arguments
+=========
+
+``<pattern>``
+    The pattern to install the associated debuginfo package for.
+
+Options
+=======
+
+``--allowerasing``
+    | Allow erasing of installed packages to resolve any potential dependency problems.
+
+``--skip-broken``
+    | Resolve any dependency problems by removing packages that are causing problems from the transaction.
+
+``--skip-unavailable``
+    | Allow skipping packages that are not available in repositories. All available packages will be installed.
+
+
+Examples
+========
+
+``dnf debuginfo-install foobar``
+    Install the debuginfo packages for the foobar package.
+
+``dnf upgrade --enablerepo=*-debuginfo <package-name>-debuginfo``
+    Upgrade debuginfo package of a <package-name>.
+
+``dnf upgrade --enablerepo=*-debuginfo "*-debuginfo"``
+    Upgrade all debuginfo packages.

--- a/include/libdnf5/base/goal.hpp
+++ b/include/libdnf5/base/goal.hpp
@@ -65,6 +65,12 @@ public:
     /// @param settings  A structure to override default goal settings.
     void add_install(const std::string & spec, const libdnf5::GoalJobSettings & settings = libdnf5::GoalJobSettings());
 
+    /// Process spec to install related debug info and debug source packages
+    /// @param spec  A string with installation spec
+    /// @param settings  A structure to override default goal settings.
+    void add_debug_install(
+        const std::string & spec, const libdnf5::GoalJobSettings & settings = libdnf5::GoalJobSettings());
+
     /// High level API for an artifact upgrade. See `add_install()` for details.
     /// @param spec      A string with upgrade spec
     /// @param settings  A structure to override default goal settings.

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -152,7 +152,8 @@ enum class GoalAction {
     REPLAY_REINSTALL,
     REPLAY_REASON_CHANGE,
     REPLAY_REASON_OVERRIDE,
-    REVERT_COMPS_UPGRADE
+    REVERT_COMPS_UPGRADE,
+    INSTALL_DEBUG
 };
 
 /// Convert GoalAction enum to user-readable string

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -142,6 +142,12 @@ public:
     /// @since 5.0
     void enable_source_repos();
 
+    /// For each enabled repository enable corresponding debug repository.
+    /// When repo ID has suffix -rpm then it enables <ID>-debug-rpms
+    /// otherwise it enables <ID>-debuginfo
+    /// @since 5.2.4
+    void enable_debug_repos();
+
     ~RepoSack();
 
 private:

--- a/libdnf5/base/goal_elements.cpp
+++ b/libdnf5/base/goal_elements.cpp
@@ -396,6 +396,8 @@ std::string goal_action_to_string(GoalAction action) {
             return _("Reason override");
         case GoalAction::REVERT_COMPS_UPGRADE:
             return _("Revert comps upgrade");
+        case GoalAction::INSTALL_DEBUG:
+            return _("Install debug RPMs");
     }
     return "";
 }


### PR DESCRIPTION
### Not delivered in this PR:

- Documentation
- Reporting when binary RPM does not have available debug package

Tests: [Enable several tests for debuginfo-install command](https://github.com/rpm-software-management/ci-dnf-stack/pull/1523)

Closes: https://github.com/rpm-software-management/dnf5/issues/846