### PR TITLE
Bash completion: Always offer NEVRAs and NAMEs for packages

### DIFF
--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -48,7 +48,7 @@ void ReinstallCommand::set_argument_parser() {
             }
             return true;
         });
-    keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, true, true); });
+    keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, true, false); });
     cmd.register_positional_arg(keys);
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -55,7 +55,7 @@ void RemoveCommand::set_argument_parser() {
             }
             return true;
         });
-    keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, true); });
+    keys->set_complete_hook_func([&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, false); });
     cmd.register_positional_arg(keys);
 
     create_offline_option(*this);

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -106,7 +106,7 @@ void RepoqueryCommand::set_argument_parser() {
         });
     keys->set_complete_hook_func([this, &ctx](const char * arg) {
         if (this->installed_option->get_value()) {
-            return match_specs(ctx, arg, true, false, false, true);
+            return match_specs(ctx, arg, true, false, false, false);
         } else {
             return match_specs(ctx, arg, false, true, true, false);
         }

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -51,7 +51,7 @@ void SwapCommand::set_argument_parser() {
         return true;
     });
     remove_spec_arg->set_complete_hook_func(
-        [&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, true); });
+        [&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, false); });
     cmd.register_positional_arg(remove_spec_arg);
 
     auto install_spec_arg = parser.add_new_positional_arg("install_spec", 1, nullptr, nullptr);

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -285,8 +285,9 @@ private:
 
 DNF_API void run_transaction(libdnf5::rpm::Transaction & transaction);
 
-/// Returns the names of matching packages and paths of matching package file names and directories.
-/// If `nevra_for_same_name` is true, it returns a full nevra for packages with the same name.
+/// Returns the names and nevras of the matching packages and
+/// the paths to the matching package file names and directories.
+/// The names of the matching packages are returned only if `only_nevras` is false.
 /// Only files whose names match `file_name_regex` are returned.
 /// NOTE: This function is intended to be used only for autocompletion purposes as the argument parser's
 /// complete hook argument. It does the base setup and repos loading inside.
@@ -296,7 +297,7 @@ DNF_API std::vector<std::string> match_specs(
     bool installed,
     bool available,
     bool paths,
-    bool nevra_for_same_name,
+    bool only_nevras,
     const char * file_name_regex = ".*\\.rpm");
 
 }  // namespace dnf5


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1956

Originally, for packages, the NAME was offered in bash completion. In the case of multiple packages with the same NAME, there was an option to offer NEVRA instead of a NAME for those packages.

Now, bash completion always offers NEVRA for packages. There is an option to offer package NAME in addition to NEVRAs. This is useful, for example, when the user wants to install a package. Usually the user only wants to enter the package NAME and not the entire NEVRA. If multiple packages with the same NAME are available, the specific
package is then selected by the solver.

The DNF5 aplication now always offers both NEVRAs and NAMEs.
