### PR TITLE
Unify marking of depraceted API, deprications page 

### DIFF
--- a/common/utils/deprecate.hpp
+++ b/common/utils/deprecate.hpp
@@ -1,0 +1,30 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_UTILS_DEPRACATE_HPP
+#define LIBDNF5_UTILS_DEPRACATE_HPP
+
+#include <iostream>
+
+#define LIBDNF5_DEPRECATED(msg)                                                     \
+    {                                                                               \
+        std::cerr << __PRETTY_FUNCTION__ << " is deprecated: " << msg << std::endl; \
+    }
+
+#endif  // LIBDNF5_UTILS_DEPRACATE_HPP

--- a/doc/api/c++/libdnf5.rst
+++ b/doc/api/c++/libdnf5.rst
@@ -7,6 +7,7 @@ libdnf5
     libdnf5_base_log_event
     libdnf5_base_transaction
     libdnf5_base_transaction_package
+    libdnf5_config_main
     libdnf5_goal
     libdnf5_goal_elements
     libdnf5_query_cmp

--- a/doc/api/c++/libdnf5_config_main.rst
+++ b/doc/api/c++/libdnf5_config_main.rst
@@ -1,0 +1,6 @@
+ConfigMain
+==========
+
+
+.. doxygenclass:: libdnf5::ConfigMain
+    :members:

--- a/doc/api/deprecations.rst
+++ b/doc/api/deprecations.rst
@@ -1,0 +1,40 @@
+############
+Deprecations
+############
+
+While the deprecations here are denoted in C++ they also include bindings versions of the API.
+
+Currently deprecated methods:
+=============================
+
+.. doxygenpage:: deprecated
+    :content-only:
+
+
+📢 Deprecation signaling
+========================
+
+- build-time warnings using ``[[deprecated]]`` attribute, see: `cppreference <https://en.cppreference.com/w/cpp/language/attributes/deprecated>`_
+- run-time warnings on ``stderr`` via ``LIBDNF5_DEPRECATED(msg)``
+- deprecated API is marked in documentation using the ``@deprecated`` tag
+- deprecations should be publicly announced on mailing list and GitHub
+- deprecations should include guidance on what to use instead
+
+Example:
+
+.. code-block:: cpp
+    :caption: foo.hpp
+
+    /// @deprecated Use baz()
+    [[deprecated("Use baz()")]]
+    void foo();
+
+.. code-block:: cpp
+    :caption: foo.cpp
+
+    #include "utils/deprecate.hpp"
+
+    void foo() {
+        LIBDNF5_DEPRECATED("Use baz()");
+        ...
+    }

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -9,3 +9,4 @@ API Reference
     python/python
     c++/cpp
     changes_dnf5.2
+    deprecations

--- a/doc/api/python/libdnf5_conf.rst
+++ b/doc/api/python/libdnf5_conf.rst
@@ -4,3 +4,4 @@ libdnf5.conf
 
 .. toctree::
     libdnf5_conf_vars
+    libdnf5_conf_config_main

--- a/doc/api/python/libdnf5_conf_config_main.rst
+++ b/doc/api/python/libdnf5_conf_config_main.rst
@@ -1,0 +1,6 @@
+ConfigMain
+==========
+
+
+.. autoclass:: libdnf5.conf.ConfigMain
+    :members:

--- a/include/libdnf5-cli/output/interfaces/repo.hpp
+++ b/include/libdnf5-cli/output/interfaces/repo.hpp
@@ -56,7 +56,8 @@ public:
     virtual bool get_skip_if_unavailable() const = 0;
     virtual std::vector<std::string> get_gpgkey() const = 0;
     virtual bool get_pkg_gpgcheck() const = 0;
-    /// @deprecated It is going to be removed, use get_pkg_gpgcheck()
+    /// @deprecated Use get_pkg_gpgcheck() const
+    [[deprecated("Use get_pkg_gpgcheck() const")]]
     virtual bool get_gpgcheck() const = 0;
     virtual bool get_repo_gpgcheck() const = 0;
     virtual std::string get_repo_file_path() const = 0;

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -44,12 +44,10 @@ public:
 
     OptionNumber<std::int32_t> & get_debuglevel_option();
     const OptionNumber<std::int32_t> & get_debuglevel_option() const;
-    /// @deprecated errorlevel option does nothing and is scheduled for removal
-    [[deprecated("errorlevel option does nothing and is scheduled for removal")]] OptionNumber<std::int32_t> &
-    get_errorlevel_option();
-    /// @deprecated errorlevel option does nothing and is scheduled for removal
-    [[deprecated("errorlevel option does nothing and is scheduled for removal")]] const OptionNumber<std::int32_t> &
-    get_errorlevel_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionNumber<std::int32_t> & get_errorlevel_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionNumber<std::int32_t> & get_errorlevel_option() const;
     OptionPath & get_installroot_option();
     const OptionPath & get_installroot_option() const;
     OptionPath & get_config_file_path_option();
@@ -178,8 +176,11 @@ public:
     const OptionStringList & get_history_record_packages_option() const;
     OptionString & get_rpmverbosity_option();
     const OptionString & get_rpmverbosity_option() const;
-    /// Option `strict` is deprecated. Please use skip_broken and skip_unavailable
+    /// @deprecated Use get_skip_broken_option() and get_skip_unavailable_option()
+    [[deprecated("Use get_skip_broken_option() and get_skip_unavailable_option()")]]
     OptionBool & get_strict_option();
+    /// @deprecated Use get_skip_broken_option() const and get_skip_unavailable_option() const
+    [[deprecated("Use get_skip_broken_option() const and get_skip_unavailable_option() const")]]
     const OptionBool & get_strict_option() const;
     /// Solver is allowed to skip transaction packages with broken dependencies
     OptionBool & get_skip_broken_option();
@@ -248,9 +249,11 @@ public:
     const OptionString & get_username_option() const;
     OptionString & get_password_option();
     const OptionString & get_password_option() const;
-    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
+    /// @deprecated Use get_pkg_gpgcheck_option()
+    [[deprecated("Use get_pkg_gpgcheck_option()")]]
     OptionBool & get_gpgcheck_option();
-    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
+    /// @deprecated Use get_pkg_gpgcheck_option() const
+    [[deprecated("Use get_pkg_gpgcheck_option() const")]]
     const OptionBool & get_gpgcheck_option() const;
     OptionBool & get_pkg_gpgcheck_option();
     const OptionBool & get_pkg_gpgcheck_option() const;

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -79,9 +79,11 @@ public:
     const OptionChild<OptionString> & get_password_option() const;
     OptionChild<OptionStringAppendList> & get_protected_packages_option();
     const OptionChild<OptionStringAppendList> & get_protected_packages_option() const;
-    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
+    /// @deprecated Use get_pkg_gpgcheck_option()
+    [[deprecated("Use get_pkg_gpgcheck_option()")]]
     OptionChild<OptionBool> & get_gpgcheck_option();
-    /// @deprecated It is going to be removed, use get_pkg_gpgcheck_option()
+    /// @deprecated Use get_pkg_gpgcheck_option() const
+    [[deprecated("Use get_pkg_gpgcheck_option() const")]]
     const OptionChild<OptionBool> & get_gpgcheck_option() const;
     OptionChild<OptionBool> & get_pkg_gpgcheck_option();
     const OptionChild<OptionBool> & get_pkg_gpgcheck_option() const;

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -113,12 +113,13 @@ public:
     /// @param dir The directory into which to dump the debugdata.
     void dump_comps_debugdata(const std::string & dir);
 
-    /// @deprecated It is going to be removed, please use load_repos with allows specifying repo type.
     /// Downloads (if necessary) all enabled repository metadata and loads them in parallel.
     ///
     /// This is just a thin wrapper around load_repos.
     ///
     /// @param load_system Whether to load the system repository
+    /// @deprecated Use load_repos() which allows specifying repo type.
+    [[deprecated("Use load_repos() which allows specifying repo type.")]]
     void update_and_load_enabled_repos(bool load_system);
 
     /// Downloads (if necessary) repositories of selected type and loads them in parallel.

--- a/include/libdnf5/rpm/transaction_callbacks.hpp
+++ b/include/libdnf5/rpm/transaction_callbacks.hpp
@@ -35,9 +35,9 @@ class TransactionPackage;
 namespace libdnf5::rpm {
 
 
-/// @deprecated This alias is confusing, do not use it.
 /// Class represents one item in transaction set.
-using TransactionItem = base::TransactionPackage;
+/// @deprecated This alias is confusing, do not use it.
+using TransactionItem [[deprecated("This alias is confusing, do not use it.")]] = base::TransactionPackage;
 
 
 /// The base class for Transaction callbacks.

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -171,7 +171,7 @@ void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction &
     auto & logger = *get_base().get_logger();
     const auto & config = get_base().get_config();
 
-    if (!config.get_gpgcheck_option().get_value()) {
+    if (!config.get_pkg_gpgcheck_option().get_value()) {
         return;
     }
 

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "config.h"
 #include "config_utils.hpp"
+#include "utils/deprecate.hpp"
 #include "utils/system.hpp"
 
 #include "libdnf5/common/xdg.hpp"
@@ -475,9 +476,11 @@ const OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() const {
 }
 
 OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->errorlevel;
 }
 const OptionNumber<std::int32_t> & ConfigMain::get_errorlevel_option() const {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->errorlevel;
 }
 
@@ -912,9 +915,11 @@ const OptionString & ConfigMain::get_rpmverbosity_option() const {
 }
 
 OptionBool & ConfigMain::get_strict_option() {
+    LIBDNF5_DEPRECATED("Use get_skip_broken_option() and get_skip_unavailable_option()");
     return p_impl->strict;
 }
 const OptionBool & ConfigMain::get_strict_option() const {
+    LIBDNF5_DEPRECATED("Use get_skip_broken_option() const and get_skip_unavailable_option() const");
     return p_impl->strict;
 }
 
@@ -1142,9 +1147,11 @@ const OptionString & ConfigMain::get_password_option() const {
 }
 
 OptionBool & ConfigMain::get_gpgcheck_option() {
+    LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option()");
     return p_impl->pkg_gpgcheck;
 }
 const OptionBool & ConfigMain::get_gpgcheck_option() const {
+    LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option() const");
     return p_impl->pkg_gpgcheck;
 }
 

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/repo/config_repo.hpp"
 
 #include "conf/config_utils.hpp"
+#include "utils/deprecate.hpp"
 
 #include "libdnf5/conf/const.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
@@ -324,9 +325,11 @@ const OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_o
 }
 
 OptionChild<OptionBool> & ConfigRepo::get_gpgcheck_option() {
+    LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option()");
     return p_impl->pkg_gpgcheck;
 }
 const OptionChild<OptionBool> & ConfigRepo::get_gpgcheck_option() const {
+    LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option() const");
     return p_impl->pkg_gpgcheck;
 }
 

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -31,6 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/solver.hpp"
 #include "solv_repo.hpp"
 #include "utils/auth.hpp"
+#include "utils/deprecate.hpp"
 #include "utils/fs/utils.hpp"
 #include "utils/string.hpp"
 #include "utils/url.hpp"
@@ -607,6 +608,7 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
 
 
 void RepoSack::update_and_load_enabled_repos(bool load_system) {
+    LIBDNF5_DEPRECATED("Use load_repos() which allows specifying repo type.");
     if (load_system) {
         load_repos();
     } else {

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -61,10 +61,13 @@ void ConfTest::test_config_repo() {
 void ConfTest::test_config_pkg_gpgcheck() {
     // Ensure both pkg_gpgcheck and gpgcheck point to the same underlying OptionBool object
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // For ConfigMain
     CPPUNIT_ASSERT_EQUAL(&config.get_pkg_gpgcheck_option(), &config.get_gpgcheck_option());
 
     // For ConfigRepo
     repo::ConfigRepo config_repo(config, "test-repo");
     CPPUNIT_ASSERT_EQUAL(&config_repo.get_pkg_gpgcheck_option(), &config_repo.get_gpgcheck_option());
+#pragma GCC diagnostic pop
 }


### PR DESCRIPTION
It also adds `ConfigMain` to the docs (both cpp and python), mostly because it contains most of the deprecated API but it is an important class in general.

Closes: https://github.com/rpm-software-management/dnf5/issues/865