### PR TITLE
Unit tests: Fix problematic nasty hack in run_tests

### DIFF
--- a/test/shared/base_test_case.cpp
+++ b/test/shared/base_test_case.cpp
@@ -21,7 +21,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "base_test_case.hpp"
 
 #include "base/base_impl.hpp"
+#include "logger_redirector.hpp"
 #include "private_accessor.hpp"
+#include "test_logger.hpp"
 #include "utils.hpp"
 #include "utils/string.hpp"
 
@@ -221,6 +223,8 @@ libdnf5::rpm::Package BaseTestCase::first_query_pkg(libdnf5::rpm::PackageQuery &
 
 void BaseTestCase::setUp() {
     TestCaseFixture::setUp();
+
+    base.get_logger()->add_logger(std::make_unique<LoggerRedirector>(test_logger));
 
     // TODO we could use get_preconfigured_base() for this now, but that would
     // need changing the `base` member to a unique_ptr

--- a/test/shared/logger_redirector.hpp
+++ b/test/shared/logger_redirector.hpp
@@ -1,0 +1,43 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF5_LOGGER_REDIRECTOR_HPP
+#define TEST_LIBDNF5_LOGGER_REDIRECTOR_HPP
+
+#include <libdnf5/logger/logger.hpp>
+
+// LoggerRedirector is used in tests to route logging from libdnf5::Base to the global logger.
+class LoggerRedirector : public libdnf5::Logger {
+public:
+    LoggerRedirector(libdnf5::Logger & target_logger) : target_logger{target_logger} {}
+
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept override {
+        target_logger.write(time, pid, level, message);
+    }
+
+private:
+    libdnf5::Logger & target_logger;
+};
+
+#endif  // TEST_LIBDNF5_LOGGER_REDIRECTOR_HPP

--- a/test/shared/test_logger.cpp
+++ b/test/shared/test_logger.cpp
@@ -1,0 +1,23 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_logger.hpp"
+
+libdnf5::MemoryBufferLogger test_logger(10000, 256);

--- a/test/shared/test_logger.hpp
+++ b/test/shared/test_logger.hpp
@@ -1,0 +1,30 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF5_TEST_LOGGER_HPP
+#define TEST_LIBDNF5_TEST_LOGGER_HPP
+
+#include <libdnf5/logger/memory_buffer_logger.hpp>
+
+// Global logger used in many tests.
+// Logging from libdnf5::Base is routed to it using LoggerRedirector.
+extern libdnf5::MemoryBufferLogger test_logger;
+
+#endif  // TEST_LIBDNF5_TEST_LOGGER_HPP


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1947

I found a nasty hack in the code. A pointer to the `CPPUnit::TestCaller` class was cast to a pointer to `HackTestCaller` using `reinterpret_cast`. The hack was used to make private members accessible in the original class for `LogCaptureListener`.
Additionally, `BaseTestCase` has been modified in the `LogCaptureListener` class.

The code has been rewritten to not need this hack. And the `BaseTestCase` modification was moved to
the `BaseTestCase::setUp` method.

Solves:
```
    Start  1: test_libdnf
1/3 Test  #1: test_libdnf ......................***Failed    4.64 sec
/dnf5/test/libdnf5/run_tests.cpp:69:53: runtime error: member access
 within address 0x50800001a7a0 which does not point to an object of type 'HackTestCaller'
0x50800001a7a0: note: object is of type 'CppUnit::TestCaller<AdvisoryAdvisoryModuleTest>'
 00 00 00 00  a0 7d c1 01 00 00 00 00  30 7e c1 01 00 00 00 00  90 c3 01 00 40 50 00 00  29 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'CppUnit::TestCaller<AdvisoryAdvisoryModuleTest>'
```
```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 2 object(s) allocated from:
    #0 0x7f19b32c17d8 in realloc.part.0 (/lib64/libasan.so.8+0xc17d8)
     (BuildId: 5294bd2731fcae07af92dfea7808576c57d53bc9)
    #1 0x7f19b261e242 in d_growable_string_callback_adapter
     (/lib64/libstdc++.so.6+0x1e242)

SUMMARY: AddressSanitizer: 128 byte(s) leaked in 2 allocation(s).
```