### PR TITLE
Birectional communication of libdnf5 actions plugin with running processes - "json" mode

### DIFF
--- a/libdnf5-plugins/actions/CMakeLists.txt
+++ b/libdnf5-plugins/actions/CMakeLists.txt
@@ -11,6 +11,10 @@ add_library(actions MODULE actions.cpp)
 # disable the 'lib' prefix in order to create actions.so
 set_target_properties(actions PROPERTIES PREFIX "")
 
+pkg_check_modules(JSONC REQUIRED json-c)
+include_directories(${JSONC_INCLUDE_DIRS})
+target_link_libraries(actions PRIVATE ${JSONC_LIBRARIES})
+
 target_link_libraries(actions PRIVATE libdnf5)
 
 install(TARGETS actions LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -45,7 +45,7 @@ using namespace libdnf5;
 namespace {
 
 constexpr const char * PLUGIN_NAME = "actions";
-constexpr plugin::Version PLUGIN_VERSION{1, 1, 0};
+constexpr plugin::Version PLUGIN_VERSION{1, 1, 1};
 
 constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
 constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "Actions Plugin."};
@@ -274,14 +274,14 @@ std::pair<std::string, bool> Actions::substitute(
             }
         } else if (var_name.starts_with("conf.")) {
             auto key = std::string(var_name.substr(5));
-            const auto dot_pos = key.rfind('.');
-            if (dot_pos != std::string::npos) {
+            const auto equal_pos = key.find('=');
+            const auto dot_pos = key.find('.');
+            if (dot_pos < equal_pos) {
                 // It is a repository option. The repoid is part of the key and can contain globs.
                 // Will be substituted by a list of "repoid.option=value" pairs for the matching repositories.
                 // Pairs are separated by ',' character. The ',' character in the value is replaced by escape sequence.
                 // Supported formats: `<repoid_pattern>.<opt_name>` or `<repoid_pattern>.<opt_name>=<value_pattern>`
                 std::string value_pattern;
-                const auto equal_pos = key.find('=');
                 if (equal_pos != std::string::npos) {
                     value_pattern = key.substr(equal_pos + 1);
                     key = key.substr(0, equal_pos);


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1538

Introduces a "mode" option in the hook handler definition.
Option "mode" defines communication model between actions plugin and process.
Introduces 2 modes of communication: "plain" and "json".

### "mode=plain" - Original and default communication model.

Parameters are passed to the process only by arguments when it starts. Arguments may contain variables that are substituted before the process is started. A process can modify libdnf5 settings (main configuration, repository configuration, variables) and plugin actions variables by writing to standard
output.

**Output line format:**
- `tmp.<actions_plugin_variable_name>=<value>` - sets the value of action plugins variable `<actions_plugin_variable_name>`
-` tmp.<actions_plugin_variable_name>` - removes the action plugins variable if it exists
- `conf.<option_name>=<value>` - sets the value of option <option_name> in the base configuration
- `conf.<repoid_pattern>.<option_name>=<value>` - sets the value of option <option_name> in the matching repositories
- `var.<variable_name>=<value>` - sets value of the variable <variable_name>

### "mode=json" - Newly introduced communication model.

Parameters can be passed to the process before it starts using arguments just like in "plain" mode. This mode adds bidirectional communication between the actions plugin and the process. This is request/response communication.
The process sends requests and the actions plugin sends responses. The process writes requests to the standard output and reads responses from the standard input.

**Processes send requests and the actions plugin responds:**

- Request format:
    `{"op":"<operation>", "domain":"<domain>", "args":{<op_domain_spec_args>}}`

"domain" is ignored in the case of the "log" operation.

- Response format:
    `{"op": "reply", "requested_op":"<op_from_request>", "domain": "<domain_from_request>", "status": "OK", "return":{<data>}}`

    `{"op": "reply", "requested_op":"<op_from_request>", "domain": "<domain_from_request>", "status": "ERROR", "message":"<error message>"`}

"return" is not included in the response to a request for a "log"
operation.

If the JSON request is unparsable - a syntax error or incomplete message, or the response cannot be written, the action plugin closes both communication pipes. The process must terminate if the communication pipes are closed.