### PR TITLE
Own /var/lib/dnf by libdnf5

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -393,6 +393,7 @@ Package management library.
 %{_libdir}/libdnf5.so.2*
 %license lgpl-2.1.txt
 %ghost %attr(0755, root, root) %dir %{_var}/cache/libdnf5
+%ghost %attr(0755, root, root) %dir %{_sharedstatedir}/dnf
 
 # ========== libdnf5-cli ==========
 


### PR DESCRIPTION
DNF5 uses that directory at least for storing countme cookies.

This patch does not install that directory because /var is effemeral on bootc systems (see commit
5cc72c6c490c82604d83fc8d8ec262d854617d2d).

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2332856
Related: #1968