### PR TITLE
chore: Clean up Fedora 37-related conditionals in RPM spec

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -22,8 +22,7 @@ Recommends:     (dnf5-plugins if dnf-plugins-core)
 Recommends:     bash-completion
 Requires:       coreutils
 
-# Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 10
+%if 0%{?fedora} || 0%{?rhel} > 10
 Provides:       microdnf = %{version}-%{release}
 Obsoletes:      microdnf < 4
 %endif
@@ -271,8 +270,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_bindir}/yum
 %endif
 
-# Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 10
+%if 0%{?fedora} || 0%{?rhel} > 10
 %{_bindir}/microdnf
 %endif
 
@@ -857,8 +855,7 @@ mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/comps_groups
 mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/offline
 touch %{buildroot}%{_sysconfdir}/dnf/versionlock.toml
 
-# Remove if condition when Fedora 37 is EOL
-%if 0%{?fedora} > 37 || 0%{?rhel} > 10
+%if 0%{?fedora} || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/microdnf
 %endif
 


### PR DESCRIPTION
Fedora 37 was end-of-life on 2023-12-05.