### PR TITLE
package_downloader: Ensure creation of intermediate directories

### DIFF
--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -153,7 +153,7 @@ void PackageDownloader::download() try {
                 pkg_target.package.get_nevra());
         }
 
-        std::filesystem::create_directory(pkg_target.destination);
+        std::filesystem::create_directories(pkg_target.destination);
 
         if (auto * download_callbacks = pkg_target.package.get_base()->get_download_callbacks()) {
             pkg_target.user_cb_data = download_callbacks->add_new_download(


### PR DESCRIPTION
Packages in repositories are typically stored in a multi-level directory
structure. Previously, the `download()` method only created the final
directory in the destination path, failing if any intermediate
directories were missing. This patch ensures the entire destination path
is created.