### PR TITLE
During package donwload setup first add all downloads then handle local 

### DIFF
--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -117,6 +117,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         text_buffer << "\r";
     }
 
+    // Number of lines that need to be cleared, including the last line even if it is empty
     mbar.num_of_lines_to_clear = 0;
     mbar.line_printed = false;
 
@@ -209,6 +210,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         }
 
         text_buffer << mbar.total;
+        // +1 for the divider line, +1 for the total bar line
         mbar.num_of_lines_to_clear += 2;
         if (mbar.total.is_finished()) {
             text_buffer << std::endl;

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -40,6 +40,7 @@ namespace {
 std::string perform_control_sequences(std::string target) {
     const char * raw_string = target.c_str();
 
+    std::string amount_str = "";
     size_t amount = 1;
     enum ControlSequence {
         EMPTY,
@@ -63,9 +64,11 @@ std::string perform_control_sequences(std::string target) {
         } else if (current_value == '[' && state == ESC) {
             state = CONTROL_SEQUENCE_INTRO;
             amount = 1;
-        } else if (isdigit(current_value) && state == CONTROL_SEQUENCE_INTRO) {
+            amount_str.clear();
+        } else if ((state == CONTROL_SEQUENCE_INTRO || state == CONTROL_SEQUENCE_AMOUNT) && isdigit(current_value)) {
             // current_value has to be one of: 0123456789
-            amount = static_cast<size_t>(current_value - '0');
+            amount_str += current_value;
+            amount = (size_t)stoi(amount_str);
             state = CONTROL_SEQUENCE_AMOUNT;
         } else if ((state == CONTROL_SEQUENCE_INTRO || state == CONTROL_SEQUENCE_AMOUNT) && current_value == 'A') {
             if (amount > current_row) {
@@ -82,6 +85,12 @@ std::string perform_control_sequences(std::string target) {
                 output[current_row].clear();
             }
             state = EMPTY;
+        } else if (state == CONTROL_SEQUENCE_AMOUNT && current_value == 'm') {
+            // This is a color control sequence, just skip it
+            state = EMPTY;
+        } else if (state == CONTROL_SEQUENCE_INTRO || state == CONTROL_SEQUENCE_AMOUNT) {
+            CPPUNIT_FAIL(fmt::format(
+                "Unknown control sequence: \\x1b[{}{} at position: {}", amount_str, current_value, input_pos));
         } else {
             while (current_row >= output.size()) {
                 output.push_back({});

--- a/test/libdnf5-cli/test_progressbar_interactive.hpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.hpp
@@ -36,6 +36,7 @@ class ProgressbarInteractiveTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_multi_progress_bar_with_messages);
     CPPUNIT_TEST(test_multi_progress_bar_with_short_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages);
+    CPPUNIT_TEST(test_multi_progress_bars_with_already_downloaded);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -52,6 +53,7 @@ public:
     void test_multi_progress_bar_with_messages();
     void test_multi_progress_bar_with_short_messages();
     void test_multi_progress_bars_with_messages();
+    void test_multi_progress_bars_with_already_downloaded();
 };
 
 


### PR DESCRIPTION
See the last commit for details.

The new unit test doesn't test the fix but I have created it during development and it seems valuable enough to keep.

A proper test would probably need to be added to `ci-dnf-stack` because it requires dnf5 `DownloadCallbacks`.

Closes: https://github.com/rpm-software-management/dnf5/issues/1957