### PR TITLE
Bumb readthedocs ubuntu image version to fix the docs generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   apt_packages:
     - swig
   tools:


### PR DESCRIPTION
The old `ubuntu-22.04` uses version `swig4.0` which fails on C++11 attributes. We have started to use them in: https://github.com/rpm-software-management/dnf5/pull/1793 and the readthedocs build has been failing since then.

Use `24.04` (https://about.readthedocs.com/blog/2024/06/ubuntu-24-04/) because it uses `swig_4.2.0` which at least ignores the attributes.

According to the changelog the attributes should be ignored since version 4.1.0: https://www.swig.org/Release/CHANGES
```
2022-07-07: jmarrec
	    #1158 #2286 Add basic support for C++11 attributes.  These are now
	    crudely ignored by SWIG's parser's tokeniser, which is better than
	    failing with a parse error.
```