### PR TITLE
Show the output of failed scriptlets to the user

### DIFF
--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -259,6 +259,8 @@ private:
 
     DNF_LOCAL static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
 
+    DNF_LOCAL void script_output_to_progress(libdnf5::cli::progressbar::MessageType message_type);
+
     libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};
     Context & context;

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -193,12 +193,17 @@ public:
     void set_download_local_pkgs(bool value);
     bool get_download_local_pkgs() const noexcept;
 
+    /// Retrieve output of the last executed rpm scriptlet.
+    std::string get_last_script_output();
+
 private:
     friend class TransactionEnvironment;
     friend class TransactionGroup;
     friend class TransactionModule;
     friend class TransactionPackage;
     friend class libdnf5::Goal;
+    friend class libdnf5::rpm::
+        Transaction;  // to access clear_last_script_output() from the rpm transaction SCRIPT_START callback
 
     LIBDNF_LOCAL Transaction(const libdnf5::BaseWeakPtr & base);
 
@@ -209,6 +214,9 @@ private:
     std::optional<uint32_t> user_id;
     std::string comment;
     std::string description;
+
+    /// Clear the recorded last scriptlet output
+    LIBDNF_LOCAL void clear_last_script_output();
 };
 
 }  // namespace libdnf5::base

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -37,6 +37,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <solv/transaction.h>
 
+#include <mutex>
+
 
 namespace libdnf5::base {
 
@@ -91,6 +93,12 @@ public:
         const std::optional<uint32_t> user_id,
         const std::string & comment);
 
+    /// Handling of rpm scriptlets output
+    std::string get_last_script_output();
+    void clear_last_script_output();
+    void append_last_script_output(std::string_view output);
+    void process_scriptlets_output(int fd);
+
 private:
     friend Transaction;
     friend class libdnf5::Goal;
@@ -124,6 +132,9 @@ private:
 
     // whether also the command line repo packages should be downloaded to the destination
     bool download_local_pkgs{false};
+
+    std::string last_script_output{};
+    std::mutex last_script_output_mutex;
 
     TransactionRunResult _run(
         std::unique_ptr<libdnf5::rpm::TransactionCallbacks> && callbacks,

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -618,6 +618,10 @@ void * Transaction::ts_callback(
         }
         case RPMCALLBACK_SCRIPT_START: {
             // amount is script tag
+            if (callbacks_holder.base_transaction) {
+                // a new scriptlet is running, clear the stored output
+                callbacks_holder.base_transaction->clear_last_script_output();
+            }
             auto script_type = rpm_tag_to_script_type(static_cast<rpmTag_e>(amount));
             auto nevra = trans_element_to_nevra(trans_element);
             logger.info(

--- a/libdnf5/rpm/transaction.hpp
+++ b/libdnf5/rpm/transaction.hpp
@@ -281,6 +281,12 @@ public:
         callbacks_holder.callbacks = std::move(callbacks);
     }
 
+    /// Set pointer to the running libdnf5::Base::Transaction.
+    /// @param base_transaction a pointer to the transaction
+    void set_base_transaction(libdnf5::base::Transaction * base_transaction) {
+        callbacks_holder.base_transaction = base_transaction;
+    }
+
     /// Fill the RPM transaction from base::Transaction.
     /// @param transcation The base::Transaction object.
     void fill(const base::Transaction & transaction);
@@ -327,12 +333,13 @@ private:
     struct CallbacksHolder {
         std::unique_ptr<TransactionCallbacks> callbacks;
         Transaction * transaction;
+        libdnf5::base::Transaction * base_transaction;
     };
 
     BaseWeakPtr base;
     rpmts ts;
     FD_t script_fd{nullptr};
-    CallbacksHolder callbacks_holder{nullptr, this};
+    CallbacksHolder callbacks_holder{nullptr, this, nullptr};
     FD_t fd_in_cb{nullptr};  // file descriptor used by transaction in callback (install/reinstall package)
 
     TransactionItem * last_added_item{nullptr};  // item added by last install/reinstall/erase/...


### PR DESCRIPTION
Currently, the output of RPM scriptlets is somewhat hidden in the log. This patch introduces a new `libdnf5::base::Transaction::get_last_script_output()` method, which returns the outputs of the most recently executed RPM scriptlet. This method is then utilized in the transaction callbacks in DNF5 to display the output to the user.

Although it would be more intuitive to add the scriptlet output as a new parameter in script_end and script_error, doing so would break the existing API.

The scriptlet output is only printed in the event of a failure; it is not displayed when the execution is successful.

Resolves: https://github.com/rpm-software-management/dnf5/issues/522
Replaces: https://github.com/rpm-software-management/dnf5/pull/1645


Changes:

57715716 (Marek Blaha, 5 minutes ago)
   dnf5: Print rpm scriptlets outputs to the user

   If a scriptlet fails, its output is displayed to the user in addition to 
   being written to the log. For scriptlets that complete successfully, the 
   output is only logged.

27d322a8 (Marek Blaha, 9 minutes ago)
   transaction: Store outputs of the last rpm scriptlet

   The outputs of the most recently executed RPM scriptlet in the transaction
   are stored and can be accessed by the user through the 
   Base::Transaction::get_last_script_output() method.

55cf66fe (Marek Blaha, 21 minutes ago)
   rpm::transaction: Base::Transaction to callback holder

   Handling scriptlet outputs requires rpm transaction callbacks to have 
   access to the `libdnf5::Base::Transaction` instance the rpm transaction 
   belongs to.