### PR TITLE
setlocale: If locale setting fails, try using C.UTF-8 as fallback

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -957,8 +957,11 @@ static void print_new_leaves(Context & context) {
 }
 
 static void set_locale() {
-    auto * locale = setlocale(LC_ALL, "");
-    if (locale) {
+    if (setlocale(LC_ALL, "")) {
+        return;
+    }
+    if (setlocale(LC_ALL, "C.UTF-8")) {
+        std::cerr << "Failed to set locale, defaulting to \"C.UTF-8\"" << std::endl;
         return;
     }
     std::cerr << "Failed to set locale, defaulting to \"C\"" << std::endl;

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -217,10 +217,23 @@ static void add_commands(Context & context) {
 
 }  // namespace dnfdaemon::client
 
+
+static void set_locale() {
+    if (setlocale(LC_ALL, "")) {
+        return;
+    }
+    if (setlocale(LC_ALL, "C.UTF-8")) {
+        std::cerr << "Failed to set locale, defaulting to \"C.UTF-8\"" << std::endl;
+        return;
+    }
+    std::cerr << "Failed to set locale, defaulting to \"C\"" << std::endl;
+}
+
+
 int main(int argc, char * argv[]) {
     std::unique_ptr<sdbus::IConnection> connection;
 
-    setlocale(LC_ALL, "");
+    set_locale();
 
     dnfdaemon::client::Context context;
 


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1685