### PR TITLE
build: Remove an explicit swig option -ruby

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -15,7 +15,7 @@ function(add_ruby_module LIBRARY_NAME MODULE_NAME)
     set_source_files_properties(../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTIES CPLUSPLUS ON)
     set_property(SOURCE ../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTY SWIG_MODULE_NAME ${MODULE_NAME})
     set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS}
-        -module ${MODULE_NAME} -ruby
+        -module ${MODULE_NAME}
     )
     swig_add_library(${TARGET_NAME} LANGUAGE ruby SOURCES ../../${LIBRARY_NAME}/${MODULE_NAME}.i)
     set_property(TARGET ${TARGET_NAME} PROPERTY OUTPUT_NAME ${MODULE_NAME})


### PR DESCRIPTION
Building Ruby binding with Swig 4.3.0 failed:

    cd /home/test/dnf5/redhat-linux-build/bindings/ruby/libdnf5 && /usr/bin/cmake -E env SWIG_LIB=/usr/share/swig/4.3.0 /usr/bin/swig -ruby -DSWIGWORDSIZE64 -module advisory -ruby -outdir /home/test/dnf5/redhat-linux-build/bindings/ruby/libdnf5 -c++ -module advisory -I/home/test/dnf5/include -I/home/test/dnf5/common -I/usr/include -o /home/test/dnf5/redhat-linux-build/bindings/ruby/libdnf5/CMakeFiles/ruby_advisory.dir/advisoryRUBY_wrap.cxx /home/test/dnf5/bindings/libdnf5/advisory.i
    Only one target language can be supported at a time (both -ruby and -ruby were specified).

The cause was an explcitit and unnecessary "-ruby" option in CMAKE_SWIG_FLAGS.

This patch removes it. The targetted langauge is already set with swig_add_library().

Resolves: #1794