### PR TITLE
doc: `history info` no longer merges transactions

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -209,6 +209,7 @@ Changes to individual commands
   * ``store`` subcommand's ``--output`` option now accepts a directory path instead of a file. The default is ``./transaction``.
   * ``replay`` subcommand was moved to a standalone ``replay`` command, that now accepts a path to a directory instead of a file path.
     The directory can be created with ``--store`` option and in addition to the JSON transaction, it can contain packages, group and environments used in the transaction.
+  * ``info`` subcommand now prints a separate section for each selected transaction. It no longer merges all selected transactions into a single transaction section.
 
 ``info``
   * Dropped ``--all`` option since this behavior is the default one.


### PR DESCRIPTION
We have agreed that the new dnf5 behavior of simply listing all selected transactions is more expected.

Originally the merging was introduced 15 years ago in commits https://github.com/rpm-software-management/dnf/commit/6e949500aa3300c196f1cb82cef7d53795f79aac and
https://github.com/rpm-software-management/dnf/commit/b0581428c57a7ebfc1f6c9eb3d62ec5137e74e82