### PR TITLE
automatic: add a setting to not emit boring messages

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -425,25 +425,27 @@ void AutomaticCommand::run() {
         }
     }
 
-    for (const auto & emitter_name : config_automatic.config_emitters.emit_via.get_value()) {
-        std::unique_ptr<Emitter> emitter;
-        if (emitter_name == "stdio") {
-            emitter = std::make_unique<EmitterStdIO>(config_automatic, transaction, output_stream, success);
-        } else if (emitter_name == "motd") {
-            emitter = std::make_unique<EmitterMotd>(config_automatic, transaction, output_stream, success);
-        } else if (emitter_name == "command") {
-            emitter = std::make_unique<EmitterCommand>(config_automatic, transaction, output_stream, success);
-        } else if (emitter_name == "command_email") {
-            emitter = std::make_unique<EmitterCommandEmail>(config_automatic, transaction, output_stream, success);
-        } else if (emitter_name == "email") {
-            emitter = std::make_unique<EmitterEmail>(config_automatic, transaction, output_stream, success);
-        } else {
-            auto & logger = *base.get_logger();
-            logger.warning(_("Unknown report emitter for dnf5 automatic: \"{}\"."), emitter_name);
-            continue;
+    auto emit_no_updates = config_automatic.config_emitters.emit_no_updates.get_value();
+    if (emit_no_updates || !success || !transaction.empty())
+        for (const auto & emitter_name : config_automatic.config_emitters.emit_via.get_value()) {
+            std::unique_ptr<Emitter> emitter;
+            if (emitter_name == "stdio") {
+                emitter = std::make_unique<EmitterStdIO>(config_automatic, transaction, output_stream, success);
+            } else if (emitter_name == "motd") {
+                emitter = std::make_unique<EmitterMotd>(config_automatic, transaction, output_stream, success);
+            } else if (emitter_name == "command") {
+                emitter = std::make_unique<EmitterCommand>(config_automatic, transaction, output_stream, success);
+            } else if (emitter_name == "command_email") {
+                emitter = std::make_unique<EmitterCommandEmail>(config_automatic, transaction, output_stream, success);
+            } else if (emitter_name == "email") {
+                emitter = std::make_unique<EmitterEmail>(config_automatic, transaction, output_stream, success);
+            } else {
+                auto & logger = *base.get_logger();
+                logger.warning(_("Unknown report emitter for dnf5 automatic: \"{}\"."), emitter_name);
+                continue;
+            }
+            emitter->notify();
         }
-        emitter->notify();
-    }
 
     if (!success) {
         throw libdnf5::cli::SilentCommandExitError(1);

--- a/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
@@ -53,6 +53,9 @@ reboot_command = "shutdown -r +5 'Rebooting after applying package updates'"
 #   sendmail.
 # If emit_via is left blank, no messages will be sent.
 emit_via = stdio
+# Whether to emit a message when nothing interesting happened - the operation
+# succeeded and no packages were available/installed.
+emit_no_updates = no
 
 
 [command]

--- a/dnf5-plugins/automatic_plugin/config_automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/config_automatic.cpp
@@ -52,6 +52,7 @@ ConfigAutomaticCommands::ConfigAutomaticCommands() {
 ConfigAutomaticEmitters::ConfigAutomaticEmitters() {
     opt_binds().add("emit_via", emit_via);
     opt_binds().add("system_name", system_name);
+    opt_binds().add("emit_no_updates", emit_no_updates);
 }
 
 std::string ConfigAutomaticEmitters::gethostname() {

--- a/dnf5-plugins/automatic_plugin/config_automatic.hpp
+++ b/dnf5-plugins/automatic_plugin/config_automatic.hpp
@@ -57,6 +57,7 @@ public:
 
     libdnf5::OptionStringList emit_via{std::vector<std::string>{"stdio"}};
     libdnf5::OptionString system_name{gethostname()};
+    libdnf5::OptionBool emit_no_updates{false};
 
 private:
     static std::string gethostname();

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -140,6 +140,11 @@ Choosing how the results should be reported.
 
     How the system is called in the reports.
 
+``emit_no_updates``
+    boolean, default: False
+
+    Whether to emit a message when nothing interesting happened - the operation succeeded and no packages were available/installed.
+
 
 ---------------------
 ``[command]`` section


### PR DESCRIPTION
Currently, we always emit messages every time automatic runs, even if it does nothing very interesting (the operation succeeds and there are no changed packages). This is flooding Fedora infra with boring emails that effectively just say "nothing happened".

This adds a setting to only emit if *something* interesting happened - the operation failed, or we saw package changes.