### PR TITLE
[swig] Bindings and tests for libdnf5::utils::[is_glob_pattern | is_file_pattern]

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 
 # list of all modules that will be included in libdnf5 bindings
-list(APPEND SWIG_LIBDNF5_MODULES advisory base common comps conf logger repo rpm transaction plugin)
+list(APPEND SWIG_LIBDNF5_MODULES advisory base common comps conf logger repo rpm transaction plugin utils)
 
 
 # list of all modules that will be included in libdnf5-cli bindings

--- a/bindings/libdnf5/utils.i
+++ b/bindings/libdnf5/utils.i
@@ -1,0 +1,19 @@
+#if defined(SWIGPYTHON)
+%module(package="libdnf5") utils
+#elif defined(SWIGPERL)
+%module "libdnf5::utils"
+#elif defined(SWIGRUBY)
+%module "libdnf5/utils"
+#endif
+
+%include <std_string.i>
+
+%include <shared.i>
+
+%{
+    #include "libdnf5/utils/patterns.hpp"
+%}
+
+#define CV __perl_CV
+
+%include "libdnf5/utils/patterns.hpp"

--- a/test/libdnf5/utils/test_patterns.cpp
+++ b/test/libdnf5/utils/test_patterns.cpp
@@ -1,0 +1,44 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_patterns.hpp"
+
+#include <libdnf5/utils/patterns.hpp>
+
+using namespace libdnf5::utils;
+
+CPPUNIT_TEST_SUITE_REGISTRATION(UtilsPatternsTest);
+
+
+void UtilsPatternsTest::test_is_file_pattern() {
+    CPPUNIT_ASSERT(!is_file_pattern(""));
+    CPPUNIT_ASSERT(!is_file_pattern("no_file_pattern"));
+    CPPUNIT_ASSERT(!is_file_pattern("no_file/pattern"));
+    CPPUNIT_ASSERT(is_file_pattern("/pattern"));
+    CPPUNIT_ASSERT(is_file_pattern("*/pattern"));
+}
+
+
+void UtilsPatternsTest::test_is_glob_pattern() {
+    CPPUNIT_ASSERT(!is_glob_pattern(""));
+    CPPUNIT_ASSERT(!is_glob_pattern("no_glob_pattern"));
+    CPPUNIT_ASSERT(is_glob_pattern("glob*_pattern"));
+    CPPUNIT_ASSERT(is_glob_pattern("glob[sdf]_pattern"));
+    CPPUNIT_ASSERT(is_glob_pattern("glob?_pattern"));
+}

--- a/test/libdnf5/utils/test_patterns.hpp
+++ b/test/libdnf5/utils/test_patterns.hpp
@@ -1,0 +1,37 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TEST_UTILS_PATTERNS_HPP
+#define LIBDNF5_TEST_UTILS_PATTERNS_HPP
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+class UtilsPatternsTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(UtilsPatternsTest);
+    CPPUNIT_TEST(test_is_file_pattern);
+    CPPUNIT_TEST(test_is_glob_pattern);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_is_file_pattern();
+    void test_is_glob_pattern();
+};
+
+#endif  // LIBDNF5_TEST_UTILS_PATTERNS_HPP

--- a/test/perl5/libdnf5/utils/test_patterns.t
+++ b/test/perl5/libdnf5/utils/test_patterns.t
@@ -1,0 +1,41 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use libdnf5::utils;
+
+{
+    ok(!libdnf5::utils::is_file_pattern(''), 'is_file_pattern ""');
+    ok(!libdnf5::utils::is_file_pattern('no_file_pattern'), 'is_file_pattern "no_file_pattern"');
+    ok(!libdnf5::utils::is_file_pattern('no_file/pattern'), 'is_file_pattern "no_file/pattern"');
+    ok(libdnf5::utils::is_file_pattern('/pattern') == 1, 'is_file_pattern "/pattern"');
+    ok(libdnf5::utils::is_file_pattern('*/pattern') == 1, 'is_file_pattern "*/pattern"');
+}
+
+{
+    ok(!libdnf5::utils::is_glob_pattern(''), 'is_glob_pattern ""');
+    ok(!libdnf5::utils::is_glob_pattern('no_glob_pattern'), 'is_glob_pattern "no_glob_pattern"');
+    ok(libdnf5::utils::is_glob_pattern('glob*_pattern'), 'is_glob_pattern "glob*_pattern"');
+    ok(libdnf5::utils::is_glob_pattern('glob[sdf]_pattern') == 1, 'is_glob_pattern "glob[sdf]_pattern"');
+    ok(libdnf5::utils::is_glob_pattern('glob?_pattern') == 1, 'is_glob_pattern "glob?_pattern"');
+}
+
+done_testing()

--- a/test/python3/libdnf5/utils/test_patterns.py
+++ b/test/python3/libdnf5/utils/test_patterns.py
@@ -1,0 +1,36 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import libdnf5.utils
+
+
+class TestIsXPattern(unittest.TestCase):
+    def test_is_file_pattern(self):
+        self.assertFalse(libdnf5.utils.is_file_pattern(''))
+        self.assertFalse(libdnf5.utils.is_file_pattern('no_file_pattern'))
+        self.assertFalse(libdnf5.utils.is_file_pattern('no_file/pattern'))
+        self.assertTrue(libdnf5.utils.is_file_pattern('/pattern'))
+        self.assertTrue(libdnf5.utils.is_file_pattern('*/pattern'))
+
+    def test_is_glob_pattern(self):
+        self.assertFalse(libdnf5.utils.is_glob_pattern(''))
+        self.assertFalse(libdnf5.utils.is_glob_pattern('no_glob_pattern'))
+        self.assertTrue(libdnf5.utils.is_glob_pattern('glob*_pattern'))
+        self.assertTrue(libdnf5.utils.is_glob_pattern('glob[sdf]_pattern'))
+        self.assertTrue(libdnf5.utils.is_glob_pattern('glob?_pattern'))

--- a/test/ruby/libdnf5/utils/test_patterns.rb
+++ b/test/ruby/libdnf5/utils/test_patterns.rb
@@ -1,0 +1,39 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+require 'test/unit'
+include Test::Unit::Assertions
+
+require 'libdnf5/utils'
+
+class TestIsXPattern < Test::Unit::TestCase
+    def test_is_file_pattern()
+        assert(!Utils::is_file_pattern(''))
+        assert(!Utils::is_file_pattern('no_file_pattern'))
+        assert(!Utils::is_file_pattern('no_file/pattern'))
+        assert(Utils::is_file_pattern('/pattern'))
+        assert(Utils::is_file_pattern('*/pattern'))
+    end
+
+    def test_is_glob_pattern()
+        assert(!Utils::is_glob_pattern(''))
+        assert(!Utils::is_glob_pattern('no_glob_pattern'))
+        assert(Utils::is_glob_pattern('glob*_pattern'))
+        assert(Utils::is_glob_pattern('glob[sdf]_pattern'))
+        assert(Utils::is_glob_pattern('glob?_pattern'))
+    end
+end


### PR DESCRIPTION
`libdnf5::utils::is_glob_pattern` and `libdnf5::utils::is_file_pattern` are C++ public API functions.

Adds a new "utils" module to the bindings.

Includes `C++`, `Perl`, `Python` and `Ruby` unit tests for `is_glob_pattern` and `is_file_pattern` .

Closes: https://github.com/rpm-software-management/dnf5/issues/1563

Requires fix: https://github.com/rpm-software-management/dnf5/pull/1742