### PR TITLE
Do not install /var/cache/libdnf5 directory

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -381,7 +381,7 @@ Package management library.
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so.2*
 %license lgpl-2.1.txt
-%{_var}/cache/libdnf5/
+%ghost %attr(0755, root, root) %dir %{_var}/cache/libdnf5
 
 # ========== libdnf5-cli ==========
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -142,9 +142,6 @@ list(JOIN LIBDNF5_PC_REQUIRES_PRIVATE ", " LIBDNF5_PC_REQUIRES_PRIVATE_STRING)
 configure_file("libdnf5.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
 
-# Makes an empty directory for libdnf5 cache
-install(DIRECTORY DESTINATION "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/cache/libdnf5")
-
 # Makes an empty directory for libdnf5 distribution drop-in configuration files
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/share/dnf5/libdnf.conf.d")
 


### PR DESCRIPTION
Bootc systems tend to prune /var directory
<https://containers.github.io/bootc/filesystem.html#var>. That breaks verifying integrity with "rpm --verify libdnf5".

This patch stops installing /var/cache/libdnf5 directory, but keeps tracking it by libdn5 RPM package. The directory is created by libdnf5 whenever it is needed.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2313032