### PR TITLE
Set `POOL_FLAG_ADDFILEPROVIDESFILTERED` only when not loading filelists

### DIFF
--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -84,11 +84,6 @@ public:
         pool_set_flag(pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
         // Allow packages of the same name with different architectures to be installed in parallel
         pool_set_flag(pool, POOL_FLAG_IMPLICITOBSOLETEUSESCOLORS, 1);
-        // Configures the pool_addfileprovides_queue() method to only add files from primary.xml.
-        // This ensures the method works correctly even if filelist.xml metadata are not loaded.
-        // At the same time when filelist.xml are loaded libsolv is able to search them for required
-        // files if needed.
-        pool_set_flag(pool, POOL_FLAG_ADDFILEPROVIDESFILTERED, 1);
     }
 
     Pool(const Pool & pool) = delete;
@@ -259,6 +254,8 @@ public:
         }
     }
 
+    int set_flag(int flag, int value) { return pool_set_flag(pool, flag, value); }
+
 protected:
     SolvMap considered;  // owner of the considered map, `pool->considered` is only a raw pointer
     ::Pool * pool;
@@ -323,6 +320,10 @@ static inline solv::RpmPool & get_rpm_pool(const libdnf5::BaseWeakPtr & base) {
 
 static inline solv::CompsPool & get_comps_pool(const libdnf5::BaseWeakPtr & base) {
     return InternalBaseUser::get_comps_pool(base);
+}
+
+static inline int set_rpm_pool_flag(const libdnf5::BaseWeakPtr & base, int flag, int value) {
+    return InternalBaseUser::get_rpm_pool(base).set_flag(flag, value);
 }
 
 }  // namespace libdnf5


### PR DESCRIPTION
When filelists are loaded and file provides are used it is much faster not to set `POOL_FLAG_ADDFILEPROVIDESFILTERED` because libsolv goes through all the files just once during `pool_addfileprovides_queue`.

This is based on: https://github.com/rpm-software-management/libdnf/issues/1674

Specifically this is an improvement for users that use repos with file provides outside of primary.xml and download filelsits.xml.