### PR TITLE
Add --json output to advisory info

### DIFF
--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -61,12 +61,22 @@ void AdvisoryInfoCommand::process_and_print_queries(
         advisories.filter_packages(installed_packages, libdnf5::sack::QueryCmp::GT);
     }
 
-    for (auto advisory : advisories) {
-        libdnf5::cli::output::AdvisoryInfo advisory_info;
-        output::AdvisoryAdapter cli_advisory(advisory);
-        advisory_info.add_advisory(cli_advisory);
+    if (ctx.get_json_output_requested()) {
+        libdnf5::cli::output::AdvisoryInfoJSON advisory_info;
+        for (auto advisory : advisories) {
+            output::AdvisoryAdapter cli_advisory(advisory);
+            advisory_info.add_advisory(cli_advisory);
+        }
         advisory_info.print();
         std::cout << std::endl;
+    } else {
+        for (auto advisory : advisories) {
+            libdnf5::cli::output::AdvisoryInfo advisory_info;
+            output::AdvisoryAdapter cli_advisory(advisory);
+            advisory_info.add_advisory(cli_advisory);
+            advisory_info.print();
+            std::cout << std::endl;
+        }
     }
 }
 

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_subcommand.hpp"
 
+#include <dnf5/shared_options.hpp>
+
 namespace dnf5 {
 
 class AdvisoryInfoCommand : public AdvisorySubCommand {
@@ -31,6 +33,7 @@ public:
     void set_argument_parser() override {
         AdvisorySubCommand::set_argument_parser();
         get_argument_parser_command()->set_description(_("Print details about advisories"));
+        create_json_option(*this);
     }
 
 protected:

--- a/include/libdnf5-cli/output/advisoryinfo.hpp
+++ b/include/libdnf5-cli/output/advisoryinfo.hpp
@@ -40,6 +40,19 @@ private:
     std::unique_ptr<Impl> p_impl;
 };
 
+class LIBDNF_CLI_API AdvisoryInfoJSON {
+public:
+    AdvisoryInfoJSON();
+    ~AdvisoryInfoJSON();
+
+    void add_advisory(IAdvisory & advisory);
+    void print();
+
+private:
+    class LIBDNF_CLI_LOCAL Impl;
+    std::unique_ptr<Impl> p_impl;
+};
+
 }  // namespace libdnf5::cli::output
 
 #endif  // LIBDNF5_CLI_OUTPUT_ADVISORYLIST_HPP


### PR DESCRIPTION
Enable --json for 'dnf advisory info'. The same information as would be displayed as text is included in the JSON output. While the libscols code could be adapted to produce JSON as well, without serious reworking of key_value_table (and all callers), the produced JSON is quite weird, so we instead choose to implement the JSON output separately.

Example output from `dnf5  advisory info --json FEDORA-2024-1ec4cd5fd3`:

```
{
  "FEDORA-2024-1ec4cd5fd3":{
    "Name":"FEDORA-2024-1ec4cd5fd3",
    "Title":"libtirpc-1.3.6-1.fc41",
    "Severity":"None",
    "Type":"unspecified",
    "Status":"stable",
    "Vendor":"updates@fedoraproject.org",
    "Issued":"2024-11-16 02:13:46",
    "Description":"    - Fix regression in NVR\n    - Removed libtirpc-1-3-7-rc1 patch (bz 2325556)\n",
    "Message":"",
    "Rights":"Copyright (C) 2024 Red Hat, Inc. and others.",
    "references":[
      {
        "Title":"[nfs-utils] nfs-server restart times out",
        "Id":"2325556",
        "Type":"bugzilla",
        "Url":"https:\/\/bugzilla.redhat.com\/show_bug.cgi?id=2325556"
      }
    ],
    "collections":{
      "packages":[
        "libtirpc-1.3.6-1.fc41.src",
        "libtirpc-debuginfo-1.3.6-1.fc41.i686",
        "libtirpc-1.3.6-1.fc41.i686",
        "libtirpc-debugsource-1.3.6-1.fc41.i686",
        "libtirpc-devel-1.3.6-1.fc41.i686",
        "libtirpc-debuginfo-1.3.6-1.fc41.x86_64",
        "libtirpc-1.3.6-1.fc41.x86_64",
        "libtirpc-devel-1.3.6-1.fc41.x86_64",
        "libtirpc-debugsource-1.3.6-1.fc41.x86_64",
        "libtirpc-debuginfo-1.3.6-1.fc41.aarch64",
        "libtirpc-debugsource-1.3.6-1.fc41.aarch64",
        "libtirpc-devel-1.3.6-1.fc41.aarch64",
        "libtirpc-1.3.6-1.fc41.aarch64",
        "libtirpc-1.3.6-1.fc41.ppc64le",
        "libtirpc-debuginfo-1.3.6-1.fc41.ppc64le",
        "libtirpc-debugsource-1.3.6-1.fc41.ppc64le",
        "libtirpc-devel-1.3.6-1.fc41.ppc64le",
        "libtirpc-devel-1.3.6-1.fc41.s390x",
        "libtirpc-debuginfo-1.3.6-1.fc41.s390x",
        "libtirpc-debugsource-1.3.6-1.fc41.s390x",
        "libtirpc-1.3.6-1.fc41.s390x"
      ]
    }
  }
}
```