### PR TITLE
Consistently use "removing" instead of "erasing" packages

### DIFF
--- a/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
+++ b/dnf5-plugins/automatic_plugin/transaction_callbacks_simple.cpp
@@ -68,7 +68,7 @@ void TransactionCallbacksSimple::install_start(
 void TransactionCallbacksSimple::uninstall_start(
     const libdnf5::base::TransactionPackage & item, [[maybe_unused]] uint64_t total) {
     if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE) {
-        output_stream << "  Erasing ";
+        output_stream << "  Removing ";
     } else {
         output_stream << "  Cleanup ";
     }

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -832,7 +832,7 @@ void RpmTransCB::uninstall_start(const libdnf5::base::TransactionPackage & item,
     const char * msg{nullptr};
     if (item.get_action() == libdnf5::transaction::TransactionItemAction::REMOVE ||
         item.get_action() == libdnf5::transaction::TransactionItemAction::REPLACED) {
-        msg = _("Erasing {}");
+        msg = _("Removing {}");
     }
     if (!msg) {
         msg = _("Cleanup {}");

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1069,7 +1069,7 @@ static void print_resolve_hints(dnf5::Context & context) {
             const std::string_view arg{"--allowerasing"};
             if (has_named_arg(command, arg.substr(2))) {
                 hints.emplace_back(
-                    libdnf5::utils::sformat(_("{} to allow erasing of installed packages to resolve problems"), arg));
+                    libdnf5::utils::sformat(_("{} to allow removing of installed packages to resolve problems"), arg));
             }
         }
 

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -29,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 AllowErasingOption::AllowErasingOption(libdnf5::cli::session::Command & command)
-    : BoolOption(command, "allowerasing", '\0', _("Allow erasing of installed packages to resolve problems"), false) {}
+    : BoolOption(command, "allowerasing", '\0', _("Allow removing of installed packages to resolve problems"), false) {}
 
 AllowErasingOption::~AllowErasingOption() = default;
 

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -377,7 +377,7 @@ void TransactionCB::action_start(sdbus::Signal & signal) {
                 msg = "Installing";
                 break;
             case dnfdaemon::RpmTransactionItemActions::ERASE:
-                msg = "Erasing";
+                msg = "Removing";
                 break;
             case dnfdaemon::RpmTransactionItemActions::DOWNGRADE:
                 msg = "Downgrading";

--- a/doc/commands/debuginfo-install.rst
+++ b/doc/commands/debuginfo-install.rst
@@ -50,7 +50,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -42,7 +42,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -40,7 +40,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.
@@ -68,7 +68,7 @@ Examples
     | Downgrade the ``nano`` package to the given version.
 
 ``dnf5 downgrade gcc glibc --allowerasing``
-    | Downgrade ``gcc``, ``glibc`` packages and allow erasing of installed packages when needed.
+    | Downgrade ``gcc``, ``glibc`` packages and allow removing of installed packages when needed.
 
 
 See Also

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -114,7 +114,7 @@ Options for ``install``, ``remove`` and ``upgrade``
     | Used with ``install`` and ``remove`` commands.
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
     | Used with ``install`` and ``upgrade`` commands.
 
 ``--skip-broken``

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -50,7 +50,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -39,7 +39,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-broken``
     | Resolve any dependency problems by removing packages that are causing problems from the transaction.

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -39,7 +39,7 @@ Options
 =======
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--offline``
     | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -49,7 +49,7 @@ Options
     | that fix advisories matching selected advisory properties
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to upgrade. All remaining packages will be upgraded.

--- a/doc/dnf5_plugins/builddep.8.rst
+++ b/doc/dnf5_plugins/builddep.8.rst
@@ -48,7 +48,7 @@ Options
     | Enable or disable conditional build OPTION when parsing spec files. Does not apply for source rpm files.
 
 ``--allowerasing``
-    | Allow erasing of installed packages to resolve any potential dependency problems.
+    | Allow removing of installed packages to resolve any potential dependency problems.
 
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to downgrade. All remaining packages will be downgraded.

--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -96,7 +96,7 @@ void construct_job(
 void init_solver(libdnf5::solv::Pool & pool, libdnf5::solv::Solver & solver) {
     solver.init(pool);
 
-    /* don't erase packages that are no longer in repo during distupgrade */
+    /* don't remove packages that are no longer in repo during distupgrade */
     solver.set_flag(SOLVER_FLAG_KEEP_ORPHANS, 1);
     /* no arch change for forcebest */
     solver.set_flag(SOLVER_FLAG_BEST_OBEY_POLICY, 1);
@@ -424,7 +424,7 @@ libdnf5::GoalProblem GoalPrivate::resolve() {
 
     // either allow solutions callback or installonlies, both at the same time are not supported
     if (limit_installonly_packages(job, protected_running_kernel.id)) {
-        // allow erasing non-installonly packages that depend on a kernel about to be erased
+        // allow removing non-installonly packages that depend on a kernel about to be removed
         allow_uninstall_all_but_protected(*pool, job, protected_packages.get(), protected_running_kernel);
         if (libsolv_solver.solve(job)) {
             return libdnf5::GoalProblem::SOLVER_ERROR;

--- a/libdnf5/rpm/transaction.hpp
+++ b/libdnf5/rpm/transaction.hpp
@@ -338,7 +338,7 @@ private:
     CallbacksHolder callbacks_holder{nullptr, this, nullptr};
     FD_t fd_in_cb{nullptr};  // file descriptor used by transaction in callback (install/reinstall package)
 
-    base::TransactionPackage * last_added_item{nullptr};  // item added by last install/reinstall/erase/...
+    base::TransactionPackage * last_added_item{nullptr};  // item added by last install/reinstall/remove/...
     bool last_item_added_ts_element{false};               // Did the last item add the element ts?
 
     std::map<unsigned int, rpmte> implicit_ts_elements;  // elements added to the librpm transaction by librpm itself
@@ -385,14 +385,14 @@ private:
     /// @param item  item to be reinstalled
     void reinstall(base::TransactionPackage & item);
 
-    /// Add package to be erased to transaction set.
+    /// Add package to be removed to transaction set.
     /// @param item  item to be erased
     void erase(base::TransactionPackage & item);
 
     /// Add package to be installed to transaction set.
     /// The transaction set is checked for duplicate package names.
     /// If found, the package with the "newest" EVR will be replaced.
-    /// @param item  item to be erased
+    /// @param item  item to be removed
     /// @param action  one of TransactionItemAction::UPGRADE,
     ///     TransactionItemAction::DOWNGRADE, TransactionItemAction::INSTALL
     void install_up_down(base::TransactionPackage & item, libdnf5::transaction::TransactionItemAction action);
@@ -401,7 +401,7 @@ private:
 
     /// Function triggered by rpmtsNotifyChange()
     ///
-    /// On explicit install/erase add events, "other" is NULL, on implicit
+    /// On explicit install/remove add events, "other" is NULL, on implicit
     /// add events (erasures due to obsolete/upgrade/reinstall, replaced by newer)
     /// it points to the replacing package.
     ///


### PR DESCRIPTION
A Fedora user noticed that an output of "dnf remove" command marks transaction actions as "Erasing" instead of "Removing" <https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/GL3RTOI5FUSZUQU3L2PVY2U5LQDB5BDI/>:

    # dnf remove dontpanic
    Package                          Arch      Version                          Repository             Size
    Removing:
     dontpanic                       x86_64    1.02-16.fc41                     f42-build          49.5 KiB

    Transaction Summary:
     Removing:           1 package

    Is this ok [y/N]: y

    Running transaction
    [1/2] Prepare transaction                                      100% |  15.0   B/s |   1.0   B |  00m00s
    [2/2] Erasing dontpanic-0:1.02-16.fc41.x8 100% [==================] | 225.0   B/s |  13.0   B | -00m00s
    >>> Running trigger-post-uninstall scriptlet: glibc-common-0:2.40.9000-1.fc42.x86_64warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
    warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
    warning: posix.exec(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() o[2/2] Erasing dontpanic-0:1.02-16.fc41.x86_64                  100% |  50.0   B/s |  13.0   B |  00m00s
    Complete!

That's not only inconsistent with other "Removing:" and "Removed:" titles, it also promotes "erase" word and people try running "dnf erase" which is an old alias never implemented in DNF5.

This patch changes "erase" to "remove" everywhere in the output, a documentation, and code comments where appropriate.