### PR TITLE
ruby bindings: Fix namespacing for libdnf5 classes/modules

### DIFF
--- a/bindings/libdnf5/advisory.i
+++ b/bindings/libdnf5/advisory.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::advisory"
 #elif defined(SWIGRUBY)
-%module "libdnf5/advisory"
+%module "libdnf5::advisory"
 #endif
 
 #if defined(SWIGRUBY)

--- a/bindings/libdnf5/base.i
+++ b/bindings/libdnf5/base.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::base"
 #elif defined(SWIGRUBY)
-%module "libdnf5/base"
+%module "libdnf5::base"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::common"
 #elif defined(SWIGRUBY)
-%module "libdnf5/common"
+%module "libdnf5::common"
 #endif
 
 %include <cstring.i>

--- a/bindings/libdnf5/comps.i
+++ b/bindings/libdnf5/comps.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::comps"
 #elif defined(SWIGRUBY)
-%module "libdnf5/comps"
+%module "libdnf5::comps"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::conf"
 #elif defined(SWIGRUBY)
-%module "libdnf5/conf"
+%module "libdnf5::conf"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/logger.i
+++ b/bindings/libdnf5/logger.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module(directors="1") "libdnf5::logger"
 #elif defined(SWIGRUBY)
-%module(directors="1") "libdnf5/logger"
+%module(directors="1") "libdnf5::logger"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/plugin.i
+++ b/bindings/libdnf5/plugin.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::plugin"
 #elif defined(SWIGRUBY)
-%module "libdnf5/plugin"
+%module "libdnf5::plugin"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::repo"
 #elif defined(SWIGRUBY)
-%module(directors="1") "libdnf5/repo"
+%module(directors="1") "libdnf5::repo"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::rpm"
 #elif defined(SWIGRUBY)
-%module "libdnf5/rpm"
+%module "libdnf5::rpm"
 #endif
 
 #if defined(SWIGRUBY)

--- a/bindings/libdnf5/transaction.i
+++ b/bindings/libdnf5/transaction.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::transaction"
 #elif defined(SWIGRUBY)
-%module "libdnf5/transaction"
+%module "libdnf5::transaction"
 #endif
 
 %include <exception.i>

--- a/bindings/libdnf5/utils.i
+++ b/bindings/libdnf5/utils.i
@@ -3,7 +3,7 @@
 #elif defined(SWIGPERL)
 %module "libdnf5::utils"
 #elif defined(SWIGRUBY)
-%module "libdnf5/utils"
+%module "libdnf5::utils"
 #endif
 
 %include <std_string.i>

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -13,10 +13,7 @@ include_directories(${RUBY_INCLUDE_DIRS})
 function(add_ruby_module LIBRARY_NAME MODULE_NAME)
     set(TARGET_NAME "ruby_${MODULE_NAME}")
     set_source_files_properties(../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTIES CPLUSPLUS ON)
-    set_property(SOURCE ../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTY SWIG_MODULE_NAME ${MODULE_NAME})
-    set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS}
-        -module ${MODULE_NAME}
-    )
+    set_property(SOURCE ../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTY SWIG_MODULE_NAME ${LIBRARY_NAME}::${MODULE_NAME})
     swig_add_library(${TARGET_NAME} LANGUAGE ruby SOURCES ../../${LIBRARY_NAME}/${MODULE_NAME}.i)
     set_property(TARGET ${TARGET_NAME} PROPERTY OUTPUT_NAME ${MODULE_NAME})
     target_compile_options(${TARGET_NAME} PUBLIC ${SWIG_COMPILE_OPTIONS})

--- a/test/ruby/libdnf5/base/test_base.rb
+++ b/test/ruby/libdnf5/base/test_base.rb
@@ -22,7 +22,7 @@ require 'libdnf5/base'
 
 class TestBase < Test::Unit::TestCase
     def test_base()
-        base = Base::Base.new()
+        base = Libdnf5::Base::Base.new()
         logger = base.get_logger()
         config = base.get_config()
         repo_sack = base.get_repo_sack()
@@ -31,7 +31,7 @@ class TestBase < Test::Unit::TestCase
 
     def test_weak_ptr()
         # Creates a new Base object
-        base = Base::Base.new()
+        base = Libdnf5::Base::Base.new()
 
         # Gets a WeakPtr pointing to Vars in the Base object
         vars = base.get_vars()

--- a/test/ruby/libdnf5/base_test_case.rb
+++ b/test/ruby/libdnf5/base_test_case.rb
@@ -30,7 +30,7 @@ PROJECT_SOURCE_DIR = ENV["PROJECT_SOURCE_DIR"]
 
 class BaseTestCase < Test::Unit::TestCase
     def setup()
-        @base = Base::Base.new()
+        @base = Libdnf5::Base::Base.new()
 
         @temp_dir = Dir.mktmpdir("libdnf5_ruby_unittest.")
 
@@ -57,7 +57,7 @@ class BaseTestCase < Test::Unit::TestCase
         repo.get_config().get_baseurl_option().set("file://" + repo_path)
 
         if load
-          @repo_sack.load_repos(Repo::Repo::Type_AVAILABLE)
+          @repo_sack.load_repos(Libdnf5::Repo::Repo::Type_AVAILABLE)
         end
 
         return repo

--- a/test/ruby/libdnf5/logger/test_loggers.rb
+++ b/test/ruby/libdnf5/logger/test_loggers.rb
@@ -23,14 +23,14 @@ require 'stringio'
 require 'libdnf5/logger'
 
 # Tests overloading of log() method
-class LibdnfLoggerCB1 < Logger::Logger
+class LibdnfLoggerCB1 < Libdnf5::Logger::Logger
     def initialize(stream)
         super()
         @stream = stream
     end
 
     def log_line(level, message)
-       @stream.write("%s: %s\n" % [Logger::Logger::level_to_cstr(level), message])
+       @stream.write("%s: %s\n" % [Libdnf5::Logger::Logger::level_to_cstr(level), message])
     end
 
     def write(time, pid, level, message)
@@ -39,14 +39,14 @@ class LibdnfLoggerCB1 < Logger::Logger
 end
 
 # Tests overloading of write() method
-class LibdnfLoggerCB2 < Logger::Logger
+class LibdnfLoggerCB2 < Libdnf5::Logger::Logger
     def initialize(stream)
         super()
         @stream = stream
     end
 
     def write(time, pid, level, message)
-       @stream.write("%s: %s\n" % [Logger::Logger::level_to_cstr(level), message])
+       @stream.write("%s: %s\n" % [Libdnf5::Logger::Logger::level_to_cstr(level), message])
     end
 end
 
@@ -96,12 +96,12 @@ class TestLoggers < Test::Unit::TestCase
         #  1. Create a LogRouter instance with one MemoryBufferLogger instances attached.
         #  ====================
         # Create log router.
-        log_router = Logger::LogRouter.new()
+        log_router = Libdnf5::Logger::LogRouter.new()
         # Create circular memory buffer logger with capacity 10 messages (4 pre-allocated from start).
         max_items_to_keep = 10
         reserve = 4
-        memory_buffer_logger = Logger::MemoryBufferLogger.new(max_items_to_keep, reserve)
-        logger_uniq_ptr = Logger::LoggerUniquePtr.new(memory_buffer_logger)
+        memory_buffer_logger = Libdnf5::Logger::MemoryBufferLogger.new(max_items_to_keep, reserve)
+        logger_uniq_ptr = Libdnf5::Logger::LoggerUniquePtr.new(memory_buffer_logger)
         log_router.add_logger(logger_uniq_ptr)
 
         # Test the number of registered loggers.
@@ -111,13 +111,13 @@ class TestLoggers < Test::Unit::TestCase
         # 2. Write messages into log_router. They will be routed into memory_buffer_logger.
         # ====================
         for i in 0..1
-            log_router.log(Logger::Logger::Level_CRITICAL, "Critical message")
-            log_router.log(Logger::Logger::Level_ERROR, "Error message")
-            log_router.log(Logger::Logger::Level_WARNING, "Warning message")
-            log_router.log(Logger::Logger::Level_NOTICE, "Notice message")
-            log_router.log(Logger::Logger::Level_INFO, "Info message")
-            log_router.log(Logger::Logger::Level_DEBUG, "Debug message")
-            log_router.log(Logger::Logger::Level_TRACE, "Trace message")
+            log_router.log(Libdnf5::Logger::Logger::Level_CRITICAL, "Critical message")
+            log_router.log(Libdnf5::Logger::Logger::Level_ERROR, "Error message")
+            log_router.log(Libdnf5::Logger::Logger::Level_WARNING, "Warning message")
+            log_router.log(Libdnf5::Logger::Logger::Level_NOTICE, "Notice message")
+            log_router.log(Libdnf5::Logger::Logger::Level_INFO, "Info message")
+            log_router.log(Libdnf5::Logger::Logger::Level_DEBUG, "Debug message")
+            log_router.log(Libdnf5::Logger::Logger::Level_TRACE, "Trace message")
         end
 
         # ====================
@@ -131,14 +131,14 @@ class TestLoggers < Test::Unit::TestCase
         # Create StreamLogger instance and swap it with MemoryBufferLogger instance which was added
         # into LogRouter before.
         tmp_logger = LibdnfLoggerCB2.new(stream1)
-        tmp_logger_uniq_ptr = Logger::LoggerUniquePtr.new(tmp_logger)
+        tmp_logger_uniq_ptr = Libdnf5::Logger::LoggerUniquePtr.new(tmp_logger)
         # In the log_router is registered only instance of MemoryBufferLogger just now.
         # The index of the first logger is "0".
         log_router.swap_logger(tmp_logger_uniq_ptr, 0)
 
         # Create secondary StreamLogger instance and add it to LogRouter as another logger.
         log2_stream = LibdnfLoggerCB2.new(stream2)
-        log2_stream_uniq_ptr = Logger::LoggerUniquePtr.new(log2_stream)
+        log2_stream_uniq_ptr = Libdnf5::Logger::LoggerUniquePtr.new(log2_stream)
         log_router.add_logger(log2_stream_uniq_ptr)
 
         # Test the number of registered loggers.
@@ -153,7 +153,7 @@ class TestLoggers < Test::Unit::TestCase
         # ====================
         # 5. Write additional message into LogRouter instance.
         # ====================
-        log_router.log(Logger::Logger::Level_INFO, "Info additional message")
+        log_router.log(Libdnf5::Logger::Logger::Level_INFO, "Info additional message")
 
         # ====================
         # 6. Check content of streams of both StreamLogger instances.

--- a/test/ruby/libdnf5/repo/test_file_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_file_downloader.rb
@@ -27,7 +27,7 @@ require 'base_test_case'
 class TestFileDownloader < BaseTestCase
     USER_DATA = 25
 
-    class DownloadCallbacks < Repo::DownloadCallbacks
+    class DownloadCallbacks < Libdnf5::Repo::DownloadCallbacks
         attr_accessor :start_cnt, :progress_cnt, :mirror_failure_cnt, :end_cnt
         attr_accessor :end_status, :end_msg
 
@@ -76,9 +76,9 @@ class TestFileDownloader < BaseTestCase
         dest_file_path = File.join(@temp_dir, "file_downloader.pub")
 
         dl_cbs = DownloadCallbacks.new()
-        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
+        @base.set_download_callbacks(Libdnf5::Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
 
-        file_downloader = Repo::FileDownloader.new(@base)
+        file_downloader = Libdnf5::Repo::FileDownloader.new(@base)
         file_downloader.add(source_url, dest_file_path, USER_DATA)
         file_downloader.download()
 

--- a/test/ruby/libdnf5/repo/test_package_downloader.rb
+++ b/test/ruby/libdnf5/repo/test_package_downloader.rb
@@ -24,7 +24,7 @@ require 'base_test_case'
 
 
 class TestPackageDownloader < BaseTestCase
-    class PackageDownloadCallbacks < Repo::DownloadCallbacks
+    class PackageDownloadCallbacks < Libdnf5::Repo::DownloadCallbacks
         attr_accessor :user_cb_data_container
         attr_accessor :start_cnt, :progress_cnt, :mirror_failure_cnt, :end_cnt
         attr_accessor :user_data_array, :user_cb_data_array, :end_status, :end_msg
@@ -75,15 +75,15 @@ class TestPackageDownloader < BaseTestCase
     def test_package_downloader()
         repo = add_repo_rpm("rpm-repo1")
 
-        query = Rpm::PackageQuery.new(@base)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
         query.filter_name(["one"])
         query.filter_arch(["noarch"])
         assert_equal(2, query.size())
 
-        downloader = Repo::PackageDownloader.new(@base)
+        downloader = Libdnf5::Repo::PackageDownloader.new(@base)
 
         cbs = PackageDownloadCallbacks.new()
-        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(cbs))
+        @base.set_download_callbacks(Libdnf5::Repo::DownloadCallbacksUniquePtr.new(cbs))
 
         user_data = 2
         it = query.begin()

--- a/test/ruby/libdnf5/repo/test_repo.rb
+++ b/test/ruby/libdnf5/repo/test_repo.rb
@@ -27,7 +27,7 @@ require 'base_test_case'
 class TestRepo < BaseTestCase
     USER_DATA = 25
 
-    class DownloadCallbacks < Repo::DownloadCallbacks
+    class DownloadCallbacks < Libdnf5::Repo::DownloadCallbacks
         attr_accessor :start_cnt, :last_user_data
         attr_accessor :end_cnt, :end_error_message
         attr_accessor :progress_cnt, :fastest_mirror_cnt, :handle_mirror_failure_cnt
@@ -65,7 +65,7 @@ class TestRepo < BaseTestCase
         end
     end
 
-    class RepoCallbacks < Repo::RepoCallbacks
+    class RepoCallbacks < Libdnf5::Repo::RepoCallbacks
         attr_accessor :repokey_import_cnt
 
         def initialize()
@@ -88,12 +88,12 @@ class TestRepo < BaseTestCase
         assert_equal(USER_DATA, repo.get_user_data())
 
         dl_cbs = DownloadCallbacks.new()
-        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
+        @base.set_download_callbacks(Libdnf5::Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
 
         cbs = RepoCallbacks.new()
-        repo.set_callbacks(Repo::RepoCallbacksUniquePtr.new(cbs))
+        repo.set_callbacks(Libdnf5::Repo::RepoCallbacksUniquePtr.new(cbs))
 
-        @repo_sack.load_repos(Repo::Repo::Type_AVAILABLE)
+        @repo_sack.load_repos(Libdnf5::Repo::Repo::Type_AVAILABLE)
 
         assert_equal(USER_DATA, dl_cbs.last_user_data)
 
@@ -111,10 +111,10 @@ class TestRepo < BaseTestCase
         repo = add_repo_repomd(repoid, load=false)
 
         dl_cbs = DownloadCallbacks.new()
-        @base.set_download_callbacks(Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
+        @base.set_download_callbacks(Libdnf5::Repo::DownloadCallbacksUniquePtr.new(dl_cbs))
 
         cbs = RepoCallbacks.new()
-        repo.set_callbacks(Repo::RepoCallbacksUniquePtr.new(cbs))
+        repo.set_callbacks(Libdnf5::Repo::RepoCallbacksUniquePtr.new(cbs))
 
         @repo_sack.load_repos()
 

--- a/test/ruby/libdnf5/rpm/test_package_query.rb
+++ b/test/ruby/libdnf5/rpm/test_package_query.rb
@@ -28,13 +28,13 @@ class TestPackageQuery < BaseTestCase
     end
 
     def test_size()
-        query = Rpm::PackageQuery.new(@base)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
         assert_equal(3, query.size(), 'Number of items in the newly created query')
     end
 
     def test_filter_name()
         # Test QueryCmp::EQ
-        query = Rpm::PackageQuery.new(@base)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
         query.filter_name(["pkg"])
         assert_equal(1, query.size())
 
@@ -50,8 +50,8 @@ class TestPackageQuery < BaseTestCase
         # ---
 
         # Test QueryCmp::GLOB
-        query = Rpm::PackageQuery.new(@base)
-        query.filter_name(["pk*"], Common::QueryCmp_GLOB)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
+        query.filter_name(["pk*"], Libdnf5::Common::QueryCmp_GLOB)
         assert_equal(2, query.size())
 
         actual = []
@@ -65,7 +65,7 @@ class TestPackageQuery < BaseTestCase
     end
 
     def test_implements_enumerable()
-        query = Rpm::PackageQuery.new(@base)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
         query.filter_name(["pkg"])
         assert_equal(1, query.size())
 
@@ -73,7 +73,7 @@ class TestPackageQuery < BaseTestCase
         assert_instance_of(Enumerator, query.each)
 
         # Using each() with a block should return the collection.
-        assert_instance_of(Rpm::PackageSet, query.each(&:get_name))
+        assert_instance_of(Libdnf5::Rpm::PackageSet, query.each(&:get_name))
 
         actual_nevra = query.map { |pkg| pkg.get_nevra }
 
@@ -81,8 +81,8 @@ class TestPackageQuery < BaseTestCase
 
         # ---
 
-        query = Rpm::PackageQuery.new(@base)
-        query.filter_name(["pk*"], Common::QueryCmp_GLOB)
+        query = Libdnf5::Rpm::PackageQuery.new(@base)
+        query.filter_name(["pk*"], Libdnf5::Common::QueryCmp_GLOB)
         assert_equal(2, query.size())
 
         # Test other method than each that comes with Enumerable

--- a/test/ruby/libdnf5/rpm/test_package_query_set_operators.rb
+++ b/test/ruby/libdnf5/rpm/test_package_query_set_operators.rb
@@ -29,12 +29,12 @@ class TestPackageQuerySetOperators < BaseTestCase
 
     def test_update()
         # packages with releases: 1, 2
-        q1 = Rpm::PackageQuery.new(@base)
+        q1 = Libdnf5::Rpm::PackageQuery.new(@base)
         q1.filter_release(["1", "2"])
         assert_equal(2, q1.size())
 
         # packages with releases: 2, 3
-        q2 = Rpm::PackageQuery.new(@base)
+        q2 = Libdnf5::Rpm::PackageQuery.new(@base)
         q2.filter_release(["2", "3"])
         assert_equal(2, q2.size())
 
@@ -45,12 +45,12 @@ class TestPackageQuerySetOperators < BaseTestCase
 
     def test_difference()
         # packages with releases: 1, 2
-        q1 = Rpm::PackageQuery.new(@base)
+        q1 = Libdnf5::Rpm::PackageQuery.new(@base)
         q1.filter_release(["1", "2"])
         assert_equal(2, q1.size())
 
         # packages with releases: 2, 3
-        q2 = Rpm::PackageQuery.new(@base)
+        q2 = Libdnf5::Rpm::PackageQuery.new(@base)
         q2.filter_release(["2", "3"])
         assert_equal(2, q2.size())
 
@@ -61,12 +61,12 @@ class TestPackageQuerySetOperators < BaseTestCase
 
     def test_intersection()
         # packages with releases: 1, 2
-        q1 = Rpm::PackageQuery.new(@base)
+        q1 = Libdnf5::Rpm::PackageQuery.new(@base)
         q1.filter_release(["1", "2"])
         assert_equal(2, q1.size())
 
         # packages with releases: 2, 3
-        q2 = Rpm::PackageQuery.new(@base)
+        q2 = Libdnf5::Rpm::PackageQuery.new(@base)
         q2.filter_release(["2", "3"])
         assert_equal(2, q2.size())
 

--- a/test/ruby/libdnf5/utils/test_patterns.rb
+++ b/test/ruby/libdnf5/utils/test_patterns.rb
@@ -22,18 +22,18 @@ require 'libdnf5/utils'
 
 class TestIsXPattern < Test::Unit::TestCase
     def test_is_file_pattern()
-        assert(!Utils::is_file_pattern(''))
-        assert(!Utils::is_file_pattern('no_file_pattern'))
-        assert(!Utils::is_file_pattern('no_file/pattern'))
-        assert(Utils::is_file_pattern('/pattern'))
-        assert(Utils::is_file_pattern('*/pattern'))
+        assert(!Libdnf5::Utils::is_file_pattern(''))
+        assert(!Libdnf5::Utils::is_file_pattern('no_file_pattern'))
+        assert(!Libdnf5::Utils::is_file_pattern('no_file/pattern'))
+        assert(Libdnf5::Utils::is_file_pattern('/pattern'))
+        assert(Libdnf5::Utils::is_file_pattern('*/pattern'))
     end
 
     def test_is_glob_pattern()
-        assert(!Utils::is_glob_pattern(''))
-        assert(!Utils::is_glob_pattern('no_glob_pattern'))
-        assert(Utils::is_glob_pattern('glob*_pattern'))
-        assert(Utils::is_glob_pattern('glob[sdf]_pattern'))
-        assert(Utils::is_glob_pattern('glob?_pattern'))
+        assert(!Libdnf5::Utils::is_glob_pattern(''))
+        assert(!Libdnf5::Utils::is_glob_pattern('no_glob_pattern'))
+        assert(Libdnf5::Utils::is_glob_pattern('glob*_pattern'))
+        assert(Libdnf5::Utils::is_glob_pattern('glob[sdf]_pattern'))
+        assert(Libdnf5::Utils::is_glob_pattern('glob?_pattern'))
     end
 end


### PR DESCRIPTION
See https://github.com/rpm-software-management/dnf5/issues/1779

The ruby/CMakeLists.txt also defined `-module` twice. Once "by hand" appending the raw `-module ${MODULENAME}` and then it is also added via the `set_property` for `SWIG_MODULE_NAME`. Once is enough, so I just deleted appending it to CLI and just adjusted the `set_property` call. This results in all constants in Ruby now prepended with `Libdnf5`, therefore preventing top-level constant collision (and allowing me to get on with my project).

By the way since setting SWIG_MODULE_NAME appends `-module` to swig CLI, it is overriding what is present in the files in the `%module` directive. Both Perl and Ruby are setting `-module` which makes specifying the module path via `%module` relatively useless even if there seems to be intent, judging by the fact that they are guarded in module files via `#if defined`.

JFTR not sure if there is or isn't possibility or some sane way of flattening the namespaces, Logger::Logger::$LOG_LEVEL is a bit unwieldy.