### PR TITLE
daemon: D-Bus API to cancel current transaction

### DIFF
--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -60,7 +60,7 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
     if (is_time_to_print()) {
         print();
     }
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
@@ -87,7 +87,7 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             break;
     }
     print();
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
@@ -98,7 +98,7 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
     }
     progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
     print();
-    return 0;
+    return ReturnCode::OK;
 }
 
 void DownloadCallbacks::reset_progress_bar() {

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -66,6 +66,9 @@ void * DownloadCB::add_new_download(void * user_data, const char * description, 
 }
 
 int DownloadCB::progress(void * user_cb_data, double total_to_download, double downloaded) {
+    if (session.get_cancel_download() == Session::CancelDownload::REQUESTED) {
+        return ReturnCode::ERROR;
+    }
     try {
         if (is_time_to_print()) {
             auto signal = create_signal_download(dnfdaemon::SIGNAL_DOWNLOAD_PROGRESS, user_cb_data);

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -75,7 +75,7 @@ int DownloadCB::progress(void * user_cb_data, double total_to_download, double d
         }
     } catch (...) {
     }
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCB::end(void * user_cb_data, TransferStatus status, const char * msg) {
@@ -86,7 +86,7 @@ int DownloadCB::end(void * user_cb_data, TransferStatus status, const char * msg
         dbus_object->emitSignal(signal);
     } catch (...) {
     }
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCB::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
@@ -98,7 +98,7 @@ int DownloadCB::mirror_failure(void * user_cb_data, const char * msg, const char
         dbus_object->emitSignal(signal);
     } catch (...) {
     }
-    return 0;
+    return ReturnCode::OK;
 }
 
 

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -94,6 +94,18 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="options" type="a{sv}" direction="in" />
     </method>
 
+    <!--
+        cancel:
+        @success: true if the cancellation was sucessfully requested
+        @error_msg: error message if the cancellation was refused
+
+        Cancel the transaction that was initiated by `do_transaction()`. The transaction can only be canceled during the package download phase. Once the RPM transaction has begun, cancellation is no longer permitted.
+    -->
+    <method name="cancel">
+        <arg name="success" type="b" />
+        <arg name="error_msg" type="s" />
+    </method>
+
 </interface>
 
 </node>

--- a/dnf5daemon-server/services/goal/goal.hpp
+++ b/dnf5daemon-server/services/goal/goal.hpp
@@ -36,6 +36,7 @@ private:
     sdbus::MethodReply get_transaction_problems_string(sdbus::MethodCall & call);
     sdbus::MethodReply get_transaction_problems(sdbus::MethodCall & call);
     sdbus::MethodReply do_transaction(sdbus::MethodCall & call);
+    sdbus::MethodReply cancel(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -313,6 +313,7 @@ void Session::store_transaction_offline() {
     std::filesystem::create_directories(dest_dir);
     base->get_config().get_destdir_option().set(dest_dir);
     download_transaction_packages();
+    set_cancel_download(Session::CancelDownload::NOT_ALLOWED);
 
     const auto & offline_datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
     std::filesystem::create_directories(offline_datadir);

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -52,6 +52,7 @@ protected:
 
 class Session {
 public:
+    enum class CancelDownload { NOT_RUNNING, NOT_REQUESTED, REQUESTED, NOT_ALLOWED };
     Session(
         std::vector<std::unique_ptr<libdnf5::Logger>> && loggers,
         sdbus::IConnection & connection,
@@ -93,6 +94,11 @@ public:
     /// prepare the current transaction to run during the next reboot
     void store_transaction_offline();
 
+    /// Getter for download cancel request flag.
+    CancelDownload get_cancel_download() { return cancel_download.load(); }
+    /// Setter for download cancel request flag.
+    void set_cancel_download(CancelDownload value) { cancel_download.store(value); }
+
 private:
     sdbus::IConnection & connection;
     std::unique_ptr<libdnf5::Base> base;
@@ -110,6 +116,7 @@ private:
     std::mutex key_import_mutex;
     std::condition_variable key_import_condition;
     std::map<std::string, KeyConfirmationStatus> key_import_status{};  // map key_id: confirmation status
+    std::atomic<CancelDownload> cancel_download{CancelDownload::NOT_RUNNING};
 };
 
 #endif

--- a/include/libdnf5/repo/download_callbacks.hpp
+++ b/include/libdnf5/repo/download_callbacks.hpp
@@ -67,6 +67,10 @@ public:
     /// Transfer status codes.
     enum class TransferStatus { SUCCESSFUL, ALREADYEXISTS, ERROR };
 
+    /// Download callbacks return values.
+    /// RETURN_OK - all is fine, RETURN_ABORT - abort just the current download, RETURN_ERROR - abort all downloading
+    enum ReturnCode : int { OK = 0, ABORT = 1, ERROR = 2 };
+
     DownloadCallbacks() = default;
     DownloadCallbacks(const DownloadCallbacks &) = delete;
     DownloadCallbacks(DownloadCallbacks &&) = delete;

--- a/libdnf5/repo/download_callbacks.cpp
+++ b/libdnf5/repo/download_callbacks.cpp
@@ -30,14 +30,14 @@ void * DownloadCallbacks::add_new_download(
 
 int DownloadCallbacks::end(
     [[maybe_unused]] void * user_cb_data, [[maybe_unused]] TransferStatus status, [[maybe_unused]] const char * msg) {
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCallbacks::progress(
     [[maybe_unused]] void * user_cb_data,
     [[maybe_unused]] double total_to_download,
     [[maybe_unused]] double downloaded) {
-    return 0;
+    return ReturnCode::OK;
 }
 
 int DownloadCallbacks::mirror_failure(
@@ -45,7 +45,7 @@ int DownloadCallbacks::mirror_failure(
     [[maybe_unused]] const char * msg,
     [[maybe_unused]] const char * url,
     [[maybe_unused]] const char * metadata) {
-    return 0;
+    return ReturnCode::OK;
 }
 
 void DownloadCallbacks::fastest_mirror(


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/1660

Changes:

41f5a93e (Marek Blaha, 38 minutes ago)
   dnfdaemon: API to cancel running Goal.do_transaction()

   During the download phase, calling Goal.cancel() will cause all downloads
   to abort and transaction will not be performed. Once the rpm transaction is
   started, the cancel is not any more allowed and rpm transaction will
   finish.

b8e03b20 (Marek Blaha, 39 minutes ago)
   DownloadCallbacks: Enum for possible return codes

   Instead of hard coded constants use enum as callbacks return values.