### PR TITLE
doc: configuration options update

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -411,11 +411,18 @@ Changes to individual options
   * Supported values are now extended to the following list: ``comps``, ``filelists``, ``other``, ``presto``, ``updateinfo``.
 
 
-Newly introduced options
-------------------------
+Newly introduced configuration options
+--------------------------------------
 ``allow_downgrade``
   * New option used to enable or disable downgrade of dependencies when resolving transaction.
 
 ``skip_broken``, ``skip_unavailable``, ``strict``
   * New options ``skip_broken``, ``skip_unavailable`` were added due to deprecation of ``strict`` option.
   * See the :ref:`strict deprecation <strict_option_conf_changes_ref-label>` above.
+
+
+Dropped configuration options
+-----------------------------
+``arch`` and ``basearch``
+  * It is no longer possible to change the detected architecute in configuration files.
+  * See the :manpage:`dnf5-forcearch(7)`, :ref:`Forcearch parameter <forcearch_misc_ref-label>` for overriding architecture.

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -77,10 +77,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
 ``reset_nice``
 
-.. _system_cachedir_options-label:
-
-``system_cachedir``
-
 .. _debuglevel_options-label:
 
 ``debuglevel``
@@ -152,10 +148,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 .. _use_host_config_options-label:
 
 ``use_host_config``
-
-.. _config_file_age_options-label:
-
-``config_file_age``
 
 .. _allow_downgrade_options-label:
 

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -302,49 +302,17 @@ This section does not track any deprecated option. For such options see :ref:`De
 Repo Options
 ============
 
-.. _baseurl_repo_options-label:
-
-``baseurl``
-
-.. _cost_repo_options-label:
-
-``cost``
-
-.. _gpgcheck_options-label:
-
 ``gpgcheck``
 
 .. _gpgkey_repo_options-label:
-
-``gpgkey``
-
-.. _metalink_repo_options-label:
-
-``metalink``
 
 .. _metadata_timer_sync_options-label:
 
 ``metadata_timer_sync``
 
-.. _mirrorlist_repo_options-label:
-
-``mirrorlist``
-
 .. _module_hotfixes_repo_options-label:
 
 ``module_hotfixes``
-
-.. _name_repo_options-label:
-
-``name``
-
-.. _priority_repo_options-label:
-
-``priority``
-
-.. _type_repo_options-label:
-
-``type``
 
 
 Repo Variables

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -53,17 +53,9 @@ This section does not track any deprecated option. For such options see :ref:`De
 
 ``log_compress``
 
-.. _transaction_history_dir_options-label:
-
-``transaction_history_dir``
-
 .. _transformdb_options-label:
 
 ``transformdb``
-
-.. _recent_options-label:
-
-``recent``
 
 .. _reset_nice_options-label:
 
@@ -78,10 +70,6 @@ This section does not track any deprecated option. For such options see :ref:`De
     more debug output is put to stdout.
 
     Default: ``2``.
-
-.. _debugdir_options-label:
-
-``debugdir``
 
 .. _diskspacecheck_options-label:
 
@@ -137,16 +125,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
     Default: ``False``.
 
-.. _use_host_config_options-label:
-
-``use_host_config``
-
-.. _allow_downgrade_options-label:
-
-``allow_downgrade``
-
-.. _bugtracker_url_options-label:
-
 ``bugtracker_url``
 
 .. _history_record_options-label:
@@ -157,14 +135,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
 ``history_record_packages``
 
-.. _skip_broken_options-label:
-
-``skip_broken``
-
-.. _skip_unavailable_options-label:
-
-``skip_unavailable``
-
 .. _history_list_view_options-label:
 
 ``history_list_view``
@@ -172,22 +142,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 .. _comment_options-label:
 
 ``comment``
-
-.. _downloadonly_options-label:
-
-``downloadonly``
-
-.. _build_cache_options-label:
-
-``build_cache``
-
-.. _exclude_from_weak_options-label:
-
-``exclude_from_weak``
-
-.. _exclude_from_weak_autodetect_options-label:
-
-``exclude_from_weak_autodetect``
 
 .. _releasever_options-label:
 
@@ -199,15 +153,6 @@ This section does not track any deprecated option. For such options see :ref:`De
     :ref:`boolean <boolean-label>`
 
     If enabled, DNF5 tries to apply modular obsoletes when possible.
-
-    Default: ``False``.
-
-.. _module_stream_switch_options-label:
-
-``module_stream_switch``
-    :ref:`boolean <boolean-label>`
-
-    If enabled, allows switching enabled streams of a module.
 
     Default: ``False``.
 

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -33,10 +33,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 [main] Options
 ==============
 
-.. _arch_options-label:
-
-``arch``
-
 .. _autocheck_running_kernel_options-label:
 
 ``autocheck_running_kernel``
@@ -48,10 +44,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
     .. NOTE::
        YUM compatibility option
-
-.. _basearch_options-label:
-
-``basearch``
 
 .. _logfilelevel_options-label:
 

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -302,10 +302,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 Repo Options
 ============
 
-``gpgcheck``
-
-.. _gpgkey_repo_options-label:
-
 .. _metadata_timer_sync_options-label:
 
 ``metadata_timer_sync``

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -41,6 +41,15 @@ repository configuration file should aside from repo ID consists of baseurl, met
 [main] Options
 ==============
 
+.. _allow_downgrade_options-label:
+
+``allow_downgrade``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 allows downgrading packages while resolving dependencies.
+
+    Default: ``True``.
+
 .. _allow_vendor_change_options-label:
 
 ``allow_vendor_change``
@@ -147,13 +156,23 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``True``.
 
+.. _debugdir_options-label:
+
+``debugdir``
+    :ref:`string <string-label>`
+
+    Location where libsolv debug files will be created when enabled
+    by :ref:`debug_solver <_debug_solver_options-label>`.
+
+    Default `./debugdata`.
+
 .. _debug_solver_options-label:
 
 ``debug_solver``
     :ref:`boolean <boolean-label>`
 
     If enabled, libsolv debug files will be created when solving the
-    transaction. The debug files are created in the `./debugdata` directory.
+    transaction. The debug files are created in the :ref:`debugdir <_debugdir_options-label>` directory.
 
     Default: ``False``.
 
@@ -175,6 +194,29 @@ repository configuration file should aside from repo ID consists of baseurl, met
     Redirect downloaded packages to provided directory.
 
     Default: <package repository :ref:`cachedir <cachedir_options-label>`>/packages
+
+.. _exclude_from_weak_options-label:
+
+``exclude_from_weak``
+    :ref:`list <list-label>`
+
+    Prevent installing packages as weak dependencies (recommends or
+    supplements). The packages can be specified by a name or a glob and
+    separated by a comma.
+
+    Defaults to [].
+
+.. _exclude_from_weak_autodetect_options-label:
+
+``exclude_from_weak_autodetect``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will autodetect unmet weak dependencies (recommends or
+    supplements) of packages installed on the system. Providers of these weak
+    dependencies will not be installed by dnf as weak dependencies any more
+    (they will still be installed if pulled in as a regular dependency).
+
+    Defaults to true.
 
 .. _group_package_types_options-label:
 
@@ -304,6 +346,15 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: empty.
 
+.. _module_stream_switch_options-label:
+
+``module_stream_switch``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, allows switching enabled streams of a module.
+
+    Default: ``False``.
+
 .. _multilib_policy_options-label:
 
 ``multilib_policy``
@@ -413,6 +464,16 @@ repository configuration file should aside from repo ID consists of baseurl, met
     .. NOTE::
        YUM compatibility option
 
+.. _recent_options-label:
+
+``recent``
+    :ref:`integer <integer-label>`
+
+    Sets the time period in days used for the ``--recent`` option in the :ref:`repoquery <repoquery_command_ref-label>`,
+    :ref:`info <info_command_ref-label>` and :ref:`list <list_command_ref-label>` commands.
+
+    Default: 7
+
 .. _reposdir_options-label:
 
 ``reposdir``
@@ -424,6 +485,26 @@ repository configuration file should aside from repo ID consists of baseurl, met
     along with \-\ :ref:`-installroot <installroot_options-label>` option.
 
     Default: [``/etc/yum.repos.d``, ``/etc/distro.repos.d``, ``/usr/share/dnf5/repos.d``]
+
+.. _skip_broken_options-label:
+
+``skip_broken``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will skip uninstallable packages instead of failing while
+    resolving dependencies.
+
+    Default: ``False``.
+
+.. _skip_unavailable_options-label:
+
+``skip_unavailable``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will skip unavailable packages instead of failing while
+    preparing rpm transactions.
+
+    Default: ``False``.
 
 .. _system_cachedir_options-label:
 
@@ -445,6 +526,16 @@ repository configuration file should aside from repo ID consists of baseurl, met
     System state files location. See :manpage:`dnf5-system-state(7)`, :ref:`system state <systemstate_misc_ref-label>` for details.
 
     Default: ``/usr/lib/sysimage/libdnf5``.
+
+.. _transaction_history_dir_options-label:
+
+``transaction_history_dir``
+
+    :ref:`string <string-label>`
+
+    History database location.
+
+    By default it has the same value as :ref:`system_state_dir <_system_state_dir_options-label>`.
 
 .. _tsflags_options-label:
 
@@ -482,6 +573,12 @@ repository configuration file should aside from repo ID consists of baseurl, met
 .. _use_host_config_options-label:
 
 ``use_host_config``
+
+    Use configuration files and variable definitions from the host system rather
+    than the installroot.
+    :ref:`See <installroot_misc_ref-label>` :manpage:`dnf5-installroot(7)` for more info.
+
+    Default: ``False``.
 
 .. _varsdir_options-label:
 
@@ -749,6 +846,17 @@ configuration.
     Meaningful when used with the :ref:`throttle option <throttle_options-label>`.
 
     Default: ``0``.
+
+.. _build_cache_options-label:
+
+``build_cache``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will save libsolv cache generated from downloaded metadata
+    to cachedir. These solv files are loaded during subsequent runs which
+    significantly speeds up DNF5.
+
+    Default: ``True``.
 
 .. _countme_options-label:
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -590,7 +590,28 @@ repository configuration file should aside from repo ID consists of baseurl, met
 Repo Options
 ============
 
-.. _enabled_options-label:
+.. _baseurl_repo_options-label:
+
+``baseurl``
+    :ref:`list <list-label>`
+
+    List of URLs for the repository.
+
+    Default [].
+
+    URLs are tried in the listed order (equivalent to yum’s “failovermethod=priority” behaviour).
+
+.. _cost_repo_options-label:
+
+``cost``
+    :ref:`integer <integer-label>`
+
+    The relative cost of accessing this repository, defaulting to 1000. This
+    value is compared when the priorities of two repositories are the same. The
+    repository with the lowest cost is picked. It is useful to make the library
+    prefer on-disk repositories to remote ones.
+
+.. _enabled_repo_options-label:
 
 ``enabled``
     :ref:`boolean <boolean-label>`
@@ -598,6 +619,66 @@ Repo Options
     Include this repository as a package source.
 
     Default: ``True``.
+
+.. _gpgkey_repo_options-label:
+
+``gpgkey``
+    :ref:`list <list-label>`
+
+    URLs of a GPG key files that can be used for signing metadata and packages
+    of this repository. If a file can not be verified using
+    the already imported keys, import of keys from this option is attempted and
+    the keys are then used for verification.
+
+    Default: ``[]``
+
+.. _metalink_repo_options-label:
+
+``metalink``
+    :ref:`string <string-label>`
+
+    URL of a metalink for the repository.
+
+    Default: ``None``.
+
+.. _mirrorlist_repo_options-label:
+
+``mirrorlist``
+    :ref:`string <string-label>`
+
+    URL of a mirrorlist for the repository.
+
+    Default: ``None``.
+
+
+.. _name_repo_options-label:
+
+``name``
+    :ref:`string <string-label>`
+
+    A human-readable name of the repository. Defaults to the ID of the repository.
+
+.. _priority_repo_options-label:
+
+``priority``
+    :ref:`integer <integer-label>`
+
+    The priority value of this repository. If there is more than
+    one candidate package for a particular operation, the one from a repo with
+    the lowest priority value is picked, possibly despite being less convenient
+    otherwise (e.g. by being a lower version).
+
+    Default: 99
+
+.. _type_repo_options-label:
+
+``type``
+    :ref:`string <string-label>`
+
+    Type of repository metadata. Supported values are: ``rpm-md``. Aliases for
+    ``rpm-md``: ``rpm``, ``repomd``, ``rpmmd``, ``yum``, ``YUM``.
+
+    Default: empty.
 
 
 Source and debuginfo repository names

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -423,7 +423,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     The behavior of ``reposdir`` could differ when it is used
     along with \-\ :ref:`-installroot <installroot_options-label>` option.
 
-    Default: TODO add default
+    Default: [``/etc/yum.repos.d``, ``/etc/distro.repos.d``, ``/usr/share/dnf5/repos.d``]
 
 .. _system_cachedir_options-label:
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -864,6 +864,18 @@ configuration.
 
     Default: ``False``.
 
+.. _gpgcheck_options-label:
+
+``gpgcheck``
+    :ref:`boolean <boolean-label>`
+
+    Whether to perform GPG signature check on packages found in this repository.
+
+    The default is False.
+
+    Doesn't apply for packages passed directly as arguments, as they are not in any repository,
+    see :ref:`localpkg_gpgcheck <localpkg_gpgcheck_options-label>`.
+
 .. _includepkgs_options-label:
 
 ``includepkgs``
@@ -898,9 +910,6 @@ configuration.
     :ref:`boolean <boolean-label>`
 
     If enabled, DNF5 will perform a GPG signature check on local packages (packages in a file, not in a repository).
-
-    This option is subject to the active RPM security policy
-    (see :ref:`gpgcheck <gpgcheck_options-label>` for more details).
 
     Default: ``False``.
 


### PR DESCRIPTION
Regarding the `gpgcheck` option, we might want to match the dnf4 behavior described in https://bugzilla.redhat.com/show_bug.cgi?id=1614351, like https://github.com/rpm-software-management/dnf/pull/1293.
However for now  lets remove the incorrect info.