### PR TITLE
Argument completion without description, Bash completion "menu complete"

### DIFF
--- a/dnf5/bash-completion/dnf5
+++ b/dnf5/bash-completion/dnf5
@@ -13,7 +13,18 @@ _do_dnf5_completion()
         _init_completion -n "><=;|&(:" -- "$@" || return
     fi
 
-    mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
+    case ${COMP_TYPE} in
+        # <TAB> (code 9) - normal completion, the identical part of the suggestions is completed
+        # '%' (code 37) - menu completion, cyclically completes the suggestions from the list
+        # In these cases the list of suggestions is not printed and we do not want
+        # to complete the argument with a description (help).
+        9 | 37)
+            mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword},add_description=0" "${words[@]}")
+            ;;
+        *)
+            mapfile -t COMPREPLY <<<$("${1}" "--complete=${cword}" "${words[@]}")
+            ;;
+    esac
 
     # In Bash, with a colon in COMP_WORDBREAKS, words containing colons are
     # always completed as entire words if the word to complete contains a colon.

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1228,12 +1228,36 @@ int main(int argc, char * argv[]) try {
         dnf5::load_cmdline_aliases(context);
 
         // Argument completion handler
-        // If the argument at position 1 is "--complete=<index>", this is a request to complete the argument
-        // at position <index>.
+        // If the argument at position 1 is "--complete=<index>[,add_description=1/0]", this is a request to complete
+        // the argument at position <index>.
         // The first two arguments are not subject to completion (skip them). The original arguments of the program
         // (including the program name) start from position 2.
         if (argc >= 2 && strncmp(argv[1], "--complete=", 11) == 0) {
-            context.get_argument_parser().complete(argc - 2, argv + 2, std::stoi(argv[1] + 11));
+            const char * current_pos = argv[1] + 11;
+            auto & arg_parser = context.get_argument_parser();
+
+            int complete_arg_idx;
+            try {
+                std::size_t used_chars;
+                complete_arg_idx = std::stoi(current_pos, &used_chars);
+                current_pos += used_chars;
+            } catch (const std::logic_error &) {
+                std::cerr << libdnf5::utils::sformat(
+                                 _("Invalid \"index\" in \"--complete=<index>[,...]\": {}"), argv[1])
+                          << std::endl;
+                return static_cast<int>(libdnf5::cli::ExitCode::ARGPARSER_ERROR);
+            }
+
+            if (strncmp(current_pos, ",add_description=", 17) == 0) {
+                current_pos += 17;
+                if (*current_pos == '1') {
+                    arg_parser.set_complete_add_description(true);
+                } else if (*current_pos == '0') {
+                    arg_parser.set_complete_add_description(false);
+                }
+            }
+
+            arg_parser.complete(argc - 2, argv + 2, complete_arg_idx);
             return 0;
         }
 

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -853,6 +853,12 @@ public:
     /// potential completion matches, prints a table with the potential matches along with their short help descriptions.
     void complete(int argc, const char * const argv[], int complete_arg_idx);
 
+    /// Sets whether the description is added to the suggested arguments on completion.
+    void set_complete_add_description(bool enable) noexcept;
+
+    /// Returns whether the description is added to the suggested arguments on completion.
+    bool get_complete_add_description() noexcept;
+
 private:
     class LIBDNF_CLI_LOCAL ArgumentParserImpl;
     const std::unique_ptr<ArgumentParserImpl> p_impl;

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -84,6 +84,7 @@ public:
     Command * selected_command{nullptr};
     bool inherit_named_args{false};
     const char * const * complete_arg_ptr{nullptr};
+    bool complete_add_description{true};  // Indicates whether to add a description to the suggested arguments
 };
 
 
@@ -822,9 +823,15 @@ ArgumentParser::Command::Command(ArgumentParser & owner, const std::string & id)
 
 void ArgumentParser::Command::print_complete(
     const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments) {
-    // Using the Help class to print the completion suggestions, as it prints a table of two columns
+    const bool add_description = get_argument_parser().p_impl->complete_add_description;
+
+    // Using the Help class to print the completion suggestions wits description, as it prints a table of two columns
     // which is also what we need here.
     libdnf5::cli::output::Help help;
+
+    // Used to store a list of suggestions when a table is not needed (description is not added).
+    std::vector<std::string> suggestions;
+
     std::string last;
 
     // Search for matching commands.
@@ -835,10 +842,16 @@ void ArgumentParser::Command::print_complete(
             }
             auto & name = opt->get_id();
             if (name.compare(0, strlen(arg), arg) == 0) {
-                help.add_line(name, '(' + opt->get_description() + ')', nullptr);
+                if (add_description) {
+                    help.add_line(name, '(' + opt->get_description() + ')', nullptr);
+                } else {
+                    suggestions.emplace_back(name);
+                }
                 last = name + ' ';
             }
         }
+
+        // No matching command found. But there may be a positional argument.
         if (last.empty() && used_positional_arguments < get_positional_args().size()) {
             auto pos_arg = get_positional_args()[used_positional_arguments];
             if (pos_arg->get_complete() && pos_arg->complete_hook) {
@@ -866,11 +879,15 @@ void ArgumentParser::Command::print_complete(
             if ((arg[1] == '\0' && opt->get_short_name() != '\0') ||
                 (arg[1] == opt->get_short_name() && arg[2] == '\0')) {
                 std::string name = std::string("-") + opt->get_short_name();
-                std::string extended_name = name;
-                if (opt->get_has_value()) {
-                    extended_name += opt->get_arg_value_help().empty() ? "VALUE" : opt->get_arg_value_help();
+                if (add_description) {
+                    std::string extended_name = name;
+                    if (opt->get_has_value()) {
+                        extended_name += opt->get_arg_value_help().empty() ? "VALUE" : opt->get_arg_value_help();
+                    }
+                    help.add_line(extended_name, '(' + opt->get_description() + ')', nullptr);
+                } else {
+                    suggestions.emplace_back(name);
                 }
-                help.add_line(extended_name, '(' + opt->get_description() + ')', nullptr);
                 last = name;
                 if (!opt->get_has_value()) {
                     last += ' ';
@@ -878,13 +895,19 @@ void ArgumentParser::Command::print_complete(
             }
             if (!opt->get_long_name().empty()) {
                 std::string name = "--" + opt->get_long_name();
-                std::string extended_name = name;
-                if (opt->get_has_value()) {
-                    name += '=';
-                    extended_name += '=' + (opt->get_arg_value_help().empty() ? "VALUE" : opt->get_arg_value_help());
-                }
                 if (name.compare(0, strlen(arg), arg) == 0) {
-                    help.add_line(extended_name, '(' + opt->get_description() + ')', nullptr);
+                    if (opt->get_has_value()) {
+                        name += '=';
+                    }
+                    if (add_description) {
+                        std::string extended_name = name;
+                        if (opt->get_has_value()) {
+                            extended_name += opt->get_arg_value_help().empty() ? "VALUE" : opt->get_arg_value_help();
+                        }
+                        help.add_line(extended_name, '(' + opt->get_description() + ')', nullptr);
+                    } else {
+                        suggestions.emplace_back(name);
+                    }
                     last = name;
                     if (!opt->get_has_value()) {
                         last += ' ';
@@ -894,9 +917,14 @@ void ArgumentParser::Command::print_complete(
         }
     }
 
-    // Prints a completed argument or a table with suggestions and help to complete if there is more than one solution.
+    // Prints the completed argument or suggestions if there is more than one solution.
+    // Suggestions may be completed with a description.
     if (scols_table_get_nlines(help.get_table()) > 1) {
         help.print();
+    } else if (suggestions.size() > 1) {
+        for (const auto & suggestion : suggestions) {
+            std::cout << suggestion << std::endl;
+        }
     } else if (!last.empty() && last != arg) {
         std::cout << last << std::endl;
     }
@@ -1558,6 +1586,16 @@ void ArgumentParser::complete(int argc, const char * const argv[], int complete_
         parse(argc, argv);
     } catch (...) {
     }
+}
+
+
+void ArgumentParser::set_complete_add_description(bool enable) noexcept {
+    p_impl->complete_add_description = enable;
+}
+
+
+bool ArgumentParser::get_complete_add_description() noexcept {
+    return p_impl->complete_add_description;
 }
 
 }  // namespace libdnf5::cli


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1990

- Added support for suggesting arguments for completion without adding a description in `cli:.ArgumentParser`
- Added support for suggesting command line arguments without descriptions in dnf5.
- Added support for "menu completion" in bash completion.