### PR TITLE
Fix regressions from stderr/stdout changes

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -493,7 +493,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
             print_error(entry);
         }
         for (auto & problem : transaction.get_transaction_problems()) {
-            print_error(problem);
+            print_error(fmt::format("  - {}", problem));
         }
         throw libdnf5::cli::SilentCommandExitError(1);
     }

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1406,12 +1406,13 @@ int main(int argc, char * argv[]) try {
                 context.download_and_run(*context.get_transaction());
             }
         } catch (libdnf5::cli::GoalResolveError & ex) {
-            context.print_error(ex.what());
+            std::cerr << ex.what() << std::endl;
             if (!any_repos_from_system_configuration && base.get_config().get_installroot_option().get_value() != "/" &&
                 !base.get_config().get_use_host_config_option().get_value()) {
-                context.print_error(
-                    "No repositories were loaded from the installroot. To use the configuration and repositories "
-                    "of the host system, pass --use-host-config.");
+                std::cerr
+                    << "No repositories were loaded from the installroot. To use the configuration and repositories "
+                       "of the host system, pass --use-host-config."
+                    << std::endl;
             } else {
                 if (context.get_transaction() != nullptr) {
                     // download command can throw GoalResolveError without context.transaction being set
@@ -1420,11 +1421,10 @@ int main(int argc, char * argv[]) try {
             }
             return static_cast<int>(libdnf5::cli::ExitCode::ERROR);
         } catch (libdnf5::cli::ArgumentParserError & ex) {
-            context.print_error(
-                fmt::format("{}{}", ex.what(), _(". Add \"--help\" for more information about the arguments.")));
+            std::cerr << ex.what() << _(". Add \"--help\" for more information about the arguments.") << std::endl;
             return static_cast<int>(libdnf5::cli::ExitCode::ARGPARSER_ERROR);
         } catch (libdnf5::cli::CommandExitError & ex) {
-            context.print_error(ex.what());
+            std::cerr << ex.what() << std::endl;
             return ex.get_exit_code();
         } catch (libdnf5::cli::SilentCommandExitError & ex) {
             return ex.get_exit_code();


### PR DESCRIPTION
Follow-up to https://github.com/rpm-software-management/dnf5/pull/1641, I forgot to push these two commits.

More details in the commit messages.

Fixes the following ci-dnf-stack tests:
- `dnf/install-file-conflicts.feature:8  An error is reported when a package with a file conflict is tried to be installed`
- `dnf/dnf-automatic/reboot.feature:95  dnf-automatic shows error message when reboot command failed`