### PR TITLE
Use actual repository ID in stored transactions

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -322,8 +322,8 @@ void OfflineRebootCommand::run() {
             .storeResultsTo(unit_object_path);
 
         auto unit_proxy = sdbus::createProxy(SYSTEMD_DESTINATION_NAME, unit_object_path);
-        const auto & wants =
-            std::vector<std::string>{unit_proxy->getProperty("Wants").onInterface(SYSTEMD_UNIT_INTERFACE)};
+        const auto wants =
+            std::vector<std::string>(unit_proxy->getProperty("Wants").onInterface(SYSTEMD_UNIT_INTERFACE));
         if (std::find(wants.begin(), wants.end(), SYSTEMD_SERVICE_NAME) == wants.end()) {
             throw libdnf5::cli::CommandExitError(
                 1, M_("{} is not wanted by system-update.target."), SYSTEMD_SERVICE_NAME);

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -183,7 +183,7 @@ private:
     /// @param calculate_checksum Whether libsolv should calculate and store checksum of added packages. Setting to true significantly reduces performance.
     /// @return Newly created rpm::Package object in cmdline repo
     LIBDNF_LOCAL libdnf5::rpm::Package add_stored_transaction_package(
-        const std::string & path, bool calculate_checksum = false);
+        const std::string & path, const std::string & repo_id, bool calculate_checksum = false);
 
     LIBDNF_LOCAL void internalize_repos();
 

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -791,8 +791,8 @@ GoalProblem Goal::Impl::add_replay_to_goal(
         std::optional<libdnf5::rpm::Package> local_pkg;
         if (!package_replay.package_path.empty()) {
             // Package paths are relative to replay location
-            local_pkg =
-                base->get_repo_sack()->add_stored_transaction_package(replay_location / package_replay.package_path);
+            local_pkg = base->get_repo_sack()->add_stored_transaction_package(
+                replay_location / package_replay.package_path, package_replay.repo_id);
         }
 
         const auto nevras = rpm::Nevra::parse(package_replay.nevra, {rpm::Nevra::Form::NEVRA});

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -501,7 +501,9 @@ rpm::Package Repo::add_rpm_package(const std::string & path, bool with_hdrid) {
     }
 
     p_impl->solv_repo->set_needs_internalizing();
-    p_impl->base->get_rpm_package_sack()->p_impl->invalidate_provides();
+    auto pkg_sack = p_impl->base->get_rpm_package_sack();
+    pkg_sack->p_impl->register_local_rpm_id(new_id);
+    pkg_sack->p_impl->invalidate_provides();
 
     return rpm::Package(p_impl->base, rpm::PackageId(new_id));
 }

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -482,6 +482,7 @@ void Repo::add_xml_comps(const std::string & path) {
         throw RepoCompsError(
             M_("Failed to load xml Comps \"{}\": {}"), path, std::string(pool_errstr(p_impl->solv_repo->repo->pool)));
     }
+    p_impl->base->get_rpm_package_sack()->p_impl->invalidate_provides();
 }
 
 rpm::Package Repo::add_rpm_package(const std::string & path, bool with_hdrid) {

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -501,6 +501,9 @@ rpm::Package Repo::add_rpm_package(const std::string & path, bool with_hdrid) {
             M_("Failed to load RPM \"{}\": {}"), path, std::string(pool_errstr(p_impl->solv_repo->repo->pool)));
     }
 
+    // repo altered by adding an rpm package should not be written back to the cache
+    get_config().get_build_cache_option().set(libdnf5::Option::Priority::RUNTIME, false);
+
     p_impl->solv_repo->set_needs_internalizing();
     auto pkg_sack = p_impl->base->get_rpm_package_sack();
     pkg_sack->p_impl->register_local_rpm_id(new_id);

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -192,8 +192,20 @@ void RepoSack::add_stored_transaction_comps(const std::string & path) {
 }
 
 
-libdnf5::rpm::Package RepoSack::add_stored_transaction_package(const std::string & path, bool calculate_checksum) {
-    auto stored_repo = get_stored_transaction_repo();
+libdnf5::rpm::Package RepoSack::add_stored_transaction_package(
+    const std::string & path, const std::string & repo_id, bool calculate_checksum) {
+    RepoWeakPtr stored_repo;
+    if (!repo_id.empty()) {
+        for (const auto & existing_repo : get_data()) {
+            if (existing_repo->get_id() == repo_id) {
+                stored_repo = existing_repo->get_weak_ptr();
+                break;
+            }
+        }
+    }
+    if (!stored_repo.is_valid()) {
+        stored_repo = get_stored_transaction_repo();
+    }
 
     auto pkg = stored_repo->add_rpm_package(path, calculate_checksum);
 

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -388,7 +388,8 @@ std::vector<std::string> Package::get_remote_locations(const std::set<std::strin
 std::string Package::get_package_path() const {
     Solvable * solvable = get_rpm_pool(p_impl->base).id2solvable(p_impl->id.id);
     if (auto repo = static_cast<repo::Repo *>(solvable->repo->appdata)) {
-        if (repo->get_type() == repo::Repo::Type::COMMANDLINE) {
+        if (repo->get_type() == repo::Repo::Type::COMMANDLINE ||
+            p_impl->base->get_rpm_package_sack()->p_impl->is_local_rpm_id(p_impl->id.id)) {
             // Command line packages are used from their original location.
             return get_location();
         }

--- a/libdnf5/rpm/package_sack.cpp
+++ b/libdnf5/rpm/package_sack.cpp
@@ -637,4 +637,12 @@ rpm::Package PackageSack::get_running_kernel() {
     return rpm::Package(p_impl->base, p_impl->get_running_kernel_id());
 }
 
+void PackageSack::Impl::register_local_rpm_id(const Id id) {
+    local_rpm_ids.emplace(id);
+}
+
+bool PackageSack::Impl::is_local_rpm_id(const Id id) {
+    return local_rpm_ids.contains(id);
+}
+
 }  // namespace libdnf5::rpm

--- a/libdnf5/rpm/package_sack_impl.hpp
+++ b/libdnf5/rpm/package_sack_impl.hpp
@@ -127,6 +127,9 @@ public:
     /// And sets `considered_uptodate` to` true`.
     void recompute_considered_in_pool();
 
+    void register_local_rpm_id(const Id id);
+    bool is_local_rpm_id(const Id id);
+
 private:
     bool provides_ready{false};
 
@@ -160,6 +163,9 @@ private:
     libdnf5::solv::SolvMap cached_solvables{0};
     int cached_solvables_size{0};
     PackageId running_kernel;
+
+    // ids of packages created from local rpm files
+    std::unordered_set<Id> local_rpm_ids;
 
     friend PackageSack;
     friend Package;


### PR DESCRIPTION
Currently, when replaying a stored transaction, all RPM files are placed into a single `@stored_transaction` repository. This can be confusing, especially during a system upgrade, which also uses stored transactions.

With this patch, local RPM files from stored transactions are placed to the repository they originally came from.

Fixes: https://github.com/rpm-software-management/dnf5/issues/1851