### PR TITLE
builddep: Add support for --spec and --srpm options

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -131,7 +131,7 @@ void BuildDepCommand::set_argument_parser() {
                                       [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                       [[maybe_unused]] const char * option,
                                       [[maybe_unused]] const char * value) {
-        this->spec_type = "spec";
+        this->arg_type = ArgType::SPEC;
         return true;
     });
     cmd.register_named_arg(spec_arg);
@@ -143,7 +143,7 @@ void BuildDepCommand::set_argument_parser() {
                                       [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                       [[maybe_unused]] const char * option,
                                       [[maybe_unused]] const char * value) {
-        this->spec_type = "srpm";
+        this->arg_type = ArgType::SRPM;
         return true;
     });
     cmd.register_named_arg(srpm_arg);
@@ -182,18 +182,22 @@ void BuildDepCommand::parse_builddep_specs(int specs_count, const char * const s
                     spec_location = downloaded_remotes.back()->get_path();
                 }
             }
-            if (spec_type == "spec") {
-                spec_file_paths.emplace_back(std::move(spec_location));
-            } else if (spec_type == "srpm") {
-                srpm_file_paths.emplace_back(std::move(spec_location));
-            } else {
-                if (spec.ends_with(ext_spec)) {
+            switch (arg_type) {
+                case ArgType::SPEC:
                     spec_file_paths.emplace_back(std::move(spec_location));
-                } else if (spec.ends_with(ext_srpm) || spec.ends_with(ext_nosrpm)) {
+                    break;
+                case ArgType::SRPM:
                     srpm_file_paths.emplace_back(std::move(spec_location));
-                } else {
-                    pkg_specs.emplace_back(std::move(spec_location));
-                }
+                    break;
+                case ArgType::AUTO:
+                    if (spec.ends_with(ext_spec)) {
+                        spec_file_paths.emplace_back(std::move(spec_location));
+                    } else if (spec.ends_with(ext_srpm) || spec.ends_with(ext_nosrpm)) {
+                        srpm_file_paths.emplace_back(std::move(spec_location));
+                    } else {
+                        pkg_specs.emplace_back(std::move(spec_location));
+                    }
+                    break;
             }
         }
     }

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -44,6 +44,8 @@ public:
     void goal_resolved() override;
 
 private:
+    enum class ArgType { AUTO, SPEC, SRPM };
+
     void parse_builddep_specs(int specs_count, const char * const specs[]);
     bool add_from_spec_file(
         std::set<std::string> & install_specs, std::set<std::string> & conflicts_specs, const char * spec_file_name);
@@ -57,7 +59,7 @@ private:
     std::vector<std::string> srpm_file_paths{};
     std::vector<std::pair<std::string, std::string>> rpm_macros{};
 
-    std::string spec_type{"auto"};
+    ArgType arg_type{ArgType::AUTO};
 
     // Args downloaded into temp files which are automatically cleaned up
     std::vector<std::unique_ptr<libdnf5::utils::fs::TempFile>> downloaded_remotes{};

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -57,6 +57,8 @@ private:
     std::vector<std::string> srpm_file_paths{};
     std::vector<std::pair<std::string, std::string>> rpm_macros{};
 
+    std::string spec_type{"auto"};
+
     // Args downloaded into temp files which are automatically cleaned up
     std::vector<std::unique_ptr<libdnf5::utils::fs::TempFile>> downloaded_remotes{};
 

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -154,7 +154,7 @@ Changes to individual commands
   * Specific variants of the command, ``autoremove-n``, ``autoremove-na``, and ``autoremove-nevra``, are not supported anymore.
 
 ``builddep``
-  * Dropped ``--spec`` and ``--srpm`` arguments as automatic detection from file extensions is implemented now.
+  * The ``--spec`` and ``--srpm`` options only apply to arguments that follow them. This allows for use cases that combine spec files and source RPMs (e.g., ``dnf5 builddep --spec pkg1.spec.in --srpm pkg2.src.rpm``). However, the previously supported syntax ``dnf builddep pkg1.spec.in --spec`` no longer has any effect.
 
 ``config-manager``
   * New behavior introduced.

--- a/doc/dnf5_plugins/builddep.8.rst
+++ b/doc/dnf5_plugins/builddep.8.rst
@@ -59,6 +59,12 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+``--spec``
+    | Treat command line arguments following this option as spec files.
+
+``--srpm``
+    | Treat command line arguments following this option as source rpms.
+
 
 Arguments
 =========


### PR DESCRIPTION
By default, the type of positional argument (spec file, source RPM, or
package) is deduced based on its extension. However, when a file does
not have a traditional extension, the type can now be explicitly
specified using the following new options:

--spec: Treats subsequent arguments as spec files.
--srpm: Treats subsequent arguments as source RPMs.

Resolves: https://github.com/rpm-software-management/dnf5/issues/799