### PR TITLE
repo: Fix logging metadata download errors handling

### DIFF
--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -397,7 +397,7 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
         const auto & error_lines = utils::string::split(format(e, FormatDetailLevel::Plain), "\n");
         for (const auto & line : error_lines) {
             if (!line.empty()) {
-                base->get_logger()->warning(' ' + line);
+                base->get_logger()->warning(" {}", line);
             }
         }
         return false;


### PR DESCRIPTION
Previously, if a download error message line contained `{}`,
logger.warning would interpret it as a format string without any
arguments passed, causing the libdnf5::utils::sformat function to crash.
This commit addresses the issue by ensuring error messages are handled
safely.

Fixes: https://github.com/rpm-software-management/dnf5/issues/1919