### PR TITLE
daemon: Reset the goal

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -106,6 +106,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="error_msg" type="s" direction="out" />
     </method>
 
+    <!--
+        reset:
+        Reset the prepared rpm transaction. After this call the session is ready to perform another rpm transaction.
+    -->
+    <method name="reset">
+    </method>
+
 </interface>
 
 </node>

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -114,6 +114,10 @@ void Goal::dbus_register() {
         [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(*this, &Goal::cancel, call, session.session_locale);
         });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_GOAL, "reset", "", {}, "", {}, [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Goal::reset, call, session.session_locale);
+        });
 }
 
 sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
@@ -344,5 +348,11 @@ sdbus::MethodReply Goal::cancel(sdbus::MethodCall & call) {
     auto reply = call.createReply();
     reply << success;
     reply << error_msg;
+    return reply;
+}
+
+sdbus::MethodReply Goal::reset(sdbus::MethodCall & call) {
+    session.reset_goal();
+    auto reply = call.createReply();
     return reply;
 }

--- a/dnf5daemon-server/services/goal/goal.hpp
+++ b/dnf5daemon-server/services/goal/goal.hpp
@@ -37,6 +37,7 @@ private:
     sdbus::MethodReply get_transaction_problems(sdbus::MethodCall & call);
     sdbus::MethodReply do_transaction(sdbus::MethodCall & call);
     sdbus::MethodReply cancel(sdbus::MethodCall & call);
+    sdbus::MethodReply reset(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -377,3 +377,8 @@ void Session::store_transaction_offline() {
 
     state.write();
 }
+
+void Session::reset_goal() {
+    transaction.reset(nullptr);
+    goal.reset();
+}

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -99,6 +99,8 @@ public:
     /// Setter for download cancel request flag.
     void set_cancel_download(CancelDownload value) { cancel_download.store(value); }
 
+    void reset_goal();
+
 private:
     sdbus::IConnection & connection;
     std::unique_ptr<libdnf5::Base> base;

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -3296,12 +3296,17 @@ void Goal::add_redo_transaction(
 void Goal::reset() {
     p_impl->module_specs.clear();
     p_impl->rpm_specs.clear();
+    p_impl->rpm_reason_change_specs.clear();
     p_impl->rpm_ids.clear();
     p_impl->group_specs.clear();
     p_impl->rpm_filepaths.clear();
     p_impl->resolved_group_specs.clear();
     p_impl->resolved_environment_specs.clear();
+    p_impl->group_specs.clear();
     p_impl->rpm_goal = rpm::solv::GoalPrivate(p_impl->base);
+    p_impl->serialized_transaction.reset();
+    p_impl->revert_transactions.reset();
+    p_impl->redo_transaction.reset();
 }
 
 BaseWeakPtr Goal::get_base() const {


### PR DESCRIPTION
New D-Bus API to reset the goal.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1653

Changes:

3cd0a6e3 (Marek Blaha, 5 minutes ago)
   dnfdaemon: D-Bus API to reset the goal

   With this patch the user can re-use the session to resolve multiple 
   transactions without running them. The use case might be to check what 
   dependencies would be installed with given package.

d77231b8 (Marek Blaha, 17 hours ago)
   dnfdaemon: Add reset_goal() method

   The method resets the current goal and transaction, which is necessary for
   scenarios where the user wants to reuse the D-Bus session to resolve or
   execute multiple transactions.

5dbe16a0 (Marek Blaha, 17 hours ago)
   goal: Add missing members to reset() method

   The reset() method currently does not reset all Goal members. This patch 
   adds those that are missing.