### PR TITLE
Drop `errorlevel` config option

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -66,7 +66,7 @@ Changes to individual options
   * When downloading packages using the ``system-upgrade`` or ``offline`` command, the target path construction now utilizes the configured ``installroot`` and ``cachedir`` options.
 
 ``-e, --errorlevel``
-  * Dropped. Now only the ``errorlevel`` configuration option is available.
+  * Both the ``--errorlevel`` option and ``errorlevel`` configuration option are dropped.
 
 ``--help-cmd``
   * Dropped. Now only the ``-h`` or ``--help`` options are available.
@@ -422,3 +422,6 @@ Dropped configuration options
 ``arch`` and ``basearch``
   * It is no longer possible to change the detected architecute in configuration files.
   * See the :manpage:`dnf5-forcearch(7)`, :ref:`Forcearch parameter <forcearch_misc_ref-label>` for overriding architecture.
+
+``errorlevel``
+  * The option was deprecated in dnf < 5 and is dropped now.

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -52,7 +52,7 @@ Changes to individual options
    ``-d, --debuglevel``
      * Dropped. Now only the ``debuglevel`` configuration option is available.
 
-``--disableexcludes``
+``--disableexcludes`` and ``--disableexcludepkgs``
   * Dropped. Now only the ``disable_excludes`` configuration option is available.
 
 ``--disable, --enable``

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -80,19 +80,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 
     Default: ``True``.
 
-.. _errorlevel_options-label:
-
-``errorlevel``
-    :ref:`integer <integer-label>`
-
-    Error messages output level, in the range ``0`` to ``10``. The higher the number the
-    more error output is put to stderr.
-
-    Default: ``3``.
-
-    .. WARNING::
-       This is deprecated in DNF and overwritten by -verbose commandline option.
-
 .. _exit_on_lock_options-label:
 
 ``exit_on_lock``

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -44,8 +44,6 @@ public:
 
     OptionNumber<std::int32_t> & get_debuglevel_option();
     const OptionNumber<std::int32_t> & get_debuglevel_option() const;
-    OptionNumber<std::int32_t> & get_errorlevel_option();
-    const OptionNumber<std::int32_t> & get_errorlevel_option() const;
     OptionPath & get_installroot_option();
     const OptionPath & get_installroot_option() const;
     OptionPath & get_config_file_path_option();

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -113,7 +113,6 @@ class ConfigMain::Impl {
     Config & owner;
 
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
-    OptionNumber<std::int32_t> errorlevel{3, 0, 10};
     OptionPath installroot{"/", false, true};
     OptionBool use_host_config{false};
     OptionPath config_file_path{CONF_FILENAME};
@@ -300,7 +299,6 @@ class ConfigMain::Impl {
 
 ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("debuglevel", debuglevel);
-    owner.opt_binds().add("errorlevel", errorlevel);
     owner.opt_binds().add("installroot", installroot);
     owner.opt_binds().add("use_host_config", use_host_config);
     owner.opt_binds().add("config_file_path", config_file_path);
@@ -472,13 +470,6 @@ OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() {
 }
 const OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() const {
     return p_impl->debuglevel;
-}
-
-OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() {
-    return p_impl->errorlevel;
-}
-const OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() const {
-    return p_impl->errorlevel;
 }
 
 OptionPath & ConfigMain::get_installroot_option() {


### PR DESCRIPTION
It isn't doing anything and it was deprecated in dnf < 5 probably since dnf was first created.