### PR TITLE
dnfdaemon: system-upgrade API and command

### DIFF
--- a/dnf5daemon-client/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5daemon-client/commands/system-upgrade/system-upgrade.cpp
@@ -1,0 +1,81 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "system-upgrade.hpp"
+
+#include "commands/shared_options.hpp"
+#include "context.hpp"
+#include "exception.hpp"
+#include "utils/auth.hpp"
+
+#include <dnf5daemon-server/dbus.hpp>
+#include <libdnf5/conf/option_string.hpp>
+
+namespace dnfdaemon::client {
+
+using namespace libdnf5::cli;
+
+void SystemUpgradeCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("software_management_commands").register_argument(arg_parser_this_cmd);
+}
+
+void SystemUpgradeCommand::set_argument_parser() {
+    auto & parser = get_context().get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_description("prepare system for upgrade to a new release");
+
+    auto no_downgrade = parser.add_new_named_arg("no_downgrade");
+    no_downgrade->set_long_name("no-downgrade");
+    no_downgrade->set_description(
+        "Do not install packages from the new release if they are older than what is currently installed");
+    no_downgrade->set_has_value(true);
+    no_downgrade->set_arg_value_help("<yes|no>");
+    no_downgrade->link_value(&no_downgrade_option);
+    cmd.register_named_arg(no_downgrade);
+
+    // TODO(mblaha): set the releasever named arg as required (currently no API for this)
+}
+
+void SystemUpgradeCommand::run() {
+    auto & ctx = get_context();
+
+    if (!libdnf5::utils::am_i_root()) {
+        throw UnprivilegedUserError();
+    }
+
+    // TODO(mblaha): check the target releasever is set and different from the detected one
+
+    dnfdaemon::KeyValueMap options = {};
+    if (no_downgrade_option.get_value()) {
+        options["mode"] = "upgrade";
+    }
+
+    ctx.session_proxy->callMethod("system_upgrade")
+        .onInterface(dnfdaemon::INTERFACE_RPM)
+        .withTimeout(static_cast<uint64_t>(-1))
+        .withArguments(options);
+
+    run_transaction(true);
+}
+
+}  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5daemon-client/commands/system-upgrade/system-upgrade.hpp
@@ -1,0 +1,42 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5DAEMON_CLIENT_COMMANDS_SYSTEM_UPGRADE_SYSTEM_UPGRADE_HPP
+#define DNF5DAEMON_CLIENT_COMMANDS_SYSTEM_UPGRADE_SYSTEM_UPGRADE_HPP
+
+#include "commands/command.hpp"
+
+#include <libdnf5/conf/option_bool.hpp>
+
+namespace dnfdaemon::client {
+
+class SystemUpgradeCommand : public TransactionCommand {
+public:
+    explicit SystemUpgradeCommand(Context & context) : TransactionCommand(context, "system-upgrade") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void run() override;
+
+private:
+    libdnf5::OptionBool no_downgrade_option{false};
+};
+
+}  // namespace dnfdaemon::client
+
+#endif

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/repo/repo.hpp"
 #include "commands/repolist/repolist.hpp"
 #include "commands/repoquery/repoquery.hpp"
+#include "commands/system-upgrade/system-upgrade.hpp"
 #include "commands/upgrade/upgrade.hpp"
 #include "context.hpp"
 
@@ -211,6 +212,7 @@ static void add_commands(Context & context) {
 
     context.add_and_initialize_command(std::make_unique<AdvisoryCommand>(context));
     context.add_and_initialize_command(std::make_unique<CleanCommand>(context));
+    context.add_and_initialize_command(std::make_unique<SystemUpgradeCommand>(context));
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -213,6 +213,24 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     </method>
 
     <!--
+        system_upgrade:
+        @options: an array of key/value pairs to modify system_upgrade behavior
+
+        Prepare a transaction for upgrade to the new distribution release. The prepared transaction should be executed during reboot (see `offline` option of the `do_transaction` method of the `Goal` interface).
+        The method relies on the `releasever` option being correctly set to the new distribution release during the `open_session()` call.
+
+        Following @options are supported:
+
+            - mode: string (one of "distrosync", "upgrade", default is "distrosync")
+                By default the system_upgrade behaves like `dnf distro-sync`, always installing packages from the new release, even if they are older than the currently installed version. If set to "upgrade", packages from the new release are not installed if they are older than what is currently installed (behave like `dnf upgrade`).
+
+        Unknown options are ignored.
+    -->
+    <method name="system_upgrade">
+        <arg name="options" type="a{sv}" direction="in" />
+    </method>
+
+    <!--
         transaction_elem_progress:
         @session_object_path: object path of the dnf5daemon session
         @nevra: full NEVRA of the package

--- a/dnf5daemon-server/services/rpm/rpm.hpp
+++ b/dnf5daemon-server/services/rpm/rpm.hpp
@@ -43,6 +43,7 @@ private:
     sdbus::MethodReply distro_sync(sdbus::MethodCall & call);
     sdbus::MethodReply downgrade(sdbus::MethodCall & call);
     sdbus::MethodReply reinstall(sdbus::MethodCall & call);
+    sdbus::MethodReply system_upgrade(sdbus::MethodCall & call);
 
     void list_fd(sdbus::MethodCall & call, const std::string & transfer_id);
 };

--- a/doc/dnf_daemon/examples/print_upgrades_with_severities.py
+++ b/doc/dnf_daemon/examples/print_upgrades_with_severities.py
@@ -1,3 +1,21 @@
+#!/usr/bin/python3
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
 import dbus
 import os
 

--- a/doc/dnf_daemon/examples/system_upgrade.py
+++ b/doc/dnf_daemon/examples/system_upgrade.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+This is an example how to perform a system-upgrade with dnf5daemon-server.
+"""
+
+import dbus
+
+DNFDAEMON_BUS_NAME = 'org.rpm.dnf.v0'
+DNFDAEMON_OBJECT_PATH = '/' + DNFDAEMON_BUS_NAME.replace('.', '/')
+
+IFACE_SESSION_MANAGER = '{}.SessionManager'.format(DNFDAEMON_BUS_NAME)
+IFACE_RPM = '{}.rpm.Rpm'.format(DNFDAEMON_BUS_NAME)
+IFACE_GOAL = '{}.Goal'.format(DNFDAEMON_BUS_NAME)
+
+
+bus = dbus.SystemBus()
+iface_session = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, DNFDAEMON_OBJECT_PATH),
+    dbus_interface=IFACE_SESSION_MANAGER)
+
+# set the releasever to the new distribution release
+session = iface_session.open_session(
+    dbus.Dictionary({"releasever": "40"}, signature=dbus.Signature('sv')))
+
+iface_rpm = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, session),
+    dbus_interface=IFACE_RPM)
+iface_goal = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, session),
+    dbus_interface=IFACE_GOAL)
+
+# Add system upgrade to the transaction
+options = {
+    "mode": "distrosync",
+}
+iface_rpm.system_upgrade(options)
+
+# resolve the transaction
+resolved, result = iface_goal.resolve({})
+
+# now you can print the transaction table and ask the user for confirmation
+print("Resolved.")
+
+if result == 0:
+    # execute the transaction offline (durint the next reboot)
+    iface_goal.do_transaction({"offline": True}, timeout=2000)
+    print("Reboot to continue with system upgrade...")
+else:
+    errors = iface_goal.get_transaction_problems_string()
+    print("Errors while resolving the transaction:")
+    for error in errors:
+        print(error)


### PR DESCRIPTION
Changes:

c5831738 (Marek Blaha, 72 minutes ago)
   doc: Add system-upgrade example using D-Bus API

960882be (Marek Blaha, 6 days ago)
   dnf5daemon-client: system-upgrade command

fe4b380f (Marek Blaha, 7 weeks ago)
   dnfdaemon: Add system_upgrade() method to Rpm interface

   The method fills the goal to perform upgrade of the distribution to the new
   release.