### PR TITLE
dnfdaemon: Fix issues with introspection files

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
@@ -60,7 +60,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         A new download has started.
     -->
     <signal name="download_add_new">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="download_id" type="s" />
         <arg name="description" type="s" />
         <arg name="total_to_download" type="x" />
@@ -76,7 +76,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Progress in downloading.
     -->
     <signal name="download_progress">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="download_id" type="s" />
         <arg name="total_to_download" type="x" />
         <arg name="downloaded" type="x" />
@@ -93,7 +93,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Mirror failure during the download.
     -->
     <signal name="download_mirror_failure">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="download_id" type="s" />
         <arg name="message" type="s" />
         <arg name="url" type="s" />
@@ -110,7 +110,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Downloading has ended.
     -->
     <signal name="download_end">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="download_id" type="s" />
         <arg name="transfer_status" type="u" />
         <arg name="message" type="s" />
@@ -128,7 +128,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Request for repository key import confirmation.
     -->
     <signal name="repo_key_import_request">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="key_id" type="s" />
         <arg name="user_ids" type="as" />
         <arg name="key_fingerprint" type="s" />

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -102,8 +102,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Cancel the transaction that was initiated by `do_transaction()`. The transaction can only be canceled during the package download phase. Once the RPM transaction has begun, cancellation is no longer permitted.
     -->
     <method name="cancel">
-        <arg name="success" type="b" />
-        <arg name="error_msg" type="s" />
+        <arg name="success" type="b" direction="out" />
+        <arg name="error_msg" type="s" direction="out" />
     </method>
 
 </interface>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -240,7 +240,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Overall progress in transaction item processing. Called right before an item is processed.
     -->
     <signal name="transaction_elem_progress">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="processed" type="t" />
         <arg name="total" type="t" />
@@ -254,7 +254,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Send right before the rpm transaction is run.
     -->
     <signal name="transaction_before_begin">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="total" type="t" />
     </signal>
 
@@ -266,7 +266,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Send right after the rpm transaction run finished.
     -->
     <signal name="transaction_after_complete">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="success" type="b" />
     </signal>
 
@@ -280,7 +280,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Processing (installation or removal) of the package has started.
     -->
     <signal name="transaction_action_start">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="action" type="u" />
         <arg name="total" type="t" />
@@ -296,7 +296,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Progress in processing of the package.
     -->
     <signal name="transaction_action_progress">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="processed" type="t" />
         <arg name="total" type="t" />
@@ -311,7 +311,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Processing of the package has finished.
     -->
     <signal name="transaction_action_stop">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="total" type="t" />
     </signal>
@@ -325,7 +325,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         The scriptlet has started.
     -->
     <signal name="transaction_script_start">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="scriptlet_type" type="u" />
     </signal>
@@ -340,7 +340,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         The scriptlet has successfully finished.
     -->
     <signal name="transaction_script_stop">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="scriptlet_type" type="u" />
         <arg name="return_code" type="t" />
@@ -356,7 +356,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         The scriptlet has finished with an error.
     -->
     <signal name="transaction_script_error">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
         <arg name="scriptlet_type" type="u" />
         <arg name="return_code" type="t" />
@@ -370,7 +370,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Package files verification has started.
     -->
     <signal name="transaction_verify_start">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="total" type="t" />
     </signal>
 
@@ -383,7 +383,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Progress in processing of the package.
     -->
     <signal name="transaction_verify_progress">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="processed" type="t" />
         <arg name="total" type="t" />
     </signal>
@@ -396,7 +396,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Package files verification has finished.
     -->
     <signal name="transaction_verify_stop">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="total" type="t" />
     </signal>
 
@@ -408,7 +408,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Preparation of transaction packages has started.
     -->
     <signal name="transaction_transaction_start">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="total" type="t" />
     </signal>
 
@@ -421,7 +421,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Progress in preparation of transaction packages.
     -->
     <signal name="transaction_transaction_progress">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="processed" type="t" />
         <arg name="total" type="t" />
     </signal>
@@ -434,7 +434,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Preparation of transaction packages has finished.
     -->
     <signal name="transaction_transaction_stop">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="total" type="t" />
     </signal>
 
@@ -446,7 +446,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Error while unpacking the package.
     -->
     <signal name="transaction_unpack_error">
-        <arg name="session_object_path" type="o" />
+        <arg name="session_object_path" type="s" />
         <arg name="nevra" type="s" />
     </signal>
 

--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -62,27 +62,27 @@ void Base::dbus_register() {
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_DOWNLOAD_ADD_NEW,
-        "ossx",
+        "sssx",
         {"session_object_path", "download_id", "description", "total_to_download"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_DOWNLOAD_PROGRESS,
-        "osxx",
+        "ssxx",
         {"session_object_path", "download_id", "total_to_download", "downloaded"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_DOWNLOAD_END,
-        "osus",
+        "ssus",
         {"session_object_path", "download_id", "transfer_status", "message"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_DOWNLOAD_MIRROR_FAILURE,
-        "ossss",
+        "sssss",
         {"session_object_path", "download_id", "message", "url", "metadata"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_BASE,
         dnfdaemon::SIGNAL_REPO_KEY_IMPORT_REQUEST,
-        "osasssx",
+        "ssasssx",
         {"session_object_path", "key_id", "user_ids", "key_fingerprint", "key_url", "timestamp"});
 }
 

--- a/dnf5daemon-server/services/rpm/rpm.cpp
+++ b/dnf5daemon-server/services/rpm/rpm.cpp
@@ -125,73 +125,73 @@ void Rpm::dbus_register() {
         });
 
     dbus_object->registerSignal(
-        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_BEFORE_BEGIN, "ot", {"session_object_path", "total"});
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_BEFORE_BEGIN, "st", {"session_object_path", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_AFTER_COMPLETE,
-        "ob",
+        "sb",
         {"session_object_path", "success"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_ELEM_PROGRESS,
-        "ostt",
+        "sstt",
         {"session_object_path", "nevra", "processed", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_ACTION_START,
-        "osut",
+        "ssut",
         {"session_object_path", "nevra", "action", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_ACTION_PROGRESS,
-        "ostt",
+        "sstt",
         {"session_object_path", "nevra", "processed", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_ACTION_STOP,
-        "ost",
+        "sst",
         {"session_object_path", "nevra", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START,
-        "osu",
+        "ssu",
         {"session_object_path", "nevra", "scriptlet_type"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_STOP,
-        "osut",
+        "ssut",
         {"session_object_path", "nevra", "scriptlet_type", "return_code"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_ERROR,
-        "osut",
+        "ssut",
         {"session_object_path", "nevra", "scriptlet_type", "return_code"});
     dbus_object->registerSignal(
-        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_START, "ot", {"session_object_path", "total"});
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_START, "st", {"session_object_path", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_VERIFY_PROGRESS,
-        "ott",
+        "stt",
         {"session_object_path", "processed", "total"});
     dbus_object->registerSignal(
-        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_STOP, "ot", {"session_object_path", "total"});
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_VERIFY_STOP, "st", {"session_object_path", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_START,
-        "ot",
+        "st",
         {"session_object_path", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_PROGRESS,
-        "ott",
+        "stt",
         {"session_object_path", "processed", "total"});
     dbus_object->registerSignal(
         dnfdaemon::INTERFACE_RPM,
         dnfdaemon::SIGNAL_TRANSACTION_TRANSACTION_STOP,
-        "ot",
+        "st",
         {"session_object_path", "total"});
     dbus_object->registerSignal(
-        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_UNPACK_ERROR, "os", {"session_object_path", "nevra"});
+        dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_UNPACK_ERROR, "ss", {"session_object_path", "nevra"});
 }
 
 std::vector<std::string> get_filter_patterns(dnfdaemon::KeyValueMap options, const std::string & option) {


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/1646
Resolves: https://github.com/rpm-software-management/dnf5/pull/1665#discussion_r1745152462

Changes:

dd04451b (Marek Blaha, 4 minutes ago)
   daemon: Adjust signal argument types

   It looks like the server is sending session_object_path argument as a 
   string, although it is declared as "object path" type. Changing to strings
   to resolve runtime warnings on the client side. See
   https://github.com/rpm-software-management/dnf5/issues/1646 for details.

5fe2eaef (Marek Blaha, 2 hours ago)
   daemon: Fix missing direction for Goal.cancel()