### PR TITLE
transaction_callbacks: Deprecate confusing alias

### DIFF
--- a/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
+++ b/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
@@ -33,7 +33,7 @@ void TransactionCallbacksSimple::transaction_start([[maybe_unused]] uint64_t tot
 
 
 void TransactionCallbacksSimple::install_start(
-    const libdnf5::rpm::TransactionItem & item, [[maybe_unused]] uint64_t total) {
+    const libdnf5::base::TransactionPackage & item, [[maybe_unused]] uint64_t total) {
     switch (item.get_action()) {
         case libdnf5::transaction::TransactionItemAction::UPGRADE:
             output_stream << "  Upgrading ";
@@ -66,7 +66,7 @@ void TransactionCallbacksSimple::install_start(
 }
 
 void TransactionCallbacksSimple::uninstall_start(
-    const libdnf5::rpm::TransactionItem & item, [[maybe_unused]] uint64_t total) {
+    const libdnf5::base::TransactionPackage & item, [[maybe_unused]] uint64_t total) {
     if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE) {
         output_stream << "  Erasing ";
     } else {
@@ -75,16 +75,16 @@ void TransactionCallbacksSimple::uninstall_start(
     output_stream << item.get_package().get_full_nevra() << std::endl;
 }
 
-void TransactionCallbacksSimple::unpack_error(const libdnf5::rpm::TransactionItem & item) {
+void TransactionCallbacksSimple::unpack_error(const libdnf5::base::TransactionPackage & item) {
     output_stream << "  Unpack error: " << item.get_package().get_full_nevra() << std::endl;
 }
 
-void TransactionCallbacksSimple::cpio_error(const libdnf5::rpm::TransactionItem & item) {
+void TransactionCallbacksSimple::cpio_error(const libdnf5::base::TransactionPackage & item) {
     output_stream << "  Cpio error: " << item.get_package().get_full_nevra() << std::endl;
 }
 
 void TransactionCallbacksSimple::script_error(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
@@ -93,7 +93,7 @@ void TransactionCallbacksSimple::script_error(
 }
 
 void TransactionCallbacksSimple::script_start(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type) {
     output_stream << "  Running " << script_type_to_string(type) << " scriptlet: " << to_full_nevra_string(nevra)
@@ -101,7 +101,7 @@ void TransactionCallbacksSimple::script_start(
 }
 
 void TransactionCallbacksSimple::script_stop(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     [[maybe_unused]] uint64_t return_code) {

--- a/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.hpp
+++ b/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.hpp
@@ -36,21 +36,21 @@ public:
           output_stream(output_stream) {}
 
     void transaction_start(uint64_t total) override;
-    void install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
-    void uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
-    void unpack_error(const libdnf5::rpm::TransactionItem & item) override;
-    void cpio_error(const libdnf5::rpm::TransactionItem & item) override;
+    void install_start(const libdnf5::base::TransactionPackage & item, uint64_t total) override;
+    void uninstall_start(const libdnf5::base::TransactionPackage & item, uint64_t total) override;
+    void unpack_error(const libdnf5::base::TransactionPackage & item) override;
+    void cpio_error(const libdnf5::base::TransactionPackage & item) override;
     void script_error(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
     void script_start(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type) override;
     void script_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         [[maybe_unused]] uint64_t return_code) override;

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -129,7 +129,7 @@ class PlymouthTransCB : public RpmTransCB {
 public:
     PlymouthTransCB(Context & context, PlymouthOutput plymouth) : RpmTransCB(context), plymouth(std::move(plymouth)) {}
     void elem_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         [[maybe_unused]] uint64_t amount,
         [[maybe_unused]] uint64_t total) override {
         RpmTransCB::elem_progress(item, amount, total);

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -756,14 +756,14 @@ libdnf5::cli::progressbar::MultiProgressBar * RpmTransCB::get_multi_progress_bar
 }
 
 void RpmTransCB::install_progress(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
+    [[maybe_unused]] const libdnf5::base::TransactionPackage & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
     active_progress_bar->set_ticks(static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
 }
 
-void RpmTransCB::install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
+void RpmTransCB::install_start(const libdnf5::base::TransactionPackage & item, uint64_t total) {
     const char * msg{nullptr};
     switch (item.get_action()) {
         case libdnf5::transaction::TransactionItemAction::UPGRADE:
@@ -798,7 +798,7 @@ void RpmTransCB::install_start(const libdnf5::rpm::TransactionItem & item, uint6
 }
 
 void RpmTransCB::install_stop(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
     [[maybe_unused]] uint64_t amount,
     [[maybe_unused]] uint64_t total) {
     multi_progress_bar.print();
@@ -821,14 +821,14 @@ void RpmTransCB::transaction_stop([[maybe_unused]] uint64_t total) {
 }
 
 void RpmTransCB::uninstall_progress(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
+    [[maybe_unused]] const libdnf5::base::TransactionPackage & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
     active_progress_bar->set_ticks(static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
 }
 
-void RpmTransCB::uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
+void RpmTransCB::uninstall_start(const libdnf5::base::TransactionPackage & item, uint64_t total) {
     const char * msg{nullptr};
     if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE ||
         item.get_action() == libdnf5::transaction::TransactionItemAction::REPLACED) {
@@ -841,21 +841,21 @@ void RpmTransCB::uninstall_start(const libdnf5::rpm::TransactionItem & item, uin
 }
 
 void RpmTransCB::uninstall_stop(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
     [[maybe_unused]] uint64_t amount,
     [[maybe_unused]] uint64_t total) {
     multi_progress_bar.print();
 }
 
 
-void RpmTransCB::unpack_error(const libdnf5::rpm::TransactionItem & item) {
+void RpmTransCB::unpack_error(const libdnf5::base::TransactionPackage & item) {
     active_progress_bar->add_message(
         libdnf5::cli::progressbar::MessageType::ERROR, "Unpack error: " + item.get_package().get_full_nevra());
     active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
     multi_progress_bar.print();
 }
 
-void RpmTransCB::cpio_error(const libdnf5::rpm::TransactionItem & item) {
+void RpmTransCB::cpio_error(const libdnf5::base::TransactionPackage & item) {
     active_progress_bar->add_message(
         libdnf5::cli::progressbar::MessageType::ERROR, "Cpio error: " + item.get_package().get_full_nevra());
     active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
@@ -874,7 +874,7 @@ void RpmTransCB::script_output_to_progress(const libdnf5::cli::progressbar::Mess
 }
 
 void RpmTransCB::script_error(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
@@ -890,7 +890,7 @@ void RpmTransCB::script_error(
 }
 
 void RpmTransCB::script_start(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type) {
     active_progress_bar->add_message(
@@ -900,7 +900,7 @@ void RpmTransCB::script_start(
 }
 
 void RpmTransCB::script_stop(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
@@ -929,7 +929,7 @@ void RpmTransCB::script_stop(
 }
 
 void RpmTransCB::elem_progress(
-    [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+    [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
     [[maybe_unused]] uint64_t amount,
     [[maybe_unused]] uint64_t total) {
     //std::cout << "Element progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -199,13 +199,13 @@ public:
     libdnf5::cli::progressbar::MultiProgressBar * get_multi_progress_bar();
 
     void install_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         uint64_t amount,
         [[maybe_unused]] uint64_t total) override;
 
-    void install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
+    void install_start(const libdnf5::base::TransactionPackage & item, uint64_t total) override;
     void install_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         [[maybe_unused]] uint64_t amount,
         [[maybe_unused]] uint64_t total) override;
 
@@ -216,41 +216,41 @@ public:
     void transaction_stop([[maybe_unused]] uint64_t total) override;
 
     void uninstall_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         uint64_t amount,
         [[maybe_unused]] uint64_t total) override;
 
-    void uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override;
+    void uninstall_start(const libdnf5::base::TransactionPackage & item, uint64_t total) override;
 
     void uninstall_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         [[maybe_unused]] uint64_t amount,
         [[maybe_unused]] uint64_t total) override;
 
 
-    void unpack_error(const libdnf5::rpm::TransactionItem & item) override;
+    void unpack_error(const libdnf5::base::TransactionPackage & item) override;
 
-    void cpio_error(const libdnf5::rpm::TransactionItem & item) override;
+    void cpio_error(const libdnf5::base::TransactionPackage & item) override;
 
     void script_error(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
 
     void script_start(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type) override;
 
     void script_stop(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem * item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         [[maybe_unused]] uint64_t return_code) override;
 
     void elem_progress(
-        [[maybe_unused]] const libdnf5::rpm::TransactionItem & item,
+        [[maybe_unused]] const libdnf5::base::TransactionPackage & item,
         [[maybe_unused]] uint64_t amount,
         [[maybe_unused]] uint64_t total) override;
 

--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -146,7 +146,7 @@ void DbusTransactionCB::after_complete(bool success) {
     }
 }
 
-void DbusTransactionCB::install_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) {
+void DbusTransactionCB::install_start(const libdnf5::base::TransactionPackage & item, uint64_t total) {
     try {
         dnfdaemon::RpmTransactionItemActions action;
         action = dnfdaemon::transaction_package_to_action(item);
@@ -159,7 +159,8 @@ void DbusTransactionCB::install_start(const libdnf5::rpm::TransactionItem & item
     }
 }
 
-void DbusTransactionCB::install_progress(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) {
+void DbusTransactionCB::install_progress(
+    const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) {
     try {
         if (is_time_to_print()) {
             auto signal = create_signal_pkg(
@@ -174,7 +175,8 @@ void DbusTransactionCB::install_progress(const libdnf5::rpm::TransactionItem & i
     }
 }
 
-void DbusTransactionCB::install_stop(const libdnf5::rpm::TransactionItem & item, uint64_t /*amount*/, uint64_t total) {
+void DbusTransactionCB::install_stop(
+    const libdnf5::base::TransactionPackage & item, uint64_t /*amount*/, uint64_t total) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_STOP, item.get_package().get_full_nevra());
@@ -186,7 +188,7 @@ void DbusTransactionCB::install_stop(const libdnf5::rpm::TransactionItem & item,
 
 
 void DbusTransactionCB::script_start(
-    const libdnf5::rpm::TransactionItem * /*item*/,
+    const libdnf5::base::TransactionPackage * /*item*/,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type) {
     try {
@@ -199,7 +201,7 @@ void DbusTransactionCB::script_start(
 }
 
 void DbusTransactionCB::script_stop(
-    const libdnf5::rpm::TransactionItem * /*item*/,
+    const libdnf5::base::TransactionPackage * /*item*/,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
@@ -213,7 +215,7 @@ void DbusTransactionCB::script_stop(
     }
 }
 
-void DbusTransactionCB::elem_progress(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) {
+void DbusTransactionCB::elem_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ELEM_PROGRESS, item.get_package().get_full_nevra());
@@ -225,7 +227,7 @@ void DbusTransactionCB::elem_progress(const libdnf5::rpm::TransactionItem & item
 }
 
 void DbusTransactionCB::script_error(
-    const libdnf5::rpm::TransactionItem * /*item*/,
+    const libdnf5::base::TransactionPackage * /*item*/,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
@@ -298,7 +300,7 @@ void DbusTransactionCB::verify_stop(uint64_t total) {
 }
 
 
-void DbusTransactionCB::unpack_error(const libdnf5::rpm::TransactionItem & item) {
+void DbusTransactionCB::unpack_error(const libdnf5::base::TransactionPackage & item) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_UNPACK_ERROR, item.get_package().get_full_nevra());

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -103,44 +103,44 @@ public:
     void transaction_stop(uint64_t total) override;
 
     // install a package
-    void install_start(const libdnf5::rpm::TransactionItem & item, uint64_t) override;
-    void install_progress(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
-    void install_stop(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
+    void install_start(const libdnf5::base::TransactionPackage & item, uint64_t) override;
+    void install_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) override;
+    void install_stop(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) override;
 
     // uninstall a package (the same messages as for install are used)
-    void uninstall_start(const libdnf5::rpm::TransactionItem & item, uint64_t total) override {
+    void uninstall_start(const libdnf5::base::TransactionPackage & item, uint64_t total) override {
         install_start(item, total);
     }
-    void uninstall_progress(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override {
+    void uninstall_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) override {
         install_progress(item, amount, total);
     }
-    void uninstall_stop(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override {
+    void uninstall_stop(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) override {
         install_stop(item, amount, total);
     }
 
     void script_start(
-        const libdnf5::rpm::TransactionItem * item,
+        const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type) override;
     void script_stop(
-        const libdnf5::rpm::TransactionItem * item,
+        const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
     void script_error(
-        const libdnf5::rpm::TransactionItem * item,
+        const libdnf5::base::TransactionPackage * item,
         libdnf5::rpm::Nevra nevra,
         libdnf5::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
 
-    void elem_progress(const libdnf5::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
+    void elem_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total) override;
 
     void verify_start(uint64_t total) override;
     void verify_progress(uint64_t amount, uint64_t total) override;
     void verify_stop(uint64_t total) override;
 
-    void unpack_error(const libdnf5::rpm::TransactionItem & item) override;
-    void cpio_error(const libdnf5::rpm::TransactionItem & /*item*/) override{};
+    void unpack_error(const libdnf5::base::TransactionPackage & item) override;
+    void cpio_error(const libdnf5::base::TransactionPackage & /*item*/) override{};
 
     // whole rpm transaction is finished
     void finish();

--- a/include/libdnf5/rpm/transaction_callbacks.hpp
+++ b/include/libdnf5/rpm/transaction_callbacks.hpp
@@ -35,6 +35,7 @@ class TransactionPackage;
 namespace libdnf5::rpm {
 
 
+/// @deprecated This alias is confusing, do not use it.
 /// Class represents one item in transaction set.
 using TransactionItem = base::TransactionPackage;
 
@@ -96,20 +97,20 @@ public:
     /// @param item The TransactionPackage class instance for the package currently being installed
     /// @param amount The portion of the package already installed
     /// @param total The disk space used by the package after installation
-    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void install_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total);
 
     /// Installation of a package has started
     ///
     /// @param item The TransactionPackage class instance for the package currently being installed
     /// @param total The disk space used by the package after installation
-    virtual void install_start(const TransactionItem & item, uint64_t total);
+    virtual void install_start(const libdnf5::base::TransactionPackage & item, uint64_t total);
 
     /// Installation of a package finished
     ///
     /// @param item The TransactionPackage class instance for the package currently being installed
     /// @param amount The portion of the package that has been installed
     /// @param total The disk space used by the package after installation
-    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void install_stop(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total);
 
     /// Preparation of a package has started.
     ///
@@ -132,30 +133,30 @@ public:
     /// @param item The TransactionPackage class instance for the package currently being removed
     /// @param amount The portion of the package already uninstalled
     /// @param total The disk space freed by the package after removal
-    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void uninstall_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total);
 
     /// Removal of a package has started
     ///
     /// @param item The TransactionPackage class instance for the package currently being removed
     /// @param total The disk space freed by the package after removal
-    virtual void uninstall_start(const TransactionItem & item, uint64_t total);
+    virtual void uninstall_start(const libdnf5::base::TransactionPackage & item, uint64_t total);
 
     /// Removal of a package finished
     ///
     /// @param item The TransactionPackage class instance for the package currently being removed
     /// @param amount The portion of the package already uninstalled
     /// @param total The disk space freed by the package after removal
-    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void uninstall_stop(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total);
 
     /// Unpacking of the package failed.
     ///
     /// @param item The TransactionPackage class instance representing the package that failed to unpack
-    virtual void unpack_error(const TransactionItem & item);
+    virtual void unpack_error(const libdnf5::base::TransactionPackage & item);
 
     /// cpio error during the package installation. Currently not used by librpm.
     ///
     /// @param item The TransactionPackage class instance representing the package that caused the error
-    virtual void cpio_error(const TransactionItem & item);
+    virtual void cpio_error(const libdnf5::base::TransactionPackage & item);
 
     /// Execution of the rpm scriptlet finished with error
     ///
@@ -163,14 +164,15 @@ public:
     /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
     /// @param type Type of the scriptlet
     /// @param return_code The return code of the scriptlet execution
-    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+    virtual void script_error(
+        const libdnf5::base::TransactionPackage * item, Nevra nevra, ScriptType type, uint64_t return_code);
 
     /// Execution of the rpm scriptlet has started
     ///
     /// @param item The TransactionPackage class instance for the package that owns the executed or triggered scriptlet. It can be `nullptr` if the scriptlet owner is not part of the transaction (e.g., a package installation triggered an update of the man database, owned by man-db package).
     /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
     /// @param type Type of the scriptlet
-    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type);
+    virtual void script_start(const libdnf5::base::TransactionPackage * item, Nevra nevra, ScriptType type);
 
     /// Execution of the rpm scriptlet finished without critical error
     ///
@@ -178,13 +180,14 @@ public:
     /// @param nevra Nevra of the package that owns the executed or triggered scriptlet.
     /// @param type Type of the scriptlet
     /// @param return_code The return code of the scriptlet execution
-    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code);
+    virtual void script_stop(
+        const libdnf5::base::TransactionPackage * item, Nevra nevra, ScriptType type, uint64_t return_code);
 
     /// The installation/removal process for the item has started
     ///
     /// @param amount Index of the package currently being processed. Items are indexed starting from 0.
     /// @param total The total number of packages in the transaction
-    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total);
+    virtual void elem_progress(const libdnf5::base::TransactionPackage & item, uint64_t amount, uint64_t total);
 
     /// Verification of a package files has started.
     ///

--- a/libdnf5/rpm/transaction.cpp
+++ b/libdnf5/rpm/transaction.cpp
@@ -311,7 +311,7 @@ Header Transaction::get_header(unsigned int rec_offset) {
     return hdr;
 }
 
-void Transaction::reinstall(TransactionItem & item) {
+void Transaction::reinstall(base::TransactionPackage & item) {
     auto file_path = item.get_package().get_package_path();
     auto * header = read_pkg_header(file_path);
     last_added_item = &item;
@@ -328,7 +328,7 @@ void Transaction::reinstall(TransactionItem & item) {
         item.get_package().get_full_nevra());
 }
 
-void Transaction::erase(TransactionItem & item) {
+void Transaction::erase(base::TransactionPackage & item) {
     auto rpmdb_id = static_cast<unsigned int>(item.get_package().get_rpmdbid());
     auto * header = get_header(rpmdb_id);
     int unused = -1;
@@ -352,7 +352,7 @@ void Transaction::erase(TransactionItem & item) {
     }
 }
 
-void Transaction::install_up_down(TransactionItem & item, libdnf5::transaction::TransactionItemAction action) {
+void Transaction::install_up_down(base::TransactionPackage & item, libdnf5::transaction::TransactionItemAction action) {
     BgettextMessage msg_error;
     std::string msg_action;
     bool upgrade{true};
@@ -493,7 +493,7 @@ void * Transaction::ts_callback(
     auto & logger = *transaction.base->get_logger();
     auto * const callbacks = callbacks_holder.callbacks.get();
     auto * const trans_element = static_cast<rpmte>(const_cast<void *>(te));
-    auto * const item = trans_element ? static_cast<TransactionItem *>(rpmteUserdata(trans_element)) : nullptr;
+    auto * const item = trans_element ? static_cast<base::TransactionPackage *>(rpmteUserdata(trans_element)) : nullptr;
 
     switch (what) {
         case RPMCALLBACK_INST_PROGRESS:

--- a/libdnf5/rpm/transaction.hpp
+++ b/libdnf5/rpm/transaction.hpp
@@ -48,10 +48,6 @@ namespace libdnf5::rpm {
 class RpmProblemSet;
 
 
-/// Class represents one item in transaction set.
-using TransactionItem = base::TransactionPackage;
-
-
 /// Class for access RPM header
 class RpmHeader {
 public:
@@ -103,8 +99,8 @@ public:
     rpmProblemType get_type() const { return rpmProblemGetType(problem); }
 
     /// Return pointer to transaction item associated to the problem or nullptr.
-    const TransactionItem * get_transaction_item() const noexcept {
-        return static_cast<const TransactionItem *>(rpmProblemGetKey(problem));
+    const base::TransactionPackage * get_transaction_item() const noexcept {
+        return static_cast<const base::TransactionPackage *>(rpmProblemGetKey(problem));
     }
 
     /// Return a generic data string from a problem
@@ -342,12 +338,12 @@ private:
     CallbacksHolder callbacks_holder{nullptr, this, nullptr};
     FD_t fd_in_cb{nullptr};  // file descriptor used by transaction in callback (install/reinstall package)
 
-    TransactionItem * last_added_item{nullptr};  // item added by last install/reinstall/erase/...
-    bool last_item_added_ts_element{false};      // Did the last item add the element ts?
+    base::TransactionPackage * last_added_item{nullptr};  // item added by last install/reinstall/erase/...
+    bool last_item_added_ts_element{false};               // Did the last item add the element ts?
 
     std::map<unsigned int, rpmte> implicit_ts_elements;  // elements added to the librpm transaction by librpm itself
     bool downgrade_requested{false};
-    std::vector<TransactionItem> transaction_items;
+    std::vector<base::TransactionPackage> transaction_items;
 
     RpmLogGuard rpm_log_guard;
 
@@ -365,7 +361,7 @@ private:
     /// The transaction set is checked for duplicate package names.
     /// If found, the package with the "newest" EVR will be replaced.
     /// @param item  item to be installed
-    void install(TransactionItem & item) {
+    void install(base::TransactionPackage & item) {
         install_up_down(item, libdnf5::transaction::TransactionItemAction::INSTALL);
     }
 
@@ -373,7 +369,7 @@ private:
     /// The transaction set is checked for duplicate package names.
     /// If found, the package with the "newest" EVR will be replaced.
     /// @param item  item to be upgraded
-    void upgrade(TransactionItem & item) {
+    void upgrade(base::TransactionPackage & item) {
         install_up_down(item, libdnf5::transaction::TransactionItemAction::UPGRADE);
     }
 
@@ -381,17 +377,17 @@ private:
     /// The transaction set is checked for duplicate package names.
     /// If found, the package with the "newest" EVR will be replaced.
     /// @param item  item to be upgraded
-    void downgrade(TransactionItem & item) {
+    void downgrade(base::TransactionPackage & item) {
         install_up_down(item, libdnf5::transaction::TransactionItemAction::DOWNGRADE);
     }
 
     /// Add package to be reinstalled to transaction set.
     /// @param item  item to be reinstalled
-    void reinstall(TransactionItem & item);
+    void reinstall(base::TransactionPackage & item);
 
     /// Add package to be erased to transaction set.
     /// @param item  item to be erased
-    void erase(TransactionItem & item);
+    void erase(base::TransactionPackage & item);
 
     /// Add package to be installed to transaction set.
     /// The transaction set is checked for duplicate package names.
@@ -399,7 +395,7 @@ private:
     /// @param item  item to be erased
     /// @param action  one of TransactionItemAction::UPGRADE,
     ///     TransactionItemAction::DOWNGRADE, TransactionItemAction::INSTALL
-    void install_up_down(TransactionItem & item, libdnf5::transaction::TransactionItemAction action);
+    void install_up_down(base::TransactionPackage & item, libdnf5::transaction::TransactionItemAction action);
 
     static Nevra trans_element_to_nevra(rpmte te);
 

--- a/libdnf5/rpm/transaction_callbacks.cpp
+++ b/libdnf5/rpm/transaction_callbacks.cpp
@@ -57,11 +57,11 @@ void TransactionCallbacks::before_begin(uint64_t) {}
 
 void TransactionCallbacks::after_complete(bool) {}
 
-void TransactionCallbacks::install_progress(const TransactionItem &, uint64_t, uint64_t) {}
+void TransactionCallbacks::install_progress(const libdnf5::base::TransactionPackage &, uint64_t, uint64_t) {}
 
-void TransactionCallbacks::install_start(const TransactionItem &, uint64_t) {}
+void TransactionCallbacks::install_start(const libdnf5::base::TransactionPackage &, uint64_t) {}
 
-void TransactionCallbacks::install_stop(const TransactionItem &, uint64_t, uint64_t) {}
+void TransactionCallbacks::install_stop(const libdnf5::base::TransactionPackage &, uint64_t, uint64_t) {}
 
 void TransactionCallbacks::transaction_progress(uint64_t, uint64_t) {}
 
@@ -69,23 +69,23 @@ void TransactionCallbacks::transaction_start(uint64_t) {}
 
 void TransactionCallbacks::transaction_stop(uint64_t) {}
 
-void TransactionCallbacks::uninstall_progress(const TransactionItem &, uint64_t, uint64_t) {}
+void TransactionCallbacks::uninstall_progress(const libdnf5::base::TransactionPackage &, uint64_t, uint64_t) {}
 
-void TransactionCallbacks::uninstall_start(const TransactionItem &, uint64_t) {}
+void TransactionCallbacks::uninstall_start(const libdnf5::base::TransactionPackage &, uint64_t) {}
 
-void TransactionCallbacks::uninstall_stop(const TransactionItem &, uint64_t, uint64_t) {}
+void TransactionCallbacks::uninstall_stop(const libdnf5::base::TransactionPackage &, uint64_t, uint64_t) {}
 
-void TransactionCallbacks::unpack_error(const TransactionItem &) {}
+void TransactionCallbacks::unpack_error(const libdnf5::base::TransactionPackage &) {}
 
-void TransactionCallbacks::cpio_error(const TransactionItem &) {}
+void TransactionCallbacks::cpio_error(const libdnf5::base::TransactionPackage &) {}
 
-void TransactionCallbacks::script_error(const TransactionItem *, Nevra, ScriptType, uint64_t) {}
+void TransactionCallbacks::script_error(const libdnf5::base::TransactionPackage *, Nevra, ScriptType, uint64_t) {}
 
-void TransactionCallbacks::script_start(const TransactionItem *, Nevra, ScriptType) {}
+void TransactionCallbacks::script_start(const libdnf5::base::TransactionPackage *, Nevra, ScriptType) {}
 
-void TransactionCallbacks::script_stop(const TransactionItem *, Nevra, ScriptType, uint64_t) {}
+void TransactionCallbacks::script_stop(const libdnf5::base::TransactionPackage *, Nevra, ScriptType, uint64_t) {}
 
-void TransactionCallbacks::elem_progress(const TransactionItem &, uint64_t, uint64_t) {}
+void TransactionCallbacks::elem_progress(const libdnf5::base::TransactionPackage &, uint64_t, uint64_t) {}
 
 void TransactionCallbacks::verify_progress(uint64_t, uint64_t) {}
 

--- a/test/tutorial/transaction/transaction.cpp
+++ b/test/tutorial/transaction/transaction.cpp
@@ -53,7 +53,7 @@ transaction.download();
 // complete list of the callbacks see `libdnf5::rpm::TransactionCallbacks`
 // documentation.
 class TransactionCallbacks : public libdnf5::rpm::TransactionCallbacks {
-    void install_start(const libdnf5::rpm::TransactionItem & item, [[maybe_unused]] uint64_t total) override {
+    void install_start(const libdnf5::base::TransactionPackage & item, [[maybe_unused]] uint64_t total) override {
         std::cout << transaction_item_action_to_string(item.get_action()) << " " << item.get_package().get_nevra()
                   << std::endl;
     }


### PR DESCRIPTION
Given that there is another TransactionItem class in
libdnf5::transaction namespace, the alias libnf5::rpm::TransactionItem ->
libdnf5::base::TransactionPackage is confusing and does not add any
value to the user.
This patch deprecates it and uses directly TransactionPackage in all
places.