### PR TITLE
doc: TransactionCallbacks class documentation

### DIFF
--- a/doc/api/c++/libdnf5_rpm.rst
+++ b/doc/api/c++/libdnf5_rpm.rst
@@ -7,3 +7,4 @@ libdnf5::rpm
     libdnf5_rpm_package_query
     libdnf5_rpm_package_sack
     libdnf5_rpm_package_set
+    libdnf5_rpm_transaction_callbacks

--- a/doc/api/c++/libdnf5_rpm_transaction_callbacks.rst
+++ b/doc/api/c++/libdnf5_rpm_transaction_callbacks.rst
@@ -1,0 +1,5 @@
+TransactionCallbacks
+====================
+
+.. doxygenclass:: libdnf5::rpm::TransactionCallbacks
+    :members:

--- a/doc/api/python/libdnf5_rpm.rst
+++ b/doc/api/python/libdnf5_rpm.rst
@@ -5,3 +5,4 @@ libdnf5.rpm
 .. toctree::
     libdnf5_rpm_package
     libdnf5_rpm_package_query
+    libdnf5_rpm_transaction_callbacks

--- a/doc/api/python/libdnf5_rpm_transaction_callbacks.rst
+++ b/doc/api/python/libdnf5_rpm_transaction_callbacks.rst
@@ -1,0 +1,5 @@
+TransactionCallbacks
+====================
+
+.. autoclass:: libdnf5.rpm.TransactionCallbacks
+    :members:

--- a/include/libdnf5/rpm/transaction_callbacks.hpp
+++ b/include/libdnf5/rpm/transaction_callbacks.hpp
@@ -39,8 +39,20 @@ namespace libdnf5::rpm {
 using TransactionItem = base::TransactionPackage;
 
 
-/// Base class for Transaction callbacks
+/// The base class for Transaction callbacks.
 /// User implements Transaction callbacks by inheriting this class and overriding its methods.
+///
+/// Typical order in which the transaction callbacks are called is:
+///
+/// - before_begin
+/// - verification phase: verify_start, verify_progress, verify_stop
+/// - script_start, script_stop, script_error for pre transaction scriplets
+/// - preparation phase: transaction_start, transaction_progress, transaction_stop
+/// - install packages: elem_progress, install_start, install_progress, install_stop, with their scriptlets
+/// - remove packages: elem_progress, uninstall_start, uninstall_progress, uninstall_stop, with their scriptlets
+/// - script_start, script_stop, script_error for post transaction scriplets
+/// - after_complete
+///
 class LIBDNF_API TransactionCallbacks {
 public:
     /// Scriptlet type
@@ -74,27 +86,120 @@ public:
     /// Called right before the rpm transaction is run
     /// @param total Number of elements in the rpm transaction
     virtual void before_begin(uint64_t total);
+
     /// Called after the transaction run finished
     /// @param success Whether the rpm transaction was completed successfully
     virtual void after_complete(bool success);
 
+    /// Report the package installation progress periodically.
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being installed
+    /// @param amount The portion of the package already installed
+    /// @param total The disk space used by the package after installation
     virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+
+    /// Installation of a package has started
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being installed
+    /// @param total The disk space used by the package after installation
     virtual void install_start(const TransactionItem & item, uint64_t total);
+
+    /// Installation of a package finished
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being installed
+    /// @param amount The portion of the package that has been installed
+    /// @param total The disk space used by the package after installation
     virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+
+    /// Preparation of a package has started.
+    ///
+    /// @param amount Index of the package currently being prepared. Items are indexed starting from 0.
+    /// @param total The total number of packages in the transaction
     virtual void transaction_progress(uint64_t amount, uint64_t total);
+
+    /// Preparation phase has started.
+    ///
+    /// @param total The total number of packages in the transaction
     virtual void transaction_start(uint64_t total);
+
+    /// Preparation phase finished.
+    ///
+    /// @param total The total number of packages in the transaction
     virtual void transaction_stop(uint64_t total);
+
+    /// Report the package removal progress periodically.
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being removed
+    /// @param amount The portion of the package already uninstalled
+    /// @param total The disk space freed by the package after removal
     virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+
+    /// Removal of a package has started
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being removed
+    /// @param total The disk space freed by the package after removal
     virtual void uninstall_start(const TransactionItem & item, uint64_t total);
+
+    /// Removal of a package finished
+    ///
+    /// @param item The TransactionPackage class instance for the package currently being removed
+    /// @param amount The portion of the package already uninstalled
+    /// @param total The disk space freed by the package after removal
     virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+
+    /// Unpacking of the package failed.
+    ///
+    /// @param item The TransactionPackage class instance representing the package that failed to unpack
     virtual void unpack_error(const TransactionItem & item);
+
+    /// cpio error during the package installation. Currently not used by librpm.
+    ///
+    /// @param item The TransactionPackage class instance representing the package that caused the error
     virtual void cpio_error(const TransactionItem & item);
+
+    /// Execution of the rpm scriptlet finished with error
+    ///
+    /// @param item The TransactionPackage class instance for the package that owns the executed or triggered scriptlet. It can be `nullptr` if the scriptlet owner is not part of the transaction.
+    /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
+    /// @param type Type of the scriptlet
+    /// @param return_code The return code of the scriptlet execution
     virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+
+    /// Execution of the rpm scriptlet has started
+    ///
+    /// @param item The TransactionPackage class instance for the package that owns the executed or triggered scriptlet. It can be `nullptr` if the scriptlet owner is not part of the transaction (e.g., a package installation triggered an update of the man database, owned by man-db package).
+    /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
+    /// @param type Type of the scriptlet
     virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type);
+
+    /// Execution of the rpm scriptlet finished without critical error
+    ///
+    /// @param item The TransactionPackage class instance for the package that owns the executed or triggered scriptlet. It can be `nullptr` if the scriptlet owner is not part of the transaction.
+    /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
+    /// @param type Type of the scriptlet
+    /// @param return_code The return code of the scriptlet execution
     virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+
+    /// The installation/removal process for the item has started
+    ///
+    /// @param amount Index of the package currently being processed. Items are indexed starting from 0.
+    /// @param total The total number of packages in the transaction
     virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+
+    /// Verification of a package files has started.
+    ///
+    /// @param amount Index of the package currently being verified. Items are indexed starting from 0.
+    /// @param total The total number of packages to verify
     virtual void verify_progress(uint64_t amount, uint64_t total);
+
+    /// Packages files verification phase has started. In this phase the signature of packages are verified.
+    ///
+    /// @param total The total number of packages to verify
     virtual void verify_start(uint64_t total);
+
+    /// Packages files verification phase finished.
+    ///
+    /// @param total The total number of packages to verify
     virtual void verify_stop(uint64_t total);
 };
 


### PR DESCRIPTION
Add missing documentation to rpm transaction callbacks.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1658