### PR TITLE
spec: fix modularity man page

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -333,7 +333,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_mandir}/man7/dnf*-filtering.7.*
 %{_mandir}/man7/dnf*-forcearch.7.*
 %{_mandir}/man7/dnf*-installroot.7.*
- %%{_mandir}/man7/dnf*-modularity.7.*
+%{_mandir}/man7/dnf*-modularity.7.*
 %{_mandir}/man7/dnf*-specs.7.*
 %{_mandir}/man5/dnf*.conf.5.*
 %{_mandir}/man5/dnf*.conf-todo.5.*


### PR DESCRIPTION
This should fix the currently failing builds.

For f41 and rawhide they will still be failing because of the toml11 break.