### PR TITLE
Print RPM messages to the user

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -456,7 +456,9 @@ void OfflineExecuteCommand::run() {
 
     goal->add_serialized_transaction(transaction_json_path);
 
-    auto transaction = goal->resolve();
+    auto & context = get_context();
+    context.set_transaction(goal->resolve());
+    auto transaction = *context.get_transaction();
     if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
         std::cerr << "Failed to resolve transaction. This indicates some bigger problem, since the offline transaction "
                      "was already successfully resolved before. Was the cache at "

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -864,15 +864,18 @@ void RpmTransCB::cpio_error(const libdnf5::base::TransactionPackage & item) {
     multi_progress_bar.print();
 }
 
-void RpmTransCB::script_output_to_progress(const libdnf5::cli::progressbar::MessageType message_type) {
+int RpmTransCB::script_output_to_progress(const libdnf5::cli::progressbar::MessageType message_type) {
     auto transaction = context.get_transaction();
     auto output = transaction->get_last_script_output();
+    int retval = 0;
     if (!output.empty()) {
         active_progress_bar->add_message(message_type, _("Scriptlet output:"));
         for (auto & line : libdnf5::utils::string::split(output, "\n")) {
             active_progress_bar->add_message(message_type, line);
+            ++retval;
         }
     }
+    return retval;
 }
 
 void RpmTransCB::script_error(

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -268,10 +268,15 @@ private:
     DNF_LOCAL static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
 
     /// Print the current scriptlet output to the user using the currently active
-    /// progressbar.
+    /// progress bar.
     /// @param message_type type of the messages (e.g. WARNING, or ERROR)
     /// @return  the number of printed lines
     DNF_LOCAL int script_output_to_progress(libdnf5::cli::progressbar::MessageType message_type);
+
+    /// Print rpm log messages to the user using the currently active progress bar.
+    /// @param message_type type of the messages (e.g. WARNING, or ERROR)
+    /// @return  the number of printed lines
+    DNF_LOCAL int rpm_messages_to_progress(libdnf5::cli::progressbar::MessageType message_type);
 
     libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -267,7 +267,11 @@ private:
 
     DNF_LOCAL static std::chrono::time_point<std::chrono::steady_clock> prev_print_time;
 
-    DNF_LOCAL void script_output_to_progress(libdnf5::cli::progressbar::MessageType message_type);
+    /// Print the current scriptlet output to the user using the currently active
+    /// progressbar.
+    /// @param message_type type of the messages (e.g. WARNING, or ERROR)
+    /// @return  the number of printed lines
+    DNF_LOCAL int script_output_to_progress(libdnf5::cli::progressbar::MessageType message_type);
 
     libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
     libdnf5::cli::progressbar::DownloadProgressBar * active_progress_bar{nullptr};

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -196,6 +196,9 @@ public:
     /// Retrieve output of the last executed rpm scriptlet.
     std::string get_last_script_output();
 
+    /// Retrieve captured RPM log messages
+    std::vector<std::string> get_rpm_messages();
+
 private:
     friend class TransactionEnvironment;
     friend class TransactionGroup;
@@ -217,6 +220,9 @@ private:
 
     /// Clear the recorded last scriptlet output
     LIBDNF_LOCAL void clear_last_script_output();
+
+    /// Store captured RPM log messages
+    LIBDNF_LOCAL void set_rpm_messages(std::vector<std::string> && rpm_messages);
 };
 
 }  // namespace libdnf5::base

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -1446,6 +1446,14 @@ void Transaction::Impl::append_last_script_output(std::string_view output) {
     last_script_output.append(output);
 }
 
+std::vector<std::string> Transaction::Impl::get_rpm_messages() {
+    return rpm_messages;
+}
+
+void Transaction::Impl::set_rpm_messages(std::vector<std::string> && rpm_messages) {
+    this->rpm_messages = std::move(rpm_messages);
+}
+
 std::string Transaction::serialize(
     const std::filesystem::path & packages_path, const std::filesystem::path & comps_path) const {
     transaction::TransactionReplay transaction_replay;
@@ -1540,6 +1548,14 @@ std::string Transaction::get_last_script_output() {
 
 void Transaction::clear_last_script_output() {
     p_impl->clear_last_script_output();
+}
+
+std::vector<std::string> Transaction::get_rpm_messages() {
+    return p_impl->get_rpm_messages();
+}
+
+void Transaction::set_rpm_messages(std::vector<std::string> && rpm_messages) {
+    p_impl->set_rpm_messages(std::move(rpm_messages));
 }
 
 }  // namespace libdnf5::base

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -99,6 +99,10 @@ public:
     void append_last_script_output(std::string_view output);
     void process_scriptlets_output(int fd);
 
+    /// Getter/setter for RPM log messages
+    std::vector<std::string> get_rpm_messages();
+    void set_rpm_messages(std::vector<std::string> && messages);
+
 private:
     friend Transaction;
     friend class libdnf5::Goal;
@@ -135,6 +139,8 @@ private:
 
     std::string last_script_output{};
     std::mutex last_script_output_mutex;
+
+    std::vector<std::string> rpm_messages;
 
     TransactionRunResult _run(
         std::unique_ptr<libdnf5::rpm::TransactionCallbacks> && callbacks,

--- a/libdnf5/rpm/rpm_log_guard.hpp
+++ b/libdnf5/rpm/rpm_log_guard.hpp
@@ -42,9 +42,18 @@ class RpmLogGuard : public RpmLogGuardBase {
 public:
     RpmLogGuard(const BaseWeakPtr & base);
     ~RpmLogGuard();
+    BaseWeakPtr & get_base();
+
+    /// Add new RPM message to the buffer.
+    void add_rpm_log(std::string_view log);
+
+    /// Retrieve RPM messages that have been received since the last call of this method.
+    std::vector<std::string> extract_rpm_logs_buffer();
 
 private:
     int old_log_mask{0};
+    std::vector<std::string> rpm_logs_buffer{};
+    BaseWeakPtr base;
 };
 
 class RpmLogGuardStrings : public RpmLogGuardBase {

--- a/libdnf5/rpm/transaction.hpp
+++ b/libdnf5/rpm/transaction.hpp
@@ -321,6 +321,10 @@ public:
     /// @param file_path  new file path
     void set_script_out_file(const std::string & file_path);
 
+    /// Retrieve recently emitted rpm log messages. After the method is called,
+    /// the stored rpm log messages are cleared.
+    std::vector<std::string> extract_rpm_messages();
+
     /// @return A `Base` object to which the transaction belongs.
     /// @since 5.0
     BaseWeakPtr get_base() const;


### PR DESCRIPTION
The RPM messages contain vital information for debugging RPM transaction.
Currently are these messages only written to the dnf5.log file. This patch
also prints them to the user during the transaction execution.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1710
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2312906