### PR TITLE
doc: "dnf history userinstalled" replaced with "dnf repoquery --userinstalled"

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -202,6 +202,7 @@ Changes to individual commands
 
 ``history``
   * ``undo`` subcommand now accepts ``--ignore-extras`` and ``--ignore-installed`` like original ``history replay`` command.
+  * ``userinstalled`` subcommand was dropped. It is replaced by ``dnf repoquery --userinstalled``.
   * ``store`` subcommand now creates a directory with transaction JSON file instead of a single transaction JSON file directly.
   * ``store`` subcommand's ``--output`` option now accepts a directory path instead of a file. The default is ``./transaction``.
   * ``replay`` subcommand was moved to a standalone ``replay`` command, that now accepts a path to a directory instead of a file path.


### PR DESCRIPTION
The replacement has already been recommended in dnf(8) manual of DNF4 project.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2335257