### PR TITLE
expired-pgp-keys: New plugin for detecting expired PGP keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(WITH_DNF5 "Build dnf5 command-line package manager" ON)
 option(WITH_DNF5_PLUGINS "Build plugins for dnf5 command-line package manager" ON)
 option(WITH_PLUGIN_ACTIONS "Build a dnf5 actions plugin" ON)
 option(WITH_PLUGIN_APPSTREAM "Build with plugin to install repo's Appstream metadata" ON)
+option(WITH_PLUGIN_EXPIRED_PGP_KEYS "Build a libdnf5 expired pgp keys plugin" ON)
 option(WITH_PLUGIN_RHSM "Build a libdnf5 rhsm (Red Hat Subscription Manager) plugin" OFF)
 option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python plugins. Requires WITH_PYTHON3=ON." ON)
 

--- a/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"automatic"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Marek Blaha", "mblaha@redhat.com", "automatic command."};
@@ -18,7 +19,7 @@ class AutomaticCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -52,7 +53,7 @@ std::vector<std::unique_ptr<Command>> AutomaticCmdPlugin::create_commands() {
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"builddep"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Marek Blaha", "mblaha@redhat.com", "builddep command."};
@@ -18,7 +19,7 @@ class BuildDepCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -52,7 +53,7 @@ std::vector<std::unique_ptr<Command>> BuildDepCmdPlugin::create_commands() {
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"changelog"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "changelog command."};
@@ -18,7 +19,7 @@ class ChangelogCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -52,7 +53,7 @@ std::vector<std::unique_ptr<Command>> ChangelogCmdPlugin::create_commands() {
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
+++ b/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"config-manager"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 0, .minor = 1, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "config-manager command"};
@@ -18,7 +19,7 @@ class ConfigManagerCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -52,7 +53,7 @@ std::vector<std::unique_ptr<Command>> ConfigManagerCmdPlugin::create_commands() 
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
+++ b/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
@@ -27,6 +27,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"copr"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 0, .minor = 1, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", nullptr};
 constexpr const char * attrs_value[]{
@@ -38,7 +39,7 @@ class CoprCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -72,7 +73,7 @@ public:
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"needs_restarting"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Evan Goode", "egoode@redhat.com", "needs_restarting command."};
@@ -18,7 +19,7 @@ class NeedsRestartingCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -52,7 +53,7 @@ std::vector<std::unique_ptr<Command>> NeedsRestartingCmdPlugin::create_commands(
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
@@ -29,6 +29,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"repoclosure"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Marek Blaha", "mblaha@redhat.com", "repoclosure command."};
@@ -37,7 +38,7 @@ class RepoclosureCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -71,7 +72,7 @@ std::vector<std::unique_ptr<Command>> RepoclosureCmdPlugin::create_commands() {
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
@@ -29,6 +29,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"reposync"};
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Marek Blaha", "mblaha@redhat.com", "reposync command."};
@@ -37,7 +38,7 @@ class ReposyncCmdPlugin : public IPlugin {
 public:
     using IPlugin::IPlugin;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -71,7 +72,7 @@ std::vector<std::unique_ptr<Command>> ReposyncCmdPlugin::create_commands() {
 
 
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * dnf5_plugin_get_name(void) {

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -78,6 +78,7 @@ Provides:       dnf5-command(versionlock)
 %bcond_without dnf5_plugins
 %bcond_without plugin_actions
 %bcond_without plugin_appstream
+%bcond_without plugin_expired_pgp_keys
 %bcond_without plugin_rhsm
 %bcond_without python_plugins_loader
 
@@ -624,6 +625,23 @@ Libdnf5 plugin that installs repository's Appstream data, for repositories which
 
 %endif
 
+# ========== libdnf5-plugin-expired-pgp-keys ==========
+
+%if %{with plugin_expired_pgp_keys}
+%package -n libdnf5-plugin-expired-pgp-keys
+Summary:        Libdnf5 plugin for detecting and removing expired PGP keys
+License:        LGPL-2.1-or-later
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+
+%description -n libdnf5-plugin-expired-pgp-keys
+Libdnf5 plugin for detecting and removing expired PGP keys.
+
+%files -n libdnf5-plugin-expired-pgp-keys -f libdnf5-plugin-expired-pgp-keys.lang
+%{_libdir}/libdnf5/plugins/expired-pgp-keys.*
+%config %{_sysconfdir}/dnf/libdnf5-plugins/expired-pgp-keys.conf
+%{_mandir}/man8/libdnf5-expired-pgp-keys.8.*
+%endif
+
 # ========== libdnf5-plugin-plugin_rhsm ==========
 
 %if %{with plugin_rhsm}
@@ -825,6 +843,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
     -DWITH_DNF5=%{?with_dnf5:ON}%{!?with_dnf5:OFF} \
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
     -DWITH_PLUGIN_APPSTREAM=%{?with_plugin_appstream:ON}%{!?with_plugin_appstream:OFF} \
+    -DWITH_PLUGIN_EXPIRED_PGP_KEYS=%{?with_plugin_expired_pgp_keys:ON}%{!?with_plugin_expired_pgp_keys:OFF} \
     -DWITH_PLUGIN_RHSM=%{?with_plugin_rhsm:ON}%{!?with_plugin_rhsm:OFF} \
     -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \
     \
@@ -915,6 +934,7 @@ popd
 %find_lang libdnf5
 %find_lang libdnf5-cli
 %find_lang libdnf5-plugin-actions
+%find_lang libdnf5-plugin-expired-pgp-keys
 %find_lang libdnf5-plugin-rhsm
 
 %ldconfig_scriptlets

--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -56,8 +56,7 @@ PluginLibrary::PluginLibrary(Context & context, const std::string & library_path
 
     const auto & application_plugin_api_version = dnf5::get_plugin_api_version();
     const auto & plugin_api_version = get_api_version();
-    if (plugin_api_version.major != application_plugin_api_version.major ||
-        plugin_api_version.minor < application_plugin_api_version.minor) {
+    if (plugin_api_version.major != application_plugin_api_version.major) {
         auto msg = fmt::format(
             "Unsupported plugin API combination. API version provided by plugin \"{}\" (\"{}\") is \"{}.{}\"."
             " API version in dnf5 is \"{}.{}\".",

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -41,6 +41,10 @@ if(WITH_MAN)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/libdnf5-actions.8 DESTINATION share/man/man8)
     endif()
 
+    if(WITH_PLUGIN_EXPIRED_PGP_KEYS)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/libdnf5-expired-pgp-keys.8 DESTINATION share/man/man8)
+    endif()
+
     if(WITH_DNF5DAEMON_CLIENT)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5daemon-client.8 DESTINATION share/man/man8)
     endif()

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -151,6 +151,7 @@ man_pages = [
     ('dnf5_plugins/repoclosure.8', 'dnf5-repoclosure', 'Repoclosure Command', AUTHORS, 8),
     ('dnf5_plugins/reposync.8', 'dnf5-reposync', 'Reposync Command', AUTHORS, 8),
     ('libdnf5_plugins/actions.8', 'libdnf5-actions', 'Actions Plugin', AUTHORS, 8),
+    ('libdnf5_plugins/expired-pgp-keys.8', 'libdnf5-expired-pgp-keys', 'Expired PGP Keys Plugin', AUTHORS, 8),
     ('misc/aliases.7', 'dnf5-aliases', 'Aliases for command line arguments', AUTHORS, 7),
     ('misc/caching.7', 'dnf5-caching', 'Caching', AUTHORS, 7),
     ('misc/comps.7', 'dnf5-comps', 'Comps Groups And Environments', AUTHORS, 7),

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -452,6 +452,7 @@ Application Plugins:
 
 Library Plugins:
     | :manpage:`libdnf5-actions(8)`, :ref:`Actions plugin <actions_plugin_ref-label>`
+    | :manpage:`libdnf5-expired-pgp-keys(8)`, :ref:`Expired PGP keys plugin <expired-pgp-keys_plugin_ref-label>`
 
 Configuration:
     | :manpage:`dnf5-conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`

--- a/doc/dnf5_workflow.rst
+++ b/doc/dnf5_workflow.rst
@@ -52,6 +52,7 @@ Typical DNF5 workflow consists of:
     #. add commandline packages
     #. libdnf5 plugin ``post_add_cmdline_packages`` hook
     #. resolve goal (resolve dependencies)
+    #. libdnf5 plugin ``goal_resolved`` hook
     #. run command specific ``goal_resolved`` step
     #. print transaction table
     #. check for user approval

--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -26,7 +26,7 @@ Description
 ===========
 
 This plugin allows defining actions to be executed through libdnf5 callbacks hooks.
-Each action is hooked to one specific callback. Actions for ``pre_transaction`` and
+Each action is hooked to one specific callback. Actions for ``goal_resolved``, ``pre_transaction`` and
 ``post_transaction`` callbacks may define a (glob-like) filtering rule on the package
 NEVRA or package files, as well as whether the package is incoming or outgoing.
 
@@ -55,6 +55,7 @@ Each non-comment line defines an action and consists of five items separated by 
    * ``repos_loaded``  (added in version 1.0.0)
    * ``pre_add_cmdline_packages``  (added in version 1.0.0)
    * ``post_add_cmdline_packages``  (added in version 1.0.0)
+   * ``goal_resolved`` (added in version 1.3.0)
    * ``pre_transaction``
    * ``post_transaction``
 
@@ -63,7 +64,7 @@ Each non-comment line defines an action and consists of five items separated by 
 
    Empty filter means executing the command once with no information about the package.
    The "*" filter means executing the command for each package in the transaction that matches the ``direction`` filter.
-   The filter can be non-empty only for ``pre_transaction`` and ``post_transaction`` callbacks.
+   The filter can be non-empty only for ``goal_resolved``, ``pre_transaction`` and ``post_transaction`` callbacks.
 
 ``direction``
    Filters packages by their direction (coming into the system/going out of the system) in a transaction.

--- a/doc/libdnf5_plugins/expired-pgp-keys.8.rst
+++ b/doc/libdnf5_plugins/expired-pgp-keys.8.rst
@@ -1,0 +1,40 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _expired-pgp-keys_plugin_ref-label:
+
+########################
+ Expired PGP Keys Plugin
+########################
+
+Description
+===========
+
+The plugin checks for installed but expired PGP keys before executing the transaction.
+For each expired key, the user is prompted with information about the specific key
+and can confirm its removal, allowing for the import of an updated key later.
+When the ``assumeyes`` option is configured, expired keys are removed automatically.
+
+Configuration
+=============
+
+The plugin configuration is in ``/etc/dnf/libdnf5-plugins/expired-pgp-keys.conf``. All configuration
+options are in the ``[main]`` section.
+
+``enabled``
+    Whether the plugin is enabled. Default value is ``True``.

--- a/doc/libdnf5_plugins/index.rst
+++ b/doc/libdnf5_plugins/index.rst
@@ -9,5 +9,6 @@ LIBDNF5 Plugins
     :maxdepth: 1
 
     actions.8
+    expired-pgp-keys.8
 
 ..

--- a/doc/templates/dnf5-plugin/template_cmd_plugin.cpp
+++ b/doc/templates/dnf5-plugin/template_cmd_plugin.cpp
@@ -7,8 +7,8 @@ using namespace dnf5;
 namespace {
 
 constexpr const char * PLUGIN_NAME{"template"};
-
 constexpr PluginVersion PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Fred Fedora", "dummy@email.com", "Plugin description."};
@@ -20,7 +20,7 @@ public:
     /// Fill in the API version of your plugin.
     /// This is used to check if the provided plugin API version is compatible with the application's plugin API version.
     /// MANDATORY to override.
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     /// Enter the name of your new plugin.
     /// This is used in log messages when an action or error related to the plugin occurs.
@@ -72,7 +72,7 @@ std::vector<std::unique_ptr<Command>> TemplateCmdPlugin::create_commands() {
 
 /// Return plugin's API version.
 PluginAPIVersion dnf5_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 /// Return plugin's name.

--- a/doc/templates/libdnf5-plugin/template.cpp
+++ b/doc/templates/libdnf5-plugin/template.cpp
@@ -8,8 +8,8 @@ using namespace libdnf5;
 namespace {
 
 constexpr const char * PLUGIN_NAME{"template"};
-
 constexpr plugin::Version PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Fatima Freedom", "dummy@email.com", "Plugin description."};
@@ -24,7 +24,7 @@ public:
     /// Fill in the API version of your plugin.
     /// This is used to check if the provided plugin API version is compatible with the library's plugin API version.
     /// MANDATORY to override.
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     /// Enter the name of your new plugin.
     /// This is used in log messages when an action or error related to the plugin occurs.
@@ -88,7 +88,7 @@ void TemplatePlugin::pre_transaction_magic(const libdnf5::base::Transaction & tr
 
 /// Return plugin's API version.
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 /// Return plugin's name.

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -125,6 +125,18 @@ private:
     ImplPtr<Impl> p_impl;
 };
 
+/// @brief Extended plugin interface with additional hooks introduced in version 2.1 of the plugin API.
+class LIBDNF_PLUGIN_API IPlugin2_1 : public IPlugin {
+public:
+    explicit IPlugin2_1(IPluginData & data);
+    ~IPlugin2_1();
+
+    /// The goal resolved hook.
+    /// It is called right after the goal is resolved.
+    /// @param transaction Contains the transaction that was resolved.
+    virtual void goal_resolved(const libdnf5::base::Transaction & transaction);
+};
+
 }  // namespace libdnf5::plugin
 
 

--- a/include/libdnf5/repo/repo_callbacks.hpp
+++ b/include/libdnf5/repo/repo_callbacks.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_REPO_CALLBACKS_HPP
 #define LIBDNF5_REPO_REPO_CALLBACKS_HPP
 
+#include "libdnf5/common/message.hpp"
 #include "libdnf5/defs.h"
 
 #include <string>
@@ -51,6 +52,22 @@ public:
     /// Called on successful repo key import.
     /// @param key_info The key that was successfully imported
     virtual void repokey_imported(const libdnf5::rpm::KeyInfo & key_info);
+};
+
+/// @brief Extended repository callbacks with additional methods for support of key removal.
+class LIBDNF_API RepoCallbacks2_1 : public RepoCallbacks {
+public:
+    explicit RepoCallbacks2_1();
+    ~RepoCallbacks2_1();
+
+    /// OpenPGP key remove callback. Allows to confirm or deny the removal.
+    /// @param key_info The key that is about to be removed
+    /// @param removal_info Additional information about the key removal
+    /// @return `true` to remove the key, `false` to not remove
+    virtual bool repokey_remove(const libdnf5::rpm::KeyInfo & key_info, const libdnf5::Message & removal_info);
+    /// Called on successful repo key removal.
+    /// @param key_info The key that was successfully removed
+    virtual void repokey_removed(const libdnf5::rpm::KeyInfo & key_info);
 };
 
 }  // namespace libdnf5::repo

--- a/include/libdnf5/version.hpp
+++ b/include/libdnf5/version.hpp
@@ -46,7 +46,7 @@ struct PluginAPIVersion {
     std::uint16_t minor;  // plugin must implement the `minor` version >= than the libdnf5 to work together
 };
 
-static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 2, .minor = 0};
+static constexpr PluginAPIVersion PLUGIN_API_VERSION{.major = 2, .minor = 1};
 
 /// @return Library version
 /// @since 5.0

--- a/libdnf5-plugins/CMakeLists.txt
+++ b/libdnf5-plugins/CMakeLists.txt
@@ -3,5 +3,6 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 add_subdirectory("actions")
 add_subdirectory("appstream")
+add_subdirectory("expired-pgp-keys")
 add_subdirectory("python_plugins_loader")
 add_subdirectory("rhsm")

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -48,6 +48,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME = "actions";
 constexpr plugin::Version PLUGIN_VERSION{1, 3, 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 1};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "Actions Plugin."};
@@ -92,7 +93,7 @@ public:
     Actions(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin2_1(data) {}
     virtual ~Actions() = default;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -1985,7 +1986,7 @@ void Actions::on_transaction(const libdnf5::base::Transaction & transaction, con
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * libdnf_plugin_get_name(void) {

--- a/libdnf5-plugins/appstream/appstream.cpp
+++ b/libdnf5-plugins/appstream/appstream.cpp
@@ -32,6 +32,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME{"appstream"};
 constexpr libdnf5::plugin::Version PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Milan Crha", "mcrha@redhat.com", "install repo Appstream data."};
@@ -41,7 +42,7 @@ public:
     AppstreamPlugin(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~AppstreamPlugin() = default;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -103,7 +104,7 @@ void AppstreamPlugin::install_appstream(libdnf5::repo::Repo * repo) {
 
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * libdnf_plugin_get_name(void) {

--- a/libdnf5-plugins/expired-pgp-keys/CMakeLists.txt
+++ b/libdnf5-plugins/expired-pgp-keys/CMakeLists.txt
@@ -1,0 +1,24 @@
+if(NOT WITH_PLUGIN_EXPIRED_PGP_KEYS)
+    return()
+endif()
+
+# set gettext domain for translations
+set(GETTEXT_DOMAIN libdnf5-plugin-expired-pgp-keys)
+add_definitions(-DGETTEXT_DOMAIN=\"${GETTEXT_DOMAIN}\")
+
+add_library(expired-pgp-keys MODULE expired-pgp-keys.cpp)
+
+# disable the 'lib' prefix in order to create expired-pgp-keys.so
+set_target_properties(expired-pgp-keys PROPERTIES PREFIX "")
+
+target_link_libraries(expired-pgp-keys PRIVATE common_obj)
+target_link_libraries(expired-pgp-keys PRIVATE libdnf5 libdnf5-cli)
+
+pkg_check_modules(RPM REQUIRED rpm)
+target_link_libraries(expired-pgp-keys PRIVATE ${RPM_LIBRARIES})
+
+install(TARGETS expired-pgp-keys LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")
+
+install(FILES "expired-pgp-keys.conf" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")
+
+add_subdirectory(po)

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.conf
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.conf
@@ -1,0 +1,3 @@
+[main]
+name = expired-pgp-keys
+enabled = 1

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -42,6 +42,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME = "expired-pgp-keys";
 constexpr plugin::Version PLUGIN_VERSION{1, 0, 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 1};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jan Kolarik", "jkolarik@redhat.com", "Expired PGP Keys Plugin."};
@@ -53,7 +54,7 @@ public:
     ExpiredPgpKeys(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin2_1(data) {}
     virtual ~ExpiredPgpKeys() = default;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -225,7 +226,7 @@ void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction &
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * libdnf_plugin_get_name(void) {

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -1,0 +1,250 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "utils/string.hpp"
+
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/base/transaction.hpp>
+#include <libdnf5/common/message.hpp>
+#include <libdnf5/plugin/iplugin.hpp>
+#include <libdnf5/rpm/rpm_signature.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/format_locale.hpp>
+#include <rpm/header.h>
+#include <rpm/rpmdb.h>
+#include <rpm/rpmts.h>
+#include <string.h>
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+using namespace libdnf5;
+
+namespace {
+
+constexpr const char * PLUGIN_NAME = "expired-pgp-keys";
+constexpr plugin::Version PLUGIN_VERSION{1, 0, 0};
+
+constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
+constexpr const char * attrs_value[]{"Jan Kolarik", "jkolarik@redhat.com", "Expired PGP Keys Plugin."};
+
+/// @brief Find expired PGP keys and suggest their removal.
+///        This is a workaround to solve https://github.com/rpm-software-management/dnf5/issues/1192.
+class ExpiredPgpKeys final : public plugin::IPlugin2_1 {
+public:
+    ExpiredPgpKeys(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin2_1(data) {}
+    virtual ~ExpiredPgpKeys() = default;
+
+    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    plugin::Version get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    const char * const * get_attributes() const noexcept override { return attrs; }
+
+    const char * get_attribute(const char * attribute) const noexcept override {
+        for (size_t i = 0; attrs[i]; ++i) {
+            if (std::strcmp(attribute, attrs[i]) == 0) {
+                return attrs_value[i];
+            }
+        }
+        return nullptr;
+    }
+
+    void goal_resolved(const libdnf5::base::Transaction & transaction) override {
+        process_expired_pgp_keys(transaction);
+    }
+
+private:
+    void process_expired_pgp_keys(const libdnf5::base::Transaction & transaction) const;
+};
+
+class ExpiryInfoMessage : public libdnf5::Message {
+public:
+    ExpiryInfoMessage(int64_t expiration_timestamp) : expiration_timestamp(expiration_timestamp) {}
+
+    std::string format(bool translate, const libdnf5::utils::Locale * locale) const override {
+        return libdnf5::utils::format(
+            locale, translate, M_("Expired on {}"), 1, libdnf5::utils::string::format_epoch(expiration_timestamp));
+    }
+
+private:
+    int64_t expiration_timestamp;
+};
+
+/// Check that GPG is installed to enable querying expired keys later.
+static bool is_gpg_installed() {
+    auto ts = rpmtsCreate();
+    rpmdbMatchIterator mi;
+    mi = rpmtsInitIterator(ts, RPMDBI_PROVIDENAME, "gpg", 0);
+    bool found = rpmdbNextIterator(mi) != NULL;
+    rpmdbFreeIterator(mi);
+    rpmtsFree(ts);
+    return found;
+}
+
+/// Check if the transaction contains any inbound actions.
+/// This determines if new software is to be installed, which might require downloading a new PGP signing key.
+static bool any_inbound_action(const libdnf5::base::Transaction & transaction) {
+    for (const auto & package : transaction.get_transaction_packages()) {
+        if (transaction_item_action_is_inbound(package.get_action())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Retrieve the PGP key expiration timestamp, or return -1 if the expiration is not available.
+static int64_t get_key_expire_timestamp(std::string raw_key) {
+    // open gpg process to retrieve information about the key
+    std::unique_ptr<FILE, int (*)(FILE *)> pipe(
+        popen(libdnf5::utils::sformat("echo \"{}\" | gpg --show-keys --with-colon", raw_key).c_str(), "r"), pclose);
+    if (!pipe) {
+        return -1;
+    }
+
+    // read key information from the gpg process
+    char buffer[1024];
+    std::string output;
+    while (fgets(buffer, sizeof(buffer), pipe.get()) != nullptr) {
+        output += buffer;
+    }
+
+    // check expired time is a numeric value
+    auto lines = libdnf5::utils::string::split(output, "\n");
+    if (lines.empty()) {
+        return -1;
+    }
+    auto fields = libdnf5::utils::string::split(lines.front(), ":");
+    if (fields.size() <= 6) {
+        return -1;
+    }
+    auto expired_date_string = fields[6];
+    if (expired_date_string.empty() || expired_date_string.find_first_not_of("0123456789") != std::string::npos) {
+        return -1;
+    }
+
+    return static_cast<int64_t>(std::stoull(expired_date_string));
+}
+
+/// Remove the system package corresponding to the PGP key from the given RPM header.
+static bool remove_pgp_key(const libdnf5::rpm::KeyInfo & key) {
+    bool retval{false};
+    auto ts = rpmtsCreate();
+    Header h;
+    rpmdbMatchIterator mi;
+    mi = rpmtsInitIterator(ts, RPMDBI_NAME, "gpg-pubkey", 0);
+    auto key_id = key.get_short_key_id();
+    while ((h = rpmdbNextIterator(mi)) != nullptr) {
+        if (headerGetAsString(h, RPMTAG_VERSION) == libdnf5::utils::string::tolower(key_id)) {
+            rpmtsAddEraseElement(ts, h, -1);
+            retval = rpmtsRun(ts, nullptr, RPMPROB_FILTER_NONE) == 0;
+            break;
+        }
+    }
+    rpmdbFreeIterator(mi);
+    rpmtsFree(ts);
+    return retval;
+}
+
+void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction & transaction) const {
+    auto & logger = *get_base().get_logger();
+    const auto & config = get_base().get_config();
+
+    if (!config.get_gpgcheck_option().get_value()) {
+        return;
+    }
+
+    if (!is_gpg_installed()) {
+        logger.error("Expired PGP Keys Plugin: GPG is not installed on the system. Aborting...");
+        return;
+    }
+
+    if (!any_inbound_action(transaction)) {
+        return;
+    }
+
+    auto current_date = std::chrono::system_clock::now();
+    auto current_timestamp = std::chrono::duration_cast<std::chrono::seconds>(current_date.time_since_epoch()).count();
+
+    libdnf5::rpm::RpmSignature rpm_signature(get_base());
+    libdnf5::repo::RepoQuery enabled_repos(get_base());
+    enabled_repos.filter_enabled(true);
+    enabled_repos.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
+
+    for (auto const & repo : enabled_repos) {
+        auto key_urls = repo->get_config().get_gpgkey_option().get_value();
+        if (key_urls.empty()) {
+            continue;
+        }
+
+        auto callbacks = dynamic_cast<libdnf5::repo::RepoCallbacks2_1 *>(repo->get_callbacks().get());
+
+        for (auto const & key_url : key_urls) {
+            for (auto & key_info : rpm_signature.parse_key_file(key_url)) {
+                if (rpm_signature.key_present(key_info)) {
+                    auto key_timestamp = get_key_expire_timestamp(key_info.get_raw_key());
+                    if (key_timestamp > 0 && key_timestamp < current_timestamp) {
+                        if (callbacks && !callbacks->repokey_remove(key_info, ExpiryInfoMessage(key_timestamp))) {
+                            continue;
+                        }
+                        logger.debug("Expired PGP Keys Plugin: Removing the 0x{} key.", key_info.get_short_key_id());
+                        auto removed = remove_pgp_key(key_info);
+                        if (!removed) {
+                            logger.error(
+                                "Expired PGP Keys Plugin: Failed to remove the 0x{} key.", key_info.get_short_key_id());
+                        } else if (callbacks) {
+                            callbacks->repokey_removed(key_info);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+PluginAPIVersion libdnf_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+const char * libdnf_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+plugin::Version libdnf_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+plugin::IPlugin * libdnf_plugin_new_instance(
+    [[maybe_unused]] LibraryVersion library_version,
+    libdnf5::plugin::IPluginData & data,
+    libdnf5::ConfigParser & parser) try {
+    return new ExpiredPgpKeys(data, parser);
+} catch (...) {
+    return nullptr;
+}
+
+void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
+    delete plugin_object;
+}

--- a/libdnf5-plugins/expired-pgp-keys/po/CMakeLists.txt
+++ b/libdnf5-plugins/expired-pgp-keys/po/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(NOT WITH_TRANSLATIONS)
+    return()
+endif()
+
+include(Translations)

--- a/libdnf5-plugins/expired-pgp-keys/po/cs.po
+++ b/libdnf5-plugins/expired-pgp-keys/po/cs.po
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Bot <dummy@bot.cz>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-25 06:01+0000\n"
+"PO-Revision-Date: 2024-07-25 06:01+0000\n"
+"Last-Translator: Bot <dummy@bot.cz>\n"
+"Language-Team: Czech <https://translate.fedoraproject.org/projects/dnf5/"
+"libdnf5-plugin-expired-pgp-keys/cs/>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: expired-pgp-keys.cpp:182
+#, c++-format
+msgid "The following PGP key has expired on {}:"
+msgstr "Následující PGP klíč vypršel dne {}:"
+
+#: expired-pgp-keys.cpp:186
+msgid "For more information about the key:"
+msgstr "Pro více informací o klíči:"
+
+#: expired-pgp-keys.cpp:189
+msgid "As a result, installing packages signed with this key will fail."
+msgstr "V důsledku toho se instalace balíčků podepsaných tímto klíčem nezdaří."
+
+#: expired-pgp-keys.cpp:190
+msgid "It is recommended to remove the expired key to allow importing"
+msgstr "Doporučuje se odstranit vypršelý klíč, aby bylo možné importovat"
+
+#: expired-pgp-keys.cpp:191
+msgid ""
+"an updated key. This might leave already installed packages unverifiable."
+msgstr ""
+"aktualizovaný klíč. To může zanechat již nainstalované balíčky neověřitelné."
+
+#: expired-pgp-keys.cpp:194
+msgid "The system will now proceed with removing the key."
+msgstr "Systém nyní přistoupí k odstranění klíče."
+
+#: expired-pgp-keys.cpp:199
+msgid "Key successfully removed."
+msgstr "Klíč byl úspěšně odstraněn."
+
+#: expired-pgp-keys.cpp:201
+msgid "Failed to remove the key."
+msgstr "Nepodařilo se odstranit klíč."

--- a/libdnf5-plugins/expired-pgp-keys/po/libdnf5-plugin-expired-pgp-keys.pot
+++ b/libdnf5-plugins/expired-pgp-keys/po/libdnf5-plugin-expired-pgp-keys.pot
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-25 06:01+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: expired-pgp-keys.cpp:182
+#, c++-format
+msgid "The following PGP key has expired on {}:"
+msgstr ""
+
+#: expired-pgp-keys.cpp:186
+msgid "For more information about the key:"
+msgstr ""
+
+#: expired-pgp-keys.cpp:189
+msgid "As a result, installing packages signed with this key will fail."
+msgstr ""
+
+#: expired-pgp-keys.cpp:190
+msgid "It is recommended to remove the expired key to allow importing"
+msgstr ""
+
+#: expired-pgp-keys.cpp:191
+msgid ""
+"an updated key. This might leave already installed packages unverifiable."
+msgstr ""
+
+#: expired-pgp-keys.cpp:194
+msgid "The system will now proceed with removing the key."
+msgstr ""
+
+#: expired-pgp-keys.cpp:199
+msgid "Key successfully removed."
+msgstr ""
+
+#: expired-pgp-keys.cpp:201
+msgid "Failed to remove the key."
+msgstr ""

--- a/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -35,6 +35,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME = "python_plugin_loader";
 constexpr plugin::Version PLUGIN_VERSION{0, 1, 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "Plugin for loading Python plugins."};
@@ -44,7 +45,7 @@ public:
     PythonPluginLoader(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~PythonPluginLoader();
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -316,7 +317,7 @@ void PythonPluginLoader::load_plugins() {
 
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * libdnf_plugin_get_name(void) {

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -32,6 +32,7 @@ namespace {
 
 constexpr const char * PLUGIN_NAME = "rhsm";
 constexpr plugin::Version PLUGIN_VERSION{0, 1, 0};
+constexpr PluginAPIVersion REQUIRED_PLUGIN_API_VERSION{.major = 2, .minor = 0};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{
@@ -43,7 +44,7 @@ public:
     Rhsm(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
     virtual ~Rhsm() = default;
 
-    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+    PluginAPIVersion get_api_version() const noexcept override { return REQUIRED_PLUGIN_API_VERSION; }
 
     const char * get_name() const noexcept override { return PLUGIN_NAME; }
 
@@ -142,7 +143,7 @@ void Rhsm::setup_enrollments() {
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
-    return PLUGIN_API_VERSION;
+    return REQUIRED_PLUGIN_API_VERSION;
 }
 
 const char * libdnf_plugin_get_name(void) {

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -3269,6 +3269,9 @@ base::Transaction Goal::resolve() {
 #endif
         ret);
 
+    auto & plugins = p_impl->base->p_impl->get_plugins();
+    plugins.goal_resolved(transaction);
+
     return transaction;
 }
 

--- a/libdnf5/plugin/iplugin.cpp
+++ b/libdnf5/plugin/iplugin.cpp
@@ -63,4 +63,10 @@ Base & IPlugin::get_base() const noexcept {
     return p_impl->get_base();
 }
 
+IPlugin2_1::IPlugin2_1(IPluginData & data) : IPlugin(data) {}
+
+IPlugin2_1::~IPlugin2_1() = default;
+
+void IPlugin2_1::goal_resolved([[maybe_unused]] const libdnf5::base::Transaction & transaction) {}
+
 }  // namespace libdnf5::plugin

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -298,6 +298,14 @@ void Plugins::post_add_cmdline_packages() {
     }
 }
 
+void Plugins::goal_resolved(const libdnf5::base::Transaction & transaction) {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->goal_resolved(transaction);
+        }
+    }
+}
+
 void Plugins::pre_transaction(const libdnf5::base::Transaction & transaction) {
     for (auto & plugin : plugins) {
         if (plugin->get_enabled()) {

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -60,8 +60,7 @@ PluginLibrary::PluginLibrary(Base & base, ConfigParser && parser, const std::str
 
     const auto & libdnf_plugin_api_version = libdnf5::get_plugin_api_version();
     const auto & plugin_api_version = get_api_version();
-    if (plugin_api_version.major != libdnf_plugin_api_version.major ||
-        plugin_api_version.minor < libdnf_plugin_api_version.minor) {
+    if (plugin_api_version.major != libdnf_plugin_api_version.major) {
         throw PluginError(
             M_("Unsupported plugin API combination. API version provided by plugin \"{}\" (\"{}\") is \"{}.{}\"."
                " API version in libdnf is \"{}.{}\"."),

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -62,6 +62,7 @@ public:
     void repos_loaded();
     void pre_add_cmdline_packages(const std::vector<std::string> & paths);
     void post_add_cmdline_packages();
+    void goal_resolved(const libdnf5::base::Transaction & transaction);
     void pre_transaction(const libdnf5::base::Transaction & transaction);
     void post_transaction(const libdnf5::base::Transaction & transaction);
     void finish() noexcept;
@@ -109,6 +110,8 @@ public:
     void pre_add_cmdline_packages(const std::vector<std::string> & paths);
 
     void post_add_cmdline_packages();
+
+    void goal_resolved(const libdnf5::base::Transaction & transaction);
 
     void pre_transaction(const libdnf5::base::Transaction & transaction);
 
@@ -189,6 +192,14 @@ inline void Plugin::pre_add_cmdline_packages(const std::vector<std::string> & pa
 inline void Plugin::post_add_cmdline_packages() {
     if (iplugin_instance) {
         iplugin_instance->post_add_cmdline_packages();
+    }
+}
+
+inline void Plugin::goal_resolved(const libdnf5::base::Transaction & transaction) {
+    if (iplugin_instance) {
+        if (auto iplugin2_1_instance = dynamic_cast<IPlugin2_1 *>(iplugin_instance)) {
+            iplugin2_1_instance->goal_resolved(transaction);
+        }
     }
 }
 

--- a/libdnf5/repo/repo_callbacks.cpp
+++ b/libdnf5/repo/repo_callbacks.cpp
@@ -31,4 +31,14 @@ bool RepoCallbacks::repokey_import(const libdnf5::rpm::KeyInfo &) {
 
 void RepoCallbacks::repokey_imported(const libdnf5::rpm::KeyInfo &) {}
 
+RepoCallbacks2_1::RepoCallbacks2_1() = default;
+
+RepoCallbacks2_1::~RepoCallbacks2_1() = default;
+
+bool RepoCallbacks2_1::repokey_remove(const libdnf5::rpm::KeyInfo &, const libdnf5::Message &) {
+    return true;
+}
+
+void RepoCallbacks2_1::repokey_removed(const libdnf5::rpm::KeyInfo &) {}
+
 }  // namespace libdnf5::repo

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -73,7 +73,7 @@ static bool rpmdb_lookup(const RpmTransactionPtr & ts_ptr, const KeyInfo & key) 
     mi = rpmtsInitIterator(ts_ptr.get(), RPMDBI_NAME, "gpg-pubkey", 0);
     auto key_id = key.get_short_key_id();
     while ((h = rpmdbNextIterator(mi)) != nullptr) {
-        if (headerGetAsString(h, RPMTAG_VERSION) == key_id) {
+        if (headerGetAsString(h, RPMTAG_VERSION) == utils::string::tolower(key_id)) {
             retval = true;
             break;
         }


### PR DESCRIPTION
Based on the implementation from https://github.com/rpm-software-management/dnf-plugins-core/pull/533.

Workaround for: https://github.com/rpm-software-management/dnf5/issues/1192.

CI fix: https://github.com/rpm-software-management/ci-dnf-stack/pull/1625.