### PR TITLE
Optimize build process: Do not create object files archive library `libdnf5_static.a`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 message("Running CMake on dnf5...")
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.21)
 
 
 include(VERSION.cmake)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -2,9 +2,9 @@ file(GLOB_RECURSE COMMON_SOURCES *.cpp *.c)
 
 include_directories(.)
 
-add_library(common OBJECT ${COMMON_SOURCES})
-set_property(TARGET common PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_target_properties(common PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_PRESET hidden)
+add_library(common_obj OBJECT ${COMMON_SOURCES})
+set_property(TARGET common_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(common_obj PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_PRESET hidden)
 
 # required by clang
-target_link_libraries(common PUBLIC stdc++)
+target_link_libraries(common_obj PUBLIC stdc++)

--- a/dnf5-plugins/builddep_plugin/CMakeLists.txt
+++ b/dnf5-plugins/builddep_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(builddep_cmd_plugin PRIVATE ${RPMBUILD})
 pkg_check_modules(RPM REQUIRED rpm)
 target_link_libraries(builddep_cmd_plugin PRIVATE ${RPM_LIBRARIES})
 
-target_link_libraries(builddep_cmd_plugin PRIVATE common)
+target_link_libraries(builddep_cmd_plugin PRIVATE common_obj)
 target_link_libraries(builddep_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(builddep_cmd_plugin PRIVATE dnf5)
 

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -39,7 +39,7 @@ set_property(TARGET dnf5 PROPERTY ENABLE_EXPORTS 1)
 # Export only explicitly marked symbols.
 set_target_properties(dnf5 PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_PRESET hidden)
 
-target_link_libraries(dnf5 PRIVATE common libdnf5 libdnf5-cli Threads::Threads)
+target_link_libraries(dnf5 PRIVATE common_obj libdnf5 libdnf5-cli Threads::Threads)
 install(TARGETS dnf5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)

--- a/dnf5daemon-client/CMakeLists.txt
+++ b/dnf5daemon-client/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(${DNF5DAEMON_CLIENT_BIN} ${DNF5DAEMON_CLIENT_SOURCES})
 target_link_libraries(
     ${DNF5DAEMON_CLIENT_BIN}
     PRIVATE
-        common
+        common_obj
         libdnf5
         libdnf5-cli
         ${SDBUS_CPP_LIBRARIES}

--- a/dnf5daemon-server/CMakeLists.txt
+++ b/dnf5daemon-server/CMakeLists.txt
@@ -22,7 +22,6 @@ add_executable(${DNF5DAEMON_SERVER_BIN} ${DNF5DAEMON_SERVER_SOURCES})
 target_link_libraries(
     ${DNF5DAEMON_SERVER_BIN}
     PRIVATE
-        common
         libdnf5
         libdnf5-cli
         ${SDBUS_CPP_LIBRARIES}

--- a/libdnf5-cli/CMakeLists.txt
+++ b/libdnf5-cli/CMakeLists.txt
@@ -42,7 +42,7 @@ install(TARGETS libdnf5-cli LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # link libraries and set pkg-config requires
 
-target_link_libraries(libdnf5-cli PRIVATE common)
+target_link_libraries(libdnf5-cli PRIVATE common_obj)
 
 target_link_libraries(libdnf5-cli PUBLIC libdnf5)
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -54,8 +54,8 @@ target_link_libraries(libdnf5 PUBLIC stdc++)
 # install libdnf5.so
 install(TARGETS libdnf5 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
-target_link_libraries(libdnf5 PRIVATE common)
-target_link_libraries(libdnf5_static PRIVATE common)
+target_link_libraries(libdnf5 PRIVATE common_obj)
+target_link_libraries(libdnf5_static PRIVATE common_obj)
 
 # link libraries and set pkg-config requires
 

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -37,8 +37,8 @@ set_target_properties(libdnf5_obj PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISI
 
 # build libdnf5.a - static library is used by unit tests
 # Unit tests use private symbols that are not exported from libdnfř.so shared library.
-add_library(libdnf5_static STATIC $<TARGET_OBJECTS:libdnf5_obj>)
-set_target_properties(libdnf5_static PROPERTIES OUTPUT_NAME "dnf5_static")
+add_library(libdnf5_iface INTERFACE)
+target_link_libraries(libdnf5_iface INTERFACE libdnf5_obj $<TARGET_OBJECTS:libdnf5_obj>)
 
 # build libdnf5.so
 add_library(libdnf5 SHARED $<TARGET_OBJECTS:libdnf5_obj>)
@@ -55,7 +55,7 @@ target_link_libraries(libdnf5 PUBLIC stdc++)
 install(TARGETS libdnf5 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 target_link_libraries(libdnf5 PRIVATE common_obj)
-target_link_libraries(libdnf5_static PRIVATE common_obj)
+target_link_libraries(libdnf5_iface INTERFACE $<TARGET_OBJECTS:common_obj>)
 
 # link libraries and set pkg-config requires
 
@@ -67,18 +67,18 @@ endif()
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
 target_link_libraries(libdnf5 PUBLIC ${LIBFMT_LIBRARIES})
-target_link_libraries(libdnf5_static PUBLIC ${LIBFMT_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${LIBFMT_LIBRARIES})
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})
 target_link_libraries(libdnf5 PRIVATE ${JSONC_LIBRARIES})
-target_link_libraries(libdnf5_static PRIVATE ${JSONC_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${JSONC_LIBRARIES})
 
 if (WITH_MODULEMD)
     pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
     list(APPEND LIBDNF5_PC_REQUIRES "${LIBMODULEMD_MODULE_NAME}")
     target_link_libraries(libdnf5 PRIVATE ${LIBMODULEMD_LIBRARIES})
-    target_link_libraries(libdnf5_static PRIVATE ${LIBMODULEMD_LIBRARIES})
+    target_link_libraries(libdnf5_iface INTERFACE ${LIBMODULEMD_LIBRARIES})
 endif()
 
 if (ENABLE_SOLV_FOCUSNEW)
@@ -88,24 +88,24 @@ else()
 endif()
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBSOLV_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLV_LIBRARIES})
-target_link_libraries(libdnf5_static PRIVATE ${LIBSOLV_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${LIBSOLV_LIBRARIES})
 
 pkg_check_modules(LIBSOLVEXT REQUIRED libsolvext>=0.7.7)
 list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBSOLVEXT_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLVEXT_LIBRARIES})
-target_link_libraries(libdnf5_static PRIVATE ${LIBSOLVEXT_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${LIBSOLVEXT_LIBRARIES})
 
 pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${RPM_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${RPM_LIBRARIES})
-target_link_libraries(libdnf5_static PRIVATE ${RPM_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${RPM_LIBRARIES})
 
 if(WITH_COMPS)
     pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
     list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBXML2_MODULE_NAME}")
     include_directories(${LIBXML2_INCLUDE_DIRS})
     target_link_libraries(libdnf5 PRIVATE ${LIBXML2_LIBRARIES})
-    target_link_libraries(libdnf5_static PRIVATE ${LIBXML2_LIBRARIES})
+    target_link_libraries(libdnf5_iface INTERFACE ${LIBXML2_LIBRARIES})
 endif()
 
 if (WITH_ZCHUNK)
@@ -122,13 +122,13 @@ pkg_check_modules(LIBREPO REQUIRED librepo>=1.18.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
 target_include_directories(libdnf5 PUBLIC PRIVATE ${LIBREPO_INCLUDE_DIRS})
 target_link_libraries(libdnf5 PRIVATE ${LIBREPO_LDFLAGS})
-target_link_libraries(libdnf5_static PRIVATE ${LIBREPO_LDFLAGS})
+target_link_libraries(libdnf5_iface INTERFACE ${LIBREPO_LDFLAGS})
 
 # SQLite3
 pkg_check_modules(SQLite3 REQUIRED sqlite3>=3.35.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${SQLite3_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${SQLite3_LIBRARIES})
-target_link_libraries(libdnf5_static PRIVATE ${SQLite3_LIBRARIES})
+target_link_libraries(libdnf5_iface INTERFACE ${SQLite3_LIBRARIES})
 
 
 # sort the pkg-config requires and concatenate them into a string

--- a/test/libdnf5/CMakeLists.txt
+++ b/test/libdnf5/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_options(run_tests PRIVATE "-Wno-self-assign-overloaded")
 target_compile_options(run_tests PRIVATE "-Wno-self-move")
 
 target_link_directories(run_tests PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
-target_link_libraries(run_tests PRIVATE stdc++ libdnf5_static test_shared)
+target_link_libraries(run_tests PRIVATE stdc++ libdnf5_iface test_shared)
 
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/2003

The "libdnf5_static.a" object files archive was not packaged. It was only used in unit tests of the "libdnf5" library. The use of the archive in the "libdnf5" unit tests was intentional. The unit tests call private methods that have hidden symbols not exported by the shared library.

Now the `INTERFACE` library is defined instead of the object files archive. It specify usage requirements for dependents but does not produce a library artifact on disk. The "libdnf5" unit tests link directly to the object files without the need for an intermediate archive.