### PR TITLE
Fix libdnf5 actions plugin sign conversion compilation err

### DIFF
--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -1303,7 +1303,7 @@ void Actions::process_json_command(const CommandToRun & command, struct json_obj
                     }
                     for (std::size_t idx = 0; idx < sizeof(attrs_list) / sizeof(attrs_list[0]); ++idx) {
                         if (attrs_list[idx].first == requested_attr) {
-                            requested_attrs |= 1 << idx;
+                            requested_attrs |= 1U << idx;
                         }
                     }
                 }


### PR DESCRIPTION
Fix compilation error:
error: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Werror=sign-conversion]