### PR TITLE
Fix `sdbus::ObjectPath` when checking signals `object_path`

### DIFF
--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -36,7 +36,7 @@ namespace dnfdaemon::client {
 
 bool DbusCallback::signature_valid(sdbus::Signal & signal) {
     // check that signal is emitted by the correct session object
-    std::string object_path;
+    sdbus::ObjectPath object_path;
     signal >> object_path;
     return object_path == context.get_session_object_path();
 }


### PR DESCRIPTION
1. Fix deserialization when checking signals `object_path`.

    Since https://github.com/rpm-software-management/dnf5/pull/1679 `sdbus::ObjectPath` is send over to the client not `std::string`.

    This was causing the check `signature_valid(sdbus::Signal &)` to crash, the client callback ended and the server kept waiting for result of the `key_import` userconfirm.

    (I believe we should somehow handle when `DbusCallback::signature_valid()` returns `false` but I am not sure what would be the best approach. At least logging the event would be good (through the `context`?).)

2. The other commit fixes a bug for dnf5daemon offline transactions, analogous to https://github.com/rpm-software-management/dnf5/pull/1672.