### PR TITLE
libdnf5-cli unit tests: Use only public API methods

### DIFF
--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_progressbar.hpp"
 
-#include "../shared/private_accessor.hpp"
 #include "../shared/utils.hpp"
 
 #include <libdnf5-cli/progressbar/download_progress_bar.hpp>
@@ -28,14 +27,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
-
-namespace {
-
-// Allows accessing private methods
-create_private_getter_template;
-create_getter(to_stream, &libdnf5::cli::progressbar::DownloadProgressBar::to_stream);
-
-}  //namespace
 
 void ProgressbarTest::setUp() {
     // MultiProgressBar behaves differently depending on interactivity
@@ -58,13 +49,13 @@ void ProgressbarTest::test_download_progress_bar() {
     auto download_progress_bar_raw = download_progress_bar.get();
 
     std::ostringstream oss;
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
     Pattern expected = "";
     ASSERT_MATCHES(expected, oss.str());
 
     download_progress_bar_raw->set_ticks(10);
     download_progress_bar_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
 
     expected = "\\[0/0\\] test                    100% | ????? ??B\\/s |  10.0   B | ???????";
     ASSERT_MATCHES(expected, oss.str());

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_progressbar_interactive.hpp"
 
-#include "../shared/private_accessor.hpp"
 #include "../shared/utils.hpp"
 #include "utils/string.hpp"
 
@@ -101,10 +100,6 @@ std::string perform_control_sequences(std::string target) {
     return libdnf5::utils::string::join(output, "\n");
 }
 
-// Allows accessing private methods
-create_private_getter_template;
-create_getter(to_stream, &libdnf5::cli::progressbar::DownloadProgressBar::to_stream);
-
 }  //namespace
 
 void ProgressbarInteractiveTest::setUp() {
@@ -156,14 +151,15 @@ void ProgressbarInteractiveTest::test_download_progress_bar() {
     auto download_progress_bar_raw = download_progress_bar.get();
 
     std::ostringstream oss;
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
+
     Pattern expected = "\\[0/0\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????";
     ASSERT_MATCHES(expected, oss.str());
 
     download_progress_bar_raw->set_ticks(10);
     download_progress_bar_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     oss.str("");
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
 
     expected = "\\[0/0\\] test                    100% | ????? ??B\\/s |  10.0   B | ???????";
     ASSERT_MATCHES(expected, oss.str());
@@ -180,7 +176,7 @@ void ProgressbarInteractiveTest::test_download_progress_bar_with_messages() {
     download_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
 
     std::ostringstream oss;
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
     Pattern expected =
         "\\[0/0\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????\n"
         ">>> test message1                                                     \n"
@@ -193,7 +189,7 @@ void ProgressbarInteractiveTest::test_download_progress_bar_with_messages() {
     download_progress_bar->pop_message();
 
     oss.str("");
-    (*download_progress_bar.*get(to_stream{}))(oss);
+    oss << *download_progress_bar;
     expected = "\\[0/0\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????";
     ASSERT_MATCHES(expected, oss.str());
 }


### PR DESCRIPTION
The libdnf5-cli progressbar unit tests unnecessarily used the protected method `DownloadProgressBar::to_stream`. The libdnf5-cli library publicly provides the `<<` operator (API) for `DownloadProgressBar`. This operator does the same thing and internally uses the `to_stream` method.