### PR TITLE
Copr plugin: Fix resource leak in load_all_configuration

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_config.hpp
+++ b/dnf5-plugins/copr_plugin/copr_config.hpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_COPR_COPR_CONFIG_HPP
 #define DNF5_COMMANDS_COPR_COPR_CONFIG_HPP
 
-#include <glob.h>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/conf/config_parser.hpp>
 


### PR DESCRIPTION
I discovered a resource leak while working on https://github.com/rpm-software-management/dnf5/issues/1893.
There was a missing `globfree` function call in the `CoprConfig::load_all_configuration()` method.

One can say that adding the line `globfree(&glob_result);` after the `for` loop is enough. But it's not true. The `load_copr_config_file` method called in the loop can generate an exception. So I rewrote the code to use `std::filesystem::directory_iterator`.