### PR TITLE
spec: Recommend dnf5-plugins if dnf-plugins-core installed

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -18,6 +18,7 @@ Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 %if %{without dnf5_obsoletes_dnf}
 Requires:       dnf-data
 %endif
+Recommends:     (dnf5-plugins if dnf-plugins-core)
 Recommends:     bash-completion
 Requires:       coreutils
 


### PR DESCRIPTION
Tested F40 -> F41 upgrade using `dnf4 system-upgrade --releasever=40` and `dnf4 distro-sync --releasever=40`. If `dnf-plugins-core` is installed, then the system-upgrade (or distrosync) will install `dnf5-plugins` as a weak dependency. If `dnf-plugins-core` is missing, then `dnf5-plugins` will not be installed.

For https://bugzilla.redhat.com/show_bug.cgi?id=2309697