### PR TITLE
MultiProgressBar now buffers the output text to a single write

### DIFF
--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -105,9 +105,9 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     text_buffer.clear();
 
     if (is_interactive && mbar.num_of_lines_to_clear > 0) {
-        text_buffer << tty::clear_line;
-        for (std::size_t i = 1; i < mbar.num_of_lines_to_clear; i++) {
-            text_buffer << tty::cursor_up << tty::clear_line;
+        if (mbar.num_of_lines_to_clear > 1) {
+            // Move the cursor up by the number of lines we want to write over
+            text_buffer << "\033[" << (mbar.num_of_lines_to_clear - 1) << "A";
         }
         text_buffer << "\r";
     } else if (mbar.line_printed) {


### PR DESCRIPTION
This is to avoid multiple small writes to the terminal, which can cause flickering.

On my machine (Fedora 41 GNOME) I can see that the new concurrent download status bar flickers quite a bit. I've tested this on gnome-terminal/xfce4-terminal/uterm and kitty. Only Kitty does not flicker. The flickering happens regardless if Wayland/X11 is used.

The old behaviour would issue multiple clear_line writes, followed by multiple writes to "draw" the new status bars.

The new behaviour buffers all of the screen updates for a single "frame" and then writes all of that out with a single syscall.

I've tested the code changes using gnome-terminal/xfce4-terminal/uterm and kitty. Wayland and X11 sessions. It works flawlessly for me now.

I've also tested resizing the terminal window during download, and that works as before (w/o flickering now)

I believe this also fixes #1263 