### PR TITLE
Use correct path when destdir option is set

### DIFF
--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -189,10 +189,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
 ``history_list_view``
 
-.. _destdir_options-label:
-
-``destdir``
-
 .. _comment_options-label:
 
 ``comment``

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -169,6 +169,15 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``False``.
 
+.. _destdir_options-label:
+
+``destdir``
+    :ref:`string <string-label>`
+
+    Redirect downloaded packages to provided directory.
+
+    Default: <package repository :ref:`cachedir <cachedir_options-label>`>/packages
+
 .. _group_package_types_options-label:
 
 ``group_package_types``

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -30,6 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/repo/repo_weak.hpp"
 #include "libdnf5/rpm/package.hpp"
 
+#include <filesystem>
 #include <memory>
 
 
@@ -371,6 +372,11 @@ private:
 
     // Add xml comps file at `path` to the repository.
     LIBDNF_LOCAL void add_xml_comps(const std::string & path);
+
+    /// Gets path to the directory where repository packages are downloaded.
+    /// Takes destdir config option into account.
+    LIBDNF_LOCAL std::filesystem::path get_packages_download_dir() const;
+
 
     std::unique_ptr<Impl> p_impl;
 };

--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -115,13 +115,7 @@ PackageDownloader::~PackageDownloader() = default;
 
 
 void PackageDownloader::add(const libdnf5::rpm::Package & package, void * user_data) {
-    auto default_path = std::filesystem::path(package.get_repo()->get_cachedir()) / "packages";
-    auto & destdir_option = p_impl->base->get_config().get_destdir_option();
-    if (destdir_option.empty()) {
-        add(package, default_path, user_data);
-    } else {
-        add(package, destdir_option.get_value(), user_data);
-    }
+    add(package, package.get_repo()->get_packages_download_dir(), user_data);
 }
 
 

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -626,5 +626,13 @@ void Repo::mark_fresh() {
     p_impl->expired = false;
 }
 
+std::filesystem::path Repo::get_packages_download_dir() const {
+    auto destdir_option = p_impl->base->get_config().get_destdir_option();
+    if (destdir_option.empty()) {
+        return std::filesystem::path(get_cachedir()) / "packages";
+    } else {
+        return destdir_option.get_value();
+    }
+}
 
 }  // namespace libdnf5::repo

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -392,7 +392,7 @@ std::string Package::get_package_path() const {
             return get_location();
         }
         // Returns the path to the cached file.
-        auto dir = std::filesystem::path(repo->get_cachedir()) / "packages";
+        auto dir = repo->get_packages_download_dir();
         return dir / std::filesystem::path(get_location()).filename();
     } else {
         return "";


### PR DESCRIPTION
Changes:

1e83b073 (Marek Blaha, 9 minutes ago)
   repo: New Repo.get_packages_download_dir() method

   Currently, the path where a package should be downloaded is computed in 
   several places. This patch introduces a single location for this 
   computation to reduce code duplication. The patch also fixes usage of
   incorrect package path in Package::get_package_path() call - the destdir
   config option was not taken into account.

07105d0b (Marek Blaha, 2 hours ago)
   doc: Document destdir main config option

Resolves: https://github.com/rpm-software-management/dnf5/issues/1620
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1536