### PR TITLE
Warn on sign conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ add_compile_options("-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/=")
 
 # warnings
 add_compile_options(-Wall -Wextra -Werror)
-add_compile_options(-Wcast-align -Wformat-nonliteral -Wmissing-format-attribute -Wredundant-decls -Wsign-compare -Wtype-limits -Wuninitialized -Wwrite-strings)
+add_compile_options(-Wcast-align -Wformat-nonliteral -Wmissing-format-attribute -Wredundant-decls -Wsign-compare -Wsign-conversion -Wtype-limits -Wuninitialized -Wwrite-strings)
 add_compile_options(-Werror=unused-result -Wodr)
 
 # not sure about the conversion warnings being errors; review later

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SWIG_COMPILE_OPTIONS
     -Wno-missing-declarations
     -Wno-missing-field-initializers
     -Wno-sign-compare
+    -Wno-sign-conversion
     -Wno-sometimes-uninitialized
     -Wno-strict-aliasing
     -Wno-unused-function


### PR DESCRIPTION
This patch set adds -Wsign-conversion to compiler flags and fixes the code be compilable with it. It should prevent from surprises like in #1701.