### PR TITLE
Clear up changes doc about optional subcommands

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -128,9 +128,9 @@ Newly introduced options
 Commands
 --------
 
-Optional arguments
-^^^^^^^^^^^^^^^^^^
-Commands cannot have optional subcommands and optional arguments. Optional subcommands were ambiguous,
+Optional subcommands
+^^^^^^^^^^^^^^^^^^^^
+Commands cannot have optional subcommands. Optional subcommands were ambiguous,
 making it unclear whether the input was intended as a command argument or a subcommand. Subcommands are now mandatory if present.
 
 Examples:


### PR DESCRIPTION
It is still possible to have optional arguments.
That is both `dnf5 upgrade` and `dnf5 upgrade htop --best` are fine.

The way I understand it is:
`upgrade` = command
`htop` = argument
`--best` = option