### PR TITLE
expired-pgp-keys: Drop checking for gpg command

### DIFF
--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -92,17 +92,6 @@ private:
     int64_t expiration_timestamp;
 };
 
-/// Check that GPG is installed to enable querying expired keys later.
-static bool is_gpg_installed() {
-    auto ts = rpmtsCreate();
-    rpmdbMatchIterator mi;
-    mi = rpmtsInitIterator(ts, RPMDBI_PROVIDENAME, "gpg", 0);
-    bool found = rpmdbNextIterator(mi) != NULL;
-    rpmdbFreeIterator(mi);
-    rpmtsFree(ts);
-    return found;
-}
-
 /// Check if the transaction contains any inbound actions.
 /// This determines if new software is to be installed, which might require downloading a new PGP signing key.
 static bool any_inbound_action(const libdnf5::base::Transaction & transaction) {
@@ -172,11 +161,6 @@ void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction &
     const auto & config = get_base().get_config();
 
     if (!config.get_pkg_gpgcheck_option().get_value()) {
-        return;
-    }
-
-    if (!is_gpg_installed()) {
-        logger.error("Expired PGP Keys Plugin: GPG is not installed on the system. Aborting...");
         return;
     }
 


### PR DESCRIPTION
The gpg provider is now a hard dependency in the spec file.

Follow-up on: #2051.