### PR TITLE
load_plugins: Preserve original exception with failure information

### DIFF
--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -134,20 +134,13 @@ void Plugins::load_plugins(const std::string & dir_path) {
     }
     std::sort(lib_paths.begin(), lib_paths.end());
 
-    std::string failed_filenames;
     for (const auto & path : lib_paths) {
         try {
             load_plugin(path);
         } catch (const std::exception & ex) {
             logger->error("Cannot load dnf5 plugin \"{}\": {}", path.string(), ex.what());
-            if (!failed_filenames.empty()) {
-                failed_filenames += ", ";
-            }
-            failed_filenames += path.filename();
+            std::throw_with_nested(std::runtime_error("Cannot load dnf5 plugin: " + path.string()));
         }
-    }
-    if (!failed_filenames.empty()) {
-        throw std::runtime_error("Cannot load dnf5 plugins: " + failed_filenames);
     }
 }
 

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -114,7 +114,7 @@ std::string Plugins::find_plugin_library(const std::string & plugin_name) {
     if (std::filesystem::exists(library_path)) {
         return library_path;
     }
-    throw PluginError(M_("Cannot find plugin library \"{}\""), library_name);
+    throw PluginError(M_("Cannot find plugin library \"{}\""), library_path.string());
 }
 
 void Plugins::load_plugin_library(
@@ -216,21 +216,13 @@ void Plugins::load_plugins(
     }
     std::sort(config_paths.begin(), config_paths.end());
 
-    std::string failed_filenames;
     for (const auto & path : config_paths) {
         try {
             load_plugin(path, plugin_enablement);
         } catch (const std::exception & ex) {
-            logger.error("Cannot load plugin \"{}\": {}", path.string(), ex.what());
-            if (!failed_filenames.empty()) {
-                failed_filenames += ", ";
-            }
-            failed_filenames += path.filename();
+            logger.error("Cannot load libdnf plugin enabled from \"{}\": {}", path.string(), ex.what());
+            std::throw_with_nested(PluginError(M_("Cannot load libdnf plugin enabled from: {}"), path.string()));
         }
-    }
-
-    if (!failed_filenames.empty()) {
-        throw PluginError(M_("Cannot load plugins: {}"), failed_filenames);
     }
 
     // Creates a PluginInfo for each loaded plugin.


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/1336

The original implementation threw an exception with a list of plugins that failed to load. We usually got the name of one configuration file. Information about the reason for the failure was not included in the exception.

Now the code throws an exception for the first failed plugin. Exception contains the full path (not just the filename) and includes the original exception from the source of the error.