### PR TITLE
RepoSack: New API to reload system repo

### DIFF
--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -319,10 +319,15 @@ private:
     friend class PackageDownloader;
     friend class solv::Pool;
 
-    /// Loads the repository objects into sacks.
+    /// Loads the repository objects into sacks. Only the first call actually loads the repo.
     ///
     /// Also writes the libsolv's solv/solvx cache files.
     LIBDNF_LOCAL void load();
+
+    /// Empties currently loaded repo and loads it again.
+    LIBDNF_LOCAL void reload();
+
+    LIBDNF_LOCAL void _load();
 
     /// Downloads repository metadata.
     // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -91,6 +91,9 @@ public:
     /// @return The system repository.
     libdnf5::repo::RepoWeakPtr get_system_repo();
 
+    /// Reloads the system repository. If the system repository has not been created yet, it will create and load it.
+    void reload_system_repo();
+
     /// Add given paths to comdline repository.
     /// @param paths Vector of paths to rpm files to be inserted to cmdline repo. Can contain paths to local files or URLs of remote rpm files. Specifications that are neither file paths, nor URLs are ignored.
     /// @param calculate_checksum Whether libsolv should calculate and store checksum of added packages. Setting to true significantly reduces performance.

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -216,12 +216,7 @@ void Repo::download_metadata(const std::string & destdir) {
     p_impl->downloader->download_metadata(destdir);
 }
 
-void Repo::load() {
-    // Each repository can only be loaded once. This one has already loaded, so just return instantly
-    if (is_loaded()) {
-        return;
-    }
-
+void Repo::_load() {
     make_solv_repo();
 
     if (p_impl->type == Type::AVAILABLE) {
@@ -232,6 +227,21 @@ void Repo::load() {
 
     p_impl->solv_repo->set_needs_internalizing();
     p_impl->base->get_rpm_package_sack()->p_impl->invalidate_provides();
+}
+
+void Repo::load() {
+    // Each repository can only be loaded once. This one has already loaded, so just return instantly
+    if (is_loaded()) {
+        return;
+    }
+    _load();
+}
+
+void Repo::reload() {
+    if (p_impl->solv_repo) {
+        p_impl->solv_repo->empty();
+    }
+    _load();
 }
 
 void Repo::add_libsolv_testcase(const std::string & path) {

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -286,6 +286,10 @@ RepoWeakPtr RepoSack::get_system_repo() {
     return p_impl->system_repo->get_weak_ptr();
 }
 
+void RepoSack::reload_system_repo() {
+    get_system_repo()->reload();
+}
+
 /**
  *
  * @param repos Set of repositories to load

--- a/libdnf5/repo/solv_repo.cpp
+++ b/libdnf5/repo/solv_repo.cpp
@@ -792,4 +792,9 @@ void SolvRepo::create_environment_solvable(
     repodata_internalize(data);
 }
 
+void SolvRepo::empty() {
+    // TODO(mblaha): is resuseid=true safe enough?
+    repo_empty(repo, true);
+}
+
 }  // namespace libdnf5::repo

--- a/libdnf5/repo/solv_repo.hpp
+++ b/libdnf5/repo/solv_repo.hpp
@@ -120,6 +120,10 @@ public:
     /// @return      True if the group was successfully read.
     bool read_group_solvable_from_xml(const std::string & path);
 
+    /// Free all solvables in the repository. The repository will be empty
+    /// after this call.
+    void empty();
+
 private:
     // "type_name == nullptr" means load "primary" cache (.solv file)
     bool load_solv_cache(solv::Pool & pool, const char * type_name, int flags);


### PR DESCRIPTION
Introduce a new API to clear all solvables from the system repo and
reload fresh data from the RPM database.

Re-creating the Base object can be resource-intensive, and there is a
use case in dnfdaemon where the current session (which wraps around the
Base instance) needs to be reused even after executing an RPM
transaction - whether for queries or running another transaction.