### PR TITLE
Add padding to ProgressBar messages to avoid overlapping

### DIFF
--- a/libdnf5-cli/progressbar/download_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/download_progress_bar.cpp
@@ -205,6 +205,12 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
             }
         }
 
+        // Add padding to fully fill the terminal_width, this is because MultiProgressBar
+        // overrides its own messages, it doesn't clear the lines.
+        // If the message is short some leftover characters could be still present after it.
+        if (message.length() < terminal_width - 4) {
+            message.append(terminal_width - message.length() - 4, ' ');
+        }
         // print only part of the message that fits the terminal width
         // subtracted '4' relates to the '>>> ' prefix
         stream << message.substr(0, terminal_width - 4);

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -112,6 +112,8 @@ void ProgressbarInteractiveTest::setUp() {
     setenv("DNF5_FORCE_INTERACTIVE", "1", 1);
     // Force columns to 70 to make output independ of where it is run
     setenv("FORCE_COLUMNS", "70", 1);
+    // Wide characters do not work at all until we set locales in the code
+    setlocale(LC_ALL, "C.UTF-8");
 }
 
 void ProgressbarInteractiveTest::tearDown() {
@@ -175,15 +177,18 @@ void ProgressbarInteractiveTest::test_download_progress_bar_with_messages() {
     download_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
     download_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
     download_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    download_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
 
     std::ostringstream oss;
     (*download_progress_bar.*get(to_stream{}))(oss);
     Pattern expected =
         "\\[0/0\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????\n"
         ">>> test message1                                                     \n"
-        ">>> test message2                                                     ";
+        ">>> test message2                                                     \n"
+        ">>> test もで 諤奯ゞ                                                  ";
     ASSERT_MATCHES(expected, oss.str());
 
+    download_progress_bar->pop_message();
     download_progress_bar->pop_message();
     download_progress_bar->pop_message();
 
@@ -270,7 +275,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bar_with_messages_with_tota
 
     download_progress_bar_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
     download_progress_bar_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message2");
-    download_progress_bar_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message3");
+    download_progress_bar_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
     oss << multi_progress_bar;
     download_progress_bar_raw->pop_message();
     download_progress_bar_raw->pop_message();
@@ -312,6 +317,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages_with_tot
     download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
     download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
     download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
 
     std::ostringstream oss;
     oss << multi_progress_bar;
@@ -320,11 +326,13 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages_with_tot
         "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
         ">>> test message1                                                     \n"
         ">>> test message2                                                     \n"
+        ">>> test もで 諤奯ゞ                                                  \n"
         "----------------------------------------------------------------------\n"
         "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????";
 
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
+    download_progress_bar2_raw->pop_message();
     download_progress_bar2_raw->pop_message();
     download_progress_bar2_raw->pop_message();
     oss << multi_progress_bar;
@@ -333,6 +341,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages_with_tot
         "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
         "----------------------------------------------------------------------\n"
         "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????\n"
+        "\n"
         "\n";
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
@@ -411,6 +420,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages() {
     download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
     download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
     download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test こんにちは世界！");
 
     std::ostringstream oss;
     oss << multi_progress_bar;
@@ -418,10 +428,12 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages() {
         "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
         "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
         ">>> test message1                                                     \n"
-        ">>> test message2                                                     ";
+        ">>> test message2                                                     \n"
+        ">>> test こんにちは世界！                                             ";
 
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
+    download_progress_bar2_raw->pop_message();
     download_progress_bar2_raw->pop_message();
     download_progress_bar2_raw->pop_message();
     oss << multi_progress_bar;
@@ -429,6 +441,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages() {
     expected =
         "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
         "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "\n"
         "\n";
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
@@ -441,6 +454,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages() {
     expected =
         "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
         "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "\n"
         "\n";
 
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));

--- a/test/libdnf5-cli/test_progressbar_interactive.hpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.hpp
@@ -34,6 +34,7 @@ class ProgressbarInteractiveTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_multi_progress_bar_with_messages_with_total);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages_with_total);
     CPPUNIT_TEST(test_multi_progress_bar_with_messages);
+    CPPUNIT_TEST(test_multi_progress_bar_with_short_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages);
 
     CPPUNIT_TEST_SUITE_END();
@@ -49,6 +50,7 @@ public:
     void test_multi_progress_bar_with_messages_with_total();
     void test_multi_progress_bars_with_messages_with_total();
     void test_multi_progress_bar_with_messages();
+    void test_multi_progress_bar_with_short_messages();
     void test_multi_progress_bars_with_messages();
 };
 


### PR DESCRIPTION
Add padding to fully fill the terminal_width, this is because `MultiProgressBar` overrides its own messages, it doesn't clear the lines. If the message is short some leftover characters could be still present after it.

The combination of adding/removing scriptlet messages and just overwriting `MultiProgressBar` lines is making this quite complicated.

Another approach to fix the issues could be reverting https://github.com/rpm-software-management/dnf5/commit/8fbbeb20f517f6bb160c0bc6592e3725f041d2c7 it would make our code simpler but I think this should still be more efficient though I have not tested it.

Follow up for: https://github.com/rpm-software-management/dnf5/pull/1925