### PR TITLE
spec: Stricten a dependency on DNF libraries in plugin subpackages

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -692,6 +692,7 @@ Summary:        Plugins for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
 Requires:       libcurl%{?_isa} >= 7.62.0
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Provides:       dnf5-command(builddep)
 Provides:       dnf5-command(changelog)
@@ -727,6 +728,8 @@ Summary:        Package manager - automated upgrades
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
 Requires:       libcurl-full%{?_isa}
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Provides:       dnf5-command(automatic)
 %if %{with dnf5_obsoletes_dnf}
 Provides:       dnf-automatic = %{version}-%{release}


### PR DESCRIPTION
ELF plugins of dnf5-plugins and dnf5-plugin-automatic subpackages link to libdnf and libdnf-cli libraries. Because the libraries come from the same source package, it is desired to pin the plugin subpackages to same release of the libraries subpackages.

This was hinted by rpminspect and already partially implemented in commit 97cdbe57c34259a0e0dc87431ac7c3e9a396aba7 ("Add explicit package version for libdnf5-cli").

An example of rpminspect failure <https://artifacts.dev.testing-farm.io/9c72a529-5c4b-4ff1-bf4b-21dc5403ff8d/>.