### PR TITLE
When `multi_progress_bar` finishes print new line automatically

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -304,7 +304,6 @@ void DownloadCommand::run() {
 
     std::cout << "Downloading Packages:" << std::endl;
     downloader.download();
-    std::cout << std::endl;
 }
 
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -456,7 +456,6 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     if (base.get_config().get_downloadonly_option().get_value()) {
         return;
     }
-    print_info("");
 
     if (should_store_offline) {
         store_offline(transaction);
@@ -493,7 +492,6 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     }
 
     auto result = transaction.run();
-    print_info("");
     if (result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
         print_error(libdnf5::utils::sformat(
             _("Transaction failed: {}"), libdnf5::base::Transaction::transaction_result_to_string(result)));

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -104,7 +104,6 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
 void DownloadCallbacks::reset_progress_bar() {
     multi_progress_bar.reset();
     if (printed) {
-        std::cerr << std::endl;
         printed = false;
     }
 }

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -89,7 +89,6 @@ void DownloadCB::print() {
 void DownloadCB::reset_progress_bar() {
     multi_progress_bar.reset();
     if (printed) {
-        std::cerr << std::endl;
         printed = false;
     }
 }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -124,11 +124,8 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         }
         bar->set_number(numbers.back());
         numbers.pop_back();
-        if (mbar.line_printed) {
-            stream << std::endl;
-        }
         stream << *bar;
-        mbar.line_printed = true;
+        stream << std::endl;
         mbar.bars_done.push_back(bar);
         // TODO(dmach): use iterator
         mbar.bars_todo.erase(mbar.bars_todo.begin() + static_cast<int>(i));
@@ -200,7 +197,8 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         }
 
         stream << mbar.total;
-        mbar.num_of_lines_to_clear += 2;
+        stream << std::endl;
+        mbar.num_of_lines_to_clear += 3;
     }
 
     return stream;

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -1,0 +1,85 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_progressbar.hpp"
+
+#include "../shared/private_accessor.hpp"
+
+#include <fmt/format.h>
+#include <fnmatch.h>
+#include <libdnf5-cli/progressbar/download_progress_bar.hpp>
+#include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
+
+namespace {
+
+// Allows accessing private methods
+create_private_getter_template;
+create_getter(to_stream, &libdnf5::cli::progressbar::DownloadProgressBar::to_stream);
+
+}  //namespace
+
+void ProgressbarTest::test_download_progress_bar() {
+    auto download_progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    download_progress_bar->set_ticks(10);
+    download_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    std::ostringstream oss;
+    (*download_progress_bar.*get(to_stream{}))(oss);
+    // When running the tests binary directly (run_tests_cli) it uses terminal size to determine white space count.
+    // To ensure the tests works match any number of white space.
+    std::string expected = "\\[0/0\\] test      [ ]*      100% |   0.0   B\\/s |  10.0   B |  ?     ";
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(
+        fmt::format("Expression: \"{}\" doesn't match output: \"{}\"", expected, oss.str()),
+        fnmatch(expected.c_str(), oss.str().c_str(), FNM_EXTMATCH),
+        0);
+}
+
+void ProgressbarTest::test_multi_progress_bar() {
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    download_progress_bar1->set_ticks(10);
+    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    download_progress_bar2->set_ticks(10);
+    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    auto output = oss.str();
+
+    // When running the tests binary directly (run_tests_cli) it uses terminal size to determine white space and dash count.
+    // To ensure the tests works match any number of white space and dashes.
+    std::string expected =
+        "\\[1/2\\] test1     [ ]*      100% |   0.0   B\\/s |  10.0   B |  ?     \n"
+        "\\[2/2\\] test2     [ ]*      100% |   0.0   B\\/s |  10.0   B |  ?     \n"
+        "--------------------[-]*------------------------------------------------\n"
+        "\\[2/2\\] Total     [ ]*      100% |   0.0   B\\/s |  20.0   B |  00m00s\n";
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(
+        fmt::format("Expression: \"{}\" doesn't match output: \"{}\"", expected, oss.str()),
+        fnmatch(expected.c_str(), oss.str().c_str(), FNM_EXTMATCH),
+        0);
+}

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -1,0 +1,41 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF5_CLI_PROGRESSBAR_HPP
+#define TEST_LIBDNF5_CLI_PROGRESSBAR_HPP
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+class ProgressbarTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(ProgressbarTest);
+
+    CPPUNIT_TEST(test_download_progress_bar);
+    CPPUNIT_TEST(test_multi_progress_bar);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_download_progress_bar();
+    void test_multi_progress_bar();
+};
+
+
+#endif  // TEST_LIBDNF5_CLI_PROGRESSBAR_HPP


### PR DESCRIPTION
The last line of `multi_progress_bar` can look like:
`[2/2] Total           100% |   0.0   B/s |  20.0   B |  00m00s`
or
`http://localhost:43223/api_3/rpmrepo 100% |  72.0 KiB/s | 295.0   B |  00m00s`
I don't think any client will ever want to append to that.

Instead of it needing to be printed by the client the
`multi_progress_bar` automatically ends with a new line.

This new line was missing on some places. For example in output of:
`dnf copr enable rpmsoftwaremanagement/dnf-nightly `
or
`dnf5 rq --repofrompath=test,https://www.not-available-repo.com/ --repo test --setopt=skip_if_unavailable=0`
There were also excessive new lines like in:
`dnf5 remove htop -y &> out`

Closes: https://github.com/rpm-software-management/dnf5/issues/1792