### PR TITLE
When writing main solv file (primary.xml) don't store filelists

### DIFF
--- a/libdnf5/repo/solv_repo.hpp
+++ b/libdnf5/repo/solv_repo.hpp
@@ -141,6 +141,11 @@ private:
     /// Ranges of solvables for different types of data, used for writing libsolv cache files
     int main_solvables_start{0};
     int main_solvables_end{0};
+
+    /// Range of repodata from the primary.xml, used for writing libsolv cache files
+    int main_repodata_start{0};
+    int main_repodata_end{0};
+
     int updateinfo_solvables_start{0};
     int updateinfo_solvables_end{0};
 


### PR DESCRIPTION
In a repo filelists are stored in different `repodata`, limit the written `repodata` when writing main solv file.

Otherwise the filelists are stored twice: in the main solv file and in the filelists specific solvx file. (This happens when downloading both the primary.xml and filelists.xml at the same time.)

It also improves performance because when filelists were part of main solv file they were always loaded (regardless of the `optional_metadata_types` option).

Closes: https://github.com/rpm-software-management/dnf5/issues/1749