### PR TITLE
chore: static_cast to fix sign conversion warning

### DIFF
--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -388,7 +388,7 @@ std::vector<std::vector<unsigned int>> kosaraju(const std::vector<std::vector<un
         }
 
         if (sccredges.empty()) {
-            std::vector scc(stack.begin() + s, stack.end());
+            std::vector scc(stack.begin() + static_cast<std::vector<unsigned int>::difference_type>(s), stack.end());
             std::sort(scc.begin(), scc.end());
             leaves.emplace_back(std::move(scc));
         } else {


### PR DESCRIPTION
Without this patch, the i686 build fails due to `-Werror` and a sign conversion warning, introduced in https://github.com/rpm-software-management/dnf5/pull/1703.

I only noticed the error after making an upstream release and trying to build DNF 5.2.6.1 in Koji. It might be good to have builds for non-x86_64 architectures tested in our upstream CI so we can catch these issues sooner.