### PR TITLE
Make most descriptions for `dnf5 --help` translatable.

### DIFF
--- a/dnf5-plugins/config-manager_plugin/config-manager.cpp
+++ b/dnf5-plugins/config-manager_plugin/config-manager.cpp
@@ -25,6 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "unsetopt.hpp"
 #include "unsetvar.hpp"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 namespace dnf5 {
 
 using namespace libdnf5::cli;
@@ -38,7 +40,7 @@ void ConfigManagerCommand::set_parent_command() {
 
 void ConfigManagerCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Manage configuration");
+    cmd.set_description(_("Manage configuration"));
     cmd.set_long_description("Manage main and repositories configuration, variables and add new repositories.");
 }
 

--- a/dnf5/commands/advisory/advisory.cpp
+++ b/dnf5/commands/advisory/advisory.cpp
@@ -33,7 +33,7 @@ void AdvisoryCommand::set_parent_command() {
 }
 
 void AdvisoryCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage advisories");
+    get_argument_parser_command()->set_description(_("Manage advisories"));
 }
 
 void AdvisoryCommand::register_subcommands() {

--- a/dnf5/commands/autoremove/autoremove.cpp
+++ b/dnf5/commands/autoremove/autoremove.cpp
@@ -35,7 +35,7 @@ void AutoremoveCommand::set_parent_command() {
 
 void AutoremoveCommand::set_argument_parser() {
     get_argument_parser_command()->set_description(
-        "Remove all unneeded packages originally installed as dependencies.");
+        _("Remove all unneeded packages originally installed as dependencies."));
     create_offline_option(*this);
     create_store_option(*this);
 }

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -44,7 +44,7 @@ void CheckUpgradeCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Check for available package upgrades");
+    cmd.set_description(_("Check for available package upgrades"));
 
     minimal = dynamic_cast<libdnf5::OptionBool *>(
         parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));

--- a/dnf5/commands/check/check.cpp
+++ b/dnf5/commands/check/check.cpp
@@ -244,7 +244,7 @@ void CheckCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Check for problems in the packagedb");
+    cmd.set_description(_("Check for problems in the packagedb"));
     cmd.set_long_description(
         "Checks the local packagedb and produces information on any problems it finds.\n"
         "The set of checks performed can be specified with options.");

--- a/dnf5/commands/debuginfo-install/debuginfo-install.cpp
+++ b/dnf5/commands/debuginfo-install/debuginfo-install.cpp
@@ -42,7 +42,7 @@ void DebuginfoInstallCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
     auto & cmd = *get_argument_parser_command();
 
-    get_argument_parser_command()->set_description("Install debuginfo packages.");
+    get_argument_parser_command()->set_description(_("Install debuginfo packages."));
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5/shared_options.hpp>
 #include <libdnf5/conf/option_string.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 namespace dnf5 {
 
@@ -38,7 +39,7 @@ void DistroSyncCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Upgrade or downgrade installed software to the latest available versions");
+    cmd.set_description(_("Upgrade or downgrade installed software to the latest available versions"));
 
     patterns_to_distro_sync_options = parser.add_new_values();
     auto patterns_arg = parser.add_new_positional_arg(

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -37,7 +37,7 @@ void DowngradeCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Downgrade software");
+    cmd.set_description(_("Downgrade software"));
 
     auto keys = parser.add_new_positional_arg("spec", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
     keys->set_description("List of package specs to downgrade");

--- a/dnf5/commands/environment/environment.cpp
+++ b/dnf5/commands/environment/environment.cpp
@@ -32,7 +32,7 @@ void EnvironmentCommand::set_parent_command() {
 }
 
 void EnvironmentCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage comps environments");
+    get_argument_parser_command()->set_description(_("Manage comps environments"));
 }
 
 void EnvironmentCommand::register_subcommands() {

--- a/dnf5/commands/history/history.cpp
+++ b/dnf5/commands/history/history.cpp
@@ -38,7 +38,7 @@ void HistoryCommand::set_parent_command() {
 }
 
 void HistoryCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage transaction history");
+    get_argument_parser_command()->set_description(_("Manage transaction history"));
 }
 
 void HistoryCommand::register_subcommands() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -38,7 +38,7 @@ void InstallCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Install software");
+    cmd.set_description(_("Install software"));
 
     auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
     keys->set_description("List of <package-spec>|@<group-spec>|@<environment-spec> to install");

--- a/dnf5/commands/leaves/leaves.cpp
+++ b/dnf5/commands/leaves/leaves.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 #include <iostream>
 
@@ -38,7 +39,7 @@ void LeavesCommand::set_parent_command() {
 
 void LeavesCommand::set_argument_parser() {
     get_argument_parser_command()->set_description(
-        "List groups of installed packages not required by other installed packages");
+        _("List groups of installed packages not required by other installed packages"));
     get_argument_parser_command()->set_long_description(
         R"(The `leaves` command is used to list all leaf packages.
 

--- a/dnf5/commands/mark/mark.cpp
+++ b/dnf5/commands/mark/mark.cpp
@@ -35,7 +35,7 @@ void MarkCommand::set_parent_command() {
 }
 
 void MarkCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Change the reason of an installed package");
+    get_argument_parser_command()->set_description(_("Change the reason of an installed package"));
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_store_option(*this);
 }

--- a/dnf5/commands/module/module.cpp
+++ b/dnf5/commands/module/module.cpp
@@ -40,7 +40,7 @@ void ModuleCommand::set_parent_command() {
 }
 
 void ModuleCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage modules");
+    get_argument_parser_command()->set_description(_("Manage modules"));
 }
 
 void ModuleCommand::register_subcommands() {

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5-cli/output/provides.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 #include <iostream>
 
@@ -44,7 +45,7 @@ void ProvidesCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Find what package provides the given value");
+    cmd.set_description(_("Find what package provides the given value"));
 
     auto * keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
     keys->set_description("List of package specs to query");

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -37,7 +37,7 @@ void ReinstallCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Reinstall software");
+    cmd.set_description(_("Reinstall software"));
 
     auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
     keys->set_description("List of package specs to reinstall");

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -37,7 +37,7 @@ void RemoveCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Remove (uninstall) software");
+    cmd.set_description(_("Remove (uninstall) software"));
 
     auto noautoremove = parser.add_new_named_arg("no-autoremove");
     noautoremove->set_long_name("no-autoremove");

--- a/dnf5/commands/replay/replay.cpp
+++ b/dnf5/commands/replay/replay.cpp
@@ -35,7 +35,7 @@ void ReplayCommand::set_parent_command() {
 
 void ReplayCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Replay a transaction that was previously stored to a directory");
+    cmd.set_description(_("Replay a transaction that was previously stored to a directory"));
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_list.hpp"
 
 #include <dnf5/shared_options.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 namespace dnf5 {
 
@@ -34,7 +35,7 @@ void RepoCommand::set_parent_command() {
 }
 
 void RepoCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage repositories");
+    get_argument_parser_command()->set_description(_("Manage repositories"));
 }
 
 void RepoCommand::register_subcommands() {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -77,7 +77,7 @@ void RepoqueryCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Search for packages matching various criteria");
+    cmd.set_description(_("Search for packages matching various criteria"));
 
     // OPTION GROUPS
 

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -41,7 +41,7 @@ void SearchCommand::set_parent_command() {
 
 void SearchCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Search for software matching all specified strings");
+    cmd.set_description(_("Search for software matching all specified strings"));
 
     all = std::make_unique<SearchAllOption>(*this);
     patterns = std::make_unique<SearchPatternsArguments>(*this, get_context());

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -39,7 +39,7 @@ void SwapCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Remove software and install another in one transaction");
+    cmd.set_description(_("Remove software and install another in one transaction"));
 
     auto remove_spec_arg = parser.add_new_positional_arg("remove_spec", 1, nullptr, nullptr);
     remove_spec_arg->set_description("The spec that will be removed");

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -38,7 +38,7 @@ void UpgradeCommand::set_argument_parser() {
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Upgrade software");
+    cmd.set_description(_("Upgrade software"));
 
     minimal = dynamic_cast<libdnf5::OptionBool *>(
         parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));

--- a/dnf5/commands/versionlock/versionlock.cpp
+++ b/dnf5/commands/versionlock/versionlock.cpp
@@ -25,6 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "versionlock_exclude.hpp"
 #include "versionlock_list.hpp"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 namespace dnf5 {
 
 void VersionlockCommand::set_parent_command() {
@@ -35,7 +37,7 @@ void VersionlockCommand::set_parent_command() {
 }
 
 void VersionlockCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage versionlock configuration");
+    get_argument_parser_command()->set_description(_("Manage versionlock configuration"));
 }
 
 void VersionlockCommand::register_subcommands() {

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -266,7 +266,7 @@ void RootCommand::set_argument_parser() {
     setvar->set_long_name("setvar");
     setvar->set_has_value(true);
     setvar->set_arg_value_help("VAR_NAME=VALUE");
-    setvar->set_description("set arbitrary variable");
+    setvar->set_description(_("set arbitrary variable"));
     setvar->set_parse_hook_func(
         [&ctx](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
@@ -303,7 +303,7 @@ void RootCommand::set_argument_parser() {
 
     auto best = parser.add_new_named_arg("best");
     best->set_long_name("best");
-    best->set_description(("try the best available package versions in transactions"));
+    best->set_description(_("try the best available package versions in transactions"));
     best->set_const_value("true");
     best->link_value(&config.get_best_option());
     global_options_group->register_argument(best);
@@ -430,7 +430,7 @@ void RootCommand::set_argument_parser() {
 
     auto no_plugins = parser.add_new_named_arg("no-plugins");
     no_plugins->set_long_name("no-plugins");
-    no_plugins->set_description("Disable all libdnf5 plugins");
+    no_plugins->set_description(_("Disable all libdnf5 plugins"));
     no_plugins->set_const_value("false");
     no_plugins->link_value(&config.get_plugins_option());
     global_options_group->register_argument(no_plugins);

--- a/dnf5daemon-client/commands/advisory/advisory.cpp
+++ b/dnf5daemon-client/commands/advisory/advisory.cpp
@@ -32,7 +32,7 @@ void AdvisoryCommand::set_parent_command() {
 }
 
 void AdvisoryCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage advisories");
+    get_argument_parser_command()->set_description(_("Manage advisories"));
 }
 
 void AdvisoryCommand::register_subcommands() {

--- a/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
+++ b/dnf5daemon-client/commands/distro-sync/distro-sync.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5daemon-server/dbus.hpp>
 #include <libdnf5/conf/option_string.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 #include <memory>
 
@@ -44,7 +45,7 @@ void DistroSyncCommand::set_argument_parser() {
     auto & parser = get_context().get_argument_parser();
     auto & cmd = *get_argument_parser_command();
 
-    cmd.set_description("Upgrade or downgrade installed software to the latest available versions");
+    cmd.set_description(_("Upgrade or downgrade installed software to the latest available versions"));
 
     auto specs_arg = pkg_specs_argument(parser, libdnf5::cli::ArgumentParser::PositionalArg::UNLIMITED, pkg_specs);
     specs_arg->set_description("Patterns");

--- a/dnf5daemon-client/commands/group/group.cpp
+++ b/dnf5daemon-client/commands/group/group.cpp
@@ -38,7 +38,7 @@ void GroupCommand::set_argument_parser() {
     auto & parser = context.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_description("Manage comps groups");
+    cmd.set_description(_("Manage comps groups"));
 
     // query commands
     auto * query_commands_group = parser.add_new_group("group_query_commands");

--- a/dnf5daemon-client/commands/repo/repo.cpp
+++ b/dnf5daemon-client/commands/repo/repo.cpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_disable.hpp"
 #include "repo_enable.hpp"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 namespace dnfdaemon::client {
 
 void RepoCommand::set_parent_command() {
@@ -32,7 +34,7 @@ void RepoCommand::set_parent_command() {
 }
 
 void RepoCommand::set_argument_parser() {
-    get_argument_parser_command()->set_description("Manage repositories");
+    get_argument_parser_command()->set_description(_("Manage repositories"));
 }
 
 void RepoCommand::register_subcommands() {

--- a/dnf5daemon-client/commands/repoquery/repoquery.cpp
+++ b/dnf5daemon-client/commands/repoquery/repoquery.cpp
@@ -33,6 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <limits.h>
 #include <poll.h>
@@ -91,7 +92,7 @@ void RepoqueryCommand::set_argument_parser() {
         patterns_options);
     keys->set_description("List of keys to match");
 
-    cmd.set_description("search for packages matching various criteria");
+    cmd.set_description(_("search for packages matching various criteria"));
 
     cmd.register_named_arg(available);
     cmd.register_named_arg(installed);


### PR DESCRIPTION
Use `_(msgId)` in `bgettext-lib.h` to mark text as eligible for
translation. This will allow translators to translate the short
descriptions of the commands in `dnf5 --help`. Further changes will be
required to make each command description translatable.

Related: #1736