### PR TITLE
Optimize getting counts of transaction items

### DIFF
--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -54,7 +54,9 @@ void HistoryListCommand::run() {
         std::sort(transactions.begin(), transactions.end());
     }
 
-    libdnf5::cli::output::print_transaction_list(transactions);
+    auto item_counts = history.get_transaction_item_counts(transactions);
+
+    libdnf5::cli::output::print_transaction_list(transactions, item_counts);
 }
 
 }  // namespace dnf5

--- a/include/libdnf5-cli/output/transactionlist.hpp
+++ b/include/libdnf5-cli/output/transactionlist.hpp
@@ -27,7 +27,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::cli::output {
 
-LIBDNF_CLI_API void print_transaction_list(std::vector<libdnf5::transaction::Transaction> & ts_list);
+LIBDNF_CLI_API void print_transaction_list(
+    std::vector<libdnf5::transaction::Transaction> & ts_list,
+    const std::unordered_map<int64_t, int64_t> id_to_item_count = {});
 
 }  // namespace libdnf5::cli::output
 

--- a/include/libdnf5/transaction/transaction_history.hpp
+++ b/include/libdnf5/transaction/transaction_history.hpp
@@ -86,6 +86,14 @@ public:
     TransactionItemReason transaction_item_reason_at(
         const std::string & name, const std::string & arch, int64_t transaction_id_point);
 
+    /// Get counts of transaction items for specified transactions.
+    /// It gets the counts in a single db query.
+    ///
+    /// @param transactions Get counts for these transactions.
+    ///
+    /// @return Mapped transaction id -> count.
+    std::unordered_map<int64_t, int64_t> get_transaction_item_counts(const std::vector<Transaction> & transactions);
+
 private:
     /// Create a new Transaction object.
     LIBDNF_LOCAL libdnf5::transaction::Transaction new_transaction();

--- a/libdnf5-cli/output/transactionlist.cpp
+++ b/libdnf5-cli/output/transactionlist.cpp
@@ -29,7 +29,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::cli::output {
 
-void print_transaction_list(std::vector<libdnf5::transaction::Transaction> & ts_list) {
+void print_transaction_list(
+    std::vector<libdnf5::transaction::Transaction> & ts_list,
+    const std::unordered_map<int64_t, int64_t> id_to_item_count) {
     std::unique_ptr<libscols_table, decltype(&scols_unref_table)> table(scols_new_table(), &scols_unref_table);
 
     scols_table_new_column(table.get(), "ID", 0, SCOLS_FL_RIGHT);
@@ -49,11 +51,15 @@ void print_transaction_list(std::vector<libdnf5::transaction::Transaction> & ts_
         scols_line_set_data(ln, 2, libdnf5::utils::string::format_epoch(ts.get_dt_start()).c_str());
         // TODO(lukash) fill the Actions(s), if we even want them?
         scols_line_set_data(ln, 3, "");
-        scols_line_set_data(
-            ln,
-            4,
-            std::to_string(ts.get_packages().size() + ts.get_comps_groups().size() + ts.get_comps_environments().size())
-                .c_str());
+        std::string trans_item_count;
+        if (id_to_item_count.at(ts.get_id())) {
+            trans_item_count = std::to_string(id_to_item_count.at(ts.get_id()));
+        } else {
+            // Fallback to manual calculation (very slow if the packages, groups and environments have to be fetched from DB)
+            trans_item_count = std::to_string(
+                ts.get_packages().size() + ts.get_comps_groups().size() + ts.get_comps_environments().size());
+        }
+        scols_line_set_data(ln, 4, trans_item_count.c_str());
     }
 
     scols_print_table(table.get());

--- a/libdnf5/transaction/db/trans.hpp
+++ b/libdnf5/transaction/db/trans.hpp
@@ -64,6 +64,10 @@ public:
     /// Get reason for name-arch at a point in history specified by transaction id.
     static TransactionItemReason transaction_item_reason_at(
         const BaseWeakPtr & base, const std::string & name, const std::string & arch, int64_t transaction_id_point);
+
+    /// Get transaction item count for history transactions specified by transaction ids.
+    static std::unordered_map<int64_t, int64_t> transactions_item_counts(
+        const BaseWeakPtr & base, const std::vector<Transaction> & transactions);
 };
 
 }  // namespace libdnf5::transaction

--- a/libdnf5/transaction/transaction_history.cpp
+++ b/libdnf5/transaction/transaction_history.cpp
@@ -80,4 +80,9 @@ TransactionItemReason TransactionHistory::transaction_item_reason_at(
     return TransactionDbUtils::transaction_item_reason_at(p_impl->base, name, arch, transaction_id_point);
 }
 
+std::unordered_map<int64_t, int64_t> TransactionHistory::get_transaction_item_counts(
+    const std::vector<Transaction> & transactions) {
+    return TransactionDbUtils::transactions_item_counts(p_impl->base, transactions);
+}
+
 }  // namespace libdnf5::transaction


### PR DESCRIPTION
Previously during `history list` we separately fetched all transaction packages, groups and environments only to count them. This could be quite slow because it resulted in a lot of separate DB connections.

Now we fetch only the counts and use only one DB connection. To maintain compatibility the counts are passed as an optional parameter and if missing we fallback to the old (slow) computation.