### PR TITLE
Better error messages for system state loading

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -335,6 +335,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_mandir}/man7/dnf*-installroot.7.*
 %{_mandir}/man7/dnf*-modularity.7.*
 %{_mandir}/man7/dnf*-specs.7.*
+%{_mandir}/man7/dnf*-system-state.7.*
 %{_mandir}/man5/dnf*.conf.5.*
 %{_mandir}/man5/dnf*.conf-todo.5.*
 %{_mandir}/man5/dnf*.conf-deprecated.5.*

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -93,6 +93,7 @@ if(WITH_MAN)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-installroot.7 DESTINATION share/man/man7)
          install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-modularity.7 DESTINATION share/man/man7)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-specs.7 DESTINATION share/man/man7)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-system-state.7 DESTINATION share/man/man7)
 
         # plugin commands
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/dnf5-automatic.8 DESTINATION share/man/man8)

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -158,6 +158,7 @@ man_pages = [
     ('misc/installroot.7', 'dnf5-installroot', 'Installroot Parameter', AUTHORS, 7),
     ('misc/modularity.7', 'dnf5-modularity', 'Modularity Overview', AUTHORS, 7),
     ('misc/specs.7', 'dnf5-specs', 'Patterns Specification', AUTHORS, 7),
+    ('misc/system-state.7', 'dnf5-system-state', 'System state', AUTHORS, 7),
     ('dnf_daemon/dnf5daemon_client.8', 'dnf5daemon-client', 'Command-line interface for Dnf5daemon', AUTHORS, 8),
     ('dnf_daemon/dnf5daemon_server.8', 'dnf5daemon-server', 'Package management service with a DBus interface', AUTHORS, 8),
     ('dnf_daemon/dnf5daemon_dbus_api.8', 'dnf5daemon-dbus-api', 'DBus API Reference for Dnf5daemon', AUTHORS, 8),

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -456,16 +456,12 @@ Miscellaneous:
     | :manpage:`dnf5-aliases(7)`, :ref:`Aliases for command line arguments <aliases_misc_ref-label>`
     | :manpage:`dnf5-caching(7)`, :ref:`Caching <caching_misc_ref-label>`
     | :manpage:`dnf5-comps(7)`, :ref:`Comps groups and environments <comps_misc_ref-label>`
+    | :manpage:`dnf5-filtering(7)`, :ref:`Packages filtering, <filtering_misc_ref-label>`
     | :manpage:`dnf5-forcearch(7)`, :ref:`Forcearch parameter <forcearch_misc_ref-label>`
     | :manpage:`dnf5-installroot(7)`, :ref:`Installroot parameter <installroot_misc_ref-label>`
-    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
-
-..
-    # TODO(jkolarik): Filtering is not ready yet
-    | :manpage:`dnf5-filtering(7)`, :ref:`Packages filtering, <filtering_misc_ref-label>`
-
-    # TODO(jkolarik): Modularity is not ready yet
     | :manpage:`dnf5-modularity(7)`, :ref:`Modularity overview, <modularity_misc_ref-label>`
+    | :manpage:`dnf5-specs(7)`, :ref:`Patterns specification <specs_misc_ref-label>`
+    | :manpage:`dnf5-system-state(7)`, :ref:`System state <systemstate_misc_ref-label>`
 
 Project homepage:
     | https://github.com/rpm-software-management/dnf5

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -431,15 +431,20 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     :ref:`string <string-label>`
 
-    For superuser overwrites the :ref:`cachedir <_cachedir_options-label>` option value.
+    For superuser overwrites the :ref:`cachedir <cachedir_options-label>` option value.
 
     Allows to differentiate user and superuser cachedir.
 
     Default: ``/var/cache/libdnf5``.
 
-.. _system_state_options-label:
+.. _system_state_dir_options-label:
 
-``system_state``
+``system_state_dir``
+    :ref:`string <string-label>`
+
+    System state files location. See :manpage:`dnf5-system-state(7)`, :ref:`system state <systemstate_misc_ref-label>` for details.
+
+    Default: ``/usr/lib/sysimage/libdnf5``.
 
 .. _tsflags_options-label:
 

--- a/doc/misc/index.rst
+++ b/doc/misc/index.rst
@@ -14,3 +14,4 @@ Miscellaneous
     installroot.7
     modularity.7
     specs.7
+    system-state.7

--- a/doc/misc/system-state.7.rst
+++ b/doc/misc/system-state.7.rst
@@ -1,0 +1,44 @@
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+.. _systemstate_misc_ref-label:
+
+##############
+ System state
+##############
+
+Description
+===========
+
+The DNF5 system state consists of several TOML files with their location determined by the `system_state_dir` configuration option (:manpage:`dnf5-conf(5)`, :ref:`system_state_dir <system_state_dir_options-label>`). DNF5 uses the system state to:
+
+    1. Store the reasons why each installed package was added to the system. The reasons can be "user" for packages that the user explicitly asked DNF5 to install, "dependency" and "weak dependency" for packages pulled in as dependencies of another package, "group" for packages installed by a group, or "external" for packages installed by another tool (e.g. rpm).
+
+    2. Track installed groups and packages installed by these groups.
+
+    3. Track installed environmental groups.
+
+
+The way of storing the DNF5 system state is an internal implementation detail and may change at any time. To modify the state, always use the DNF5 command-line interface or DNF5 API.
+
+
+Recovering from a corrupted system state
+========================================
+
+If the system state files become corrupted, simply back up and remove the corrupted TOML file mentioned in the error message. It will be regenerated during the next successful DNF5 transaction.
+The regenerated files may lack some data, such as the reasons why packages were installed or the repositories from which they were installed.

--- a/libdnf5/system/state.hpp
+++ b/libdnf5/system/state.hpp
@@ -101,6 +101,14 @@ public:
     const char * get_name() const noexcept override { return "UnsupportedVersionError"; }
 };
 
+class StateLoadError : public libdnf5::Error {
+public:
+    StateLoadError(const std::string & path, const std::string & error);
+
+    const char * get_domain_name() const noexcept override { return "libdnf5::system"; }
+    const char * get_name() const noexcept override { return "StateLoadError"; }
+};
+
 
 /// A class providing information and allowing modification of the DNF system
 /// state. The state consists of a list of userinstalled packages, installed


### PR DESCRIPTION
Add a man page on DNF system state. This man page is then referenced in system state loading error messages.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1550

Changes:

ac68a075 (Marek Blaha, 5 days ago)
   doc: Add man page describing the system state

   The page also contains information how to recover from corrupted system 
   state files.

888d955c (Marek Blaha, 5 days ago)
   state: Catch all errors during system state load

   There are multiple exceptions that can occur during loading the system 
   state from toml files. Now they are caught and wrapped in StateLoadError.