### PR TITLE
daemon: New API to get download size of pkg including deps

### DIFF
--- a/dnf5daemon-server/services/rpm/rpm.hpp
+++ b/dnf5daemon-server/services/rpm/rpm.hpp
@@ -44,6 +44,7 @@ private:
     sdbus::MethodReply downgrade(sdbus::MethodCall & call);
     sdbus::MethodReply reinstall(sdbus::MethodCall & call);
     sdbus::MethodReply system_upgrade(sdbus::MethodCall & call);
+    sdbus::MethodReply check_install(sdbus::MethodCall & call);
 
     void list_fd(sdbus::MethodCall & call, const std::string & transfer_id);
 };

--- a/doc/dnf_daemon/examples/check_install.py
+++ b/doc/dnf_daemon/examples/check_install.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import dbus
+
+
+def human_readable_size(size):
+    for unit in ['B', 'KiB', 'MiB', 'GiB']:
+        if size < 1024.0 or unit == 'GiB':
+            break
+        size /= 1024.0
+    return f"{size:.2f} {unit}"
+
+
+DNFDAEMON_BUS_NAME = 'org.rpm.dnf.v0'
+DNFDAEMON_OBJECT_PATH = '/' + DNFDAEMON_BUS_NAME.replace('.', '/')
+
+IFACE_SESSION_MANAGER = '{}.SessionManager'.format(DNFDAEMON_BUS_NAME)
+IFACE_RPM = '{}.rpm.Rpm'.format(DNFDAEMON_BUS_NAME)
+
+
+bus = dbus.SystemBus()
+iface_session = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, DNFDAEMON_OBJECT_PATH),
+    dbus_interface=IFACE_SESSION_MANAGER)
+
+# set the releasever to the new distribution release
+session = iface_session.open_session(
+    dbus.Dictionary({}, signature=dbus.Signature('sv')))
+
+iface_rpm = dbus.Interface(
+    bus.get_object(DNFDAEMON_BUS_NAME, session),
+    dbus_interface=IFACE_RPM)
+
+# Add system upgrade to the transaction
+options = {
+}
+packages = iface_rpm.check_install("0ad", options)
+
+print("Following packages will be downloaded and installed:")
+total_download_size = 0
+total_install_size = 0
+for pkg in packages:
+    print(pkg["install_reason"], pkg["name"], pkg["evr"])
+    print("  download size: {}, install size: {}".format(human_readable_size(
+        pkg["download_size"]), human_readable_size(pkg["install_size"])))
+    total_download_size += pkg["download_size"]
+    total_install_size += pkg["install_size"]
+
+print("Need to download {}.".format(human_readable_size(total_download_size)))
+print("Instalation will require additional {}.".format(
+    human_readable_size(total_install_size)))


### PR DESCRIPTION
The new API simulates install operation on given pkg returning all dependencies that are going to be installed with their sizes.

Changes:

be3c8b6a (Marek Blaha, 49 seconds ago)
   dnfdaemon: Example of Rpm.check_install() usage

be9411ba (Marek Blaha, 4 minutes ago)
   dnfdaemon: API to get download size including dependencies

   This can be used to get the "cost" of installation of a package - how much
   data needs to be downloaded and how much disk space will be used.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1593