### PR TITLE
utils::format: Support for formatting localized messages (translation, localization of argument format) 

### DIFF
--- a/bindings/libdnf5/utils.i
+++ b/bindings/libdnf5/utils.i
@@ -11,9 +11,11 @@
 %include <shared.i>
 
 %{
+    #include "libdnf5/utils/locale.hpp"
     #include "libdnf5/utils/patterns.hpp"
 %}
 
 #define CV __perl_CV
 
+%include "libdnf5/utils/locale.hpp"
 %include "libdnf5/utils/patterns.hpp"

--- a/include/libdnf5/utils/bgettext/bgettext-mark-common.h
+++ b/include/libdnf5/utils/bgettext/bgettext-mark-common.h
@@ -38,6 +38,11 @@ const char * b_gettextmsg_get_domain(struct BgettextMessage message);
 /// @return message id
 const char * b_gettextmsg_get_id(struct BgettextMessage message);
 
+/// Returns message plural id from encoded message.
+/// @param message message encoded for translation
+/// @return plural message id or NULL if it is not present in the encoded message
+const char * b_gettextmsg_get_plural_id(struct BgettextMessage message);
+
 /// Attempts to translate the 'message' into the user's language by searching for the translation in a message catalog.
 /// @param domain message domain used for translation, argument is used only if the domain is not present in encoded message
 /// @param message message encoded for translation

--- a/include/libdnf5/utils/format_locale.hpp
+++ b/include/libdnf5/utils/format_locale.hpp
@@ -1,0 +1,57 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_UTILS_FORMAT_LOCALE_HPP
+#define LIBDNF5_UTILS_FORMAT_LOCALE_HPP
+
+#include "bgettext/bgettext-mark-common.h"
+
+#include <fmt/format.h>
+
+
+namespace libdnf5::utils {
+
+/// Format `args` according to the `format_string`, and return the result as a string.
+///
+/// @param translate     If `true`, it will attempt to translate the message to the requested locale.
+/// @param format_string message contains formating string
+/// @param plural_form   number is used to select the appropriate plural form of the format string
+/// @param args          arguments to be formated
+/// @return A string object holding the formatted result.
+template <typename... Args>
+std::string format(bool translate, BgettextMessage format_string, unsigned long plural_form, Args &&... args) {
+    const char * final_format_string{nullptr};
+
+    if (translate) {
+        final_format_string = b_dmgettext(NULL, format_string, plural_form);
+    } else {
+        if (plural_form > 1) {
+            final_format_string = b_gettextmsg_get_plural_id(format_string);
+        }
+        if (!final_format_string) {
+            final_format_string = b_gettextmsg_get_id(format_string);
+        }
+    }
+
+    return fmt::vformat(final_format_string, fmt::make_format_args(args...));
+}
+
+}  // namespace libdnf5::utils
+
+#endif  // LIBDNF5_UTILS_FORMAT_LOCALE_HPP

--- a/include/libdnf5/utils/format_locale.hpp
+++ b/include/libdnf5/utils/format_locale.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_UTILS_FORMAT_LOCALE_HPP
 
 #include "bgettext/bgettext-mark-common.h"
+#include "locale.hpp"
 
 #include <fmt/format.h>
 
@@ -50,6 +51,44 @@ std::string format(bool translate, BgettextMessage format_string, unsigned long 
     }
 
     return fmt::vformat(final_format_string, fmt::make_format_args(args...));
+}
+
+
+/// Format `args` according to the `format_string`, and return the result as a string.
+///
+/// @param locale        requested locale for translation and argument formating, nullptr = use global/thread locale
+/// @param translate     If `true`, it will attempt to translate the message to the requested locale.
+/// @param format_string message contains formating string
+/// @param plural_form   number is used to select the appropriate plural form of the format string
+/// @param args          arguments to be formated
+/// @return A string object holding the formatted result.
+template <typename... Args>
+std::string format(
+    const Locale * locale, bool translate, BgettextMessage format_string, unsigned long plural_form, Args &&... args) {
+    const char * final_format_string{nullptr};
+
+    if (!locale) {
+        return utils::format(translate, format_string, plural_form, args...);
+    }
+
+    if (translate) {
+        // sets the requested C locale for this thread, needed for bgettext
+        ::locale_t previous_locale = uselocale(locale->get_c_locale());
+
+        final_format_string = b_dmgettext(NULL, format_string, plural_form);
+
+        // restores the previous C locale for this thread
+        uselocale(previous_locale);
+    } else {
+        if (plural_form > 1) {
+            final_format_string = b_gettextmsg_get_plural_id(format_string);
+        }
+        if (!final_format_string) {
+            final_format_string = b_gettextmsg_get_id(format_string);
+        }
+    }
+
+    return fmt::vformat(locale->get_cpp_locale(), final_format_string, fmt::make_format_args(args...));
 }
 
 }  // namespace libdnf5::utils

--- a/include/libdnf5/utils/locale.hpp
+++ b/include/libdnf5/utils/locale.hpp
@@ -1,0 +1,54 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_UTILS_LOCALE_HPP
+#define LIBDNF5_UTILS_LOCALE_HPP
+
+#include "libdnf5/common/impl_ptr.hpp"
+#include "libdnf5/defs.h"
+
+#include <locale.h>
+
+#include <locale>
+
+
+namespace libdnf5::utils {
+
+/// Class for passing locale
+class LIBDNF_API Locale {
+public:
+    /// Creates a new `Locale` object containing the system locale with the specified `std_name` (for example, "C",
+    /// or "POSIX", or "cs_CZ.UTF-8") if such a locale is supported by the operating system.
+    ///
+    /// @param std_name name of the system locale to use ("" - user-preferred locale, must not be null pointer)
+    explicit Locale(const char * std_name);
+
+    ~Locale();
+
+    const std::locale & get_cpp_locale() const;
+    ::locale_t get_c_locale() const;
+
+private:
+    class LIBDNF_LOCAL Impl;
+    ImplPtr<Impl> p_impl;
+};
+
+}  // namespace libdnf5::utils
+
+#endif  // LIBDNF5_UTILS_LOCALE_HPP

--- a/libdnf5/utils/bgettext/bgettext.c
+++ b/libdnf5/utils/bgettext/bgettext.c
@@ -89,6 +89,18 @@ LIBDNF_API const char * b_gettextmsg_get_id(struct BgettextMessage message) {
     return msgId;
 }
 
+LIBDNF_API const char * b_gettextmsg_get_plural_id(struct BgettextMessage message) {
+    if (!(*message.bgettextMsg & BGETTEXT_PLURAL)) {
+        return NULL;
+    }
+    const char * msgId = message.bgettextMsg + 1;
+    if (*message.bgettextMsg & BGETTEXT_DOMAIN) {
+        msgId = strchr(msgId, 0) + 1;
+    }
+    msgId = strchr(msgId, 0) + 1;  // skip message id
+    return msgId;
+}
+
 LIBDNF_API const char * b_dmgettext(const char * domain, struct BgettextMessage message, unsigned long int n) {
     const char * markedMsg = message.bgettextMsg;
     if ((*markedMsg & ~(BGETTEXT_PLURAL | BGETTEXT_CONTEXT | BGETTEXT_DOMAIN)) == 0) {

--- a/libdnf5/utils/locale.cpp
+++ b/libdnf5/utils/locale.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/utils/locale.hpp"
+
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+
+
+namespace libdnf5::utils {
+
+class Locale::Impl {
+public:
+    ~Impl() { freelocale(c_locale); }
+
+private:
+    explicit Impl(const char * std_name) : cpp_locale(std_name) {
+        c_locale = newlocale(LC_ALL_MASK, std_name, (locale_t)0);
+        if (c_locale == (locale_t)0) {
+            throw std::runtime_error("newlocale failed");
+        }
+    }
+
+    const std::locale & get_cpp_locale() const { return cpp_locale; }
+
+    ::locale_t get_c_locale() const { return c_locale; }
+
+    friend class Locale;
+
+    std::locale cpp_locale;
+    ::locale_t c_locale;
+};
+
+
+Locale::Locale(const char * std_name) {
+    libdnf_assert(std_name != nullptr, "Locale name \"std_name\" contains null pointer");
+
+    try {
+        p_impl = ImplPtr(new Impl(std_name));
+    } catch (const std::runtime_error & ex) {
+        throw RuntimeError(M_("Cannot set the locale \"{}\": {}"), std::string(std_name), std::string(ex.what()));
+    }
+}
+
+Locale::~Locale() = default;
+
+const std::locale & Locale::get_cpp_locale() const {
+    return p_impl->get_cpp_locale();
+}
+
+::locale_t Locale::get_c_locale() const {
+    return p_impl->get_c_locale();
+}
+
+}  // namespace libdnf5::utils


### PR DESCRIPTION
New overloads of the `utils::format` method accept `BgettextMessage` as a format string. They allow to specify whether we want to translate the format string and define the `locale` used.