### PR TITLE
Recommend --use-host-config if --installroot is used and not all repositories can be enabled

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -265,8 +265,16 @@ void Context::Impl::apply_repository_setopts() {
     }
 
     if (!missing_repo_ids.empty()) {
-        throw libdnf5::cli::ArgumentParserError(
-            M_("No matching repositories for \"{}\""), libdnf5::utils::string::join(missing_repo_ids, ", "));
+        auto missing_repo_ids_string = libdnf5::utils::string::join(missing_repo_ids, _(", "));
+        if (base.get_config().get_installroot_option().get_value() != "/" &&
+            !base.get_config().get_use_host_config_option().get_value()) {
+            throw libdnf5::cli::ArgumentParserError(
+                M_("No matching repositories for {}. To use repositories from a host system, pass --use-host-config "
+                   "option"),
+                missing_repo_ids_string);
+        } else {
+            throw libdnf5::cli::ArgumentParserError(M_("No matching repositories for {}"), missing_repo_ids_string);
+        }
     }
 }
 


### PR DESCRIPTION
It was reported that --installroot with an explicit --repo option does not recognize given repository despite the repository is defined under /etc:

    $ dnf --installroot /tmp/dnf5/ --releasever rawhide --repo koji makecache
    No matching repositories for "*, koji". Add "--help" for more information about the arguments.

That's a feature, but a difference from DNF4.

This patchs recommeds using --use-host-config in that case. We already have a similar recommendation in main.cpp in case of no --repo option is used.

This patch also fixes formatting of the list of repository identifiers with respect to localization.

The code duplicates throws because libdnf5 exception construtors do not accept nonstatic arguments.

Resolves #1756