### PR TITLE
SWIG bindings: Support DownloadCallbacks `user_data`, unit tests

### DIFF
--- a/test/dnf5-plugins/copr_plugin/CoprRepoTest.cpp
+++ b/test/dnf5-plugins/copr_plugin/CoprRepoTest.cpp
@@ -71,7 +71,7 @@ std::string repo_to_string(const dnf5::CoprRepo & repo) {
 }
 
 void CoprRepoTest::prepare_env() {
-    installroot = temp->get_path() / "installroot";
+    installroot = temp_dir->get_path() / "installroot";
     std::filesystem::create_directory(installroot);
     confdir = installroot / "etc";
     std::filesystem::create_directory(confdir);

--- a/test/libdnf5/comps/test_group.cpp
+++ b/test/libdnf5/comps/test_group.cpp
@@ -278,7 +278,7 @@ void CompsGroupTest::test_serialize() {
     q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
 
-    auto serialize_path = temp->get_path() / "serialized-standard.xml";
+    auto serialize_path = temp_dir->get_path() / "serialized-standard.xml";
     standard.serialize(serialize_path);
 
     std::string actual = libdnf5::utils::fs::File(serialize_path, "r").read();

--- a/test/libdnf5/repo/test_file_downloader.cpp
+++ b/test/libdnf5/repo/test_file_downloader.cpp
@@ -1,0 +1,117 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_file_downloader.hpp"
+
+#include "utils/string.hpp"
+
+#include <libdnf5/repo/file_downloader.hpp>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FileDownloaderTest);
+
+namespace {
+
+class DownloadCallbacks : public libdnf5::repo::DownloadCallbacks {
+public:
+    void * add_new_download(
+        [[maybe_unused]] void * user_data,
+        [[maybe_unused]] const char * description,
+        [[maybe_unused]] double total_to_download) override {
+        ++add_new_download_cnt;
+        this->user_data = user_data;
+        user_cb_data_holder = "User cb data";
+        return &user_cb_data_holder;
+    }
+
+    int end([[maybe_unused]] void * user_cb_data, TransferStatus status, const char * msg) override {
+        ++end_cnt;
+        end_user_cb_data = static_cast<std::string *>(user_cb_data);
+        end_status = status;
+        end_msg = libdnf5::utils::string::c_to_str(msg);
+        return 0;
+    }
+
+    int progress(
+        [[maybe_unused]] void * user_cb_data,
+        [[maybe_unused]] double total_to_download,
+        [[maybe_unused]] double downloaded) override {
+        ++progress_cnt;
+        return 0;
+    }
+
+    int mirror_failure(
+        [[maybe_unused]] void * user_cb_data,
+        [[maybe_unused]] const char * msg,
+        [[maybe_unused]] const char * url,
+        [[maybe_unused]] const char * metadata) override {
+        ++mirror_failure_cnt;
+        return 0;
+    }
+
+    int add_new_download_cnt = 0;
+    int progress_cnt = 0;
+    int mirror_failure_cnt = 0;
+    int end_cnt = 0;
+
+    void * user_data = nullptr;
+    std::string user_cb_data_holder;
+    std::string * end_user_cb_data = nullptr;
+
+    TransferStatus end_status;
+    std::string end_msg;
+};
+
+}  // namespace
+
+
+void FileDownloaderTest::test_file_downloader() {
+    std::string user_data = "User data";
+
+    std::string source_file_path = std::string(PROJECT_SOURCE_DIR) + "/test/data/keys/key.pub";
+    std::string source_url = "file://" + source_file_path;
+    auto dest_file_path = temp_dir->get_path() / "file_downloader.pub";
+
+    auto cbs_unique_ptr = std::make_unique<DownloadCallbacks>();
+    auto cbs = cbs_unique_ptr.get();
+    base.set_download_callbacks(std::move(cbs_unique_ptr));
+
+    libdnf5::repo::FileDownloader file_downloader(base);
+    file_downloader.add(source_url, dest_file_path, &user_data);
+    file_downloader.download();
+
+    CPPUNIT_ASSERT_EQUAL(&user_data, static_cast<std::string *>(cbs->user_data));
+    CPPUNIT_ASSERT_EQUAL(std::string("User cb data"), cbs->end_user_cb_data ? *cbs->end_user_cb_data : "");
+
+    CPPUNIT_ASSERT_EQUAL(1, cbs->add_new_download_cnt);
+    CPPUNIT_ASSERT_EQUAL(1, cbs->end_cnt);
+    CPPUNIT_ASSERT_GREATEREQUAL(1, cbs->progress_cnt);
+    CPPUNIT_ASSERT_EQUAL(0, cbs->mirror_failure_cnt);
+
+    CPPUNIT_ASSERT_EQUAL(DownloadCallbacks::TransferStatus::SUCCESSFUL, cbs->end_status);
+    CPPUNIT_ASSERT_EQUAL(std::string(), cbs->end_msg);
+
+    // Check contents of downloaded file
+    libdnf5::utils::fs::File source_file;
+    source_file.open(source_file_path, "r");
+    std::string source_file_content = source_file.read();
+    libdnf5::utils::fs::File dest_file;
+    dest_file.open(dest_file_path, "r");
+    std::string dest_file_content = dest_file.read();
+    CPPUNIT_ASSERT_EQUAL(source_file_content, dest_file_content);
+}

--- a/test/libdnf5/repo/test_file_downloader.hpp
+++ b/test/libdnf5/repo/test_file_downloader.hpp
@@ -1,0 +1,37 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TEST_REPO_FILE_DOWNLOADER_HPP
+#define LIBDNF5_TEST_REPO_FILE_DOWNLOADER_HPP
+
+#include "../shared/base_test_case.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class FileDownloaderTest : public BaseTestCase {
+    CPPUNIT_TEST_SUITE(FileDownloaderTest);
+    CPPUNIT_TEST(test_file_downloader);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_file_downloader();
+};
+
+#endif

--- a/test/libdnf5/repo/test_temp_files_memory.cpp
+++ b/test/libdnf5/repo/test_temp_files_memory.cpp
@@ -33,7 +33,7 @@ using namespace libdnf5::repo;
 
 void TempFilesMemoryTest::setUp() {
     BaseTestCase::setUp();
-    parent_dir_path = temp->get_path();
+    parent_dir_path = temp_dir->get_path();
     full_path = parent_dir_path / TempFilesMemory::MEMORY_FILENAME;
 }
 

--- a/test/libdnf5/rpm/test_transaction.cpp
+++ b/test/libdnf5/rpm/test_transaction.cpp
@@ -39,6 +39,8 @@ using namespace libdnf5::rpm;
 using namespace libdnf5::transaction;
 
 
+namespace {
+
 class PackageDownloadCallbacks : public libdnf5::repo::DownloadCallbacks {
 public:
     int end(
@@ -75,6 +77,8 @@ public:
     int progress_cnt{0};
     int mirror_failure_cnt{0};
 };
+
+}  // namespace
 
 
 void RpmTransactionTest::test_transaction() {

--- a/test/perl5/libdnf5/BaseTestCase.pm
+++ b/test/perl5/libdnf5/BaseTestCase.pm
@@ -36,11 +36,11 @@ sub new {
 
     $self->{base} = new libdnf5::base::Base();
 
-    $self->{tmpdir} = tempdir("libdnf5_perl5_unittest.XXXX", TMPDIR => 1, CLEANUP => 1);
+    $self->{temp_dir} = tempdir("libdnf5_perl5_unittest.XXXX", TMPDIR => 1, CLEANUP => 1);
 
     my $config = $self->{base}->get_config();
-    $config->get_installroot_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{tmpdir}."/installroot");
-    $config->get_cachedir_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{tmpdir}."/cache");
+    $config->get_installroot_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{temp_dir}."/installroot");
+    $config->get_cachedir_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $self->{temp_dir}."/cache");
     $config->get_optional_metadata_types_option()->set($libdnf5::conf::Option::Priority_RUNTIME, $libdnf5::conf::OPTIONAL_METADATA_TYPES);
 
     # Prevent loading plugins from host

--- a/test/perl5/libdnf5/BaseTestCase.pm
+++ b/test/perl5/libdnf5/BaseTestCase.pm
@@ -27,8 +27,8 @@ use libdnf5::base;
 use libdnf5::repo;
 
 
-my $PROJECT_BINARY_DIR = $ENV{"PROJECT_BINARY_DIR"};
-my $PROJECT_SOURCE_DIR = $ENV{"PROJECT_SOURCE_DIR"};
+our $PROJECT_BINARY_DIR = $ENV{"PROJECT_BINARY_DIR"};
+our $PROJECT_SOURCE_DIR = $ENV{"PROJECT_SOURCE_DIR"};
 
 sub new {
     my $class = shift;

--- a/test/perl5/libdnf5/repo/test_file_downloader.t
+++ b/test/perl5/libdnf5/repo/test_file_downloader.t
@@ -1,0 +1,104 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use File::Spec::Functions 'catfile';
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/..";
+use BaseTestCase;
+
+my $USER_DATA = 25;
+
+{
+    package DownloadCallbacks;
+    use base qw(libdnf5::repo::DownloadCallbacks);
+
+    my $USER_CB_DATA = 5;
+
+    sub new {
+        my $class = shift;
+        my $self = $class->SUPER::new(@_);
+        $self->{start_cnt} = 0;
+        $self->{progress_cnt} = 0;
+        $self->{mirror_failure_cnt} = 0;
+        $self->{end_cnt} = 0;
+        $self->{end_status} = undef;
+        $self->{end_msg} = undef;
+        return bless($self, $class);
+    }
+
+    sub add_new_download {
+        my ($self, $user_data, $description, $total_to_download) = @_;
+        $self->{start_cnt}++;
+        ::is($user_data, $USER_DATA);
+        return $USER_CB_DATA;
+    }
+
+    sub end {
+        my ($self, $user_cb_data, $status, $msg) = @_;
+        $self->{end_cnt}++;
+        ::is($user_cb_data, $USER_CB_DATA);
+        $self->{end_status} = $status;
+        $self->{end_msg} = $msg;
+        return 0;
+    }
+
+    sub progress {
+        my ($self, $user_cb_data, $total_to_download, $downloaded) = @_;
+        $self->{progress_cnt}++;
+        ::is($user_cb_data, $USER_CB_DATA);
+        return 0;
+    }
+
+    sub mirror_failure {
+        my ($self, $user_cb_data, $msg, $url, $metadata) = @_;
+        $self->{mirror_failure_cnt}++;
+        ::is($user_cb_data, $USER_CB_DATA);
+        return 0;
+    }
+}
+
+# test_file_downloader
+{
+    my $test = new BaseTestCase();
+
+    my $source_file_path = catfile($BaseTestCase::PROJECT_SOURCE_DIR, "test/data/keys/key.pub");
+    my $source_url = "file://" . $source_file_path;
+    my $dest_file_path = catfile($test->{temp_dir}, "file_downloader.pub");
+
+    my $dl_cbs = new DownloadCallbacks();
+    $test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($dl_cbs));
+    $dl_cbs = $test->{base}->get_download_callbacks();
+
+    my $file_downloader = new libdnf5::repo::FileDownloader($test->{base});
+    $file_downloader->add($source_url, $dest_file_path, $USER_DATA);
+    $file_downloader->download();
+
+    is($dl_cbs->{start_cnt}, 1);
+    ok($dl_cbs->{progress_cnt} >= 1);
+    is($dl_cbs->{mirror_failure_cnt}, 0);
+    is($dl_cbs->{end_cnt}, 1);
+
+    is($dl_cbs->{end_status}, $libdnf5::repo::DownloadCallbacks::TransferStatus_SUCCESSFUL);
+    is($dl_cbs->{end_msg}, undef);
+}
+
+done_testing();

--- a/test/perl5/libdnf5/repo/test_package_downloader.t
+++ b/test/perl5/libdnf5/repo/test_package_downloader.t
@@ -36,6 +36,7 @@ use BaseTestCase;
         $self->{progress_cnt} = 0;
         $self->{mirror_failure_cnt} = 0;
         $self->{end_cnt} = 0;
+        $self->{user_data_array} = [];
         $self->{user_cb_data_array} = [];
         $self->{end_status} = [];
         $self->{end_msg} = [];
@@ -45,6 +46,7 @@ use BaseTestCase;
     sub add_new_download {
         my ($self, $user_data, $description, $total_to_download) = @_;
         $self->{start_cnt}++;
+        push(@{$self->{user_data_array}}, $user_data);
         my $user_cb_data = "Package: " . $description;
         push(@{$self->{user_cb_data_container}}, $user_cb_data);
         return scalar @{$self->{user_cb_data_container}} - 1;
@@ -89,10 +91,12 @@ my $downloader = new libdnf5::repo::PackageDownloader($test->{base});
 my $cbs = new PackageDownloadCallbacks();
 $test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($cbs));
 
+my $user_data = 2;
 my $it = $query->begin();
 my $e = $query->end();
 while ($it != $e) {
-    $downloader->add($it->value());
+    $downloader->add($it->value(), $user_data);
+    $user_data *= 5;
     $it->next();
 }
 $downloader->download();
@@ -105,6 +109,8 @@ is($cbs->{start_cnt}, 2, "start_cnt");
 is($cbs->{end_cnt}, 2, "end_cnt");
 ok($cbs->{progress_cnt} >= 2, "progress_cnt");
 is($cbs->{mirror_failure_cnt}, 0, "mirror_failure_cnt");
+
+is_deeply($cbs->{user_data_array}, [2, 10], "user_data_array");
 
 is_deeply($cbs->{user_cb_data_array}, [0, 1], "user_cb_data_array");
 is_deeply($cbs->{end_status}, [$libdnf5::repo::DownloadCallbacks::TransferStatus_SUCCESSFUL,  $libdnf5::repo::DownloadCallbacks::TransferStatus_SUCCESSFUL]);

--- a/test/perl5/libdnf5/repo/test_repo.t
+++ b/test/perl5/libdnf5/repo/test_repo.t
@@ -31,11 +31,20 @@ use BaseTestCase;
     sub new {
         my $class = shift;
         my $self = $class->SUPER::new(@_);
+        $self->{last_user_data} = undef;
+        $self->{start_cnt} = 0;
         $self->{end_cnt} = 0;
         $self->{end_error_message} = undef;
         $self->{fastest_mirror_cnt} = 0;
         $self->{handle_mirror_failure_cnt} = 0;
         return bless($self, $class);
+    }
+
+    sub add_new_download {
+        my ($self, $user_data, $description, $total_to_download) = @_;
+        $self->{start_cnt}++;
+        $self->{last_user_data} = $user_data;
+        return 0;
     }
 
     sub end {
@@ -82,6 +91,10 @@ use BaseTestCase;
     my $repoid = "repomd-repo1";
     my $repo = $test->add_repo_repomd($repoid, 0);
 
+    my $USER_DATA = 25;
+    $repo->set_user_data($USER_DATA);
+    is($repo->get_user_data(), $USER_DATA);
+
     my $dl_cbs = new DownloadCallbacks();
     $test->{base}->set_download_callbacks(new libdnf5::repo::DownloadCallbacksUniquePtr($dl_cbs));
     $dl_cbs = $test->{base}->get_download_callbacks();
@@ -91,6 +104,9 @@ use BaseTestCase;
 
     $test->{repo_sack}->load_repos($libdnf5::repo::Repo::Type_AVAILABLE);
 
+    is($dl_cbs->{last_user_data}, $USER_DATA);
+
+    is($dl_cbs->{start_cnt}, 1);
     is($dl_cbs->{end_cnt}, 1);
     is($dl_cbs->{end_error_message}, undef);
 

--- a/test/python3/libdnf5/repo/test_file_downloader.py
+++ b/test/python3/libdnf5/repo/test_file_downloader.py
@@ -1,0 +1,88 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import libdnf5.base
+
+import base_test_case
+
+
+class TestFileDownloader(base_test_case.BaseTestCase):
+    USER_DATA = 25
+
+    def test_package_downloader(self):
+        class DownloadCallbacks(libdnf5.repo.DownloadCallbacks):
+            USER_CB_DATA = 5
+            test_instance = None
+
+            def __init__(self):
+                super(DownloadCallbacks, self).__init__()
+                self.start_cnt = 0
+                self.progress_cnt = 0
+                self.mirror_failure_cnt = 0
+                self.end_cnt = 0
+                self.end_status = None
+                self.end_msg = None
+
+            def add_new_download(self, user_data, description, total_to_download):
+                self.start_cnt += 1
+                self.test_instance.assertEqual(
+                    user_data, self.test_instance.USER_DATA)
+                return self.USER_CB_DATA
+
+            def end(self, user_cb_data, status, msg):
+                self.end_cnt += 1
+                self.test_instance.assertEqual(user_cb_data, self.USER_CB_DATA)
+                self.end_status = status
+                self.end_msg = msg
+                return 0
+
+            def progress(self, user_cb_data, total_to_download, downloaded):
+                self.progress_cnt += 1
+                self.test_instance.assertEqual(user_cb_data, self.USER_CB_DATA)
+                return 0
+
+            def mirror_failure(self, user_cb_data, msg, url):
+                self.mirror_failure_cnt += 1
+                self.test_instance.assertEqual(user_cb_data, self.USER_CB_DATA)
+                return 0
+
+        DownloadCallbacks.test_instance = self
+
+        source_file_path = os.path.join(
+            base_test_case.PROJECT_SOURCE_DIR, "test/data/keys/key.pub")
+        source_url = "file://" + source_file_path
+        dest_file_path = os.path.join(self.temp_dir, "file_downloader.pub")
+
+        cbs = DownloadCallbacks()
+        self.base.set_download_callbacks(
+            libdnf5.repo.DownloadCallbacksUniquePtr(cbs))
+
+        file_downloader = libdnf5.repo.FileDownloader(self.base)
+        file_downloader.add(source_url, dest_file_path, self.USER_DATA)
+        file_downloader.download()
+
+        self.assertEqual(cbs.start_cnt, 1)
+        self.assertGreaterEqual(cbs.progress_cnt, 1)
+        self.assertEqual(cbs.mirror_failure_cnt, 0)
+        self.assertEqual(cbs.end_cnt, 1)
+
+        self.assertEqual(
+            cbs.end_status, DownloadCallbacks.TransferStatus_SUCCESSFUL)
+        self.assertEqual(cbs.end_msg, None)

--- a/test/python3/libdnf5/repo/test_package_downloader.py
+++ b/test/python3/libdnf5/repo/test_package_downloader.py
@@ -35,12 +35,14 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
                 self.progress_cnt = 0
                 self.mirror_failure_cnt = 0
                 self.end_cnt = 0
+                self.user_data_array = []
                 self.user_cb_data_array = []
                 self.end_status = []
                 self.end_msg = []
 
             def add_new_download(self, user_data, description, total_to_download):
                 self.start_cnt += 1
+                self.user_data_array.append(user_data)
                 user_cb_data_reference = "Package: " + description
                 self.user_cb_data_container.append(user_cb_data_reference)
                 return len(self.user_cb_data_container) - 1
@@ -78,8 +80,10 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
         self.base.set_download_callbacks(
             libdnf5.repo.DownloadCallbacksUniquePtr(cbs))
 
+        user_data = 2
         for package in query:
-            downloader.add(package)
+            downloader.add(package, user_data)
+            user_data *= 5
 
         downloader.download()
 
@@ -95,6 +99,8 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
         self.assertGreaterEqual(cbs.progress_cnt, 2)
         self.assertEqual(cbs.mirror_failure_cnt, 0)
         self.assertEqual(cbs.end_cnt, 2)
+
+        self.assertEqual(cbs.user_data_array, [2, 10])
 
         cbs.user_cb_data_array.sort()
         self.assertEqual(cbs.user_cb_data_array, [0, 1])

--- a/test/ruby/libdnf5/repo/test_file_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_file_downloader.rb
@@ -1,0 +1,93 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+require 'test/unit'
+include Test::Unit::Assertions
+
+require 'libdnf5/base'
+require 'libdnf5/repo'
+
+require 'base_test_case'
+
+
+class TestFileDownloader < BaseTestCase
+    USER_DATA = 25
+
+    class DownloadCallbacks < Repo::DownloadCallbacks
+        attr_accessor :start_cnt, :progress_cnt, :mirror_failure_cnt, :end_cnt
+        attr_accessor :end_status, :end_msg
+
+        USER_CB_DATA = 5
+
+        def initialize()
+            super()
+            @start_cnt = 0
+            @progress_cnt = 0
+            @mirror_failure_cnt = 0
+            @end_cnt = 0
+            @end_status = nil
+            @end_msg = nil
+        end
+
+        def add_new_download(user_data, description, total_to_download)
+            @start_cnt += 1
+            assert_equal(USER_DATA, user_data)
+            return USER_CB_DATA
+        end
+
+        def end(user_cb_data, status, msg)
+            @end_cnt += 1
+            assert_equal(USER_CB_DATA, user_cb_data)
+            @end_status = status
+            @end_msg = msg
+            return 0
+        end
+
+        def progress(user_cb_data, total_to_download, downloaded)
+            @progress_cnt += 1
+            assert_equal(USER_CB_DATA, user_cb_data)
+            return 0
+        end
+
+        def mirror_failure(user_cb_data, msg, url, metadata)
+            @mirror_failure_cnt += 1
+            assert_equal(USER_CB_DATA, user_cb_data)
+            return 0
+        end
+    end
+
+    def test_file_downloader()
+        source_file_path = File.join(PROJECT_SOURCE_DIR, "test/data/keys/key.pub")
+        source_url = "file://" + source_file_path
+        dest_file_path = File.join(@temp_dir, "file_downloader.pub")
+
+        dl_cbs = DownloadCallbacks.new()
+        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
+
+        file_downloader = Repo::FileDownloader.new(@base)
+        file_downloader.add(source_url, dest_file_path, USER_DATA)
+        file_downloader.download()
+
+        assert_equal(1, dl_cbs.start_cnt)
+        assert_operator(1, :<=, dl_cbs.progress_cnt)
+        assert_equal(0, dl_cbs.mirror_failure_cnt)
+        assert_equal(1, dl_cbs.end_cnt)
+
+        assert_equal(DownloadCallbacks::TransferStatus_SUCCESSFUL, dl_cbs.end_status)
+        assert_equal(nil, dl_cbs.end_msg)
+    end
+end

--- a/test/ruby/libdnf5/repo/test_repo.rb
+++ b/test/ruby/libdnf5/repo/test_repo.rb
@@ -25,18 +25,28 @@ require 'base_test_case'
 
 
 class TestRepo < BaseTestCase
+    USER_DATA = 25
+
     class DownloadCallbacks < Repo::DownloadCallbacks
-        attr_accessor :start_cnt, :start_what
+        attr_accessor :start_cnt, :last_user_data
         attr_accessor :end_cnt, :end_error_message
         attr_accessor :progress_cnt, :fastest_mirror_cnt, :handle_mirror_failure_cnt
 
         def initialize()
             super()
+            @last_user_data = nil
+            @start_cnt = 0
             @end_cnt = 0
             @end_error_message = nil
             @progress_cnt = 0
             @fastest_mirror_cnt = 0
             @handle_mirror_failure_cnt = 0
+        end
+
+        def add_new_download(user_data, description, total_to_download)
+            @start_cnt += 1
+            @last_user_data = user_data
+            return 0
         end
 
         def end(user_cb_data, status, error_message)
@@ -74,6 +84,9 @@ class TestRepo < BaseTestCase
         repoid = "repomd-repo1"
         repo = add_repo_repomd(repoid, load=false)
 
+        repo.set_user_data(USER_DATA)
+        assert_equal(USER_DATA, repo.get_user_data())
+
         dl_cbs = DownloadCallbacks.new()
         @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
 
@@ -82,6 +95,9 @@ class TestRepo < BaseTestCase
 
         @repo_sack.load_repos(Repo::Repo::Type_AVAILABLE)
 
+        assert_equal(USER_DATA, dl_cbs.last_user_data)
+
+        assert_equal(1, dl_cbs.start_cnt)
         assert_equal(1, dl_cbs.end_cnt)
         assert_equal(nil, dl_cbs.end_error_message)
 

--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -224,11 +224,11 @@ void BaseTestCase::setUp() {
 
     // TODO we could use get_preconfigured_base() for this now, but that would
     // need changing the `base` member to a unique_ptr
-    temp = std::make_unique<libdnf5::utils::fs::TempDir>("libdnf5_unittest");
-    std::filesystem::create_directory(temp->get_path() / "installroot");
+    temp_dir = std::make_unique<libdnf5::utils::fs::TempDir>("libdnf5_unittest");
+    std::filesystem::create_directory(temp_dir->get_path() / "installroot");
 
-    base.get_config().get_installroot_option().set(temp->get_path() / "installroot");
-    base.get_config().get_cachedir_option().set(temp->get_path() / "cache");
+    base.get_config().get_installroot_option().set(temp_dir->get_path() / "installroot");
+    base.get_config().get_cachedir_option().set(temp_dir->get_path() / "cache");
     base.get_config().get_optional_metadata_types_option().set(libdnf5::OPTIONAL_METADATA_TYPES);
 
     // Prevent loading libdnf5 plugins

--- a/test/shared/test_case_fixture.cpp
+++ b/test/shared/test_case_fixture.cpp
@@ -79,12 +79,12 @@ void TestCaseFixture::tearDown() {
 }
 
 std::unique_ptr<libdnf5::Base> TestCaseFixture::get_preconfigured_base() {
-    temp = std::make_unique<libdnf5::utils::fs::TempDir>("libdnf5_unittest");
-    std::filesystem::create_directory(temp->get_path() / "installroot");
+    temp_dir = std::make_unique<libdnf5::utils::fs::TempDir>("libdnf5_unittest");
+    std::filesystem::create_directory(temp_dir->get_path() / "installroot");
 
     std::unique_ptr<libdnf5::Base> base(new libdnf5::Base());
-    base->get_config().get_installroot_option().set(temp->get_path() / "installroot");
-    base->get_config().get_cachedir_option().set(temp->get_path() / "cache");
+    base->get_config().get_installroot_option().set(temp_dir->get_path() / "installroot");
+    base->get_config().get_cachedir_option().set(temp_dir->get_path() / "cache");
 
     // Prevent loading libdnf5 plugins
     base->get_config().get_plugins_option().set(false);

--- a/test/shared/test_case_fixture.hpp
+++ b/test/shared/test_case_fixture.hpp
@@ -35,7 +35,7 @@ public:
     std::unique_ptr<libdnf5::Base> get_preconfigured_base();
 
     // Only gets created if get_preconfigured_base() is called
-    std::unique_ptr<libdnf5::utils::fs::TempDir> temp;
+    std::unique_ptr<libdnf5::utils::fs::TempDir> temp_dir;
 };
 
 


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1943

Adds support for the `user_data` argument to the `repo::DownloadCallbacks::add_new_download` method.

Its value can be set for different downloaders:

`repo::FileDownloader`: `user_data` can be passed as a parameter to the `add` method for the file being added.
`repo::PackageDownloader`: `user_data` can be passed as a parameter to the `add` method for the package being added.

The `repo::Repo::set_user_data` and `repo::Repo::get_user_data` methods to set/get `user_data` for each repository - used when downloading repository metadata.

Unit tests for all supported languages included.