### PR TITLE
Fix DNF5: Don't trigger filelists download if abs path to local RPM

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -263,7 +263,7 @@ void Context::Impl::apply_repository_setopts() {
 
 void Context::Impl::update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs) {
     for (auto & spec : pkg_specs) {
-        if (libdnf5::utils::is_file_pattern(spec)) {
+        if (libdnf5::utils::is_file_pattern(spec) && !spec.ends_with(".rpm")) {
             base.get_config().get_optional_metadata_types_option().add_item(
                 libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
             return;


### PR DESCRIPTION
If the path to the local package was specified absolutely (starting with '/'), filelists download was triggered.
Now, as in `Goal`, DNF5 checks if the path ends with the ".rpm" suffix. If it does, it is treated as the path to the local RPM package and filelists download is not triggered.

Closes: https://github.com/rpm-software-management/dnf5/issues/1577