### PR TITLE
Make offline transactions work with local rpm files

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -436,6 +436,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         std::filesystem::create_directories(offline_datadir);
 
         base.get_config().get_destdir_option().set(offline_datadir / "packages");
+        transaction.set_download_local_pkgs(true);
     }
 
     transaction.download();

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -187,6 +187,12 @@ public:
     /// specified path.
     void store_comps(const std::filesystem::path & comps_path) const;
 
+    /// Set whether local packages should be copied to the destination directory during the download().
+    ///
+    /// Default: false
+    void set_download_local_pkgs(bool value);
+    bool get_download_local_pkgs() const noexcept;
+
 private:
     friend class TransactionEnvironment;
     friend class TransactionGroup;

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -412,7 +412,8 @@ void Transaction::download() {
     libdnf5::repo::PackageDownloader downloader(p_impl->base);
     for (auto & tspkg : this->get_transaction_packages()) {
         if (transaction_item_action_is_inbound(tspkg.get_action()) &&
-            tspkg.get_package().get_repo()->get_type() != libdnf5::repo::Repo::Type::COMMANDLINE) {
+            (get_download_local_pkgs() ||
+             tspkg.get_package().get_repo()->get_type() != libdnf5::repo::Repo::Type::COMMANDLINE)) {
             downloader.add(tspkg.get_package());
         }
     }
@@ -1504,6 +1505,14 @@ void Transaction::store_comps(const std::filesystem::path & comps_path) const {
         auto xml_environment = environment.get_environment();
         xml_environment.serialize(build_comps_xml_path(comps_path, xml_environment.get_environmentid()));
     }
+}
+
+bool Transaction::get_download_local_pkgs() const noexcept {
+    return p_impl->download_local_pkgs;
+}
+
+void Transaction::set_download_local_pkgs(bool value) {
+    p_impl->download_local_pkgs = value;
 }
 
 }  // namespace libdnf5::base

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -122,6 +122,9 @@ private:
     // history db transaction id
     int64_t history_db_id = 0;
 
+    // whether also the command line repo packages should be downloaded to the destination
+    bool download_local_pkgs{false};
+
     TransactionRunResult _run(
         std::unique_ptr<libdnf5::rpm::TransactionCallbacks> && callbacks,
         const std::string & description,


### PR DESCRIPTION
Offline transactions now copy also local (command line repo) packages to the
cache.

Changes:

f30fd653 (Marek Blaha, 2 hours ago)
   dnf5: Offline transactions work with local rpm files

9ab4e873 (Marek Blaha, 2 hours ago)
   package_downloader: Handle local files

   Local packages are not passed to librepo for download, but directly copied
   to the destination directory.

74e01778 (Marek Blaha, 7 hours ago)
   transaction: Flag whether download local packages

   By default the transaction during the `download()` call does not copy local
   packages to the destination directory. These packages are used directly
   from their original location. For some use-cases (like offline transaction
   involving the command line repo packages) we need to copy them to the
   package cache.


Resolves: https://github.com/rpm-software-management/dnf5/issues/1583