### PR TITLE
Classes common::Message and common::EmptyMessage

### DIFF
--- a/bindings/libdnf5/common.i
+++ b/bindings/libdnf5/common.i
@@ -28,8 +28,11 @@
 }
 
 %{
+    #include "libdnf5/common/message.hpp"
     #include "libdnf5/common/weak_ptr.hpp"
 %}
+%include "libdnf5/common/message.hpp"
+
 %include "libdnf5/common/weak_ptr.hpp"
 #if defined(SWIGPYTHON)
 %extend libdnf5::WeakPtr {

--- a/include/libdnf5/common/message.hpp
+++ b/include/libdnf5/common/message.hpp
@@ -54,6 +54,26 @@ private:
     ImplPtr<Impl> p_impl;
 };
 
+
+/// Class for passing an empty message.
+class LIBDNF_API EmptyMessage final : public Message {
+public:
+    EmptyMessage();
+    EmptyMessage(const EmptyMessage & src);
+    EmptyMessage(EmptyMessage && src) noexcept;
+    ~EmptyMessage() override;
+
+    EmptyMessage & operator=(const EmptyMessage & src);
+    EmptyMessage & operator=(EmptyMessage && src) noexcept;
+
+    /// Returns empty string
+    ///
+    /// @param translate  ignored
+    /// @param locale     ignored
+    /// @return empty string object
+    std::string format(bool translate, const libdnf5::utils::Locale * locale = nullptr) const override;
+};
+
 }  // namespace libdnf5
 
 #endif  // LIBDNF5_COMMON_MESSAGE_HPP

--- a/include/libdnf5/common/message.hpp
+++ b/include/libdnf5/common/message.hpp
@@ -1,0 +1,59 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_COMMON_MESSAGE_HPP
+#define LIBDNF5_COMMON_MESSAGE_HPP
+
+#include "impl_ptr.hpp"
+
+#include "libdnf5/defs.h"
+#include "libdnf5/utils/locale.hpp"
+
+#include <string>
+
+namespace libdnf5 {
+
+/// A base class for passing a message whose formatting, including localization
+/// (translation, argument format) is done at the destination.
+/// Usage: The user creates a child of this class and implements the `format` method.
+class LIBDNF_API Message {
+public:
+    Message();
+    Message(const Message & src);
+    Message(Message && src) noexcept;
+    virtual ~Message();
+
+    Message & operator=(const Message & src);
+    Message & operator=(Message && src) noexcept;
+
+    /// Formats the contained message according to the specified arguments and returns the result as a string.
+    ///
+    /// @param translate  If `true`, it will attempt to translate the message to the requested locale.
+    /// @param locale     requested locale for translation and argument formating, nullptr = use global/thread locale
+    /// @return A string object holding the formatted result.
+    virtual std::string format(bool translate, const libdnf5::utils::Locale * locale = nullptr) const = 0;
+
+private:
+    class LIBDNF_LOCAL Impl;
+    ImplPtr<Impl> p_impl;
+};
+
+}  // namespace libdnf5
+
+#endif  // LIBDNF5_COMMON_MESSAGE_HPP

--- a/libdnf5/common/message.cpp
+++ b/libdnf5/common/message.cpp
@@ -37,4 +37,19 @@ Message::~Message() = default;
 Message & Message::operator=(const Message & src) = default;
 Message & Message::operator=(Message && src) noexcept = default;
 
+
+EmptyMessage::EmptyMessage() = default;
+EmptyMessage::EmptyMessage(const EmptyMessage & src) = default;
+EmptyMessage::EmptyMessage(EmptyMessage && src) noexcept = default;
+
+EmptyMessage::~EmptyMessage() = default;
+
+EmptyMessage & EmptyMessage::operator=(const EmptyMessage & src) = default;
+EmptyMessage & EmptyMessage::operator=(EmptyMessage && src) noexcept = default;
+
+std::string EmptyMessage::format(
+    [[maybe_unused]] bool translate, [[maybe_unused]] const libdnf5::utils::Locale * locale) const {
+    return "";
+}
+
 }  // namespace libdnf5

--- a/libdnf5/common/message.cpp
+++ b/libdnf5/common/message.cpp
@@ -1,0 +1,40 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf5/common/message.hpp"
+
+namespace libdnf5 {
+
+// The `Impl` class is now empty. It allows to add data members in the future.
+class Message::Impl {};
+
+// Constructors optimization:
+// `p_impl` is initialized by the default constructor. -> It is empty (set to `nullptr`).
+// The real object will need to be created when the `Impl` class will contain data members.
+// For now, only a placeholder is enought.
+Message::Message() = default;
+Message::Message(const Message & src) = default;
+Message::Message(Message && src) noexcept = default;
+
+Message::~Message() = default;
+
+Message & Message::operator=(const Message & src) = default;
+Message & Message::operator=(Message && src) noexcept = default;
+
+}  // namespace libdnf5


### PR DESCRIPTION
`common::Message`: A base abstract class for passing a message whose formatting, including localization (translation, argument format) is done at the destination.

`common::EmptyMessage`: class for passing an empty message

Closes: https://github.com/rpm-software-management/dnf5/issues/2034
Requires: https://github.com/rpm-software-management/dnf5/pull/2029
Requires: https://github.com/rpm-software-management/dnf5/pull/2031

