### PR TITLE
Fix python RPM provides

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -511,8 +511,8 @@ Perl 5 bindings for the libdnf5-cli library.
 
 %if %{with python3}
 %package -n python3-libdnf5
-%{?python_provide:%python_provide python3-libdnf}
-Summary:        Python 3 bindings for the libdnf library
+%{?python_provide:%python_provide python3-libdnf5}
+Summary:        Python 3 bindings for the libdnf5 library
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -511,7 +511,6 @@ Perl 5 bindings for the libdnf5-cli library.
 
 %if %{with python3}
 %package -n python3-libdnf5
-%{?python_provide:%python_provide python3-libdnf5}
 Summary:        Python 3 bindings for the libdnf5 library
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
@@ -531,7 +530,6 @@ Python 3 bindings for the libdnf library.
 
 %if %{with python3} && %{with libdnf_cli}
 %package -n python3-libdnf5-cli
-%{?python_provide:%python_provide python3-libdnf5-cli}
 Summary:        Python 3 bindings for the libdnf5-cli library
 License:        LGPL-2.1-or-later
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}


### PR DESCRIPTION
This fixes a wrong RPM provide ("python3-libdnf" provided by "python3-libdnf5"; watch the digit) and removes unnecessary explicit provides which are already implicit by a package name.

Forwarded from <https://src.fedoraproject.org/rpms/dnf5/pull-request/91> downstream.