### PR TITLE
doc: Use ~ instead of /home/$USER

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -386,7 +386,7 @@ Changes to individual options
 .. _cachedir_option_conf_changes_ref-label:
 
 ``cachedir``
-  * The default user cached dir is now at ``/home/$USER/.cache/libdnf5``.
+  * The default user cached dir is now at ``~/.cache/libdnf5``.
   * The default root cache directory, configured by the ``system_cachedir`` option, is now ``/var/cache/libdnf5``.
   * Users no longer access the root's cache directly; instead, metadata is copied to the user's location if it's empty or invalid.
   * For additional information, refer to the :ref:`Caching <caching_misc_ref-label>` man page.

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -99,7 +99,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     Has a reasonable root-writable default depending on the distribution. DNF5
     needs to be able to create files and directories at this location.
 
-    Regular user default: ``/home/$USER/.cache/libdnf5``.
+    Regular user default: ``~/.cache/libdnf5``.
 
     For superuser the value is overwritten by :ref:`system_cachedir <_system_cachedir_options-label>` option.
 
@@ -259,7 +259,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Directory where the log files will be stored.
 
-    Regular user default: ``/home/$USER/.local/state``.
+    Regular user default: ``~/.local/state``.
 
     Superuser default: ``/var/log``.
 

--- a/doc/misc/caching.7.rst
+++ b/doc/misc/caching.7.rst
@@ -69,7 +69,7 @@ Following directory structure illustrates a typical DNF5 cache directory:
             └── updates.solv
 
 The default root cache directory is ``/var/cache/libdnf5``, but when DNF5 runs as another user,
-it uses the cache from ``/home/$USER/.cache/libdnf5`` with the same structure. The root cache
+it uses the cache from ``~/.cache/libdnf5`` with the same structure. The root cache
 directory can be redefined using the ``system_cachedir`` configuration option, and the user
 cachedir with the ``cachedir`` option.
 

--- a/doc/tutorial/plugins/index.rst
+++ b/doc/tutorial/plugins/index.rst
@@ -28,7 +28,7 @@ Debugging Tips
 
 To test your freshly built DNF5 Plugin, redirect DNF5 to load it by setting
 the ``DNF5_PLUGINS_DIR`` environmental variable to your build directory (e.g.,
-``DNF5_PLUGINS_DIR=/home/user/dnf5/build/dnf5-plugins/template_plugin``).
+``DNF5_PLUGINS_DIR=~/dnf5/build/dnf5-plugins/template_plugin``).
 
 Speaking about LIBDNF5 Plugins, utilize the ``LIBDNF_PLUGINS_CONFIG_DIR``
 environmental variable to configure the directory with the plugin's configuration.


### PR DESCRIPTION
First not every system has user's home directories under /home directory. Second DNF does not use USER variable at all. It uses HOME environment variable with a fallback to a home directory listed in passwd(5) entry.

Alternativelly, we could write "$HOME". But I find "~" shorter, more aesthetic, more understandible, and more correct in case the HOME variable does not exist.