### PR TITLE
Python API: Method `DownloadCallbacks.add_new_download` can return `None`

### DIFF
--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -61,10 +61,15 @@
 %typemap(directorout, noblock=1) void * {
     int swig_val;
     int swig_res = SWIG_AsVal_int($1, &swig_val);
-    if (!SWIG_IsOK(swig_res)) {
+    if (SWIG_IsOK(swig_res)) {
+        $result = reinterpret_cast<void *>(swig_val);
+#if defined(SWIGPYTHON)
+    } else if (Py_IsNone($1)) {
+        $result = 0;
+#endif
+    } else {
         Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""int""'");
     }
-    $result = reinterpret_cast<void *>(swig_val);
 }
 
 %typemap(in, noblock=1) void * user_cb_data {


### PR DESCRIPTION
It's a backwards compatibility API.

Originally, return value support was not implemented in SWIG bindings for the `add_new_download` method and the method only accepted `None` as a return value.

Later, support was implemented for returning an integer, which is then passed in subsequent callbacks (`progress`, `end`, ...) as the `user_cb_data` argument. By expecting an integer instead of `None`, existing programs returning None are broken.

This PR adds the ability for Python programs to return None (it has the same meaning as returning the integer 0 in this case).