### PR TITLE
Add an example how to disable repo to `repo` command man page

### DIFF
--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -67,3 +67,7 @@ Examples
 
 ``dnf5 repo list --disabled *-debuginfo``
     | Print disabled repositories related to debugging.
+
+``dnf5 config-manger setopt repo_id.enabled=0``
+    | Persistently disable repository using the config-manger plugin command.
+    | See :manpage:`dnf5-config-manager(8)` for more details.


### PR DESCRIPTION
While this example isn't for the `repo` command it could be useful to users looking into the man page.

For: https://github.com/rpm-software-management/dnf5/issues/1213