### PR TITLE
Update pre-commit hooks to latest versions in F41

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     exclude:
@@ -12,13 +12,13 @@ repos:
   - id: check-added-large-files
   - id: check-merge-conflict
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v17.0.5
+  rev: v19.1.0
   hooks:
   - id: clang-format
     types_or:
     - c++
 - repo: https://github.com/hhatto/autopep8
-  rev: v2.0.4
+  rev: v2.2.0
   hooks:
   - id: autopep8
 - repo: https://github.com/rpm-software-management/rpmlint.git

--- a/dnf5-plugins/automatic_plugin/config_automatic.hpp
+++ b/dnf5-plugins/automatic_plugin/config_automatic.hpp
@@ -103,7 +103,7 @@ public:
 
 class ConfigAutomatic {
 public:
-    ConfigAutomatic(){};
+    ConfigAutomatic() {};
     ~ConfigAutomatic() = default;
 
     void load_from_parser(

--- a/dnf5-plugins/copr_plugin/copr_list.cpp
+++ b/dnf5-plugins/copr_plugin/copr_list.cpp
@@ -30,7 +30,7 @@ private:
     std::string hostname;
 
 public:
-    explicit RepoListCB(const std::string & host) : hostname(host){};
+    explicit RepoListCB(const std::string & host) : hostname(host) {};
     dnf5::CoprRepoCallback list = [&](dnf5::CoprRepo & cr) {
         if (!hostname.empty() && cr.get_id().rfind(hostname + "/", 0) != 0)
             return;

--- a/dnf5-plugins/copr_plugin/copr_repo.hpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.hpp
@@ -42,7 +42,7 @@ void available_chroots_error(
 
 class CoprRepoPart {
 public:
-    CoprRepoPart(){};
+    CoprRepoPart() {};
     explicit CoprRepoPart(libdnf5::repo::RepoWeakPtr dnfRepo) {
         /// Copr enable/disable simply always generates the repofile from
         /// scratch ('enable' from the json provided by Copr Frontend, 'disable'
@@ -175,7 +175,7 @@ private:
 
 class CoprRepo {
 public:
-    CoprRepo(){};
+    CoprRepo() {};
 
     explicit CoprRepo(
         libdnf5::Base & base,

--- a/dnf5daemon-client/callbacks.hpp
+++ b/dnf5daemon-client/callbacks.hpp
@@ -32,7 +32,7 @@ class Context;
 
 class DbusCallback {
 public:
-    explicit DbusCallback(Context & context) : context(context){};
+    explicit DbusCallback(Context & context) : context(context) {};
     virtual ~DbusCallback() = default;
 
 protected:

--- a/dnf5daemon-client/commands/command.hpp
+++ b/dnf5daemon-client/commands/command.hpp
@@ -29,7 +29,7 @@ namespace dnfdaemon::client {
 
 class DaemonCommand : public libdnf5::cli::session::Command {
 public:
-    explicit DaemonCommand(Context & context, const std::string & name) : Command(context, name){};
+    explicit DaemonCommand(Context & context, const std::string & name) : Command(context, name) {};
     virtual dnfdaemon::KeyValueMap session_config() {
         dnfdaemon::KeyValueMap cfg = {};
         return cfg;
@@ -41,7 +41,7 @@ public:
 
 class TransactionCommand : public DaemonCommand {
 public:
-    explicit TransactionCommand(Context & context, const std::string & name) : DaemonCommand(context, name){};
+    explicit TransactionCommand(Context & context, const std::string & name) : DaemonCommand(context, name) {};
     void run_transaction(bool offline = false);
 };
 

--- a/dnf5daemon-client/context.hpp
+++ b/dnf5daemon-client/context.hpp
@@ -41,7 +41,7 @@ constexpr const char * VERSION = "0.1.0";
 
 class Context : public libdnf5::cli::session::Session {
 public:
-    Context() : repositories_status(dnfdaemon::RepoStatus::NOT_READY){};
+    Context() : repositories_status(dnfdaemon::RepoStatus::NOT_READY) {};
 
     /// Initialize dbus connection and server session
     void init_session(sdbus::IConnection & connection);

--- a/dnf5daemon-client/wrappers/dbus_environment_wrapper.cpp
+++ b/dnf5daemon-client/wrappers/dbus_environment_wrapper.cpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-DbusEnvironmentWrapper::DbusEnvironmentWrapper(const dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata){};
+DbusEnvironmentWrapper::DbusEnvironmentWrapper(const dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata) {};
 
 std::set<std::string> DbusEnvironmentWrapper::get_repos() const {
     std::vector<std::string> repos_vector = rawdata.at("repos");

--- a/dnf5daemon-client/wrappers/dbus_package_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_package_wrapper.hpp
@@ -30,7 +30,7 @@ namespace dnfdaemon::client {
 
 class DbusPackageWrapper {
 public:
-    explicit DbusPackageWrapper(const dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata){};
+    explicit DbusPackageWrapper(const dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata) {};
 
     int get_id() { return rawdata.at("id"); }
     std::string get_name() const { return rawdata.at("name"); }

--- a/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_repo_wrapper.hpp
@@ -29,7 +29,7 @@ namespace dnfdaemon::client {
 
 class DbusRepoWrapper : public libdnf5::cli::output::IRepoInfo {
 public:
-    explicit DbusRepoWrapper(dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata){};
+    explicit DbusRepoWrapper(dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata) {};
 
     std::string get_id() const { return rawdata.at("id"); }
     std::string get_name() const { return rawdata.at("name"); }

--- a/dnf5daemon-server/callbacks.hpp
+++ b/dnf5daemon-server/callbacks.hpp
@@ -140,7 +140,7 @@ public:
     void verify_stop(uint64_t total) override;
 
     void unpack_error(const libdnf5::base::TransactionPackage & item) override;
-    void cpio_error(const libdnf5::base::TransactionPackage & /*item*/) override{};
+    void cpio_error(const libdnf5::base::TransactionPackage & /*item*/) override {};
 
     // whole rpm transaction is finished
     void finish();

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -40,7 +40,7 @@ class Session;
 
 class IDbusSessionService {
 public:
-    explicit IDbusSessionService(Session & session) : session(session){};
+    explicit IDbusSessionService(Session & session) : session(session) {};
     virtual ~IDbusSessionService() = default;
     virtual void dbus_register() = 0;
 

--- a/include/libdnf5/common/exception.hpp
+++ b/include/libdnf5/common/exception.hpp
@@ -31,8 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <type_traits>
 
-#define LIBDNF_LOCATION \
-    { __FILE__, __LINE__, __PRETTY_FUNCTION__ }
+#define LIBDNF_LOCATION {__FILE__, __LINE__, __PRETTY_FUNCTION__}
 
 /// An assert macro that throws `libdnf5::AssertionError`.
 ///

--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -74,7 +74,7 @@ public:
     TransactionTableSection(std::string header, struct libscols_line * line)
         : header(std::move(header)),
           first_line(line),
-          last_line(line){};
+          last_line(line) {};
     std::string get_header() const { return header; }
     struct libscols_line * get_first_line() const { return first_line; }
     struct libscols_line * get_last_line() const { return last_line; }

--- a/libdnf5-cli/session.cpp
+++ b/libdnf5-cli/session.cpp
@@ -293,7 +293,7 @@ StringArgumentList::StringArgumentList(
 
 StringArgumentList::StringArgumentList(
     libdnf5::cli::session::Command & command, const std::string & name, const std::string & desc)
-    : StringArgumentList(command, name, desc, ArgumentParser::PositionalArg::UNLIMITED){};
+    : StringArgumentList(command, name, desc, ArgumentParser::PositionalArg::UNLIMITED) {};
 
 StringArgumentList::~StringArgumentList() = default;
 

--- a/libdnf5/conf/option.cpp
+++ b/libdnf5/conf/option.cpp
@@ -23,7 +23,7 @@ namespace libdnf5 {
 
 class Option::Impl {
 public:
-    Impl(Priority priority) : priority(priority){};
+    Impl(Priority priority) : priority(priority) {};
 
 private:
     friend Option;

--- a/libdnf5/conf/option_binds.cpp
+++ b/libdnf5/conf/option_binds.cpp
@@ -40,7 +40,7 @@ public:
           get_value_str_func(std::move(get_value_string_func)),
           is_append_option(add_value) {}
 
-    Impl(Option & option) : option(&option){};
+    Impl(Option & option) : option(&option) {};
 
 private:
     friend OptionBinds::Item;

--- a/libdnf5/conf/option_path.cpp
+++ b/libdnf5/conf/option_path.cpp
@@ -31,7 +31,7 @@ namespace libdnf5 {
 
 class OptionPath::Impl {
 public:
-    Impl(bool exists, bool abs_path) : exists(exists), abs_path(abs_path){};
+    Impl(bool exists, bool abs_path) : exists(exists), abs_path(abs_path) {};
 
 private:
     friend OptionPath;

--- a/libdnf5/conf/option_string_list.cpp
+++ b/libdnf5/conf/option_string_list.cpp
@@ -36,20 +36,20 @@ public:
         : icase(false),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}){};
+          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
     Impl(T && default_value, std::string && regex, bool icase)
         : regex(std::move(regex)),
           icase(icase),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}){};
+          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
     Impl(T && default_value, std::string && regex, bool icase, std::string && delimiters)
         : regex(std::move(regex)),
           icase(icase),
           delimiters(std::move(delimiters)),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}){};
+          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
 
     // For append options the method stores the value to value_append multimap and
     // then recalculates this->value.

--- a/libdnf5/conf/option_string_private.hpp
+++ b/libdnf5/conf/option_string_private.hpp
@@ -23,14 +23,14 @@ namespace libdnf5 {
 
 class OptionString::Impl {
 public:
-    Impl(std::string && default_value) : icase(false), default_value(default_value), value(std::move(default_value)){};
-    Impl() : icase(false){};
-    Impl(std::string && regex, bool icase) : regex(std::move(regex)), icase(icase){};
+    Impl(std::string && default_value) : icase(false), default_value(default_value), value(std::move(default_value)) {};
+    Impl() : icase(false) {};
+    Impl(std::string && regex, bool icase) : regex(std::move(regex)), icase(icase) {};
     Impl(std::string && default_value, std::string && regex, bool icase)
         : regex(std::move(regex)),
           icase(icase),
           default_value(default_value),
-          value(std::move(default_value)){};
+          value(std::move(default_value)) {};
 
     std::string regex;
     bool icase;

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -385,8 +385,7 @@ void Vars::load(const std::string & installroot, const std::vector<std::string> 
 }
 
 void Vars::detect_vars(const std::string & installroot) {
-    set_lazy(
-        "arch", []() -> auto { return std::make_unique<std::string>(utils::detect_arch()); }, Priority::AUTO);
+    set_lazy("arch", []() -> auto { return std::make_unique<std::string>(utils::detect_arch()); }, Priority::AUTO);
 
     utils::init_lib_rpm(get_value("arch").c_str());
 

--- a/libdnf5/logger/log_router.cpp
+++ b/libdnf5/logger/log_router.cpp
@@ -23,7 +23,7 @@ namespace libdnf5 {
 
 class LogRouter::Impl {
 public:
-    Impl(){};
+    Impl() {};
     Impl(std::vector<std::unique_ptr<Logger>> && loggers) : loggers(std::move(loggers)) {}
 
 private:
@@ -31,7 +31,7 @@ private:
     std::vector<std::unique_ptr<Logger>> loggers;
 };
 
-LogRouter::LogRouter() : p_impl(new Impl()){};
+LogRouter::LogRouter() : p_impl(new Impl()) {};
 
 LogRouter::~LogRouter() = default;
 

--- a/libdnf5/module/module_metadata.cpp
+++ b/libdnf5/module/module_metadata.cpp
@@ -35,7 +35,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5::module {
 
 
-ModuleMetadata::ModuleMetadata(const BaseWeakPtr & base) : base(base){};
+ModuleMetadata::ModuleMetadata(const BaseWeakPtr & base) : base(base) {};
 ModuleMetadata::ModuleMetadata(libdnf5::Base & base) : base(base.get_weak_ptr()) {}
 
 

--- a/libdnf5/repo/repo_cache.cpp
+++ b/libdnf5/repo/repo_cache.cpp
@@ -94,7 +94,7 @@ RepoCacheRemoveStatistics & RepoCacheRemoveStatistics::operator+=(const RepoCach
     return *this;
 }
 
-RepoCacheRemoveStatistics::RepoCacheRemoveStatistics() : p_impl(new Impl()){};
+RepoCacheRemoveStatistics::RepoCacheRemoveStatistics() : p_impl(new Impl()) {};
 RepoCacheRemoveStatistics::~RepoCacheRemoveStatistics() = default;
 
 RepoCacheRemoveStatistics::RepoCacheRemoveStatistics(const RepoCacheRemoveStatistics & src) = default;

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -42,8 +42,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define PACKAGES_RELATIVE_DIR "packages"
 #define METALINK_FILENAME     "metalink.xml"
 #define MIRRORLIST_FILENAME   "mirrorlist"
-#define RECOGNIZED_CHKSUMS \
-    { "sha512", "sha256" }
+#define RECOGNIZED_CHKSUMS    {"sha512", "sha256"}
 
 
 namespace libdnf5::repo {

--- a/libdnf5/repo/repo_query.cpp
+++ b/libdnf5/repo/repo_query.cpp
@@ -28,7 +28,7 @@ namespace libdnf5::repo {
 
 class RepoQuery::Impl {
 public:
-    Impl(const BaseWeakPtr & base) : base(base){};
+    Impl(const BaseWeakPtr & base) : base(base) {};
 
 private:
     friend RepoQuery;

--- a/libdnf5/rpm/nevra.cpp
+++ b/libdnf5/rpm/nevra.cpp
@@ -293,7 +293,7 @@ int rpmvercmp(const char * lhs, const char * rhs) {
     return ::rpmvercmp(lhs, rhs);
 }
 
-Nevra::Nevra() : p_impl(new Impl()){};
+Nevra::Nevra() : p_impl(new Impl()) {};
 Nevra::~Nevra() = default;
 
 Nevra::Nevra(const Nevra & src) = default;

--- a/libdnf5/rpm/package_query.cpp
+++ b/libdnf5/rpm/package_query.cpp
@@ -746,7 +746,7 @@ void PackageQuery::filter_arch(const std::vector<std::string> & patterns, libdnf
 namespace {
 
 struct NevraID {
-    NevraID() : name(0), arch(0), evr(0){};
+    NevraID() : name(0), arch(0), evr(0) {};
     NevraID(const NevraID & src) = default;
     NevraID(NevraID && src) noexcept = default;
     NevraID & operator=(const NevraID & src) = default;

--- a/libdnf5/rpm/rpm_log_guard.hpp
+++ b/libdnf5/rpm/rpm_log_guard.hpp
@@ -59,7 +59,7 @@ private:
 class RpmLogGuardStrings : public RpmLogGuardBase {
 public:
     RpmLogGuardStrings();
-    ~RpmLogGuardStrings(){};
+    ~RpmLogGuardStrings() {};
 
     const std::vector<std::string> & get_rpm_logs() const { return rpm_logs; }
     void add_rpm_log(const std::string & log) { rpm_logs.emplace_back(log); }

--- a/libdnf5/solv/solver.hpp
+++ b/libdnf5/solv/solver.hpp
@@ -34,7 +34,7 @@ namespace libdnf5::solv {
 
 class Solver {
 public:
-    Solver(){};
+    Solver() {};
     explicit Solver(Pool & pool);
 
     Solver(const Solver & solver) = delete;

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -64,7 +64,7 @@ public:
 
 OfflineTransactionStateData::~OfflineTransactionStateData() = default;
 
-OfflineTransactionStateData::OfflineTransactionStateData() : p_impl(std::make_unique<Impl>()){};
+OfflineTransactionStateData::OfflineTransactionStateData() : p_impl(std::make_unique<Impl>()) {};
 OfflineTransactionStateData::OfflineTransactionStateData(const OfflineTransactionStateData & src)
     : p_impl(new Impl(*src.p_impl)) {}
 OfflineTransactionStateData::OfflineTransactionStateData(OfflineTransactionStateData && src) noexcept = default;

--- a/libdnf5/utils/locker.cpp
+++ b/libdnf5/utils/locker.cpp
@@ -29,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::utils {
 
-Locker::Locker(const std::string & path) : path(path){};
+Locker::Locker(const std::string & path) : path(path) {};
 
 bool Locker::read_lock() {
     return lock(F_RDLCK);

--- a/test/shared/utils.hpp
+++ b/test/shared/utils.hpp
@@ -355,7 +355,7 @@ std::vector<libdnf5::rpm::Package> to_vector(const libdnf5::rpm::PackageSet & pa
 // Together with ASSERT_MATCHES implements convenient fnmatch pattern matching
 class Pattern {
 public:
-    Pattern(const char * str) : value(str){};
+    Pattern(const char * str) : value(str) {};
     bool matches(const std::string & actual) { return !fnmatch(value.c_str(), actual.c_str(), FNM_EXTMATCH); }
     std::string value;
 };


### PR DESCRIPTION
Update clang-format and autopep8 to the latest versions in Fedora 41. Update pre-commit-hooks to the latest upstream version.

autopep8 update was needed to fix https://github.com/hhatto/autopep8/issues/720.