### PR TITLE
Plugin API: *_plugin_get_last_exception: Return pointer to last exception

### DIFF
--- a/bindings/libdnf5/plugin.i
+++ b/bindings/libdnf5/plugin.i
@@ -36,6 +36,7 @@
 %ignore libdnf_plugin_get_version;
 %ignore libdnf_plugin_new_instance;
 %ignore libdnf_plugin_delete_instance;
+%ignore libdnf_plugin_get_last_exception;
 %feature("director") IPlugin;
 %include "libdnf5/plugin/iplugin.hpp"
 

--- a/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
@@ -49,6 +49,8 @@ std::vector<std::unique_ptr<Command>> AutomaticCmdPlugin::create_commands() {
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -67,9 +69,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new AutomaticCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
@@ -49,6 +49,8 @@ std::vector<std::unique_ptr<Command>> BuildDepCmdPlugin::create_commands() {
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -67,9 +69,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new BuildDepCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
@@ -49,6 +49,8 @@ std::vector<std::unique_ptr<Command>> ChangelogCmdPlugin::create_commands() {
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -67,9 +69,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new ChangelogCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
+++ b/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
@@ -49,6 +49,8 @@ std::vector<std::unique_ptr<Command>> ConfigManagerCmdPlugin::create_commands() 
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -67,9 +69,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new ConfigManagerCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
+++ b/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
@@ -69,6 +69,8 @@ public:
 };
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -87,9 +89,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new CoprCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
@@ -49,6 +49,8 @@ std::vector<std::unique_ptr<Command>> NeedsRestartingCmdPlugin::create_commands(
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -67,9 +69,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new NeedsRestartingCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
@@ -68,6 +68,8 @@ std::vector<std::unique_ptr<Command>> RepoclosureCmdPlugin::create_commands() {
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -86,9 +88,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new RepoclosureCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
@@ -68,6 +68,8 @@ std::vector<std::unique_ptr<Command>> ReposyncCmdPlugin::create_commands() {
 }
 
 
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -86,9 +88,14 @@ PluginVersion dnf5_plugin_get_version(void) {
 IPlugin * dnf5_plugin_new_instance([[maybe_unused]] ApplicationVersion application_version, Context & context) try {
     return new ReposyncCmdPlugin(context);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void dnf5_plugin_delete_instance(IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * dnf5_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/dnf5/include/dnf5/iplugin.hpp
+++ b/dnf5/include/dnf5/iplugin.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "defs.h"
 
 #include <cstdint>
+#include <exception>
 #include <vector>
 
 namespace dnf5 {
@@ -82,24 +83,43 @@ private:
 
 extern "C" {
 
-/// Returns the version of the API required by the plugin.
+/// Returns the version of the API implemented by the plugin.
 /// Same result as IPlugin::get_api_version(), but can be called without creating an IPlugin instance.
+///
+/// @return API version implemented by the plugin.
 DNF_PLUGIN_API dnf5::PluginAPIVersion dnf5_plugin_get_api_version(void);
 
-/// Returns the name of the plugin. It can be called at any time.
+/// Returns the name of the plugin.
 /// Same result as IPlugin::get_name(), but can be called without creating an IPlugin instance.
+///
+/// @return Plugin name
 DNF_PLUGIN_API const char * dnf5_plugin_get_name(void);
 
-/// Returns the version of the plugin. It can be called at any time.
+/// Returns the version of the plugin.
 /// Same result as IPlugin::get_version(), but can be called without creating an IPlugin instance.
+///
+/// @return Plugin version
 DNF_PLUGIN_API dnf5::PluginVersion dnf5_plugin_get_version(void);
 
-/// Creates a new plugin instance. Passes the API version to the plugin.
+/// Creates a new plugin instance.
+/// On failure, returns `nullptr` and saves the exception.
+///
+/// @param aplication_version Version of dnf application.
+/// @param context            Reference to the application context.
+/// @return Pointer to the new plugin instance or `nullptr`.
 DNF_PLUGIN_API dnf5::IPlugin * dnf5_plugin_new_instance(
     dnf5::ApplicationVersion application_version, dnf5::Context & context);
 
 /// Deletes plugin instance.
+///
+/// @param plugin_instance Plugin instance to delete.
 DNF_PLUGIN_API void dnf5_plugin_delete_instance(dnf5::IPlugin * plugin_instance);
+
+/// Returns a pointer to `std::exception_ptr` containing the last caught exception.
+/// If no exception has occurred yet, returns a pointer to an empty `std::exception_ptr`.
+///
+/// @return Pointer to the `std::exception_ptr` containing the last caught exception.
+DNF_PLUGIN_API std::exception_ptr * dnf5_plugin_get_last_exception(void);
 }
 
 #endif

--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -42,11 +42,13 @@ private:
     using TGetVersionFunc = decltype(&dnf5_plugin_get_version);
     using TNewInstanceFunc = decltype(&dnf5_plugin_new_instance);
     using TDeleteInstanceFunc = decltype(&dnf5_plugin_delete_instance);
+    using TGetLastException = decltype(&dnf5_plugin_get_last_exception);
     TGetApiVersionFunc get_api_version{nullptr};
     TGetNameFunc get_name{nullptr};
     TGetVersionFunc get_version{nullptr};
     TNewInstanceFunc new_instance{nullptr};
     TDeleteInstanceFunc delete_instance{nullptr};
+    TGetLastException get_last_exception{nullptr};
     utils::Library library;
 };
 
@@ -73,9 +75,34 @@ PluginLibrary::PluginLibrary(Context & context, const std::string & library_path
     new_instance = reinterpret_cast<TNewInstanceFunc>(library.get_address("dnf5_plugin_new_instance"));
     delete_instance = reinterpret_cast<TDeleteInstanceFunc>(library.get_address("dnf5_plugin_delete_instance"));
 
+    try {
+        get_last_exception = reinterpret_cast<TGetLastException>(library.get_address("dnf5_plugin_get_last_exception"));
+    } catch (const std::runtime_error &) {
+        // The original plugin API did not have the "dnf5_plugin_get_last_exception" function.
+        // To maintain compatibility with older plugins, the "dnf5_plugin_get_last_exception" function is optional.
+    }
+
     iplugin_instance = new_instance(dnf5::get_application_version(), context);
     if (!iplugin_instance) {
-        throw std::runtime_error("Failed to create a dnf plugin instance");
+        auto & logger = *context.get_base().get_logger();
+        std::runtime_error plugin_exception("Failed to create a dnf plugin instance");
+        if (get_last_exception) {
+            if (auto * last_exception = get_last_exception()) {
+                try {
+                    if (*last_exception) {
+                        std::rethrow_exception(*last_exception);
+                    }
+                } catch (const std::exception & ex) {
+                    *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
+                    logger.error("dnf5_plugin_new_instance: {}", ex.what());
+                    std::throw_with_nested(std::move(plugin_exception));
+                } catch (...) {
+                    *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
+                    std::throw_with_nested(std::move(plugin_exception));
+                }
+            }
+        }
+        throw std::move(plugin_exception);
     }
 }
 

--- a/include/libdnf5/plugin/iplugin.hpp
+++ b/include/libdnf5/plugin/iplugin.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/defs.h"
 #include "libdnf5/version.hpp"
 
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -142,24 +143,44 @@ public:
 
 extern "C" {
 
-/// Returns the version of the API supported by the plugin.
+/// Returns the version of the API implemented by the plugin.
 /// Same result as IPlugin::get_api_version(), but can be called without creating an IPlugin instance.
+///
+/// @return API version implemented by the plugin.
 LIBDNF_PLUGIN_API libdnf5::PluginAPIVersion libdnf_plugin_get_api_version(void);
 
-/// Returns the name of the plugin. It can be called at any time.
+/// Returns the name of the plugin.
 /// Same result as IPlugin::get_name(), but can be called without creating an IPlugin instance.
+///
+/// @return Plugin name
 LIBDNF_PLUGIN_API const char * libdnf_plugin_get_name(void);
 
-/// Returns the version of the plugin. It can be called at any time.
+/// Returns the version of the plugin.
 /// Same result as IPlugin::get_version(), but can be called without creating an IPlugin instance.
+///
+/// @return Plugin version
 LIBDNF_PLUGIN_API libdnf5::plugin::Version libdnf_plugin_get_version(void);
 
-/// Creates a new plugin instance. Passes the API version to the plugin.
+/// Creates a new plugin instance.
+/// On failure, returns `nullptr` and saves the exception.
+///
+/// @param library_version Version of libdnf library.
+/// @param data            Private libdnf data passed to the plugin.
+/// @param parser          Parser with loaded plugin configuration file.
+/// @return Pointer to the new plugin instance or `nullptr`.
 LIBDNF_PLUGIN_API libdnf5::plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::LibraryVersion library_version, libdnf5::plugin::IPluginData & data, libdnf5::ConfigParser & parser);
 
 /// Deletes plugin instance.
+///
+/// @param plugin_instance Plugin instance to delete.
 LIBDNF_PLUGIN_API void libdnf_plugin_delete_instance(libdnf5::plugin::IPlugin * plugin_instance);
+
+/// Returns a pointer to `std::exception_ptr` containing the last caught exception.
+/// If no exception has occurred yet, returns a pointer to an empty `std::exception_ptr`.
+///
+/// @return Pointer to the `std::exception_ptr` containing the last caught exception.
+LIBDNF_PLUGIN_API std::exception_ptr * libdnf_plugin_get_last_exception(void);
 }
 
 #endif

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -1983,6 +1983,9 @@ void Actions::on_transaction(const libdnf5::base::Transaction & transaction, con
     }
 }
 
+
+std::exception_ptr last_exception;
+
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
@@ -2003,9 +2006,14 @@ plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::ConfigParser & parser) try {
     return new Actions(data, parser);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * libdnf_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/libdnf5-plugins/appstream/appstream.cpp
+++ b/libdnf5-plugins/appstream/appstream.cpp
@@ -100,6 +100,9 @@ void AppstreamPlugin::install_appstream(libdnf5::repo::Repo * repo) {
     }
 }
 
+
+std::exception_ptr last_exception;
+
 }  // namespace
 
 
@@ -121,9 +124,14 @@ plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::ConfigParser & parser) try {
     return new AppstreamPlugin(data, parser);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * libdnf_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -223,6 +223,9 @@ void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction &
     }
 }
 
+
+std::exception_ptr last_exception;
+
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
@@ -243,9 +246,14 @@ plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::ConfigParser & parser) try {
     return new ExpiredPgpKeys(data, parser);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * libdnf_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf5-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -175,8 +175,6 @@ static void fetch_python_error_to_exception(const char * msg) {
     throw std::runtime_error(msg + pycomp_str.get_string());
 }
 
-}  // namespace
-
 /// Load Python plugin from path
 void PythonPluginLoader::load_plugin_file(const fs::path & file_path) {
     // Very High Level Embedding
@@ -316,6 +314,11 @@ void PythonPluginLoader::load_plugins() {
 }
 
 
+std::exception_ptr last_exception;
+
+}  // namespace
+
+
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
     return REQUIRED_PLUGIN_API_VERSION;
 }
@@ -334,9 +337,14 @@ plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::ConfigParser & parser) try {
     return new PythonPluginLoader(data, parser);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * libdnf_plugin_get_last_exception(void) {
+    return &last_exception;
 }

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -140,6 +140,9 @@ void Rhsm::setup_enrollments() {
     }
 }
 
+
+std::exception_ptr last_exception;
+
 }  // namespace
 
 PluginAPIVersion libdnf_plugin_get_api_version(void) {
@@ -160,9 +163,14 @@ plugin::IPlugin * libdnf_plugin_new_instance(
     libdnf5::ConfigParser & parser) try {
     return new Rhsm(data, parser);
 } catch (...) {
+    last_exception = std::current_exception();
     return nullptr;
 }
 
 void libdnf_plugin_delete_instance(plugin::IPlugin * plugin_object) {
     delete plugin_object;
+}
+
+std::exception_ptr * libdnf_plugin_get_last_exception(void) {
+    return &last_exception;
 }


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/2047

To prevent function names from being mangled in the plugin API, these functions are linked as C language functions (extern "C"). We do not throw exceptions from these functions. Specifically, the `libdnf_plugin_new_instance` and
`dnf5_plugin_new_instance` functions return a null pointer on failure and discard the exception. Thus, the caller (libdnf library or dnf5 application) does not know the reason for the failure.

Changes:
- This modification extends the libdnf and dnf5 plugin APIs with new `libdnf_plugin_get_last_exception` and `dnf5_plugin_get_last_exception` functions. The plugin can save the exception instead of discarding it. The new functions allow access to the saved exception.

- All plugins have been modified to implement the new API functionality.

- Documentation string were improved.

Note:
The original functions are unchanged. Plugins that do not implement the new functions can still be used. API and ABI remain compatible.
