### PR TITLE
Support repo's Appstream data download and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(WITH_LIBDNF5_CLI "Build library for working with a terminal in a command-
 option(WITH_DNF5 "Build dnf5 command-line package manager" ON)
 option(WITH_DNF5_PLUGINS "Build plugins for dnf5 command-line package manager" ON)
 option(WITH_PLUGIN_ACTIONS "Build a dnf5 actions plugin" ON)
+option(WITH_PLUGIN_APPSTREAM "Build with plugin to install repo's Appstream metadata" ON)
 option(WITH_PLUGIN_RHSM "Build a libdnf5 rhsm (Red Hat Subscription Manager) plugin" OFF)
 option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python plugins. Requires WITH_PYTHON3=ON." ON)
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -77,6 +77,7 @@ Provides:       dnf5-command(versionlock)
 %bcond_without dnf5
 %bcond_without dnf5_plugins
 %bcond_without plugin_actions
+%bcond_without plugin_appstream
 %bcond_without plugin_rhsm
 %bcond_without python_plugins_loader
 
@@ -604,6 +605,24 @@ Libdnf5 plugin that allows to run actions (external executables) on hooks.
 %{_mandir}/man8/libdnf5-actions.8.*
 %endif
 
+# ========== libdnf5-plugin-appstream ==========
+
+%if %{with plugin_appstream}
+
+%package -n libdnf5-plugin-appstream
+Summary:        Libdnf5 plugin to install repo Appstream data
+License:        LGPL-2.1-or-later
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+BuildRequires:  pkgconfig(appstream) >= 0.16
+
+%description -n libdnf5-plugin-appstream
+Libdnf5 plugin that installs repository's Appstream data, for repositories which provide them.
+
+%files -n libdnf5-plugin-appstream
+%{_libdir}/libdnf5/plugins/appstream.so
+%config %{_sysconfdir}/dnf/libdnf5-plugins/appstream.conf
+
+%endif
 
 # ========== libdnf5-plugin-plugin_rhsm ==========
 
@@ -805,6 +824,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
     -DWITH_LIBDNF5_CLI=%{?with_libdnf_cli:ON}%{!?with_libdnf_cli:OFF} \
     -DWITH_DNF5=%{?with_dnf5:ON}%{!?with_dnf5:OFF} \
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
+    -DWITH_PLUGIN_APPSTREAM=%{?with_plugin_appstream:ON}%{!?with_plugin_appstream:OFF} \
     -DWITH_PLUGIN_RHSM=%{?with_plugin_rhsm:ON}%{!?with_plugin_rhsm:OFF} \
     -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \
     \

--- a/include/libdnf5/conf/const.hpp
+++ b/include/libdnf5/conf/const.hpp
@@ -64,9 +64,15 @@ constexpr const char * METADATA_TYPE_OTHER = "other";
 constexpr const char * METADATA_TYPE_PRESTO = "presto";
 constexpr const char * METADATA_TYPE_UPDATEINFO = "updateinfo";
 constexpr const char * METADATA_TYPE_ALL = "all";
+constexpr const char * METADATA_TYPE_APPSTREAM = "appstream";
 
 const std::set<std::string> OPTIONAL_METADATA_TYPES{
-    METADATA_TYPE_COMPS, METADATA_TYPE_FILELISTS, METADATA_TYPE_OTHER, METADATA_TYPE_PRESTO, METADATA_TYPE_UPDATEINFO};
+    METADATA_TYPE_COMPS,
+    METADATA_TYPE_FILELISTS,
+    METADATA_TYPE_OTHER,
+    METADATA_TYPE_PRESTO,
+    METADATA_TYPE_UPDATEINFO,
+    METADATA_TYPE_APPSTREAM};
 
 }  // namespace libdnf5
 

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -314,6 +314,9 @@ public:
     // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
     void download_metadata(const std::string & destdir);
 
+    /// Returns a list of pairs of the rpmmd type and filename of the Appstream data of the repo
+    std::vector<std::pair<std::string, std::string>> get_appstream_metadata() const;
+
 private:
     class LIBDNF_LOCAL Impl;
     friend class RepoSack;

--- a/libdnf5-plugins/CMakeLists.txt
+++ b/libdnf5-plugins/CMakeLists.txt
@@ -2,5 +2,6 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 add_subdirectory("actions")
+add_subdirectory("appstream")
 add_subdirectory("python_plugins_loader")
 add_subdirectory("rhsm")

--- a/libdnf5-plugins/appstream/CMakeLists.txt
+++ b/libdnf5-plugins/appstream/CMakeLists.txt
@@ -1,0 +1,17 @@
+if(NOT WITH_PLUGIN_APPSTREAM)
+    return()
+endif()
+
+add_library(appstream_plugin MODULE appstream.cpp)
+
+# disable the 'lib' prefix in order to create appstream.so
+set_target_properties(appstream_plugin PROPERTIES PREFIX "")
+set_target_properties(appstream_plugin PROPERTIES OUTPUT_NAME "appstream")
+
+pkg_check_modules(APPSTREAM REQUIRED appstream>=0.16)
+include_directories(${APPSTREAM_INCLUDE_DIRS})
+target_link_libraries(appstream_plugin PRIVATE ${APPSTREAM_LIBRARIES})
+target_link_libraries(appstream_plugin PRIVATE libdnf5)
+
+install(TARGETS appstream_plugin LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")
+install(FILES "appstream.conf" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/dnf/libdnf5-plugins")

--- a/libdnf5-plugins/appstream/appstream.conf
+++ b/libdnf5-plugins/appstream/appstream.conf
@@ -1,0 +1,3 @@
+[main]
+name = appstream
+enabled = 1

--- a/libdnf5-plugins/appstream/appstream.cpp
+++ b/libdnf5-plugins/appstream/appstream.cpp
@@ -1,0 +1,128 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <appstream.h>
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/conf/const.hpp>
+#include <libdnf5/plugin/iplugin.hpp>
+#include <libdnf5/repo/repo.hpp>
+#include <libdnf5/repo/repo_query.hpp>
+
+#include <iostream>
+
+using namespace libdnf5;
+
+namespace {
+
+constexpr const char * PLUGIN_NAME{"appstream"};
+constexpr libdnf5::plugin::Version PLUGIN_VERSION{.major = 1, .minor = 0, .micro = 0};
+
+constexpr const char * attrs[]{"author.name", "author.email", "description", nullptr};
+constexpr const char * attrs_value[]{"Milan Crha", "mcrha@redhat.com", "install repo Appstream data."};
+
+class AppstreamPlugin : public plugin::IPlugin {
+public:
+    AppstreamPlugin(libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser &) : IPlugin(data) {}
+    virtual ~AppstreamPlugin() = default;
+
+    PluginAPIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    plugin::Version get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    const char * const * get_attributes() const noexcept override { return attrs; }
+
+    const char * get_attribute(const char * attribute) const noexcept override {
+        for (size_t i = 0; attrs[i]; ++i) {
+            if (std::strcmp(attribute, attrs[i]) == 0) {
+                return attrs_value[i];
+            }
+        }
+        return nullptr;
+    }
+
+    void repos_loaded() override {
+        Base & base = get_base();
+        repo::RepoQuery repos(base);
+        repos.filter_enabled(true);
+        for (const auto & repo : repos) {
+            auto type = repo->get_type();
+            if (type == repo::Repo::Type::AVAILABLE || type == repo::Repo::Type::SYSTEM) {
+                install_appstream(repo.get());
+            }
+        }
+    }
+
+private:
+    void install_appstream(libdnf5::repo::Repo * repo);
+};
+
+void AppstreamPlugin::install_appstream(libdnf5::repo::Repo * repo) {
+    libdnf5::Base & base = get_base();
+    if (!repo->get_config().get_main_config().get_optional_metadata_types_option().get_value().contains(
+            libdnf5::METADATA_TYPE_APPSTREAM))
+        return;
+
+    std::string repo_id = repo->get_config().get_id();
+    auto appstream_metadata = repo->get_appstream_metadata();
+    for (auto & item : appstream_metadata) {
+        const std::string path = item.second;
+        GError * local_error = NULL;
+
+        if (!as_utils_install_metadata_file(
+                AS_METADATA_LOCATION_CACHE, path.c_str(), repo_id.c_str(), NULL, &local_error)) {
+            base.get_logger()->debug(
+                "Failed to install Appstream metadata file '{}' for repo '{}': {}",
+                path,
+                repo_id,
+                local_error ? local_error->message : "Unknown error");
+        }
+
+        g_clear_error(&local_error);
+    }
+}
+
+}  // namespace
+
+
+PluginAPIVersion libdnf_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+const char * libdnf_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+plugin::Version libdnf_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+plugin::IPlugin * libdnf_plugin_new_instance(
+    [[maybe_unused]] LibraryVersion library_version,
+    libdnf5::plugin::IPluginData & data,
+    libdnf5::ConfigParser & parser) try {
+    return new AppstreamPlugin(data, parser);
+} catch (...) {
+    return nullptr;
+}
+
+void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
+    delete plugin_object;
+}

--- a/libdnf5/repo/repo_downloader.hpp
+++ b/libdnf5/repo/repo_downloader.hpp
@@ -56,6 +56,7 @@ public:
     static constexpr const char * MD_FILENAME_GROUP_GZ = "group_gz";
     static constexpr const char * MD_FILENAME_GROUP = "group";
     static constexpr const char * MD_FILENAME_MODULES = "modules";
+    static constexpr const char * MD_FILENAME_APPSTREAM = "appstream";
 
     RepoDownloader(const libdnf5::BaseWeakPtr & base, const ConfigRepo & config, Repo::Type repo_type);
 
@@ -74,6 +75,7 @@ public:
     void * get_user_data() const noexcept;
 
     const std::string & get_metadata_path(const std::string & metadata_type) const;
+    std::vector<std::pair<std::string, std::string>> get_appstream_metadata() const;
 
 
 private:
@@ -99,6 +101,7 @@ private:
     time_t get_system_epoch() const;
 
     std::set<std::string> get_optional_metadata() const;
+    bool is_appstream_metadata_type(const std::string & type) const;
 
     libdnf5::BaseWeakPtr base;
     const ConfigRepo & config;

--- a/libdnf5/repo/solv_repo.hpp
+++ b/libdnf5/repo/solv_repo.hpp
@@ -52,7 +52,7 @@ struct SolvUserdata {
 namespace libdnf5::repo {
 
 using LibsolvRepo = ::Repo;
-enum class RepodataType { FILELISTS, PRESTO, UPDATEINFO, COMPS, OTHER };
+enum class RepodataType { FILELISTS, PRESTO, UPDATEINFO, COMPS, OTHER, APPSTREAM };
 
 
 class SolvError : public Error {
@@ -73,6 +73,7 @@ public:
 
     /// Loads additional metadata (filelist, others, ...) from available repo.
     void load_repo_ext(RepodataType type, const RepoDownloader & downloader);
+    void load_repo_ext(RepodataType type, const std::string & in_type_name, const RepoDownloader & downloader);
 
     /// Loads system repository into the pool.
     ///
@@ -128,7 +129,7 @@ private:
     void write_main(bool load_after_write);
 
     /// Writes libsolv's .solvx cache file with extended libsolv repodata.
-    void write_ext(Id repodata_id, RepodataType type);
+    void write_ext(Id repodata_id, RepodataType type, const std::string & type_name);
 
     std::string solv_file_name(const char * type = nullptr);
     std::filesystem::path solv_file_path(const char * type = nullptr);

--- a/libdnf5/utils/library.cpp
+++ b/libdnf5/utils/library.cpp
@@ -26,7 +26,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5::utils {
 
 Library::Library(const std::string & path) : path(path) {
-    handle = dlopen(path.c_str(), RTLD_LAZY);
+    // the NODELETE is needed to not garbage plugin's libraries global data,
+    // like when the plugin uses glib, then it could break its type system
+    handle = dlopen(path.c_str(), RTLD_LAZY | RTLD_NODELETE);
     if (!handle) {
         const char * err_msg = dlerror();  // returns localized message, problem with later translation
         throw LibraryLoadingError(M_("Cannot load shared library \"{}\": {}"), path, std::string(err_msg));


### PR DESCRIPTION
Repositories can provide Appstream data for the packages they contain. This Appstream data is consumed by applications like gnome-software or KDE Discover, thus the users can see the packages (apps) in them.

This is to be in pair with PackageKit, which does download and install the repo's Appstream data.

As this adds a dependency on the `appstream` library, there is also a CMake option WITH_APPSTREAM to be able to turn the support off. The support is enabled by default.

-----------------------------------------

That is, the `/var/cache/libdnf5/$REPO_NAME/repodata/` directory can have downloaded also files with `appstream` in their name and, when installed, the data is stored under `/var/cache/swcatalog/xml/`.

CC @m-blaha @jan-kolarik 