### PR TITLE
Fix: libdnf5-cli: TransactionSummary counters data type

### DIFF
--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -186,14 +186,14 @@ public:
     }
 
 private:
-    int installs = 0;
-    int reinstalls = 0;
-    int upgrades = 0;
-    int downgrades = 0;
-    int removes = 0;
-    int replaced = 0;
-    int reason_changes = 0;
-    int skips = 0;
+    unsigned int installs = 0;
+    unsigned int reinstalls = 0;
+    unsigned int upgrades = 0;
+    unsigned int downgrades = 0;
+    unsigned int removes = 0;
+    unsigned int replaced = 0;
+    unsigned int reason_changes = 0;
+    unsigned int skips = 0;
 };
 
 


### PR DESCRIPTION
Fixes `error: implicit conversion changes signedness: 'const int' to 'unsigned long' [-Werror,-Wsign-conversion]`

The bug was caused by commit https://github.com/rpm-software-management/dnf5/pull/1696