### PR TITLE
Reduce the noise around running scriptlets

### DIFF
--- a/include/libdnf5-cli/progressbar/progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/progress_bar.hpp
@@ -95,6 +95,8 @@ public:
 
     // messages
     void add_message(MessageType type, const std::string & message) { messages.emplace_back(type, message); }
+    /// remove the last message
+    void pop_message();
     const std::vector<Message> & get_messages() const noexcept { return messages; }
 
     // auto-finish feature; turn off if you want to handle state manually

--- a/libdnf5-cli/progressbar/progress_bar.cpp
+++ b/libdnf5-cli/progressbar/progress_bar.cpp
@@ -159,6 +159,13 @@ void ProgressBar::set_total_ticks(int64_t value) {
 }
 
 
+void ProgressBar::pop_message() {
+    if (!messages.empty()) {
+        messages.pop_back();
+    }
+}
+
+
 std::ostream & operator<<(std::ostream & os, ProgressBar & bar) {
     bar.to_stream(os);
     return os;


### PR DESCRIPTION
Changes:

d1ffe89f (Marek Blaha, 9 minutes ago)
   dnf5: Reduce the noise around running scriptlets

   If the scriptlet finishes successfully, do not print the
   "Running scriptlet..." / "Stop scriptlet..." pair of messages in the 
   transaction progress bar.

   The "Running scriptlet" message is displayed during the scriptlet execution
   to inform the user that a time-consuming operation is in progress. If the
   scriptlet completes successfully, the message is removed. If it fails, the
   message remains, and an error/warning message and the "Stop scriptlet"
   message is printed to enable debugging.

b3163df9 (Marek Blaha, 12 minutes ago)
   cli: Method to drop the last progress bar message

   Useful to create "temporary" messages, will be used to reduce the
   "Running scriptlet" / "Stop scriptlet" rpm transaction noise.


Resolves: https://github.com/rpm-software-management/dnf5/issues/1533