### PR TITLE
Mark 'Already downloaded' for translations

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -215,6 +215,9 @@ Changes to individual commands
   * Dropped ``--all`` option since this behavior is the default one.
   * Dropped ``--updates`` option, only ``--upgrades`` is available now.
 
+``install``
+  * Dropped ``install-n``, ``install-na`` and ``install-nevra`` command variants.
+
 ``list``
   * Dropped ``--all`` option since this behavior is the default one.
   * Changed the behavior of the ``--available`` option.
@@ -270,6 +273,7 @@ Changes to individual commands
 ``repoquery``
   * Dropped: ``-a/--all``, ``--alldeps``, ``--nevra`` options. Their behavior is and has been the default for both DNF4 and DNF5, so the options are no longer needed.
   * Dropped: ``--envra``, ``--nvr``, ``--unsatisfied`` options. They are no longer supported.
+  * Dropped: ``repoquery-n``, ``repoquery-na`` and ``repoquery-nevra`` command variants.
   * Dropped: ``--archlist`` alias for ``--arch``.
   * Dropped: ``-f`` alias for ``--file``. Also, the arguments to ``--file`` are separated by commas instead of spaces.
   * Moved ``--groupmember`` option to the ``info`` and ``list`` subcommands of the ``group`` and ``advisory`` commands, renaming it to ``--contains-pkgs``.

--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -30,6 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
 #include <fmt/format.h>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <librepo/librepo.h>
 
 #include <algorithm>
@@ -215,7 +216,7 @@ void PackageDownloader::download() try {
             } else {
                 status = DownloadCallbacks::TransferStatus::ALREADYEXISTS;
                 if (same_file) {
-                    msg = "Already downloaded";
+                    msg = _("Already downloaded");
                 } else {
                     msg = fmt::format("Copied from {}", source.string());
                 }


### PR DESCRIPTION
This translation will be used in a CI test which ensures upgrades work correctly with non-english locale and already downloaded packages.

https://github.com/rpm-software-management/ci-dnf-stack/blob/main/dnf-behave-tests/dnf/upgrade-cached.feature