### PR TITLE
dnfdaemon: implement D-Bus API for cleaning caches

### DIFF
--- a/dnf5daemon-client/commands/clean/clean.cpp
+++ b/dnf5daemon-client/commands/clean/clean.cpp
@@ -1,0 +1,92 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "clean.hpp"
+
+#include "commands/shared_options.hpp"
+#include "context.hpp"
+#include "exception.hpp"
+#include "utils/auth.hpp"
+
+#include <dnf5daemon-server/dbus.hpp>
+#include <libdnf5/conf/option_string.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+
+#include <iostream>
+#include <memory>
+
+namespace dnfdaemon::client {
+
+using namespace libdnf5::cli;
+
+void CleanCommand::set_parent_command() {
+    auto * arg_parser_parent_cmd = get_session().get_argument_parser().get_root_command();
+    auto * arg_parser_this_cmd = get_argument_parser_command();
+    arg_parser_parent_cmd->register_command(arg_parser_this_cmd);
+    arg_parser_parent_cmd->get_group("software_management_commands").register_argument(arg_parser_this_cmd);
+}
+
+void CleanCommand::set_argument_parser() {
+    auto & parser = get_context().get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_description("Remove or expire cached data");
+
+    cache_types = parser.add_new_values();
+    auto cache_types_arg = parser.add_new_positional_arg(
+        "cache_types",
+        1,
+        parser.add_init_value(std::unique_ptr<libdnf5::Option>(new libdnf5::OptionString(nullptr))),
+        cache_types);
+    cache_types_arg->set_description("Cache type to clean up");
+    cmd.register_positional_arg(cache_types_arg);
+}
+
+void CleanCommand::run() {
+    auto & ctx = get_context();
+
+    if (!libdnf5::utils::am_i_root()) {
+        throw UnprivilegedUserError();
+    }
+
+    const std::string cache_type = dynamic_cast<libdnf5::OptionString *>((*cache_types)[0].get())->get_value();
+    bool success;
+    std::string error_msg;
+    ctx.session_proxy->callMethod("clean")
+        .onInterface(dnfdaemon::INTERFACE_BASE)
+        .withTimeout(static_cast<uint64_t>(-1))
+        .withArguments(cache_type)
+        .storeResultsTo(success, error_msg);
+    // make it compatible with `dnf5 clean metadata` which also cleans solv files
+    if (success && (cache_type == "metadata")) {
+        ctx.session_proxy->callMethod("clean")
+            .onInterface(dnfdaemon::INTERFACE_BASE)
+            .withTimeout(static_cast<uint64_t>(-1))
+            .withArguments("dbcache")
+            .storeResultsTo(success, error_msg);
+    }
+
+    if (success) {
+        std::cout << "Cache successfully cleaned." << std::endl;
+    } else {
+        throw libdnf5::cli::CommandExitError(1, M_("Error cleaning the cache: {}"), error_msg);
+    }
+}
+
+}  // namespace dnfdaemon::client

--- a/dnf5daemon-client/commands/clean/clean.hpp
+++ b/dnf5daemon-client/commands/clean/clean.hpp
@@ -1,0 +1,42 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5DAEMON_CLIENT_COMMANDS_CLEAN_CLEAN_HPP
+#define DNF5DAEMON_CLIENT_COMMANDS_CLEAN_CLEAN_HPP
+
+#include "commands/command.hpp"
+
+#include <libdnf5/conf/option_bool.hpp>
+
+namespace dnfdaemon::client {
+
+class CleanCommand : public TransactionCommand {
+public:
+    explicit CleanCommand(Context & context) : TransactionCommand(context, "clean") {}
+    void set_parent_command() override;
+    void set_argument_parser() override;
+    void run() override;
+
+private:
+    std::vector<std::unique_ptr<libdnf5::Option>> * cache_types{nullptr};
+};
+
+}  // namespace dnfdaemon::client
+
+#endif

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -208,13 +208,11 @@ void RepoqueryCommand::run() {
         return;
     }
 
-    std::string fd_id;
     ctx.session_proxy->callMethod("list_fd")
         .onInterface(dnfdaemon::INTERFACE_RPM)
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options)
-        .withArguments(sdbus::UnixFd{pipefd[1]})
-        .withArguments(fd_id);
+        .withArguments(sdbus::UnixFd{pipefd[1]});
     close(pipefd[1]);
 
     int in_fd = pipefd[0];

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -18,6 +18,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "commands/advisory/advisory.hpp"
+#include "commands/clean/clean.hpp"
 #include "commands/distro-sync/distro-sync.hpp"
 #include "commands/downgrade/downgrade.hpp"
 #include "commands/group/group.hpp"
@@ -209,6 +210,7 @@ static void add_commands(Context & context) {
     context.add_and_initialize_command(std::make_unique<RepolistCommand>(context, "repoinfo"));
 
     context.add_and_initialize_command(std::make_unique<AdvisoryCommand>(context));
+    context.add_and_initialize_command(std::make_unique<CleanCommand>(context));
 }
 
 }  // namespace dnfdaemon::client

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -36,6 +36,21 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     </method>
 
     <!--
+        clean:
+        @cache_type: cache type to clean up. Supported types are "all", "packages", "metadata", "dbcache", and "expire-cache".
+        @success: `true` if the cache was successfully cleaned, `false` otherwise.
+        @error_msg: string, contains errors encountered while cleaning the cache.
+
+
+        Remove or expire cached data.
+    -->
+    <method name="clean">
+        <arg name="cache_type" type="s" direction="in"/>
+        <arg name="success" type="b" direction="out"/>
+        <arg name="error_msg" type="s" direction="out"/>
+    </method>
+
+    <!--
         download_add_new:
         @session_object_path: object path of the dnf5daemon session
         @download_id: unique id of downloaded object (repo or package)

--- a/dnf5daemon-server/services/base/base.hpp
+++ b/dnf5daemon-server/services/base/base.hpp
@@ -35,6 +35,7 @@ public:
     void dbus_deregister();
 
 private:
+    sdbus::MethodReply clean(sdbus::MethodCall & call);
     sdbus::MethodReply read_all_repos(sdbus::MethodCall & call);
 };
 


### PR DESCRIPTION
Changes:

39375118 (Marek Blaha, 46 seconds ago)
   dnfdaemon-client: Clean command implemetation

70080460 (Marek Blaha, 20 hours ago)
   dnfdaemon: D-Bus API for cleaning caches

   Implements `clean()` method on `Base` interface to clean requested types of
   caches. Supported types are "all", "packages", "metadata", "dbcache", and
   also "expire-cache" for marking repository metadata expired.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1179