### PR TITLE
doc: specs.7: document looking for file provides in /usr/[s]bin

### DIFF
--- a/doc/misc/specs.7.rst
+++ b/doc/misc/specs.7.rst
@@ -111,7 +111,8 @@ if globs are present in the ``<package-spec>``.
 
 ``<package-spec>`` matches NEVRAs the same way ``<package-name-spec>`` does,
 but in case matching NEVRAs fails, it attempts to match against provides and
-file provides of packages as well.
+file provides of packages as well. It also looks for ``<package-name-spec>``
+as file name, provided by packages, under ``/usr/bin`` and ``/usr/sbin``.
 
 You can specify globs as part of any of the five NEVRA components. You can also
 specify a glob pattern to match over multiple NEVRA components (in other words,


### PR DESCRIPTION
As discussed on devel@lists.fedoraproject.org, https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/Z2NFCBGNT2VLIDTVKS5HL5QJZ72UGHEG/.

In short, I was wondering how `dnf repoquery --whatprovides gnuradio-companion` turned up empty, and still, `dnf install gnuradio-companion` installed the `gnuradio` package. Petr Pisar was nice enough to explain that to me, so here's a PR :)

