### PR TITLE
Fix a use-after-free in EmitterEmail::notify()

### DIFF
--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -218,11 +218,11 @@ void EmitterEmail::notify() {
 
                 FILE * payload_file = fmemopen(payload.data(), payload.size(), "r");
                 curl_easy_setopt(curl, CURLOPT_READDATA, payload_file);
-                fclose(payload_file);
 
                 curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
                 res = curl_easy_perform(curl);
+                fclose(payload_file);
                 if (res != CURLE_OK) {
                     std::cerr << "libcurl error while sending e-mail: " << curl_easy_strerror(res) << std::endl;
                 }


### PR DESCRIPTION
When "dnf5 automatic" was configured to send e-mails via SMTP ("emit_via = email" in automatic.conf), it sometimes crashed:

    #0  0x00007ff7fb955184 __memcpy_avx_unaligned_erms (libc.so.6 + 0x147184)
    #1  0x00007ff7fb873bd4 fmemopen_read (libc.so.6 + 0x65bd4)
    #2  0x00007ff7fb875813 _IO_file_underflow@@GLIBC_2.2.5 (libc.so.6 + 0x67813)
    #3  0x00007ff7fb877e45 _IO_default_xsgetn (libc.so.6 + 0x69e45)
    #4  0x00007ff7fb869a40 _IO_fread (libc.so.6 + 0x5ba40)
    #5  0x00007ff7faceb1f7 cr_in_read (libcurl.so.4 + 0x541f7)
    #6  0x00007ff7facf8608 cr_eob_read (libcurl.so.4 + 0x61608)
    #7  0x00007ff7facf0f20 Curl_client_read (libcurl.so.4 + 0x59f20)
    #8  0x00007ff7facf103d Curl_req_send_more (libcurl.so.4 + 0x5a03d)
    #9  0x00007ff7fad068da Curl_readwrite (libcurl.so.4 + 0x6f8da)
    #10 0x00007ff7face6258 multi_runsingle.lto_priv.0 (libcurl.so.4 + 0x4f258)
    #11 0x00007ff7face8c64 curl_multi_perform (libcurl.so.4 + 0x51c64)
    #12 0x00007ff7facbb8a3 curl_easy_perform (libcurl.so.4 + 0x248a3)
    #13 0x00007ff7f9ee30ad _ZN4dnf512EmitterEmail6notifyEv (automatic_cmd_plugin.so + 0x170ad)
    #14 0x00007ff7f9ed61f5 _ZN4dnf516AutomaticCommand3runEv (automatic_cmd_plugin.so + 0xa1f5)
    #15 0x0000557b633d5f78 main (dnf5 + 0x39f78)
    #16 0x00007ff7fb811248 __libc_start_call_main (libc.so.6 + 0x3248)
    #17 0x00007ff7fb81130b __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x330b)
    #18 0x0000557b633d88e5 _start (dnf5 + 0x3c8e5)

or sent an e-mail without a body and some headers (e.g. Subject):

    From root@fedora-41.localdomain  Thu Aug  1 14:49:36 2024
    Return-Path: <root@fedora-41.localdomain>
    X-Original-To: test
    Delivered-To: test@fedora-41.localdomain
    Received: from fedora-41 (localhost [IPv6:::1])
	    by fedora-41.localdomain (Postfix) with ESMTP id E5A1E51
	    for <test>; Thu, 01 Aug 2024 14:49:36 +0200 (CEST)
    Message-Id: <20240801124936.E5A1E51@fedora-41.localdomain>
    Date: Thu, 01 Aug 2024 14:49:36 +0200 (CEST)
    From: root@fedora-41.localdomain

The cause was that a FILE * structure registered to curl as CURLOPT_READDATA and freed before curl_easy_perform() processed it.

This patch fixes it.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2298385