### PR TITLE
automatic: Substitute variables in command_format

### DIFF
--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -117,8 +117,9 @@ std::string quote(std::string_view str) {
 
 void EmitterCommand::notify() {
     std::string command_format = config_automatic.config_command.command_format.get_value();
+    std::string command = libdnf5::utils::sformat(command_format, fmt::arg("body", quote(output_stream.str())));
 
-    FILE * command_pipe = popen(command_format.c_str(), "w");
+    FILE * command_pipe = popen(command.c_str(), "w");
     if (command_pipe) {
         std::string stdin_format = config_automatic.config_command.stdin_format.get_value();
         fputs(libdnf5::utils::sformat(stdin_format, fmt::arg("body", output_stream.str())).c_str(), command_pipe);


### PR DESCRIPTION
`{body}` was not substituted correctly in `command_format` for the command emitter.

Resolves https://github.com/rpm-software-management/dnf5/issues/1951