### PR TITLE
automatic: Translate end-of-lines in email emitter by DNF

### DIFF
--- a/dnf5-plugins/automatic_plugin/email_message.cpp
+++ b/dnf5-plugins/automatic_plugin/email_message.cpp
@@ -23,18 +23,25 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/utils/format.hpp>
 
 #include <chrono>
+#include <string>
 
 namespace dnf5 {
 
 // TODO(mblaha): use some library to create an email instead of this template
-constexpr const char * MESSAGE_TEMPLATE =
+constexpr const char * EMAIL_HEADER_TEMPLATE =
     "Date: {date}\r\n"
     "To: {to}\r\n"
     "From: {from}\r\n"
     "Subject: {subject}\r\n"
     "X-Mailer: dnf5-automatic\r\n"
-    "\r\n"
-    "{body}";
+    "\r\n";
+
+void EmailMessage::set_body(std::stringstream & body) {
+    this->body.clear();
+    for (std::string line; std::getline(body, line);) {
+        this->body.push_back(line);
+    }
+}
 
 std::string EmailMessage::str() {
     const auto now = std::chrono::system_clock::now();
@@ -50,12 +57,15 @@ std::string EmailMessage::str() {
 
     std::string msg;
     msg = libdnf5::utils::sformat(
-        MESSAGE_TEMPLATE,
+        EMAIL_HEADER_TEMPLATE,
         fmt::arg("date", date),
         fmt::arg("to", to_str),
         fmt::arg("from", from),
-        fmt::arg("subject", subject),
-        fmt::arg("body", body));
+        fmt::arg("subject", subject));
+    for (const auto & line : body) {
+        msg.append(line).append("\r\n");
+    }
+
     return msg;
 }
 

--- a/dnf5-plugins/automatic_plugin/email_message.hpp
+++ b/dnf5-plugins/automatic_plugin/email_message.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_PLUGINS_AUTOMATIC_PLUGIN_EMAIL_MESSAGE_HPP
 #define DNF5_PLUGINS_AUTOMATIC_PLUGIN_EMAIL_MESSAGE_HPP
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ public:
     /// Set the To header value
     void set_to(const std::vector<std::string> & to) { this->to = to; };
     /// Set the message body
-    void set_body(std::string_view body) { this->body = body; };
+    void set_body(std::stringstream & body);
 
     /// Return string representation of the message
     std::string str();
@@ -47,7 +48,7 @@ private:
     std::string subject;
     std::string from;
     std::vector<std::string> to;
-    std::string body;
+    std::vector<std::string> body;
 };
 
 }  // namespace dnf5

--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -167,7 +167,7 @@ void EmitterEmail::notify() {
     message.set_to(to);
     message.set_from(from);
     message.set_subject(subject);
-    message.set_body(output_stream.str());
+    message.set_body(output_stream);
 
     {
         // use curl to send the message
@@ -221,8 +221,6 @@ void EmitterEmail::notify() {
                 curl_easy_setopt(curl, CURLOPT_READDATA, payload_file);
 
                 curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-
-                curl_easy_setopt(curl, CURLOPT_CRLF, 1L);
 
                 res = curl_easy_perform(curl);
                 fclose(payload_file);

--- a/dnf5-plugins/automatic_plugin/emitters.hpp
+++ b/dnf5-plugins/automatic_plugin/emitters.hpp
@@ -35,7 +35,7 @@ public:
     Emitter(
         const ConfigAutomatic & config_automatic,
         const libdnf5::base::Transaction & transaction,
-        const std::stringstream & output_stream,
+        std::stringstream & output_stream,
         const bool success)
         : config_automatic(config_automatic),
           transaction(transaction),
@@ -56,7 +56,7 @@ protected:
     // resolved upgrade transaction
     const libdnf5::base::Transaction & transaction;
     // stream with captured upgrade outputs
-    const std::stringstream & output_stream;
+    std::stringstream & output_stream;
     const bool success;
 
     /// Return number of available upgrades.


### PR DESCRIPTION
The fix in 9a5cba8fbb0c95f5da1410803f9ff5093895252a (automatic: Fix end-of-lines in messages sent by email emitter) utilized cURL library for translating LF ending to CR-LF in content of SMTP DATA command. It fixed the problem with curl-8.11.1, but broke end-of-lines in e-mail headers with old curl-8.9.1.

I was unable to find what has changed in cURL, but the cause was that automatic plugin already separated headers by CR-LF, therefore cURL probably double-encoded them and that was again rejected by sendmail 8.18.1.

This patch reverts 9a5cba8fbb0c95f5da1410803f9ff5093895252a and instead performs the end-of-line normalization fully in dnf5::EmailMessage::str() method. Now the output of the method is completely valid e-mail message.

Implementation detail: I changed dnf5::Emitter::output_stream variable from const to non-cost to be able to call getline() on it. If is a problem, I will need to come with a more complicated solution because I can only obtain a new-line delimiter used in the std::stringstream object by getline().

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2335508