### PR TITLE
comps: add get_base() to {Group,Environment}{,Query}

### DIFF
--- a/include/libdnf5/comps/environment/environment.hpp
+++ b/include/libdnf5/comps/environment/environment.hpp
@@ -56,6 +56,10 @@ public:
     Environment(Environment && src) noexcept;
     Environment & operator=(Environment && src) noexcept;
 
+    /// @return The `Base` object to which this object belongs.
+    /// @since 5.2.6
+    libdnf5::BaseWeakPtr get_base();
+
     /// @return The Environment id.
     /// @since 5.0
     std::string get_environmentid() const;

--- a/include/libdnf5/comps/environment/query.hpp
+++ b/include/libdnf5/comps/environment/query.hpp
@@ -46,6 +46,10 @@ public:
     EnvironmentQuery(EnvironmentQuery && src) noexcept;
     EnvironmentQuery & operator=(EnvironmentQuery && src) noexcept;
 
+    /// @return The `Base` object to which this object belongs.
+    /// @since 5.2.6
+    libdnf5::BaseWeakPtr get_base();
+
     void filter_environmentid(const std::string & pattern, sack::QueryCmp cmp = libdnf5::sack::QueryCmp::EQ);
     void filter_environmentid(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf5::sack::QueryCmp::EQ);

--- a/include/libdnf5/comps/group/group.hpp
+++ b/include/libdnf5/comps/group/group.hpp
@@ -57,6 +57,10 @@ public:
     Group(Group && src) noexcept;
     Group & operator=(Group && src) noexcept;
 
+    /// @return The `Base` object to which this object belongs.
+    /// @since 5.2.6
+    libdnf5::BaseWeakPtr get_base();
+
     /// @return The Group id.
     /// @since 5.0
     std::string get_groupid() const;

--- a/include/libdnf5/comps/group/query.hpp
+++ b/include/libdnf5/comps/group/query.hpp
@@ -46,6 +46,10 @@ public:
     GroupQuery(GroupQuery && src) noexcept;
     GroupQuery & operator=(GroupQuery && src) noexcept;
 
+    /// @return The `Base` object to which this object belongs.
+    /// @since 5.2.6
+    libdnf5::BaseWeakPtr get_base();
+
     void filter_groupid(const std::string & pattern, sack::QueryCmp cmp = libdnf5::sack::QueryCmp::EQ);
 
     void filter_groupid(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf5::sack::QueryCmp::EQ);

--- a/libdnf5/comps/environment/environment.cpp
+++ b/libdnf5/comps/environment/environment.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/xml.hpp"
 
 #include "libdnf5/base/base.hpp"
+#include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/comps/environment/query.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
@@ -104,6 +105,10 @@ bool Environment::operator!=(const Environment & rhs) const noexcept {
 
 bool Environment::operator<(const Environment & rhs) const {
     return get_environmentid() < rhs.get_environmentid() || get_repos() < rhs.get_repos();
+}
+
+libdnf5::BaseWeakPtr Environment::get_base() {
+    return p_impl->base;
 }
 
 std::string Environment::get_environmentid() const {

--- a/libdnf5/comps/environment/query.cpp
+++ b/libdnf5/comps/environment/query.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/pool.hpp"
 
 #include "libdnf5/base/base.hpp"
+#include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/comps/environment/environment.hpp"
 
 extern "C" {
@@ -136,6 +137,10 @@ EnvironmentQuery & EnvironmentQuery::operator=(const EnvironmentQuery & src) {
     return *this;
 }
 EnvironmentQuery & EnvironmentQuery::operator=(EnvironmentQuery && src) noexcept = default;
+
+libdnf5::BaseWeakPtr EnvironmentQuery::get_base() {
+    return p_impl->base;
+}
 
 void EnvironmentQuery::filter_environmentid(const std::string & pattern, sack::QueryCmp cmp) {
     filter(Impl::F::environmentid, pattern, cmp);

--- a/libdnf5/comps/group/group.cpp
+++ b/libdnf5/comps/group/group.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/xml.hpp"
 
 #include "libdnf5/base/base.hpp"
+#include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/comps/group/package.hpp"
 #include "libdnf5/comps/group/query.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
@@ -105,6 +106,10 @@ bool Group::operator<(const Group & rhs) const {
     return get_groupid() < rhs.get_groupid() || get_repos() < rhs.get_repos();
 }
 
+
+libdnf5::BaseWeakPtr Group::get_base() {
+    return p_impl->base;
+}
 
 std::string Group::get_groupid() const {
     return solv::CompsPool::split_solvable_name(

--- a/libdnf5/comps/group/query.cpp
+++ b/libdnf5/comps/group/query.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/pool.hpp"
 
 #include "libdnf5/base/base.hpp"
+#include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/comps/group/group.hpp"
 
 extern "C" {
@@ -135,6 +136,10 @@ GroupQuery & GroupQuery::operator=(const GroupQuery & src) {
     return *this;
 }
 GroupQuery & GroupQuery::operator=(GroupQuery && src) noexcept = default;
+
+libdnf5::BaseWeakPtr GroupQuery::get_base() {
+    return p_impl->base;
+}
 
 void GroupQuery::filter_package_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {

--- a/test/python3/libdnf5/comps/test_comps_iterators.py
+++ b/test/python3/libdnf5/comps/test_comps_iterators.py
@@ -24,8 +24,10 @@ import base_test_case
 class TestCompsIterators(base_test_case.BaseTestCase):
     def test_group_query_iterable(self):
         query = libdnf5.comps.GroupQuery(self.base)
+        self.assertIsInstance(query.get_base().get(), libdnf5.base.Base)
         _ = [grp.get_groupid() for grp in query]
 
     def test_environment_query_iterable(self):
         query = libdnf5.comps.EnvironmentQuery(self.base)
+        self.assertIsInstance(query.get_base().get(), libdnf5.base.Base)
         _ = [env.get_environmentid() for env in query]

--- a/test/python3/libdnf5/comps/test_comps_iterators.py
+++ b/test/python3/libdnf5/comps/test_comps_iterators.py
@@ -23,11 +23,15 @@ import base_test_case
 
 class TestCompsIterators(base_test_case.BaseTestCase):
     def test_group_query_iterable(self):
+        self.add_repo_repomd("repomd-comps-core")
         query = libdnf5.comps.GroupQuery(self.base)
         self.assertIsInstance(query.get_base().get(), libdnf5.base.Base)
-        _ = [grp.get_groupid() for grp in query]
+        assert [grp.get_groupid() for grp in query]
+        self.assertIsInstance(next(iter(query)).get_base().get(), libdnf5.base.Base)
 
     def test_environment_query_iterable(self):
+        self.add_repo_repomd("repomd-comps-core-environment")
         query = libdnf5.comps.EnvironmentQuery(self.base)
         self.assertIsInstance(query.get_base().get(), libdnf5.base.Base)
-        _ = [env.get_environmentid() for env in query]
+        assert [env.get_environmentid() for env in query]
+        self.assertIsInstance(next(iter(query)).get_base().get(), libdnf5.base.Base)


### PR DESCRIPTION
This mirrors the similar classes in libdnf5::rpm that provide the same methods. This will help fedrq implement group querying functionality.