### PR TITLE
Print diagnostic messages on stderr, not stdout

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -306,6 +306,7 @@ void AutomaticCommand::pre_configure() {
     }
 
     context.set_output_stream(output_stream);
+    context.set_error_stream(output_stream);
 }
 
 void AutomaticCommand::configure() {

--- a/dnf5-plugins/copr_plugin/copr_repo.cpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.cpp
@@ -395,7 +395,7 @@ std::string CoprRepo::get_projectname() {
 
 
 void CoprRepo::save_interactive() {
-    std::cout << COPR_THIRD_PARTY_WARNING;
+    std::cerr << COPR_THIRD_PARTY_WARNING;
     if (!libdnf5::cli::utils::userconfirm::userconfirm(base->get_config()))
         return;
 
@@ -416,9 +416,9 @@ void CoprRepo::save_interactive() {
             the_list << "     baseurl=" << repo.get_baseurl() << std::endl;
         }
 
-        std::cout << std::endl;
-        std::cout << libdnf5::utils::sformat(COPR_EXTERNAL_DEPS_WARNING, the_list.str());
-        std::cout << std::endl;
+        std::cerr << std::endl;
+        std::cerr << libdnf5::utils::sformat(COPR_EXTERNAL_DEPS_WARNING, the_list.str());
+        std::cerr << std::endl;
         if (!libdnf5::cli::utils::userconfirm::userconfirm(base->get_config())) {
             for (auto & p : repositories) {
                 auto & repo = p.second;

--- a/dnf5/commands/history/history_store.cpp
+++ b/dnf5/commands/history/history_store.cpp
@@ -62,7 +62,7 @@ void HistoryStoreCommand::run() {
     trans_file_path /= TRANSACTION_JSON;
 
     if (std::filesystem::exists(trans_file_path)) {
-        std::cout << libdnf5::utils::sformat(
+        std::cerr << libdnf5::utils::sformat(
             _("File \"{}\" already exists, it will be overwritten.\n"), trans_file_path.string());
         // ask user for the file overwrite confirmation
         if (!libdnf5::cli::utils::userconfirm::userconfirm(get_context().get_base().get_config())) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -224,6 +224,7 @@ private:
     std::string get_cmd_line();
 
     std::reference_wrapper<std::ostream> output_stream = std::cout;
+    std::reference_wrapper<std::ostream> info_stream = std::cerr;
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;
@@ -509,7 +510,7 @@ libdnf5::Goal * Context::Impl::get_goal(bool new_if_not_exist) {
 
 void Context::Impl::print_info(std::string_view msg) const {
     if (!quiet) {
-        output_stream.get() << msg << std::endl;
+        info_stream.get() << msg << std::endl;
     }
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -165,7 +165,10 @@ public:
 
     void print_info(std::string_view msg) const;
 
-    void set_output_stream(std::ostream & new_output_stream) { output_stream = new_output_stream; }
+    void set_output_stream(std::ostream & new_output_stream) {
+        err_stream = new_output_stream;
+        out_stream = new_output_stream;
+    }
 
     void set_transaction_store_path(std::filesystem::path path) { transaction_store_path = path; }
     const std::filesystem::path & get_transaction_store_path() const { return transaction_store_path; }
@@ -223,8 +226,8 @@ private:
     bool show_new_leaves{false};
     std::string get_cmd_line();
 
-    std::reference_wrapper<std::ostream> output_stream = std::cout;
-    std::reference_wrapper<std::ostream> info_stream = std::cerr;
+    std::reference_wrapper<std::ostream> out_stream = std::cout;
+    std::reference_wrapper<std::ostream> err_stream = std::cerr;
 
     std::unique_ptr<Plugins> plugins;
     std::unique_ptr<libdnf5::Goal> goal;
@@ -510,7 +513,7 @@ libdnf5::Goal * Context::Impl::get_goal(bool new_if_not_exist) {
 
 void Context::Impl::print_info(std::string_view msg) const {
     if (!quiet) {
-        info_stream.get() << msg << std::endl;
+        err_stream.get() << msg << std::endl;
     }
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -163,12 +163,12 @@ public:
     void set_load_available_repos(LoadAvailableRepos which) { load_available_repos = which; }
     LoadAvailableRepos get_load_available_repos() const noexcept { return load_available_repos; }
 
+    void print_output(std::string_view msg) const;
     void print_info(std::string_view msg) const;
+    void print_error(std::string_view msg) const;
 
-    void set_output_stream(std::ostream & new_output_stream) {
-        err_stream = new_output_stream;
-        out_stream = new_output_stream;
-    }
+    void set_output_stream(std::ostream & new_output_stream) { out_stream = new_output_stream; }
+    void set_error_stream(std::ostream & new_error_stream) { err_stream = new_error_stream; }
 
     void set_transaction_store_path(std::filesystem::path path) { transaction_store_path = path; }
     const std::filesystem::path & get_transaction_store_path() const { return transaction_store_path; }
@@ -511,10 +511,16 @@ libdnf5::Goal * Context::Impl::get_goal(bool new_if_not_exist) {
     return goal.get();
 }
 
+void Context::Impl::print_output(std::string_view msg) const {
+    out_stream.get() << msg << std::endl;
+}
 void Context::Impl::print_info(std::string_view msg) const {
     if (!quiet) {
         err_stream.get() << msg << std::endl;
     }
+}
+void Context::Impl::print_error(std::string_view msg) const {
+    err_stream.get() << msg << std::endl;
 }
 
 
@@ -654,6 +660,9 @@ void Context::print_info(std::string_view msg) const {
 }
 void Context::set_output_stream(std::ostream & new_output_stream) {
     p_impl->set_output_stream(new_output_stream);
+}
+void Context::set_error_stream(std::ostream & new_error_stream) {
+    p_impl->set_error_stream(new_error_stream);
 }
 
 void Context::set_transaction_store_path(std::filesystem::path path) {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -70,18 +70,18 @@ public:
             return false;
         }
 
-        std::cout << "Importing PGP key 0x" << key_info.get_short_key_id() << ":\n";
+        std::cerr << "Importing PGP key 0x" << key_info.get_short_key_id() << ":\n";
         for (auto & user_id : key_info.get_user_ids()) {
-            std::cout << " Userid     : \"" << user_id << "\"\n";
+            std::cerr << " Userid     : \"" << user_id << "\"\n";
         }
-        std::cout << " Fingerprint: " << key_info.get_fingerprint() << "\n";
-        std::cout << " From       : " << key_info.get_url() << std::endl;
+        std::cerr << " Fingerprint: " << key_info.get_fingerprint() << "\n";
+        std::cerr << " From       : " << key_info.get_url() << std::endl;
 
         return libdnf5::cli::utils::userconfirm::userconfirm(*config);
     }
 
     void repokey_imported([[maybe_unused]] const libdnf5::rpm::KeyInfo & key_info) override {
-        std::cout << _("The key was successfully imported.") << std::endl;
+        std::cerr << _("The key was successfully imported.") << std::endl;
     }
 
 private:
@@ -252,7 +252,7 @@ void Context::Impl::apply_repository_setopts() {
                 repo->get_config().opt_binds().at(key).new_string(
                     libdnf5::Option::Priority::COMMANDLINE, setopt.second);
             } catch (const std::exception & ex) {
-                std::cout << "setopt: \"" + setopt.first + "." + setopt.second + "\": " + ex.what() << std::endl;
+                std::cerr << "setopt: \"" + setopt.first + "." + setopt.second + "\": " + ex.what() << std::endl;
             }
         }
     }
@@ -331,7 +331,7 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
 
     auto & offline_data = state.get_data();
     if (offline_data.get_status() != libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE) {
-        std::cout << "There is already an offline transaction queued, initiated by the following command:" << std::endl
+        std::cerr << "There is already an offline transaction queued, initiated by the following command:" << std::endl
                   << "\t" << offline_data.get_cmd_line() << std::endl
                   << "Continuing will cancel the old offline transaction and replace it with this one." << std::endl;
         if (!libdnf5::cli::utils::userconfirm::userconfirm(base.get_config())) {
@@ -412,7 +412,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         constexpr const char * comps_in_trans_dir{"./comps"};
         auto comps_location = transaction_store_path / comps_in_trans_dir;
         if (std::filesystem::exists(transaction_location)) {
-            std::cout << libdnf5::utils::sformat(
+            std::cerr << libdnf5::utils::sformat(
                 _("Location \"{}\" already contains a stored transaction, it will be overwritten.\n"),
                 transaction_store_path.string());
             if (libdnf5::cli::utils::userconfirm::userconfirm(base.get_config())) {

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -104,7 +104,7 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
 void DownloadCallbacks::reset_progress_bar() {
     multi_progress_bar.reset();
     if (printed) {
-        std::cout << std::endl;
+        std::cerr << std::endl;
         printed = false;
     }
 }

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -136,10 +136,18 @@ public:
     void set_load_available_repos(LoadAvailableRepos which);
     LoadAvailableRepos get_load_available_repos() const noexcept;
 
-    /// If quiet mode is not active, it will print `msg` to standard output.
+    /// Print `msg` to the output stream, which by default is stdout.
+    void print_output(std::string_view msg) const;
+
+    /// If quiet mode is not active, it will print `msg` to the error stream, which by default is stderr.
     void print_info(std::string_view msg) const;
 
+    /// Print `msg` to the error stream, which by default is stderr.
+    void print_error(std::string_view msg) const;
+
     void set_output_stream(std::ostream & new_output_stream);
+
+    void set_error_stream(std::ostream & new_error_stream);
 
     // When set current transaction is not executed but rather stored to the specified path.
     void set_transaction_store_path(std::filesystem::path path);

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -187,11 +187,8 @@ void RootCommand::set_argument_parser() {
             try {
                 cache.write_attribute(libdnf5::repo::RepoCache::ATTRIBUTE_EXPIRED);
             } catch (const std::exception & ex) {
-                std::cerr << libdnf5::utils::sformat(
-                                 _("Failed to expire repository cache in path \"{0}\": {1}"),
-                                 dir_entry.path().native(),
-                                 ex.what())
-                          << std::endl;
+                ctx.print_error(libdnf5::utils::sformat(
+                    _("Failed to expire repository cache in path \"{0}\": {1}"), dir_entry.path().native(), ex.what()));
             }
         }
         return true;
@@ -742,37 +739,34 @@ static void print_versions(Context & context) {
     constexpr const char * appl_name = "dnf5";
     {
         const auto & version = get_application_version();
-        std::cout
-            << fmt::format(
-                   "{} version {}.{}.{}.{}", appl_name, version.prime, version.major, version.minor, version.micro)
-            << std::endl;
+        context.print_output(fmt::format(
+            "{} version {}.{}.{}.{}", appl_name, version.prime, version.major, version.minor, version.micro));
         const auto & api_version = get_plugin_api_version();
-        std::cout << fmt::format("{} plugin API version {}.{}", appl_name, api_version.major, api_version.minor)
-                  << std::endl;
+        context.print_output(
+            fmt::format("{} plugin API version {}.{}", appl_name, api_version.major, api_version.minor));
     }
     {
         const auto & version = libdnf5::get_library_version();
-        std::cout << fmt::format(
-                         "libdnf5 version {}.{}.{}.{}", version.prime, version.major, version.minor, version.micro)
-                  << std::endl;
+        context.print_output(
+            fmt::format("libdnf5 version {}.{}.{}.{}", version.prime, version.major, version.minor, version.micro));
         const auto & api_version = libdnf5::get_plugin_api_version();
-        std::cout << fmt::format("libdnf5 plugin API version {}.{}", api_version.major, api_version.minor) << std::endl;
+        context.print_output(fmt::format("libdnf5 plugin API version {}.{}", api_version.major, api_version.minor));
     }
 
     bool first{true};
     for (const auto & plugin : context.get_plugins().get_plugins()) {
         if (first) {
             first = false;
-            std::cout << fmt::format("\nLoaded {} plugins:", appl_name) << std::endl;
+            context.print_output(fmt::format("\nLoaded {} plugins:", appl_name));
         } else {
-            std::cout << std::endl;
+            context.print_output("");
         }
         auto * iplugin = plugin->get_iplugin();
-        std::cout << fmt::format("  name: {}", iplugin->get_name()) << std::endl;
+        context.print_output(fmt::format("  name: {}", iplugin->get_name()));
         const auto & version = iplugin->get_version();
-        std::cout << fmt::format("  version: {}.{}.{}", version.major, version.minor, version.micro) << std::endl;
+        context.print_output(fmt::format("  version: {}.{}.{}", version.major, version.minor, version.micro));
         const auto & api_version = iplugin->get_api_version();
-        std::cout << fmt::format("  API version: {}.{}", api_version.major, api_version.minor) << std::endl;
+        context.print_output(fmt::format("  API version: {}.{}", api_version.major, api_version.minor));
     }
 }
 
@@ -835,7 +829,7 @@ static void print_transaction_size_stats(Context & context) {
 
 static void dump_main_configuration(Context & context) {
     libdnf5::Base & base = context.get_base();
-    std::cout << _("======== Main configuration: ========") << std::endl;
+    context.print_output(_("======== Main configuration: ========"));
     for (const auto & option : base.get_config().opt_binds()) {
         const auto & val = option.second;
         std::string value;
@@ -846,9 +840,9 @@ static void dump_main_configuration(Context & context) {
         } catch (const libdnf5::OptionError &) {
         }
         if (was_set) {
-            std::cout << fmt::format("{} = {}", option.first, value) << std::endl;
+            context.print_output(fmt::format("{} = {}", option.first, value));
         } else {
-            std::cout << fmt::format("{}", option.first) << std::endl;
+            context.print_output(fmt::format("{}", option.first));
         }
     }
 }
@@ -876,8 +870,8 @@ static void dump_repository_configuration(Context & context, const std::vector<s
     }
 
     for (auto & repo : matching_repos) {
-        std::cout << libdnf5::utils::sformat(_("======== \"{}\" repository configuration: ========"), repo->get_id())
-                  << std::endl;
+        context.print_output(
+            libdnf5::utils::sformat(_("======== \"{}\" repository configuration: ========"), repo->get_id()));
         for (const auto & option : repo->get_config().opt_binds()) {
             const auto & val = option.second;
             std::string value;
@@ -888,19 +882,19 @@ static void dump_repository_configuration(Context & context, const std::vector<s
             } catch (const libdnf5::OptionError &) {
             }
             if (was_set) {
-                std::cout << fmt::format("{} = {}", option.first, value) << std::endl;
+                context.print_output(fmt::format("{} = {}", option.first, value));
             } else {
-                std::cout << fmt::format("{}", option.first) << std::endl;
+                context.print_output(fmt::format("{}", option.first));
             }
         }
     }
 }
 
 static void dump_variables(Context & context) {
-    std::cout << _("======== Variables: ========") << std::endl;
+    context.print_output(_("======== Variables: ========"));
     for (const auto & var : context.get_base().get_vars()->get_variables()) {
         const auto & val = var.second;
-        std::cout << fmt::format("{} = {}", var.first, val.value) << std::endl;
+        context.print_output(fmt::format("{} = {}", var.first, val.value));
     }
 }
 
@@ -937,11 +931,11 @@ static void print_new_leaves(Context & context) {
     }
 
     if (!new_leaves_na.empty()) {
-        std::cout << "New leaves:" << std::endl;
+        context.print_output("New leaves:");
         for (const auto & leaf_pkg : new_leaves_na) {
-            std::cout << " " << leaf_pkg << std::endl;
+            context.print_output(fmt::format(" {}", leaf_pkg));
         }
-        std::cout << std::endl;
+        context.print_output("");
     }
 }
 
@@ -1076,9 +1070,9 @@ static void print_resolve_hints(dnf5::Context & context) {
     }
 
     if (hints.size() > 0) {
-        std::cerr << _("You can try to add to command line:") << std::endl;
+        context.print_error(_("You can try to add to command line:"));
         for (const auto & hint : hints) {
-            std::cerr << "  " << hint << std::endl;
+            context.print_error(fmt::format("  {}", hint));
         }
     }
 }
@@ -1112,7 +1106,7 @@ static void print_no_match_libdnf_plugin_patterns(dnf5::Context & context) {
                 for (; it != no_match_pattern_set.end(); ++it) {
                     patterns += ", " + *it;
                 }
-                std::cerr << libdnf5::utils::sformat(TM_(no_match_message, 1), patterns) << std::endl;
+                context.print_error(libdnf5::utils::sformat(TM_(no_match_message, 1), patterns));
             }
         }
     }
@@ -1242,20 +1236,18 @@ int main(int argc, char * argv[]) try {
                     }
                 }
                 if (help_printed) {
-                    std::cerr << ex.what() << "." << std::endl;
+                    context.print_error(fmt::format("{}.", ex.what()));
                 } else {
-                    std::cerr << ex.what() << _(". Add \"--help\" for more information about the arguments.")
-                              << std::endl;
+                    context.print_error(fmt::format(
+                        "{}{}", ex.what(), _(". Add \"--help\" for more information about the arguments.")));
                 }
                 // If the error is an unknown top-level command, suggest
                 // installing a package that provides the command
                 if (auto * unknown_arg_ex = dynamic_cast<libdnf5::cli::ArgumentParserUnknownArgumentError *>(&ex)) {
                     if (unknown_arg_ex->get_command() == "dnf5" && unknown_arg_ex->get_argument()[0] != '-') {
-                        std::cerr
-                            << fmt::format(
-                                   "It could be a command provided by a plugin, try: dnf5 install 'dnf5-command({})'",
-                                   unknown_arg_ex->get_argument())
-                            << std::endl;
+                        context.print_error(fmt::format(
+                            "It could be a command provided by a plugin, try: dnf5 install 'dnf5-command({})'",
+                            unknown_arg_ex->get_argument()));
                     }
                 }
                 return static_cast<int>(libdnf5::cli::ExitCode::ARGPARSER_ERROR);
@@ -1393,18 +1385,16 @@ int main(int argc, char * argv[]) try {
 
                 if (auto transaction_store_path = context.get_transaction_store_path();
                     !transaction_store_path.empty()) {
-                    std::cerr << "The operation will only store the transaction in " << transaction_store_path << "."
-                              << std::endl;
+                    context.print_error(fmt::format(
+                        "The operation will only store the transaction in {}", transaction_store_path.string()));
                 } else if (base.get_config().get_downloadonly_option().get_value()) {
-                    std::cerr << "The operation will only download packages for the transaction." << std::endl;
+                    context.print_error("The operation will only download packages for the transaction.");
                 } else {
                     for (const auto & tsflag : base.get_config().get_tsflags_option().get_value()) {
                         if (tsflag == "test") {
-                            std::cerr
-                                << "Test mode enabled: Only package downloads, pgp key installations and transaction "
-                                   "checks "
-                                   "will be performed."
-                                << std::endl;
+                            context.print_error(
+                                "Test mode enabled: Only package downloads, pgp key installations and transaction "
+                                "checks will be performed.");
                         }
                     }
                 }
@@ -1416,13 +1406,12 @@ int main(int argc, char * argv[]) try {
                 context.download_and_run(*context.get_transaction());
             }
         } catch (libdnf5::cli::GoalResolveError & ex) {
-            std::cerr << ex.what() << std::endl;
+            context.print_error(ex.what());
             if (!any_repos_from_system_configuration && base.get_config().get_installroot_option().get_value() != "/" &&
                 !base.get_config().get_use_host_config_option().get_value()) {
-                std::cerr
-                    << "No repositories were loaded from the installroot. To use the configuration and repositories "
-                       "of the host system, pass --use-host-config."
-                    << std::endl;
+                context.print_error(
+                    "No repositories were loaded from the installroot. To use the configuration and repositories "
+                    "of the host system, pass --use-host-config.");
             } else {
                 if (context.get_transaction() != nullptr) {
                     // download command can throw GoalResolveError without context.transaction being set
@@ -1431,10 +1420,11 @@ int main(int argc, char * argv[]) try {
             }
             return static_cast<int>(libdnf5::cli::ExitCode::ERROR);
         } catch (libdnf5::cli::ArgumentParserError & ex) {
-            std::cerr << ex.what() << _(". Add \"--help\" for more information about the arguments.") << std::endl;
+            context.print_error(
+                fmt::format("{}{}", ex.what(), _(". Add \"--help\" for more information about the arguments.")));
             return static_cast<int>(libdnf5::cli::ExitCode::ARGPARSER_ERROR);
         } catch (libdnf5::cli::CommandExitError & ex) {
-            std::cerr << ex.what() << std::endl;
+            context.print_error(ex.what());
             return ex.get_exit_code();
         } catch (libdnf5::cli::SilentCommandExitError & ex) {
             return ex.get_exit_code();

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1393,14 +1393,14 @@ int main(int argc, char * argv[]) try {
 
                 if (auto transaction_store_path = context.get_transaction_store_path();
                     !transaction_store_path.empty()) {
-                    std::cout << "The operation will only store the transaction in " << transaction_store_path << "."
+                    std::cerr << "The operation will only store the transaction in " << transaction_store_path << "."
                               << std::endl;
                 } else if (base.get_config().get_downloadonly_option().get_value()) {
-                    std::cout << "The operation will only download packages for the transaction." << std::endl;
+                    std::cerr << "The operation will only download packages for the transaction." << std::endl;
                 } else {
                     for (const auto & tsflag : base.get_config().get_tsflags_option().get_value()) {
                         if (tsflag == "test") {
-                            std::cout
+                            std::cerr
                                 << "Test mode enabled: Only package downloads, pgp key installations and transaction "
                                    "checks "
                                    "will be performed."

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -217,12 +217,12 @@ void DownloadCB::key_import(sdbus::Signal & signal) {
         std::string url;
         signal >> key_id >> user_ids >> fingerprint >> url;
 
-        std::cout << std::endl << "Importing PGP key 0x" + key_id << ":\n";
+        std::cerr << std::endl << "Importing PGP key 0x" + key_id << ":\n";
         for (auto & user_id : user_ids) {
-            std::cout << " Userid     : \"" + user_id << "\"\n";
+            std::cerr << " Userid     : \"" + user_id << "\"\n";
         }
-        std::cout << " Fingerprint: " + fingerprint << std::endl;
-        std::cout << " From       : " + url << std::endl;
+        std::cerr << " Fingerprint: " + fingerprint << std::endl;
+        std::cerr << " From       : " + url << std::endl;
 
         // ask user for the key import confirmation
         auto confirmed = libdnf5::cli::utils::userconfirm::userconfirm(context);

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -89,7 +89,7 @@ void DownloadCB::print() {
 void DownloadCB::reset_progress_bar() {
     multi_progress_bar.reset();
     if (printed) {
-        std::cout << std::endl;
+        std::cerr << std::endl;
         printed = false;
     }
 }

--- a/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
@@ -44,8 +44,8 @@ public:
 
     void add_bar(std::unique_ptr<ProgressBar> && bar);
     void print() {
-        std::cout << *this;
-        std::cout << std::flush;
+        std::cerr << *this;
+        std::cerr << std::flush;
     }
     LIBDNF_CLI_API friend std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar);
 

--- a/include/libdnf5-cli/utils/userconfirm.hpp
+++ b/include/libdnf5-cli/utils/userconfirm.hpp
@@ -45,7 +45,7 @@ bool userconfirm(Config & config) {
         msg = "Is this ok [y/N]: ";
     }
     while (true) {
-        std::cout << msg;
+        std::cerr << msg;
 
         std::string choice;
         std::getline(std::cin, choice);

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -35,14 +35,14 @@ MultiProgressBar::MultiProgressBar() : total(0, "Total") {
     total.set_auto_finish(false);
     total.start();
     if (tty::is_interactive()) {
-        std::cout << tty::cursor_hide;
+        std::cerr << tty::cursor_hide;
     }
 }
 
 
 MultiProgressBar::~MultiProgressBar() {
     if (tty::is_interactive()) {
-        std::cout << tty::cursor_show;
+        std::cerr << tty::cursor_show;
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/rpm-software-management/dnf5/issues/1361

This patchset changes many messages to be printed on stderr instead of stdout.

Opinions vary, but by general convention, the "useful output" of a program (that might be e.g. piped to a pager or consumed by a script), should be on stdout. All other messages, including warnings, progress bars, "Are you sure you want to continue?"-style prompts should be on stderr.

There are gray areas here, especially when you consider the same piece of output in different contexts. You could argue that the "Updating and loading repositories" message and multiprogressbar are "useful output" of the `makecache` command, but the same messages are not "useful output" of the `repoquery` command. And DNF 5 commands such as `install` and `upgrade` are primarily "imperative" and don't have "useful output" in the same way that commands like `repolist` and `repoquery` do. So here, I've tried to use my best judgment and err on the side of keeping the status quo.

The following messages are moved from stdout to stderr:
- All messages printed via `Context::print_info` go to stderr, which includes:
    - "Updating and loading repositories:"
    - "Repositories loaded."
    - "Running transaction"
    - "Testing offline transaction"
    - "After this operation, x extra will be used (install x, remove x)."
    - "After this operation, x extra will be freed (install x, remove x)."
    - "Total size of inbound packages is x. Need to download x."
    - "Complete!"
- Warnings, errors (most were already on stderr), and userconfirm prompts
- Progress bars
- Output related to key import

To observe these changes, it's useful to redirect both streams to files:

```
sudo dnf5 <args> >/tmp/stdout 2>/tmp/stderr
```

and watch them from other terminals:

```
tail -Fqf /tmp/stdout /tmp/stderr   # merged stdout stderr
tail -Ff /tmp/stdout                # just stdout
tail -Ff /tmp/stdout                # just stderr
```

<details>

<summary>Output of <code>dnf5 --refresh rq rawhide xz</code> after this patch</summary>

(before this patch, all output was on stdout.)

<details>

<summary>merged stdout and stderr</summary>

```
Updating and loading repositories:
 Fedora 40 openh264 (From Cisco) - x86_64    100% |   6.7 KiB/s | 989.0   B |  00m00s
 Fedora 40 - x86_64 - Updates                100% | 223.7 KiB/s |  26.2 KiB |  00m00s
 Fedora 40 - x86_64                          100% | 220.3 KiB/s |  28.0 KiB |  00m00s
 Local Repository                            100% |   0.0   B/s |   1.5 KiB |  00m00s
Repositories loaded.
xz-1:5.4.6-3.fc40.x86_64
```

</details>

<details>

<summary>stdout</summary>

```
xz-1:5.4.6-3.fc40.x86_64
```

</details>

<details>

<summary>stderr</summary>

```
Updating and loading repositories:
 Fedora 40 openh264 (From Cisco) - x86_ 100% |  11.9 KiB/s | 989.0   B |  00m00s
 Local Repository                       100% |   0.0   B/s |   1.5 KiB |  00m00s
 Fedora 40 - x86_64 - Updates           100% | 219.9 KiB/s |  26.2 KiB |  00m00s
 Fedora 40 - x86_64                     100% |  87.4 KiB/s |  28.0 KiB |  00m00s
Repositories loaded.
```

</details>

</details>

<details>

<summary>Output of <code>dnf5 install hello</code> after this patch</summary>

(before this patch, all output was on stdout.)

<details>

<summary>merged stdout and stderr</summary>

```
Updating and loading repositories:
Repositories loaded.
Package Arch   Version       Repository      Size
Installing:
 hello  x86_64 2.12.1-4.fc40 fedora     196.4 KiB
Installing weak dependencies:
 info   x86_64 7.1-2.fc40    fedora     357.8 KiB

Transaction Summary:
 Installing:        2 packages

Total size of inbound packages is 269 KiB. Need to download 269 KiB.
After this operation, 554 KiB extra will be used (install 554 KiB, remove 0 B).
Is this ok [y/N]: [1/2] hello-0:2.12.1-4.fc40.x86_64      100% | 239.8 KiB/s |  87.1 KiB |  00m00s
[2/2] info-0:7.1-2.fc40.x86_64          100% | 450.2 KiB/s | 182.3 KiB |  00m00s
--------------------------------------------------------------------------------
[2/2] Total                             100% | 483.7 KiB/s | 269.4 KiB |  00m01s
Running transaction
[1/4] Verify package files              100% |   2.0 KiB/s |   2.0   B |  00m00s
[2/4] Prepare transaction               100% |  28.0   B/s |   2.0   B |  00m00s
[3/4] Installing info-0:7.1-2.fc40.x86_ 100% |  18.4 MiB/s | 358.2 KiB |  00m00s
[4/4] Installing hello-0:2.12.1-4.fc40. 100% | 352.9 KiB/s | 204.4 KiB |  00m01s
Complete!
```

</details>

<details>

<summary>stdout</summary>

```
Package Arch   Version       Repository      Size
Installing:
 hello  x86_64 2.12.1-4.fc40 fedora     196.4 KiB
Installing weak dependencies:
 info   x86_64 7.1-2.fc40    fedora     357.8 KiB

Transaction Summary:
 Installing:        2 packages

```

</details>

<details>

<summary>stderr</summary>

```
Updating and loading repositories:
Repositories loaded.
Total size of inbound packages is 269 KiB. Need to download 269 KiB.
After this operation, 554 KiB extra will be used (install 554 KiB, remove 0 B).
Is this ok [y/N]: [1/2] hello-0:2.12.1-4.fc40.x86_64      100% | 608.8 KiB/s |  87.1 KiB |  00m00s
[2/2] info-0:7.1-2.fc40.x86_64          100% |   1.0 MiB/s | 182.3 KiB |  00m00s
--------------------------------------------------------------------------------
[2/2] Total                             100% | 844.5 KiB/s | 269.4 KiB |  00m00s
Running transaction
[1/4] Verify package files              100% |   2.0 KiB/s |   2.0   B |  00m00s
[2/4] Prepare transaction               100% |  28.0   B/s |   2.0   B |  00m00s
[3/4] Installing info-0:7.1-2.fc40.x86_ 100% |  17.5 MiB/s | 358.2 KiB |  00m00s
[4/4] Installing hello-0:2.12.1-4.fc40. 100% | 364.3 KiB/s | 204.4 KiB |  00m01s
Complete!
```

</details>

</details>

I anticipate this PR needing a large ci-dnf-test patch, so I've marked it as a draft.
