### PR TITLE
Fix resource leak in unit test "libdnf5-cli/output/test_repoquery.cpp", optimization

### DIFF
--- a/test/libdnf5-cli/output/test_repoquery.cpp
+++ b/test/libdnf5-cli/output/test_repoquery.cpp
@@ -44,6 +44,7 @@ void RepoqueryTest::test_format_set_with_simple_str() {
 
     CPPUNIT_ASSERT_EQUAL(std::string("test\n"), std::string(buf));
 
+    fclose(stream);
     free(buf);
 }
 


### PR DESCRIPTION
I discovered a resource leak while working on https://github.com/rpm-software-management/dnf5/issues/1893.
There was a missing "fclose()" in "libdnf5-cli/output/test_repoquery.cpp".

I wrapped `open_memstream` in "libdnf5-cli/output/test_repoquery.cpp" in the `MemStream` class to ensure automatic resource release in the destructor. I also made an optimization - replacing `std::string` with `std::string_view` with the `len` argument in the constructor.