### PR TITLE
automatic: Use original dnf4 config file location

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -756,6 +756,8 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %ghost %{_sysconfdir}/motd.d/dnf5-automatic
 %{_libdir}/dnf5/plugins/automatic_cmd_plugin.so
 %{_datadir}/dnf5/dnf5-plugins/automatic.conf
+%ghost %config(noreplace) %{_sysconfdir}/dnf/automatic.conf
+%ghost %config(noreplace) %{_sysconfdir}/dnf/dnf5-plugins/automatic.conf
 %{_mandir}/man8/dnf*-automatic.8.*
 %{_unitdir}/dnf5-automatic.service
 %{_unitdir}/dnf5-automatic.timer

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -146,7 +146,6 @@ Changes to individual commands
 
 ``automatic``
   * Now a DNF5 plugin.
-  * Configuration file has been moved from ``/etc/dnf/automatic.conf`` to ``/etc/dnf/dnf5-plugins/automatic.conf``. However, its contents remain compatible.
   * The specific systemd units, ``dnf-automatic-download``, ``dnf-automatic-install``, and ``dnf-automatic-notifyonly``, have been dropped. Only one ``dnf5-automatic`` timer is shipped.
   * See the :ref:`Automatic command <automatic_plugin_ref-label>` for more information.
 

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -33,7 +33,7 @@ Description
 
 Alternative CLI to ``dnf upgrade`` with specific facilities to make it suitable to be executed automatically and regularly from systemd timers, cron jobs and similar.
 
-The operation of the tool is controlled by configuration files. Default values are set from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` config file. Host-specific overrides from ``/etc/dnf/dnf5-plugins/automatic.conf`` are then applied.
+The operation of the tool is controlled by configuration files. Default values are set from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` config file. Host-specific overrides from ``/etc/dnf/automatic.conf`` are then applied.
 
 The tool synchronizes package metadata as needed and then checks for updates available for the given system and then either exits, downloads the packages or downloads and applies the updates. The outcome of the operation is then reported by a selected mechanism, for instance via the standard output, email or MOTD messages.
 
@@ -65,7 +65,7 @@ The following options can be used to override values from the configuration file
 Run dnf5 automatic service
 ==========================
 
-The service is typically executed using the systemd timer ``dnf5-automatic.timer``. To configure the service, customize the ``/etc/dnf/dnf5-plugins/automatic.conf`` file. You can either copy the distribution config file from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` and use it as a baseline, or create your own configuration file from scratch with only the required overrides.
+The service is typically executed using the systemd timer ``dnf5-automatic.timer``. To configure the service, customize the ``/etc/dnf/automatic.conf`` file. You can either copy the distribution config file from ``/usr/share/dnf5/dnf5-plugins/automatic.conf`` and use it as a baseline, or create your own configuration file from scratch with only the required overrides.
 
 Then enable the timer unit:
 


### PR DESCRIPTION
Since the automatic configuration file remains compatible, this change
makes the upgrade dnf4->dnf5 easier for the user.
Having so many automatic config files seems overly complicated so the
change also deprecates /etc/dnf/dnf5-plugins/automatic.conf location and
warns the user if they use it.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1624