### PR TITLE
automatic: fix documentation on automatic.conf location in sample config

### DIFF
--- a/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
@@ -1,6 +1,6 @@
 # This configuration file is managed by the dnf5-plugin-automatic package.
 # Please do not edit it. To make changes in dnf5 automatic configuration
-# edit /etc/dnf/dnf5-plugins/automatic.conf and make your adjustments there.
+# edit /etc/dnf/automatic.conf and make your adjustments there.
 
 [commands]
 # Whether updates should be applied when they are available, by


### PR DESCRIPTION
In 73ed42f the preferred location of the `automatic.conf` file changed from `/etc/dnf/dnf5-plugins/automatic.conf` to `/etc/dnf/automatic.conf`. However, the sample config file still had a comment that changes should go to the config file in the old location. This PR fixes the comment for consistency.

fixes #1770