### PR TITLE
Ruby Bindings: Implement Enumerable for iterable collections

### DIFF
--- a/bindings/libdnf5/advisory.i
+++ b/bindings/libdnf5/advisory.i
@@ -6,6 +6,10 @@
 %module "libdnf5/advisory"
 #endif
 
+#if defined(SWIGRUBY)
+%mixin libdnf5::advisory::AdvisorySet "Enumerable";
+#endif
+
 %include <exception.i>
 %include <std_vector.i>
 
@@ -57,3 +61,8 @@
 %template(VectorAdvisoryReference) std::vector<libdnf5::advisory::AdvisoryReference>;
 
 add_iterator(AdvisorySet)
+
+#if defined(SWIGRUBY)
+fix_swigtype_trait(libdnf5::advisory::Advisory)
+#endif
+add_ruby_each(libdnf5::advisory::AdvisorySet)

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -134,6 +134,42 @@ del ClassName##__iter__
 #endif
 %enddef
 
+%define fix_swigtype_trait(ClassName)
+%traits_swigtype(ClassName)
+%fragment(SWIG_Traits_frag(ClassName));
+%enddef
+
+%define add_ruby_each(ClassName)
+#if defined(SWIGRUBY)
+/* Using swig::from method on a class instance (= $self in %extend blocks below) fails.
+ * We need to define these traits so that it compiles. This seems to be an issue related
+ * to namespacing:
+ * https://github.com/swig/swig/issues/973
+ * and to using a pointer in some places:
+ * https://github.com/swig/swig/issues/2938
+ */
+fix_swigtype_trait(ClassName)
+
+%extend ClassName {
+    VALUE each() {
+        // If no block is provided, returns Enumerator.
+        RETURN_ENUMERATOR(swig::from($self), 0, 0);
+
+        VALUE r;
+        auto i = self->begin();
+        auto e = self->end();
+
+        for (; i != e; ++i) {
+            r = swig::from(*i);
+            rb_yield(r);
+        }
+
+        return swig::from($self);
+    }
+}
+#endif
+%enddef
+
 %define add_str(ClassName)
 #if defined(SWIGPYTHON)
 %extend ClassName {

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -6,6 +6,12 @@
 %module "libdnf5/rpm"
 #endif
 
+#if defined(SWIGRUBY)
+// Mixin modules for Ruby. This has to be declared before inclusion of the
+// related header file.
+%mixin libdnf5::rpm::PackageSet "Enumerable";
+#endif
+
 %include <exception.i>
 %include <std_string.i>
 %include <std_vector.i>
@@ -98,6 +104,8 @@ add_hash(libdnf5::rpm::Package)
 
 add_iterator(PackageSet)
 add_iterator(ReldepList)
+
+add_ruby_each(libdnf5::rpm::PackageSet)
 
 %feature("director") TransactionCallbacks;
 %include "libdnf5/rpm/transaction_callbacks.hpp"

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -10,6 +10,7 @@
 // Mixin modules for Ruby. This has to be declared before inclusion of the
 // related header file.
 %mixin libdnf5::rpm::PackageSet "Enumerable";
+%mixin libdnf5::rpm::ReldepList "Enumerable";
 #endif
 
 %include <exception.i>
@@ -106,6 +107,11 @@ add_iterator(PackageSet)
 add_iterator(ReldepList)
 
 add_ruby_each(libdnf5::rpm::PackageSet)
+// Reldep needs special treatment so that the add_ruby_each can use it.
+#if defined(SWIGRUBY)
+fix_swigtype_trait(libdnf5::rpm::Reldep)
+#endif
+add_ruby_each(libdnf5::rpm::ReldepList)
 
 %feature("director") TransactionCallbacks;
 %include "libdnf5/rpm/transaction_callbacks.hpp"


### PR DESCRIPTION
Implement including Enumerable and the #each method for iterable collections.

This allows for example to iterate over a package query:
```ruby
require 'libdnf5/base'

base = Base::Base.new
base.setup()

repo_sack = base.get_repo_sack()
repo_sack.create_repos_from_system_configuration()

rq = Repo::RepoQuery.new(base)
rq.filter_id('rawhide')

repo_sack.load_repos(Repo::Repo::Type_AVAILABLE)

query = Rpm::PackageQuery.new(base)
query.filter_provides("rubygem(httparty)", Common::QueryCmp_EQ)

query.each # Returns => #<Enumerator: ...>
query.each do |pkg|
  puts pkg.get_name
end
# Prints => rubygem-httparty
# And Returns => #<Rpm::PackageSet:0x00007f14d9ecd9a8 @__swigtype__="_p_libdnf5__rpm__PackageSet">
```

Related issue: #1780 