### PR TITLE
copr: use pubkey URL returned by Copr API

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_repo.cpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.cpp
@@ -277,7 +277,11 @@ CoprRepo::CoprRepo(
     std::string results_url = json->get_dict_item("results_url")->string();
     std::string baseurl = results_url + "/" + project_owner + "/" + project_dirname + "/" + baseurl_chroot + "/";
     std::string name = "Copr repo for " + project_dirname + " owned by " + project_owner;
+
     std::string gpgkey = results_url + "/" + project_owner + "/" + project_name + "/" + "pubkey.gpg";
+    if (json->has_key("pubkey_url")) {
+        gpgkey = json->get_dict_item("pubkey_url")->string();
+    }
 
     auto main_repo_json = json_repos->get_dict_item(json_selector)->get_dict_item("arch")->get_dict_item(arch);
     auto main_repo = CoprRepoPart(repo_id, name, true, baseurl, gpgkey);


### PR DESCRIPTION
See https://github.com/fedora-copr/copr/issues/3375

When an alternative storage (such as Pulp) for Copr is used, the pubkey.gpg is still being stored on Copr backend. Therefore we can't always construct the correct pubkey URL here in the DNF plugin.