### PR TITLE
automatic: Fix end-of-lines in messages sent by email emitter

### DIFF
--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -222,6 +222,8 @@ void EmitterEmail::notify() {
 
                 curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
+                curl_easy_setopt(curl, CURLOPT_CRLF, 1L);
+
                 res = curl_easy_perform(curl);
                 fclose(payload_file);
                 if (res != CURLE_OK) {


### PR DESCRIPTION
Sendmail 8.18.1 started to reject e-mail messages without CRLF line endings:

    # dnf-automatic
    libcurl error while sending e-mail: Weird server reply

    # journalctl -f
    sendmail[7095]: 508DXZbS007095: collect: relay=localhost, from=<root@localhost>, info=Bare linefeed (LF) not allowed, where=body, status=tempfail

This is a deliberate change in Sendmail 8.18.1. And the cause is that automatic plugin composes a message body with UNIX line endings and passes it to cURL library with CURLOPT_READDATA option.

While cURL automatically escapes leading dots in the body (".\r\n"), it does not normalize end-of-lines
<https://github.com/curl/curl/issues/15942>.

This patch fixes it by asking cURL to perform the normalization.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2335508