### PR TITLE
comps: Fix memory issues in group serialization

### DIFF
--- a/libdnf5/comps/group/group.cpp
+++ b/libdnf5/comps/group/group.cpp
@@ -323,7 +323,14 @@ void Group::serialize(const std::string & path) {
     }
 
     // Save the document
-    if (xmlSaveFormatFileEnc(path.c_str(), doc, "utf-8", 1) == -1) {
+    auto save_result = xmlSaveFormatFileEnc(path.c_str(), doc, "utf-8", 1);
+
+    // Memory free
+    xmlFreeDoc(doc);
+    // reset the error handler to default
+    xmlSetGenericErrorFunc(NULL, NULL);
+
+    if (save_result == -1) {
         // There can be duplicit messages in the libxml2 errors so make them unique
         auto it = unique(xml_errors.begin(), xml_errors.end());
         xml_errors.resize(static_cast<size_t>(distance(xml_errors.begin(), it)));
@@ -333,11 +340,6 @@ void Group::serialize(const std::string & path) {
             path,
             libdnf5::utils::string::join(xml_errors, ", "));
     }
-
-    // Memory free
-    xmlFreeDoc(doc);
-    // reset the error handler to default
-    xmlSetGenericErrorFunc(NULL, NULL);
 }
 
 libdnf5::transaction::TransactionItemReason Group::get_reason() const {


### PR DESCRIPTION
This commit addresses two memory issues that occur if saving of the
group XML file fails:

Memory leak: The `doc` variable is not properly freed before an error is
thrown, leading to a memory leak.

Use after free: The libxml2 error handler continues to reference the
`error_to_strings()` function, which uses the `xml_errors` vector that
is local to the `Group::serialize()` method. If the handler is invoked
later (e.g., during the serialization of an Environment), it may cause a
crash due to accessing freed memory.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2315789