### PR TITLE
repo: Add option to download all repository metadata

### DIFF
--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -111,7 +111,7 @@ void ChangelogCommand::configure() {
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
     context.get_base().get_config().get_optional_metadata_types_option().add(
-        libdnf5::Option::Priority::RUNTIME, libdnf5::OPTIONAL_METADATA_TYPES);
+        libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_OTHER);
 }
 
 void ChangelogCommand::run() {

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1076,7 +1076,8 @@ static void print_resolve_hints(dnf5::Context & context) {
         if (broken_file_dep) {
             const std::string_view arg{"--setopt=optional_metadata_types=filelists"};
             auto optional_metadata = conf.get_optional_metadata_types_option().get_value();
-            if (!optional_metadata.contains("filelists")) {
+            if (!optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS) &&
+                !optional_metadata.contains(libdnf5::METADATA_TYPE_ALL)) {
                 hints.emplace_back(libdnf5::utils::sformat(_("{} to load additional filelists metadata"), arg));
             }
         }

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -388,9 +388,11 @@ repository configuration file should aside from repo ID consists of baseurl, met
 ``optional_metadata_types``
     :ref:`list <list-label>`
 
-    List of the following: ``comps``, ``filelists``, ``other``, ``presto``, ``updateinfo``
+    List of the following: ``comps``, ``filelists``, ``other``, ``presto``, ``updateinfo``, ``all``
 
-    Defines which types of metadata are to be loaded in addition to primary and modules, which are loaded always as they are essential. Note that the list can be extended by individual DNF commands during runtime.
+    Specifies the types of metadata to load in addition to the essential ``primary`` and ``modules`` metadata, which are always loaded. Note that individual DNF commands may extend this list at runtime.
+
+    Note: The list includes only metadata types recognized by DNF. However, a repository's metadata may include various other types (e.g., AppStream or metadata stored as databases instead of XML files). The special value ``all`` represents all metadata types present in the repository, including those unknown to DNF.
 
     Default: ``comps,updateinfo``
 

--- a/include/libdnf5/conf/const.hpp
+++ b/include/libdnf5/conf/const.hpp
@@ -63,6 +63,7 @@ constexpr const char * METADATA_TYPE_FILELISTS = "filelists";
 constexpr const char * METADATA_TYPE_OTHER = "other";
 constexpr const char * METADATA_TYPE_PRESTO = "presto";
 constexpr const char * METADATA_TYPE_UPDATEINFO = "updateinfo";
+constexpr const char * METADATA_TYPE_ALL = "all";
 
 const std::set<std::string> OPTIONAL_METADATA_TYPES{
     METADATA_TYPE_COMPS, METADATA_TYPE_FILELISTS, METADATA_TYPE_OTHER, METADATA_TYPE_PRESTO, METADATA_TYPE_UPDATEINFO};

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -411,24 +411,25 @@ void Repo::load_available_repo() {
     p_impl->solv_repo->load_repo_main(p_impl->downloader->repomd_filename, primary_fn);
 
     auto optional_metadata = p_impl->config.get_main_config().get_optional_metadata_types_option().get_value();
+    const bool all_metadata = optional_metadata.contains(libdnf5::METADATA_TYPE_ALL);
 
-    if (optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS)) {
+    if (all_metadata || optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS)) {
         p_impl->solv_repo->load_repo_ext(RepodataType::FILELISTS, *p_impl->downloader.get());
     }
 
-    if (optional_metadata.contains(libdnf5::METADATA_TYPE_OTHER)) {
+    if (all_metadata || optional_metadata.contains(libdnf5::METADATA_TYPE_OTHER)) {
         p_impl->solv_repo->load_repo_ext(RepodataType::OTHER, *p_impl->downloader.get());
     }
 
-    if (optional_metadata.contains(libdnf5::METADATA_TYPE_PRESTO)) {
+    if (all_metadata || optional_metadata.contains(libdnf5::METADATA_TYPE_PRESTO)) {
         p_impl->solv_repo->load_repo_ext(RepodataType::PRESTO, *p_impl->downloader.get());
     }
 
-    if (optional_metadata.contains(libdnf5::METADATA_TYPE_UPDATEINFO)) {
+    if (all_metadata || optional_metadata.contains(libdnf5::METADATA_TYPE_UPDATEINFO)) {
         p_impl->solv_repo->load_repo_ext(RepodataType::UPDATEINFO, *p_impl->downloader.get());
     }
 
-    if (optional_metadata.contains(libdnf5::METADATA_TYPE_COMPS)) {
+    if (all_metadata || optional_metadata.contains(libdnf5::METADATA_TYPE_COMPS)) {
         p_impl->solv_repo->load_repo_ext(RepodataType::COMPS, *p_impl->downloader.get());
     }
 

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -74,7 +74,8 @@ constexpr const char * STORED_TRANSACTION_NAME = "@stored_transaction";
 
 void load_repos_common(libdnf5::BaseWeakPtr & base) {
     auto optional_metadata = base->get_config().get_optional_metadata_types_option().get_value();
-    if (!optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS)) {
+    if (!optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS) &&
+        !optional_metadata.contains(libdnf5::METADATA_TYPE_ALL)) {
         // Configures the pool_addfileprovides_queue() method to only add files from primary.xml.
         // This ensures the method works correctly even if filelist.xml metadata are not loaded.
         // When searching for file provides outside of primary.xml this flag incurs a big performance


### PR DESCRIPTION
Needed for `dnf5 reposync --download-metadata` command.