### PR TITLE
doc: Use PGP instead of GPG

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -384,7 +384,7 @@ void OfflineExecuteCommand::pre_configure() {
     // Additional removal could trigger unwanted changes in transaction.
     ctx.get_base().get_config().get_clean_requirements_on_remove_option().set(false);
     ctx.get_base().get_config().get_install_weak_deps_option().set(false);
-    // Disable gpgcheck entirely, since GPG integrity will have already been
+    // Disable gpgcheck entirely, since PGP integrity will have already been
     // checked when the transaction was prepared and serialized. This way, we
     // don't need to keep track of which packages need to be gpgchecked.
     ctx.get_base().get_config().get_pkg_gpgcheck_option().set(false);

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -414,7 +414,7 @@ void RootCommand::set_argument_parser() {
 
     auto no_gpgchecks = parser.add_new_named_arg("no-gpgchecks");
     no_gpgchecks->set_long_name("no-gpgchecks");
-    no_gpgchecks->set_description(_("disable gpg signature checking (if RPM policy allows)"));
+    no_gpgchecks->set_description(_("disable PGP signature checking (if RPM policy allows)"));
     no_gpgchecks->set_parse_hook_func([&ctx](
                                           [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                           [[maybe_unused]] const char * option,

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -261,7 +261,7 @@ Following options are applicable in the general context for any ``dnf5`` command
     | It sets the ``RPMTRANS_FLAG_NODOCS`` flag.
 
 ``--no-gpgchecks``
-    | Skip checking GPG signatures on packages (if ``RPM`` policy allows that).
+    | Skip checking PGP signatures on packages (if ``RPM`` policy allows that).
 
 ``--no-plugins``
     | Disable all libdnf5 plugins.

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -94,7 +94,7 @@ This section does not track any deprecated option. For such options see :ref:`De
 ``gpgkey_dns_verification``
     :ref:`boolean <boolean-label>`
 
-    If enabled, DNF5 will attempt to automatically verify GPG verification keys using the DNS
+    If enabled, DNF5 will attempt to automatically verify PGP verification keys using the DNS
     system.
 
     This option requires the unbound python module (python3-unbound) to

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -564,7 +564,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     ``_RPMVSF_NODIGESTS`` VS flags.
 
     The ``test`` option provides a transaction check without performing the transaction.
-    It includes downloading of packages, gpg keys check (including permanent import of
+    It includes downloading of packages, PGP keys check (including permanent import of
     additional keys if necessary), and rpm check to prevent file conflicts.
 
     The ``nocaps`` is supported with rpm-4.14 or later. When ``nocaps`` is used but rpm
@@ -724,7 +724,7 @@ Repo Options
 ``gpgkey``
     :ref:`list <list-label>`
 
-    URLs of a GPG key files that can be used for signing metadata and packages
+    URLs of a PGP key files that can be used for signing metadata and packages
     of this repository. If a file can not be verified using
     the already imported keys, import of keys from this option is attempted and
     the keys are then used for verification.
@@ -981,7 +981,7 @@ configuration.
 ``pkg_gpgcheck``
     :ref:`boolean <boolean-label>`
 
-    Whether to perform GPG signature check on packages found in this repository.
+    Whether to perform PGP signature check on packages found in this repository.
 
     The default is False.
 
@@ -1023,7 +1023,7 @@ configuration.
 ``localpkg_gpgcheck``
     :ref:`boolean <boolean-label>`
 
-    If enabled, DNF5 will perform a GPG signature check on local packages (packages in a file, not in a repository).
+    If enabled, DNF5 will perform a PGP signature check on local packages (packages in a file, not in a repository).
 
     Default: ``False``.
 
@@ -1172,11 +1172,11 @@ configuration.
 ``repo_gpgcheck``
     :ref:`boolean <boolean-label>`
 
-    If enabled, DNF5 will perform GPG signature check on this repository's metadata.
+    If enabled, DNF5 will perform PGP signature check on this repository's metadata.
 
 
     .. NOTE::
-       GPG keys for this check are stored separately from GPG keys used in package signature
+       PGP keys for this check are stored separately from PGP keys used in package signature
        verification. Furthermore, they are also stored separately for each repository.
 
        This means that DNF5 may ask to import the same key multiple times. For example, when a key was

--- a/doc/dnf5_workflow.rst
+++ b/doc/dnf5_workflow.rst
@@ -42,8 +42,8 @@ Typical DNF5 workflow consists of:
         #. load metadata from cache if valid
         #. try to reuse root's cache
         #. metadata download
-        #. metadata gpg check
-        #. if required import repository gpg keys and try again
+        #. metadata PGP check
+        #. if required import repository PGP keys and try again
 #. libdnf5 plugin ``repos_loaded`` hook
 #. run command specific ``load_additional_packages`` step
 #. run command specific ``run`` step
@@ -56,7 +56,7 @@ Typical DNF5 workflow consists of:
     #. print transaction table
     #. check for user approval
     #. download inbound transaction packages
-    #. check gpg signatures for inbound transaction packages
+    #. check PGP signatures for inbound transaction packages
     #. lock transaction ``libdnf5::utils::Locker``
     #. create rpm transaction
     #. run rpm test transaction

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -31,7 +31,7 @@ relative to where all packages will be installed. Think of it like doing
 before the chroot is created.
 
 `cachedir`, `system_cachedir`, `log` files, `releasever`, and `gpgkey` are
-taken from or stored in the installroot. GPG keys are imported into the
+taken from or stored in the installroot. PGP keys are imported into the
 installroot from a path relative to the host which can be specified in the
 repository section of configuration files.
 

--- a/include/libdnf5/repo/repo_callbacks.hpp
+++ b/include/libdnf5/repo/repo_callbacks.hpp
@@ -44,7 +44,7 @@ public:
     RepoCallbacks & operator=(const RepoCallbacks &) = delete;
     RepoCallbacks & operator=(RepoCallbacks &&) = delete;
 
-    /// GPG key import callback. Allows to confirm or deny the import.
+    /// PGP key import callback. Allows to confirm or deny the import.
     /// @param key_info The key that is about to be imported
     /// @return `true` to import the key, `false` to not import
     virtual bool repokey_import(const libdnf5::rpm::KeyInfo & key_info);

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -119,7 +119,7 @@ public:
     CheckResult check_package_signature(const std::string & path) const;
 
     /// Import public key into rpm database.
-    /// @param key: GPG key to be imported into rpm database.
+    /// @param key: PGP key to be imported into rpm database.
     bool import_key(const KeyInfo & key) const;
 
     /// Check public key presence in rpm database

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -253,7 +253,7 @@ RpmSignature::CheckResult RpmSignature::check_package_signature(const std::strin
 }
 
 RpmSignature::CheckResult RpmSignature::check_package_signature(const rpm::Package & pkg) const {
-    // is package gpg check even required?
+    // is package PGP check even required?
     auto repo = pkg.get_repo();
     if (repo->get_type() == libdnf5::repo::Repo::Type::COMMANDLINE) {
         if (!p_impl->base->get_config().get_localpkg_gpgcheck_option().get_value()) {


### PR DESCRIPTION
The public-key technology is called Pretty Good Privacy. GPG is a synonymous for GnuPG, a piece of software which DNF5 does not use.