### PR TITLE
Change `gpgcheck` option to `pkg_gpgcheck` but stay compatible

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -387,7 +387,7 @@ void OfflineExecuteCommand::pre_configure() {
     // Disable gpgcheck entirely, since GPG integrity will have already been
     // checked when the transaction was prepared and serialized. This way, we
     // don't need to keep track of which packages need to be gpgchecked.
-    ctx.get_base().get_config().get_gpgcheck_option().set(false);
+    ctx.get_base().get_config().get_pkg_gpgcheck_option().set(false);
 }
 
 void OfflineExecuteCommand::configure() {

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -71,7 +71,8 @@ public:
         return repo->get_config().get_skip_if_unavailable_option().get_value();
     }
     std::vector<std::string> get_gpgkey() const override { return repo->get_config().get_gpgkey_option().get_value(); }
-    bool get_gpgcheck() const override { return repo->get_config().get_gpgcheck_option().get_value(); }
+    bool get_gpgcheck() const override { return repo->get_config().get_pkg_gpgcheck_option().get_value(); }
+    bool get_pkg_gpgcheck() const override { return repo->get_config().get_pkg_gpgcheck_option().get_value(); }
     bool get_repo_gpgcheck() const override { return repo->get_config().get_repo_gpgcheck_option().get_value(); }
     std::string get_repo_file_path() const override { return repo->get_repo_file_path(); }
     std::string get_revision() const override { return repo->get_revision(); }

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -419,10 +419,10 @@ void RootCommand::set_argument_parser() {
                                           [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                           [[maybe_unused]] const char * option,
                                           [[maybe_unused]] const char * value) {
-        ctx.get_base().get_config().get_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
+        ctx.get_base().get_config().get_pkg_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         ctx.get_base().get_config().get_repo_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         // Store to vector. Use it later when repositories configuration will be loaded.
-        ctx.get_setopts().emplace_back("*.gpgcheck", "0");
+        ctx.get_setopts().emplace_back("*.pkg_gpgcheck", "0");
         ctx.get_setopts().emplace_back("*.repo_gpgcheck", "0");
         return true;
     });

--- a/dnf5daemon-client/commands/repolist/repolist.cpp
+++ b/dnf5daemon-client/commands/repolist/repolist.cpp
@@ -134,7 +134,7 @@ void RepolistCommand::run() {
             "includepkgs",
             "skip_if_unavailable",
             "gpgkey",
-            "gpgcheck",
+            "pkg_gpgcheck",
             "repo_gpgcheck",
             "repofile",
             "revision",

--- a/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
@@ -45,7 +45,8 @@ public:
     std::vector<std::string> get_includepkgs() const { return rawdata.at("includepkgs"); }
     bool get_skip_if_unavailable() const { return rawdata.at("skip_if_unavailable"); }
     std::vector<std::string> get_gpgkey() const { return rawdata.at("gpgkey"); }
-    bool get_gpgcheck() const { return rawdata.at("gpgcheck"); }
+    bool get_gpgcheck() const { return rawdata.at("pkg_gpgcheck"); }
+    bool get_pkg_gpgcheck() const { return rawdata.at("pkg_gpgcheck"); }
     bool get_repo_gpgcheck() const { return rawdata.at("repo_gpgcheck"); }
     std::string get_repo_file_path() const { return rawdata.at("repofile"); }
     std::string get_revision() const { return rawdata.at("revision"); }

--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -58,7 +58,7 @@ enum class RepoAttribute {
     skip_if_unavailable,
 
     gpgkey,
-    gpgcheck,
+    pkg_gpgcheck,
     repo_gpgcheck,
 
     proxy,
@@ -106,7 +106,8 @@ const static std::map<std::string, RepoAttribute> repo_attributes{
     {"skip_if_unavailable", RepoAttribute::skip_if_unavailable},
 
     {"gpgkey", RepoAttribute::gpgkey},
-    {"gpgcheck", RepoAttribute::gpgcheck},
+    {"gpgcheck", RepoAttribute::pkg_gpgcheck},
+    {"pkg_gpgcheck", RepoAttribute::pkg_gpgcheck},
     {"repo_gpgcheck", RepoAttribute::repo_gpgcheck},
 
     {"proxy", RepoAttribute::proxy},
@@ -183,8 +184,8 @@ dnfdaemon::KeyValueMap repo_to_map(
             case RepoAttribute::gpgkey:
                 dbus_repo.emplace(attr, libdnf_repo->get_config().get_gpgkey_option().get_value());
                 break;
-            case RepoAttribute::gpgcheck:
-                dbus_repo.emplace(attr, libdnf_repo->get_config().get_gpgcheck_option().get_value());
+            case RepoAttribute::pkg_gpgcheck:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().get_pkg_gpgcheck_option().get_value());
                 break;
             case RepoAttribute::repo_gpgcheck:
                 dbus_repo.emplace(attr, libdnf_repo->get_config().get_repo_gpgcheck_option().get_value());

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -973,9 +973,10 @@ configuration.
 
     Default: ``False``.
 
+.. _pkg_gpgcheck_options-label:
 .. _gpgcheck_options-label:
 
-``gpgcheck``
+``pkg_gpgcheck``
     :ref:`boolean <boolean-label>`
 
     Whether to perform GPG signature check on packages found in this repository.
@@ -984,6 +985,8 @@ configuration.
 
     Doesn't apply for packages passed directly as arguments, as they are not in any repository,
     see :ref:`localpkg_gpgcheck <localpkg_gpgcheck_options-label>`.
+
+    Due to compatibility `gpgcheck` option is supported as well but `pkg_gpgcheck` is preferred.
 
 .. _includepkgs_options-label:
 

--- a/doc/dnf5_plugins/config-manager.8.rst
+++ b/doc/dnf5_plugins/config-manager.8.rst
@@ -167,11 +167,11 @@ Examples
 ``dnf5 config-manager setopt repo1.proxy=http://proxy.example.com:3128/ repo2.proxy=http://proxy.example.com:3128/``
     Sets override for ``proxy`` option in repositories with repository IDs ``repo1`` and ``repo2``.
 
-``dnf5 config-manager setopt '*-debuginfo.gpgcheck=0'``
-    Sets override for the ``gpgcheck`` option in all repositories whose repository ID ends with ``-debuginfo``.
+``dnf5 config-manager setopt '*-debuginfo.pkg_gpgcheck=0'``
+    Sets override for the ``pkg_gpgcheck`` option in all repositories whose repository ID ends with ``-debuginfo``.
 
-``dnf5 config-manager unsetopt '*-debuginfo.gpgcheck'``
-    Remove override for the ``gpgcheck`` option in all repositories whose repository ID ends with ``-debuginfo``.
+``dnf5 config-manager unsetopt '*-debuginfo.pkg_gpgcheck'``
+    Remove override for the ``pkg_gpgcheck`` option in all repositories whose repository ID ends with ``-debuginfo``.
 
 ``dnf5 config-manager setopt keepcache=1 log_size=10M``
     Enables the ``keepcache`` main option and sets the maximum size of logger files to 10 mebibytes (10 * 1024 * 1024 bytes).

--- a/include/libdnf5-cli/output/interfaces/repo.hpp
+++ b/include/libdnf5-cli/output/interfaces/repo.hpp
@@ -55,6 +55,8 @@ public:
     virtual std::vector<std::string> get_includepkgs() const = 0;
     virtual bool get_skip_if_unavailable() const = 0;
     virtual std::vector<std::string> get_gpgkey() const = 0;
+    virtual bool get_pkg_gpgcheck() const = 0;
+    /// @deprecated It is going to be removed, use get_pkg_gpgcheck()
     virtual bool get_gpgcheck() const = 0;
     virtual bool get_repo_gpgcheck() const = 0;
     virtual std::string get_repo_file_path() const = 0;

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -165,7 +165,7 @@ public:
 
     /// @brief Check signatures of packages in the resolved transaction.
     ///
-    /// @return True if all packages have correct signatures or checking is turned off with `gpgcheck` option,
+    /// @return True if all packages have correct signatures or checking is turned off with `pkg_gpgcheck` option,
     /// otherwise false. More info about occurred problems can be retrieved using the `get_gpg_signature_problems`
     /// method.
     bool check_gpg_signatures();

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -244,8 +244,12 @@ public:
     const OptionString & get_username_option() const;
     OptionString & get_password_option();
     const OptionString & get_password_option() const;
+    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
     OptionBool & get_gpgcheck_option();
+    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
     const OptionBool & get_gpgcheck_option() const;
+    OptionBool & get_pkg_gpgcheck_option();
+    const OptionBool & get_pkg_gpgcheck_option() const;
     OptionBool & get_repo_gpgcheck_option();
     const OptionBool & get_repo_gpgcheck_option() const;
     OptionBool & get_enabled_option();

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -79,8 +79,12 @@ public:
     const OptionChild<OptionString> & get_password_option() const;
     OptionChild<OptionStringAppendList> & get_protected_packages_option();
     const OptionChild<OptionStringAppendList> & get_protected_packages_option() const;
+    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
     OptionChild<OptionBool> & get_gpgcheck_option();
+    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
     const OptionChild<OptionBool> & get_gpgcheck_option() const;
+    OptionChild<OptionBool> & get_pkg_gpgcheck_option();
+    const OptionChild<OptionBool> & get_pkg_gpgcheck_option() const;
     OptionChild<OptionBool> & get_repo_gpgcheck_option();
     const OptionChild<OptionBool> & get_repo_gpgcheck_option() const;
     OptionChild<OptionBool> & get_enablegroups_option();

--- a/libdnf5-cli/output/repo_info.cpp
+++ b/libdnf5-cli/output/repo_info.cpp
@@ -122,7 +122,7 @@ void RepoInfo::Impl::add_repo(IRepoInfo & repo) {
     }
 
     add_line("Verify repodata", fmt::format("{}", repo.get_repo_gpgcheck()), nullptr, group_gpg);
-    add_line("Verify packages", fmt::format("{}", repo.get_gpgcheck()), nullptr, group_gpg);
+    add_line("Verify packages", fmt::format("{}", repo.get_pkg_gpgcheck()), nullptr, group_gpg);
 
     // TODO(jkolarik): Verbose is not implemented and not used yet
     // if (verbose) {
@@ -252,7 +252,7 @@ void print_repoinfo_json([[maybe_unused]] const std::vector<std::unique_ptr<IRep
         json_object_object_add(json_repo, "gpg_key", json_gpg_keys);
 
         json_object_object_add(json_repo, "repo_gpgcheck", json_object_new_boolean(repo->get_repo_gpgcheck()));
-        json_object_object_add(json_repo, "gpgcheck", json_object_new_boolean(repo->get_gpgcheck()));
+        json_object_object_add(json_repo, "pkg_gpgcheck", json_object_new_boolean(repo->get_pkg_gpgcheck()));
         json_object_object_add(json_repo, "available_pkgs", json_object_new_uint64(repo->get_available_pkgs()));
         json_object_object_add(json_repo, "pkgs", json_object_new_uint64(repo->get_pkgs()));
         json_object_object_add(json_repo, "size", json_object_new_uint64(repo->get_size()));

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -247,7 +247,7 @@ class ConfigMain::Impl {
     OptionStringAppendList protected_packages{std::vector<std::string>{"dnf5", "glob:/etc/dnf/protected.d/*.conf"}};
     OptionString username{""};
     OptionString password{""};
-    OptionBool gpgcheck{false};
+    OptionBool pkg_gpgcheck{false};
     OptionBool repo_gpgcheck{false};
     OptionBool enabled{true};
     OptionBool enablegroups{true};
@@ -435,7 +435,9 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("protected_packages", protected_packages);
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
-    owner.opt_binds().add("gpgcheck", gpgcheck);
+    owner.opt_binds().add("pkg_gpgcheck", pkg_gpgcheck);
+    // Compatiblity alias for pkg_gpgcheck
+    owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
     owner.opt_binds().add("enabled", enabled);
     owner.opt_binds().add("enablegroups", enablegroups);
@@ -1140,10 +1142,17 @@ const OptionString & ConfigMain::get_password_option() const {
 }
 
 OptionBool & ConfigMain::get_gpgcheck_option() {
-    return p_impl->gpgcheck;
+    return p_impl->pkg_gpgcheck;
 }
 const OptionBool & ConfigMain::get_gpgcheck_option() const {
-    return p_impl->gpgcheck;
+    return p_impl->pkg_gpgcheck;
+}
+
+OptionBool & ConfigMain::get_pkg_gpgcheck_option() {
+    return p_impl->pkg_gpgcheck;
+}
+const OptionBool & ConfigMain::get_pkg_gpgcheck_option() const {
+    return p_impl->pkg_gpgcheck;
 }
 
 OptionBool & ConfigMain::get_repo_gpgcheck_option() {

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -58,7 +58,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> username{main_config.get_username_option()};
     OptionChild<OptionString> password{main_config.get_password_option()};
     OptionChild<OptionStringAppendList> protected_packages{main_config.get_protected_packages_option()};
-    OptionChild<OptionBool> gpgcheck{main_config.get_gpgcheck_option()};
+    OptionChild<OptionBool> pkg_gpgcheck{main_config.get_pkg_gpgcheck_option()};
     OptionChild<OptionBool> repo_gpgcheck{main_config.get_repo_gpgcheck_option()};
     OptionChild<OptionBool> enablegroups{main_config.get_enablegroups_option()};
     OptionChild<OptionNumber<std::uint32_t>> retries{main_config.get_retries_option()};
@@ -143,7 +143,9 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
     owner.opt_binds().add("protected_packages", protected_packages);
-    owner.opt_binds().add("gpgcheck", gpgcheck);
+    owner.opt_binds().add("pkg_gpgcheck", pkg_gpgcheck);
+    // Compatibility alias for pkg_gpgcheck
+    owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
     owner.opt_binds().add("enablegroups", enablegroups);
     owner.opt_binds().add("retries", retries);
@@ -322,10 +324,17 @@ const OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_o
 }
 
 OptionChild<OptionBool> & ConfigRepo::get_gpgcheck_option() {
-    return p_impl->gpgcheck;
+    return p_impl->pkg_gpgcheck;
 }
 const OptionChild<OptionBool> & ConfigRepo::get_gpgcheck_option() const {
-    return p_impl->gpgcheck;
+    return p_impl->pkg_gpgcheck;
+}
+
+OptionChild<OptionBool> & ConfigRepo::get_pkg_gpgcheck_option() {
+    return p_impl->pkg_gpgcheck;
+}
+const OptionChild<OptionBool> & ConfigRepo::get_pkg_gpgcheck_option() const {
+    return p_impl->pkg_gpgcheck;
 }
 
 OptionChild<OptionBool> & ConfigRepo::get_repo_gpgcheck_option() {

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -192,7 +192,7 @@ RpmSignature::CheckResult RpmSignature::check_package_signature(const rpm::Packa
         }
     } else {
         auto & repo_config = repo->get_config();
-        if (!repo_config.get_gpgcheck_option().get_value()) {
+        if (!repo_config.get_pkg_gpgcheck_option().get_value()) {
             return CheckResult::SKIPPED;
         }
     }

--- a/test/libdnf5/base/test_transaction.cpp
+++ b/test/libdnf5/base/test_transaction.cpp
@@ -45,7 +45,7 @@ void BaseTransactionTest::test_check_gpg_signatures_no_gpgcheck() {
 void BaseTransactionTest::test_check_gpg_signatures_fail() {
     add_repo_repomd("repomd-repo1");
 
-    base.get_config().get_gpgcheck_option().set(true);
+    base.get_config().get_pkg_gpgcheck_option().set(true);
 
     libdnf5::Goal goal(base);
     goal.add_rpm_install("pkg");

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -57,3 +57,14 @@ void ConfTest::test_config_repo() {
     std::vector<std::string> baseurl = {"http://example.com/value123", "http://example.com/456"};
     CPPUNIT_ASSERT_EQUAL(baseurl, config_repo.get_baseurl_option().get_value());
 }
+
+void ConfTest::test_config_pkg_gpgcheck() {
+    // Ensure both pkg_gpgcheck and gpgcheck point to the same underlying OptionBool object
+
+    // For ConfigMain
+    CPPUNIT_ASSERT_EQUAL(&config.get_pkg_gpgcheck_option(), &config.get_gpgcheck_option());
+
+    // For ConfigRepo
+    repo::ConfigRepo config_repo(config, "test-repo");
+    CPPUNIT_ASSERT_EQUAL(&config_repo.get_pkg_gpgcheck_option(), &config_repo.get_gpgcheck_option());
+}

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -32,6 +32,7 @@ class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(ConfTest);
     CPPUNIT_TEST(test_config_main);
     CPPUNIT_TEST(test_config_repo);
+    CPPUNIT_TEST(test_config_pkg_gpgcheck);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -39,6 +40,7 @@ public:
 
     void test_config_main();
     void test_config_repo();
+    void test_config_pkg_gpgcheck();
 
     std::unique_ptr<libdnf5::Base> base;
     libdnf5::LogRouter logger;

--- a/test/python3/libdnf5/base/test_transaction.py
+++ b/test/python3/libdnf5/base/test_transaction.py
@@ -36,7 +36,9 @@ class TestTransaction(base_test_case.BaseTestCase):
                          transaction.get_gpg_signature_problems())
 
     def test_check_gpg_signatures_fail(self):
+        # Both options need to be available
         self.base.get_config().gpgcheck = True
+        self.base.get_config().pkg_gpgcheck = True
 
         goal = libdnf5.base.Goal(self.base)
         goal.add_rpm_install("pkg")


### PR DESCRIPTION
Changes the name to a more apt `pkg_gpgcheck` but `gpgcheck` is still accepted. At this point I am not sure we will ever be able to drop it.

It adds new getter API to both main and repo: `get_pkg_gpgcheck_option` and depracates the old `get_gpgcheck_option`.
It also extends `libdnf5::cli::output::IRepoInfo` with `get_pkg_gpgcheck` and the `dnf5daemon-server` should also accept `pkg_gpgcheck` attribute.

For: https://github.com/rpm-software-management/dnf5/issues/1649