### PR TITLE
SWIG bindings for user_cb_data in repo::DownloadCallbacks, unit tests

### DIFF
--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -53,7 +53,40 @@
 %include "libdnf5/repo/config_repo.hpp"
 
 %feature("director") DownloadCallbacks;
+
+%typemap(directorin, noblock=1) void * user_cb_data {
+    $input = SWIG_From_int(static_cast<int>(reinterpret_cast<intptr_t>($1)));
+}
+
+%typemap(directorout, noblock=1) void * {
+    int swig_val;
+    int swig_res = SWIG_AsVal_int($1, &swig_val);
+    if (!SWIG_IsOK(swig_res)) {
+        Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""int""'");
+    }
+    $result = reinterpret_cast<void *>(swig_val);
+}
+
+%typemap(in, noblock=1) void * user_cb_data {
+    {
+        int swig_val;
+        int swig_res = SWIG_AsVal_int($input, &swig_val);
+        if (!SWIG_IsOK(swig_res)) {
+            Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in input value of type '""int""'");
+        }
+        $1 = reinterpret_cast<void *>(swig_val);
+    }
+}
+
+%typemap(out, noblock=1) void * {
+    $result = SWIG_From_int(static_cast<int>(reinterpret_cast<intptr_t>($1)));
+}
+
 %include "libdnf5/repo/download_callbacks.hpp"
+%typemap(directorin) void *;
+%typemap(directorout) void * user_cb_data;
+%typemap(in) void * user_cb_data;
+%typemap(out) void *;
 wrap_unique_ptr(DownloadCallbacksUniquePtr, libdnf5::repo::DownloadCallbacks);
 
 %ignore FileDownloadError;

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -242,6 +242,7 @@ BuildRequires:  perl(strict)
 BuildRequires:  perl(Test::More)
 BuildRequires:  perl(Test::Exception)
 BuildRequires:  perl(warnings)
+BuildRequires:  perl(FindBin)
 %endif
 %endif
 

--- a/test/perl5/CMakeLists.txt
+++ b/test/perl5/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 
 find_package(Perl REQUIRED)
-foreach(MODULE "strict" "Test::More" "Test::Exception" "warnings")
+foreach(MODULE "strict" "Test::More" "Test::Exception" "warnings" "FindBin")
     message(STATUS "Checking for ${MODULE} Perl module")
     execute_process(
         COMMAND "${PERL_EXECUTABLE}" -e "require ${MODULE}"

--- a/test/perl5/libdnf5/BaseTestCase.pm
+++ b/test/perl5/libdnf5/BaseTestCase.pm
@@ -1,0 +1,110 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+package BaseTestCase;
+
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use File::Spec::Functions 'catfile';
+
+use libdnf5::base;
+use libdnf5::repo;
+
+
+my $PROJECT_BINARY_DIR = $ENV{"PROJECT_BINARY_DIR"};
+my $PROJECT_SOURCE_DIR = $ENV{"PROJECT_SOURCE_DIR"};
+
+sub new {
+    my $class = shift;
+    my $self = {};
+
+    $self->{base} = new libdnf5::base::Base();
+
+    $self->{tmpdir} = tempdir("libdnf5_perl5_unittest.XXXX", TMPDIR => 1, CLEANUP => 1);
+
+    my $config = $self->{base}->get_config();
+    $config->get_installroot_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{tmpdir}."/installroot");
+    $config->get_cachedir_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{tmpdir}."/cache");
+    $config->get_optional_metadata_types_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $libdnf5::conf::OPTIONAL_METADATA_TYPES);
+
+    # Prevent loading plugins from host
+    $config->get_plugins_option()->set(0);
+
+    my $vars = $self->{base}->get_vars()->get();
+    $vars->set("arch", "x86_64");
+
+    $self->{base}->setup();
+
+    $self->{repo_sack} = $self->{base}->get_repo_sack();
+    $self->{package_sack} = $self->{base}->get_rpm_package_sack();
+
+    return bless ($self, $class);
+}
+
+sub tearDown {
+    my $self = shift;
+  #  shutil.rmtree(self.temp_dir)
+}
+
+sub _add_repo {
+    # Add a repo from `repo_path`.
+    my $self = shift;
+    my $repoid = shift;
+    my $repo_path = shift;
+    my $load = shift // 1; # True is default
+
+    my $repo = $self->{repo_sack}->create_repo($repoid);
+    $repo->get_config()->get_baseurl_option()->set($libdnf5::conf::Option::Priority_RUNTIME, "file://".$repo_path);
+    if ($load) {
+        $self->{repo_sack}->load_repos($libdnf5::repo::Repo::Type_AVAILABLE);
+    }
+
+    return $repo
+}
+
+sub add_repo_repomd {
+    # Add a repo from PROJECT_SOURCE_DIR/test/data/repos-repomd/<repoid>/repodata
+    my $self = shift;
+    my $repoid = shift;
+    my $load = shift // 1; # True is default
+
+    my $repo_path = catfile($PROJECT_SOURCE_DIR, "/test/data/repos-repomd", $repoid);
+    return $self->_add_repo($repoid, $repo_path, $load)
+}
+
+sub add_repo_rpm {
+    # Add a repo from PROJECT_BINARY_DIR/test/data/repos-rpm/<repoid>/repodata
+    my $self = shift;
+    my $repoid = shift;
+    my $load = shift // 1; # True is default
+
+    my $repo_path = catfile($PROJECT_BINARY_DIR, "test/data/repos-rpm", $repoid);
+    return $self->_add_repo($repoid, $repo_path, $load)
+}
+
+sub add_repo_solv {
+    # Add a repo from PROJECT_SOURCE_DIR/test/data/repos-solv/<repoid>.repo
+    my $self = shift;
+    my $repoid = shift;
+
+    my $repo_path = catfile($PROJECT_SOURCE_DIR, "/test/data/repos-solv", $repoid.".repo");
+    return $self->{repo_sack}->create_repo_from_libsolv_testcase($repoid, $repo_path);
+}
+
+1;

--- a/test/perl5/libdnf5/repo/test_package_downloader.t
+++ b/test/perl5/libdnf5/repo/test_package_downloader.t
@@ -31,28 +31,46 @@ use BaseTestCase;
     sub new {
         my $class = shift;
         my $self = $class->SUPER::new(@_);
-        $self->{end_cnt} = 0;
+        $self->{user_cb_data_container} = [];
+        $self->{start_cnt} = 0;
         $self->{progress_cnt} = 0;
         $self->{mirror_failure_cnt} = 0;
+        $self->{end_cnt} = 0;
+        $self->{user_cb_data_array} = [];
+        $self->{end_status} = [];
+        $self->{end_msg} = [];
         return bless($self, $class);
+    }
+
+    sub add_new_download {
+        my ($self, $user_data, $description, $total_to_download) = @_;
+        $self->{start_cnt}++;
+        my $user_cb_data = "Package: " . $description;
+        push(@{$self->{user_cb_data_container}}, $user_cb_data);
+        return scalar @{$self->{user_cb_data_container}} - 1;
     }
 
     sub end {
         my ($self, $user_cb_data, $status, $error_message) = @_;
         $self->{end_cnt}++;
+        ::ok($user_cb_data>=0 && $user_cb_data<=1, "end: user_cb_data");
+        push @{$self->{user_cb_data_array}}, $user_cb_data;
+        push @{$self->{end_status}}, $status;
+        push @{$self->{end_msg}}, $error_message;
         return 0;
     }
 
     sub progress {
         my ($self, $user_cb_data, $total_to_download, $downloaded) = @_;
         $self->{progress_cnt}++;
+        ::ok($user_cb_data>=0 && $user_cb_data<=1, "progress: user_cb_data");
         return 0;
     }
 
     sub mirror_failure {
         my ($self, $user_cb_data, $msg, $url, $metadata) = @_;
-        my $self = shift;
         $self->{mirror_failure_cnt}++;
+        ::ok($user_cb_data>=0 && $user_cb_data<=1, "mirror_failure: user_cb_data");
         return 0;
     }
 }
@@ -64,7 +82,7 @@ my $repo = $test->add_repo_rpm("rpm-repo1");
 my $query = new libdnf5::rpm::PackageQuery($test->{base});
 $query->filter_name(["one"]);
 $query->filter_arch(["noarch"]);
-is($query->size(), 2);
+is($query->size(), 2, "number of packages in query");
 
 my $downloader = new libdnf5::repo::PackageDownloader($test->{base});
 
@@ -81,8 +99,15 @@ $downloader->download();
 
 $cbs = $test->{base}->get_download_callbacks();
 
-is($cbs->{end_cnt}, 2);
-ok($cbs->{progress_cnt} >= 2);
-is($cbs->{mirror_failure_cnt}, 0);
+is_deeply($cbs->{user_cb_data_container}, ["Package: one-0:1-1.noarch", "Package: one-0:2-1.noarch"]);
+
+is($cbs->{start_cnt}, 2, "start_cnt");
+is($cbs->{end_cnt}, 2, "end_cnt");
+ok($cbs->{progress_cnt} >= 2, "progress_cnt");
+is($cbs->{mirror_failure_cnt}, 0, "mirror_failure_cnt");
+
+is_deeply($cbs->{user_cb_data_array}, [0, 1], "user_cb_data_array");
+is_deeply($cbs->{end_status}, [$libdnf5::repo::DownloadCallbacks::TransferStatus_SUCCESSFUL,  $libdnf5::repo::DownloadCallbacks::TransferStatus_SUCCESSFUL]);
+is_deeply($cbs->{end_status}, [0, 0]);
 
 done_testing();

--- a/test/perl5/libdnf5/repo/test_package_downloader.t
+++ b/test/perl5/libdnf5/repo/test_package_downloader.t
@@ -1,0 +1,88 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/..";
+use BaseTestCase;
+
+{
+    package PackageDownloadCallbacks;
+    use base qw(libdnf5::repo::DownloadCallbacks);
+
+    sub new {
+        my $class = shift;
+        my $self = $class->SUPER::new(@_);
+        $self->{end_cnt} = 0;
+        $self->{progress_cnt} = 0;
+        $self->{mirror_failure_cnt} = 0;
+        return bless($self, $class);
+    }
+
+    sub end {
+        my ($self, $user_cb_data, $status, $error_message) = @_;
+        $self->{end_cnt}++;
+        return 0;
+    }
+
+    sub progress {
+        my ($self, $user_cb_data, $total_to_download, $downloaded) = @_;
+        $self->{progress_cnt}++;
+        return 0;
+    }
+
+    sub mirror_failure {
+        my ($self, $user_cb_data, $msg, $url, $metadata) = @_;
+        my $self = shift;
+        $self->{mirror_failure_cnt}++;
+        return 0;
+    }
+}
+
+my $test = new BaseTestCase();
+
+my $repo = $test->add_repo_rpm("rpm-repo1");
+
+my $query = new libdnf5::rpm::PackageQuery($test->{base});
+$query->filter_name(["one"]);
+$query->filter_arch(["noarch"]);
+is($query->size(), 2);
+
+my $downloader = new libdnf5::repo::PackageDownloader($test->{base});
+
+my $cbs = new PackageDownloadCallbacks();
+$test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($cbs));
+
+my $it = $query->begin();
+my $e = $query->end();
+while ($it != $e) {
+    $downloader->add($it->value());
+    $it->next();
+}
+$downloader->download();
+
+$cbs = $test->{base}->get_download_callbacks();
+
+is($cbs->{end_cnt}, 2);
+ok($cbs->{progress_cnt} >= 2);
+is($cbs->{mirror_failure_cnt}, 0);
+
+done_testing();

--- a/test/perl5/libdnf5/repo/test_repo.t
+++ b/test/perl5/libdnf5/repo/test_repo.t
@@ -1,0 +1,126 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/..";
+use BaseTestCase;
+
+{
+    package DownloadCallbacks;
+    use base qw(libdnf5::repo::DownloadCallbacks);
+
+    sub new {
+        my $class = shift;
+        my $self = $class->SUPER::new(@_);
+        $self->{end_cnt} = 0;
+        $self->{end_error_message} = undef;
+        $self->{fastest_mirror_cnt} = 0;
+        $self->{handle_mirror_failure_cnt} = 0;
+        return bless($self, $class);
+    }
+
+    sub end {
+        my ($self, $user_cb_data, $status, $error_message) = @_;
+        $self->{end_cnt}++;
+        $self->{end_error_message} = $error_message;
+        return 0;
+    }
+
+    sub fastest_mirror {
+        my ($self, $user_cb_data, $stage, $ptr) = @_;
+        $self->{fastest_mirror_cnt}++;
+    }
+
+    sub handle_mirror_failure {
+        my ($self, $user_cb_data, $msg, $url, $metadata) = @_;
+        $self->{handle_mirror_failure_cnt}++;
+        return 0;
+    }
+}
+
+{
+    package RepoCallbacks;
+    use base qw(libdnf5::repo::RepoCallbacks);
+
+    sub new {
+        my $class = shift;
+        my $self = $class->SUPER::new(@_);
+        $self->{repokey_import_cnt} = 0;
+        return bless($self, $class);
+    }
+
+    sub repokey_import {
+        my ($self, $id, $user_id, $fingerprint, $url, $timestamp) = @_;
+        $self->{repokey_import_cnt}++;
+        return 1;
+    }
+}
+
+# test_load_repo
+{
+    my $test = new BaseTestCase();
+
+    my $repoid = "repomd-repo1";
+    my $repo = $test->add_repo_repomd($repoid, 0);
+
+    my $dl_cbs = new DownloadCallbacks();
+    $test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($dl_cbs));
+    $dl_cbs = $test->{base}->get_download_callbacks();
+
+    my $cbs = new RepoCallbacks();
+    $repo->set_callbacks(new libdnf5::repo::RepoCallbacksUniquePtr($cbs));
+
+    $test->{repo_sack}->load_repos($libdnf5::repo::Repo::Type_AVAILABLE);
+
+    is($dl_cbs->{end_cnt}, 1);
+    is($dl_cbs->{end_error_message}, undef);
+
+    is($dl_cbs->{fastest_mirror_cnt}, 0);
+    is($dl_cbs->{handle_mirror_failure_cnt}, 0);
+    is($cbs->{repokey_import_cnt}, 0);
+}
+
+# test_load_repo_overload
+{
+    my $test = new BaseTestCase();
+
+    my $repoid = "repomd-repo1";
+    my $repo = $test->add_repo_repomd($repoid, 0);
+
+    my $dl_cbs = new DownloadCallbacks();
+    $test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($dl_cbs));
+    $dl_cbs = $test->{base}->get_download_callbacks();
+
+    my $cbs = new RepoCallbacks();
+    $repo->set_callbacks(new libdnf5::repo::RepoCallbacksUniquePtr($cbs));
+
+    $test->{repo_sack}->load_repos();
+
+    is($dl_cbs->{end_cnt}, 1);
+    is($dl_cbs->{end_error_message}, undef);
+
+    is($dl_cbs->{fastest_mirror_cnt}, 0);
+    is($dl_cbs->{handle_mirror_failure_cnt}, 0);
+    is($cbs->{repokey_import_cnt}, 0);
+}
+
+done_testing();

--- a/test/python3/libdnf5/repo/test_package_downloader.py
+++ b/test/python3/libdnf5/repo/test_package_downloader.py
@@ -25,43 +25,61 @@ import base_test_case
 
 class TestPackageDownloader(base_test_case.BaseTestCase):
     def test_package_downloader(self):
-        repo = self.add_repo_rpm("rpm-repo1")
-
-        query = libdnf5.rpm.PackageQuery(self.base)
-        query.filter_name(["one"])
-        query.filter_version(["2"])
-        query.filter_arch(["noarch"])
-        self.assertEqual(query.size(), 1)
-
-        downloader = libdnf5.repo.PackageDownloader(self.base)
-
         class PackageDownloadCallbacks(libdnf5.repo.DownloadCallbacks):
-            end_cnt = 0
-            end_status = None
-            end_msg = None
+            test_instance = None
 
-            progress_cnt = 0
-            mirror_failure_cnt = 0
+            def __init__(self):
+                super(PackageDownloadCallbacks, self).__init__()
+                self.user_cb_data_container = []  # Hold references to user_cb_data
+                self.start_cnt = 0
+                self.progress_cnt = 0
+                self.mirror_failure_cnt = 0
+                self.end_cnt = 0
+                self.user_cb_data_array = []
+                self.end_status = []
+                self.end_msg = []
+
+            def add_new_download(self, user_data, description, total_to_download):
+                self.start_cnt += 1
+                user_cb_data_reference = "Package: " + description
+                self.user_cb_data_container.append(user_cb_data_reference)
+                return len(self.user_cb_data_container) - 1
 
             def end(self, user_cb_data, status, msg):
                 self.end_cnt += 1
-                self.end_status = status
-                self.end_msg = msg
+                self.test_instance.assertIn(user_cb_data, [0, 1])
+                self.user_cb_data_array.append(user_cb_data)
+                self.end_status.append(status)
+                self.end_msg.append(msg)
                 return 0
 
             def progress(self, user_cb_data, total_to_download, downloaded):
                 self.progress_cnt += 1
+                self.test_instance.assertIn(user_cb_data, [0, 1])
                 return 0
 
             def mirror_failure(self, user_cb_data, msg, url):
                 self.mirror_failure_cnt += 1
+                self.test_instance.assertIn(user_cb_data, [0, 1])
                 return 0
+
+        PackageDownloadCallbacks.test_instance = self
+
+        repo = self.add_repo_rpm("rpm-repo1")
+
+        query = libdnf5.rpm.PackageQuery(self.base)
+        query.filter_name(["one"])
+        query.filter_arch(["noarch"])
+        self.assertEqual(query.size(), 2)
+
+        downloader = libdnf5.repo.PackageDownloader(self.base)
 
         cbs = PackageDownloadCallbacks()
         self.base.set_download_callbacks(
             libdnf5.repo.DownloadCallbacksUniquePtr(cbs))
 
-        downloader.add(query.begin().value())
+        for package in query:
+            downloader.add(package)
 
         downloader.download()
 
@@ -69,10 +87,18 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
         downloader = None
         gc.collect()
 
-        self.assertEqual(cbs.end_cnt, 1)
-        self.assertEqual(
-            cbs.end_status, PackageDownloadCallbacks.TransferStatus_SUCCESSFUL)
-        self.assertEqual(cbs.end_msg, None)
+        cbs.user_cb_data_container.sort()
+        self.assertEqual(cbs.user_cb_data_container, [
+                         "Package: one-0:1-1.noarch", "Package: one-0:2-1.noarch"])
 
-        self.assertGreaterEqual(cbs.progress_cnt, 1)
+        self.assertEqual(cbs.start_cnt, 2)
+        self.assertGreaterEqual(cbs.progress_cnt, 2)
         self.assertEqual(cbs.mirror_failure_cnt, 0)
+        self.assertEqual(cbs.end_cnt, 2)
+
+        cbs.user_cb_data_array.sort()
+        self.assertEqual(cbs.user_cb_data_array, [0, 1])
+        self.assertEqual(
+            cbs.end_status,
+            [PackageDownloadCallbacks.TransferStatus_SUCCESSFUL, PackageDownloadCallbacks.TransferStatus_SUCCESSFUL])
+        self.assertEqual(cbs.end_msg, [None, None])

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -24,28 +24,15 @@ import base_test_case
 
 class TestRepo(base_test_case.BaseTestCase):
     class DownloadCallbacks(libdnf5.repo.DownloadCallbacks):
-        start_cnt = 0
-        start_what = None
-
         end_cnt = 0
         end_error_message = None
 
-        progress_cnt = 0
         fastest_mirror_cnt = 0
         handle_mirror_failure_cnt = 0
-
-        def add_new_download(self, user_data, descr, total):
-            self.start_cnt += 1
-            self.start_what = descr
-            return None
 
         def end(self, user_cb_data, status, error_message):
             self.end_cnt += 1
             self.end_error_message = error_message
-            return 0
-
-        def progress(self, user_cb_data, total_to_download, downloaded):
-            self.progress_cnt += 1
             return 0
 
         def fastest_mirror(self, user_cb_data, stage, ptr):
@@ -77,13 +64,9 @@ class TestRepo(base_test_case.BaseTestCase):
 
         self.repo_sack.load_repos(libdnf5.repo.Repo.Type_AVAILABLE)
 
-        self.assertEqual(dl_cbs.start_cnt, 1)
-        self.assertEqual(dl_cbs.start_what, repoid)
-
         self.assertEqual(dl_cbs.end_cnt, 1)
         self.assertEqual(dl_cbs.end_error_message, None)
 
-        self.assertGreaterEqual(dl_cbs.progress_cnt, 1)
         self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
         self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)
@@ -101,13 +84,9 @@ class TestRepo(base_test_case.BaseTestCase):
 
         self.repo_sack.load_repos()
 
-        self.assertEqual(dl_cbs.start_cnt, 1)
-        self.assertEqual(dl_cbs.start_what, repoid)
-
         self.assertEqual(dl_cbs.end_cnt, 1)
         self.assertEqual(dl_cbs.end_error_message, None)
 
-        self.assertGreaterEqual(dl_cbs.progress_cnt, 1)
         self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
         self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1441

SWIG bindings for user_cb_data in `repo::DownloadCallbacks` in the C++ API, the user can return a pointer (`void *`) to user data in the `add_new_download` method of the `repo::DownlodCallbacks` class. This pointer is then passed as an argument to `void * user_cb_data` in other methods of the `repo::DownloadCallbacks` class.

There was a problem of how to use this mechanism in SWIG bindings.

I implemented and tested several solutions. In the case of passing a pointer, there was a problem with the ownership of the data the pointer points to. Users of Python and some other languages are used to the gargabe collector and automatically holding ownership of the passed data. While I've solved this for `user_cb_data`, passing another void pointer will need to be solved (I'll do that later). And from there, the ownership will be more complicated. We need the solution to work reliably in Python, Ruby and Perl. And possibly be easy to use for other languages in the future.

In the end, I chose the method of passing an integer instead of a pointer. When passing an integer, there is no need to deal with who owns the number. The integer is passed by value. And if the user needs to pass objects, for example, he can create an array of objects and pass the index (integer) to the array. The array also provides ownership of the objects.

PR also improves and adds unit tests for Perl and extends unit tests for other languages.
