### PR TITLE
[dnf5] Add argument "-c" - alias to "--config" (dnf4 compatibility)

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -8,6 +8,13 @@ version = '1.0'
 type = 'group'
 header = "Options Compatibility aliases:"
 
+['c']
+type = 'cloned_named_arg'
+short_name = 'c'
+source = 'config'
+group_id = 'options-compatibility-aliases'
+complete = false
+
 ['nobest']
 type = 'cloned_named_arg'
 long_name = 'nobest'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -48,9 +48,6 @@ Changes to individual options
 ``--color``
   * Dropped. Now only the ``color`` configuration option is available.
 
-``-c``
-  * The short version of the ``--config`` option has been dropped.
-
 .. TODO(jkolarik): Not implemented yet
    ``-d, --debuglevel``
      * Dropped. Now only the ``debuglevel`` configuration option is available.


### PR DESCRIPTION
We prefer the "--config" argument, for which we support bash completion. The short version "-c" is added to prevent problems with old scripts using dnf4 that may use "-c".

Closes: https://github.com/rpm-software-management/dnf5/issues/1622