### PR TITLE
Make `test_multi_progress_bar` test more resilient

### DIFF
--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -76,7 +76,7 @@ void ProgressbarTest::test_multi_progress_bar() {
         "\\[1/2\\] test1     [ ]*      100% |   0.0   B\\/s |  10.0   B |  ?     \n"
         "\\[2/2\\] test2     [ ]*      100% |   0.0   B\\/s |  10.0   B |  ?     \n"
         "--------------------[-]*------------------------------------------------\n"
-        "\\[2/2\\] Total     [ ]*      100% |   0.0   B\\/s |  20.0   B |  00m00s\n";
+        "\\[2/2\\] Total     [ ]*      100% | ????? ??B\\/s |  20.0   B |  ??m??s\n";
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE(
         fmt::format("Expression: \"{}\" doesn't match output: \"{}\"", expected, oss.str()),


### PR DESCRIPTION
If the machine doing the testing is slow enough some non-negligible time can elapse and the speed will be non zero.

'?' matches any character.

Example in our nightly builds: https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-41-aarch64/08278595-dnf5/builder-live.log.gz