### PR TITLE
spec: toggle dnf5_obsoletes_dnf for RHEL 11

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -3,7 +3,7 @@
 %global project_version_minor 7
 %global project_version_micro 0
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 11]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 10]
 
 Name:           dnf5
 Version:        %{project_version_prime}.%{project_version_major}.%{project_version_minor}.%{project_version_micro}


### PR DESCRIPTION
Fedora 41 has completed the migration to DNF5, so ELN (the future RHEL 11) is now ready to follow suit.

See also: https://github.com/rpm-software-management/dnf/pull/2161