### PR TITLE
Fix colon in bash completion

### DIFF
--- a/dnf5/bash-completion/dnf5
+++ b/dnf5/bash-completion/dnf5
@@ -14,6 +14,19 @@ _do_dnf5_completion()
     fi
 
     mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
+
+    # In Bash, with a colon in COMP_WORDBREAKS, words containing colons are
+    # always completed as entire words if the word to complete contains a colon.
+    # This behavior is fixed by removing the colon-containing prefix from the items in COMPREPLY.
+    # A side effect is the removal of this prefix in the list of bash completion suggestions.
+    #
+    # The preferred solution is to remove the colon ':' from COMP_WORDBREAKS in .bashrc:
+    #    COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+    if [[ ${cur} == *:* && ${COMP_WORDBREAKS} == *:* ]]; then
+        # Remove colon-word prefix from items in COMPREPLY
+        local _colon_word=${cur%"${cur##*:}"}
+        COMPREPLY=("${COMPREPLY[@]#"$_colon_word"}")
+    fi
 }
 
 _complete_dnf5_cmds="dnf5"

--- a/dnf5/bash-completion/dnf5
+++ b/dnf5/bash-completion/dnf5
@@ -16,11 +16,9 @@ _do_dnf5_completion()
     mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
 }
 
-complete_cmds="dnf5"
-dnf_target=$(readlink -f "/usr/bin/dnf")
-
-if [ "$dnf_target" = "/usr/bin/dnf5" ]; then
-    complete_cmds+=" dnf"
+_complete_dnf5_cmds="dnf5"
+if [ "$(readlink -fn /usr/bin/dnf)" = "/usr/bin/dnf5" ]; then
+    _complete_dnf5_cmds+=" dnf"
 fi
 
-complete -F _do_dnf5_completion -o nosort -o nospace $complete_cmds
+complete -F _do_dnf5_completion -o nosort -o nospace $_complete_dnf5_cmds


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1982

Word completion may behave improperly if there is a colon in the word to be completed. The colon can be special to readline's word completion code: it can be one of the characters that breaks words for the completer.
    
The current set of completion word break characters is available in bash as the value of the `COMP_WORDBREAKS` variable.  Removing `:` from that value is enough to make the colon not special to completion: `COMP_WORDBREAKS=${COMP_WORDBREAKS//:}`

This fix is workaround for cases where `:` is a break character (it is contained in `COMP_WORDBREAKS`). A side effect in this case is the removal of the prefix containing the colon in the list of bash completion suggestions.