### PR TITLE
Revert "Drop `errorlevel` config option"

### DIFF
--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -44,6 +44,12 @@ public:
 
     OptionNumber<std::int32_t> & get_debuglevel_option();
     const OptionNumber<std::int32_t> & get_debuglevel_option() const;
+    /// @deprecated errorlevel option does nothing and is scheduled for removal
+    [[deprecated("errorlevel option does nothing and is scheduled for removal")]] OptionNumber<std::int32_t> &
+    get_errorlevel_option();
+    /// @deprecated errorlevel option does nothing and is scheduled for removal
+    [[deprecated("errorlevel option does nothing and is scheduled for removal")]] const OptionNumber<std::int32_t> &
+    get_errorlevel_option() const;
     OptionPath & get_installroot_option();
     const OptionPath & get_installroot_option() const;
     OptionPath & get_config_file_path_option();

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -113,6 +113,7 @@ class ConfigMain::Impl {
     Config & owner;
 
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
+    OptionNumber<std::int32_t> errorlevel{3, 0, 10};
     OptionPath installroot{"/", false, true};
     OptionBool use_host_config{false};
     OptionPath config_file_path{CONF_FILENAME};
@@ -299,6 +300,7 @@ class ConfigMain::Impl {
 
 ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("debuglevel", debuglevel);
+    owner.opt_binds().add("errorlevel", errorlevel);
     owner.opt_binds().add("installroot", installroot);
     owner.opt_binds().add("use_host_config", use_host_config);
     owner.opt_binds().add("config_file_path", config_file_path);
@@ -470,6 +472,13 @@ OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() {
 }
 const OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() const {
     return p_impl->debuglevel;
+}
+
+OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() {
+    return p_impl->errorlevel;
+}
+const OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() const {
+    return p_impl->errorlevel;
 }
 
 OptionPath & ConfigMain::get_installroot_option() {


### PR DESCRIPTION
Keep the defunct options to preserve API.
 
Revert: https://github.com/rpm-software-management/dnf5/pull/1788

It keeps the docs update.