### PR TITLE
Allow unlimited number of arguments for history `list` and `info`

### DIFF
--- a/dnf5/commands/history/arguments.hpp
+++ b/dnf5/commands/history/arguments.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 class TransactionSpecArguments : public libdnf5::cli::session::StringArgumentList {
 public:
     explicit TransactionSpecArguments(
-        libdnf5::cli::session::Command & command, int nrepeats = libdnf5::cli::ArgumentParser::PositionalArg::OPTIONAL)
+        libdnf5::cli::session::Command & command, int nrepeats = libdnf5::cli::ArgumentParser::PositionalArg::UNLIMITED)
         : StringArgumentList(command, "transaction-id", _("Transaction ID"), nrepeats) {}
 };
 


### PR DESCRIPTION
1. Allow unlimited number of arguments for history `list` and `info`


     Closes: https://github.com/rpm-software-management/dnf5/issues/1721


2. `history store` command: move arg verificion above user confirmation

