### PR TITLE
plugins: Check if the plugin instantiation was successful

### DIFF
--- a/dnf5/library.cpp
+++ b/dnf5/library.cpp
@@ -43,10 +43,10 @@ void * Library::get_address(const char * symbol) const {
     void * address = dlsym(handle, symbol);
     if (!address) {
         const char * err_msg = dlerror();  // returns localized message, problem with later translation
-        if (err_msg) {
-            throw std::runtime_error(libdnf5::utils::sformat(
-                _("Cannot obtain address of symbol \"{}\": {}"), std::string(symbol), std::string(err_msg)));
-        }
+        throw std::runtime_error(libdnf5::utils::sformat(
+            _("Cannot obtain address of symbol \"{}\": {}"),
+            std::string(symbol),
+            err_msg ? std::string(err_msg) : "unknown error"));
     }
     return address;
 }

--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -74,6 +74,9 @@ PluginLibrary::PluginLibrary(Context & context, const std::string & library_path
     delete_instance = reinterpret_cast<TDeleteInstanceFunc>(library.get_address("dnf5_plugin_delete_instance"));
 
     iplugin_instance = new_instance(dnf5::get_application_version(), context);
+    if (!iplugin_instance) {
+        throw std::runtime_error("Failed to create a dnf plugin instance");
+    }
 }
 
 PluginLibrary::~PluginLibrary() {

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -76,6 +76,9 @@ PluginLibrary::PluginLibrary(Base & base, ConfigParser && parser, const std::str
     new_instance = reinterpret_cast<TNewInstanceFunc>(library.get_address("libdnf_plugin_new_instance"));
     delete_instance = reinterpret_cast<TDeleteInstanceFunc>(library.get_address("libdnf_plugin_delete_instance"));
     iplugin_instance = new_instance(libdnf5::get_library_version(), get_iplugin_data(base), get_config_parser());
+    if (!iplugin_instance) {
+        throw PluginError(M_("Failed to create a libdnf plugin instance"));
+    }
 }
 
 PluginLibrary::~PluginLibrary() {

--- a/libdnf5/utils/library.cpp
+++ b/libdnf5/utils/library.cpp
@@ -44,10 +44,10 @@ void * Library::get_address(const char * symbol) const {
     void * address = dlsym(handle, symbol);
     if (!address) {
         const char * err_msg = dlerror();  // returns localized message, problem with later translation
-        if (err_msg) {
-            throw LibrarySymbolNotFoundError(
-                M_("Cannot obtain address of symbol \"{}\": {}"), std::string(symbol), std::string(err_msg));
-        }
+        throw LibrarySymbolNotFoundError(
+            M_("Cannot obtain address of symbol \"{}\": {}"),
+            std::string(symbol),
+            err_msg ? std::string(err_msg) : "unknown error");
     }
     return address;
 }


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/2042

Fixes crash if plugin instantiation fails and returns a null pointer.