### PR TITLE
Fix plural typo

### DIFF
--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -149,7 +149,7 @@ public:
         if (replaced != 0) {
             std::fputs(
                 libdnf5::utils::sformat(
-                    P_(" Replacing:       {:4} package\n", " Replacing:       {:4} package\n", replaced), replaced)
+                    P_(" Replacing:       {:4} package\n", " Replacing:       {:4} packages\n", replaced), replaced)
                     .c_str(),
                 fd);
         }


### PR DESCRIPTION
`Replacing:       {:4} package` -> `Replacing:       {:4} packages`