### PR TITLE
Install defs.h for /usr/include/dnf5/context.hpp

### DIFF
--- a/dnf5/include/dnf5/CMakeLists.txt
+++ b/dnf5/include/dnf5/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE DNF5_HEADERS *.hpp)
+file(GLOB_RECURSE DNF5_HEADERS *.hpp *.h)
 
 # preserve relative paths of the header files
 foreach(abspath ${DNF5_HEADERS})


### PR DESCRIPTION
Since 62b8503e52b832a4e9f39786493af8f2f8be9113 (dnf5 app, dnf5 plugins: Do not export private symbols) defs.h is included into dnf5 header files but it is not installed.

This patch fixes it.

Resolves: #1913