### PR TITLE
Display remaining time as nonnegative number

### DIFF
--- a/libdnf5-cli/progressbar/widgets/time.cpp
+++ b/libdnf5-cli/progressbar/widgets/time.cpp
@@ -48,7 +48,7 @@ std::string TimeWidget::to_string() const {
         ss << format_time(get_bar()->get_elapsed_seconds(), false);
     } else {
         // in progress -> display remaining time
-        ss << format_time(get_bar()->get_remaining_seconds(), true);
+        ss << format_time(get_bar()->get_remaining_seconds(), false);
     }
     return ss.str();
 }


### PR DESCRIPTION
Currently, the time estimates in our progress bars are displayed as negative numbers, e.g:

```
Fedora 42 on Koji                          1% [                  ] |   4.9 KiB/s | 854.1 KiB | -03h18m
```

This formatting makes sense if the user reads it as "the current time is T minus 3h18m", where T is the time my download will be done. And this is the convention in some contexts, e.g. rocket launches. But it is not idiomatic here, where a user is likely to expect the number to mean "time remaining".

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2332931
Resolves https://github.com/rpm-software-management/dnf5/issues/1963