### PR TITLE
dnf clean: Do not report an error on a nonexistent cache directory

### DIFF
--- a/dnf5/commands/clean/clean.cpp
+++ b/dnf5/commands/clean/clean.cpp
@@ -22,10 +22,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dnf5/shared_options.hpp"
 
+#include <errno.h>
 #include <libdnf5-cli/argument_parser.hpp>
 #include <libdnf5/repo/repo_cache.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/format.hpp>
 
 #include <filesystem>
 #include <iostream>
@@ -168,7 +170,14 @@ void CleanCommand::run() {
     }
 
     if (ec) {
-        throw std::runtime_error(fmt::format("Cannot iterate the cache directory: \"{}\"", cachedir.string()));
+        if (ec.value() == ENOENT) {
+            std::cout << libdnf5::utils::sformat(
+                             _("Cache directory \"{}\" does not exist. Nothing to clean."), cachedir.string())
+                      << std::endl;
+            return;
+        }
+        throw std::runtime_error(
+            libdnf5::utils::sformat(_("Cannot iterate cache directory \"{}\": {}"), cachedir.string(), ec.message()));
     }
 
     std::cout << fmt::format(


### PR DESCRIPTION
If /var/cache/libdnf5 directory did not exist, "dnf clean all" reported and error:

    Cannot iterate the cache directory: "/var/cache/libdnf5"

This patch optimizes this case to no operation. If there is no cache, there is nothing to remove.

If the iterator fails for a different reason, the message is ammended with an operating system error message, explaining the cause.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2313032