### PR TITLE
CMake: Use list(APPEND FOO) over set(FOO ${FOO} ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ include(VERSION.cmake)
 project(dnf5 LANGUAGES CXX C VERSION ${VERSION_PRIME}.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_MICRO})
 cmake_policy(VERSION ${CMAKE_VERSION})
 
-set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set (SYSTEMD_DIR "/usr/lib/systemd/system")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(SYSTEMD_DIR "/usr/lib/systemd/system")
 
 message("Building ${PROJECT_NAME} version ${PROJECT_VERSION}")
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -37,12 +37,12 @@ set(SWIG_COMPILE_OPTIONS
 )
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+    list(APPEND SWIG_COMPILE_OPTIONS
         -Wno-deprecated-volatile
         -Wno-unknown-warning-option
     )
 else()
-    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+    list(APPEND SWIG_COMPILE_OPTIONS
         -Wno-catch-value
         -Wno-maybe-uninitialized
         -Wno-volatile

--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -9,7 +9,7 @@ message("Building bindings for go")
 function(add_go_module LIBRARY_NAME MODULE_NAME)
     set(TARGET_NAME "go_${MODULE_NAME}")
     set_source_files_properties(../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTIES CPLUSPLUS ON)
-    set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS}
+    list(APPEND CMAKE_SWIG_FLAGS
         -module ${TARGET_NAME} -cgo -intgosize 64 -package libdnf5
     )
     swig_add_library(${TARGET_NAME} LANGUAGE go SOURCES ../../${LIBRARY_NAME}/${MODULE_NAME}.i)

--- a/bindings/python3/CMakeLists.txt
+++ b/bindings/python3/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(${Python3_INCLUDE_DIRS})
 
 function(add_python3_module LIBRARY_NAME MODULE_NAME)
     set(TARGET_NAME "python3_${MODULE_NAME}")
-    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+    list(APPEND SWIG_COMPILE_OPTIONS
         -Wno-redundant-decls
     )
     # Currently the SWIG_PYTHON_SILENT_MEMLEAK controls only whether message:
@@ -28,10 +28,10 @@ function(add_python3_module LIBRARY_NAME MODULE_NAME)
     # print the message
     # There is an issue reported on SWIG with the same root cause: https://github.com/swig/swig/issues/2037 it
     # also contains more details.
-    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+    list(APPEND SWIG_COMPILE_OPTIONS
         -DSWIG_PYTHON_SILENT_MEMLEAK
     )
-    set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS}
+    list(APPEND CMAKE_SWIG_FLAGS
         -doxygen
     )
     set_source_files_properties(../../${LIBRARY_NAME}/${MODULE_NAME}.i PROPERTIES CPLUSPLUS ON)


### PR DESCRIPTION
```cmake
set(FOO ${FOO} BAR BAZ)
set(FOO "${FOO};BAR;BAZ")

# They're both just funny ways to spell...
list(APPEND FOO BAR BAZ)
```

This PR replaces all remaining cargo-culted occurrences of `set()` being used to extend a list variable in CMake code, for which `list(APPEND)` is the appropriate command.

Not touched are calls like:

```cmake
set(FOO_STRING "${FOO_STRING} extended-string-stuff")
```

...which are not `list(APPEND)` equivalent.