### PR TITLE
Create progress bar in script callback if one doesn't already exist

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -935,6 +935,11 @@ void RpmTransCB::script_start(
     [[maybe_unused]] const libdnf5::base::TransactionPackage * item,
     libdnf5::rpm::Nevra nevra,
     libdnf5::rpm::TransactionCallbacks::ScriptType type) {
+    if (!active_progress_bar) {
+        // Scripts could potentially be the first thing in a transaction if the verification stage
+        // is skipped, so create a progress bar for the scripts to use if one doesn't already exist.
+        new_progress_bar(static_cast<int64_t>(-1), _("Running scriptlets"));
+    }
     active_progress_bar->add_message(
         libdnf5::cli::progressbar::MessageType::INFO,
         libdnf5::utils::sformat(


### PR DESCRIPTION
Normally, the script start callback is called after package verification has been done, so there is an active progress bar (created in the verification stage), however package verification can be disabled. If verification is disabled, then the script start callback is the first callback used (to run pre-trans scripts), and there will be no active progress bar, leading to a crash.

To handle the case of disabled verification, create a new progress bar in the script start callback for it to use in the future.

Fixes https://github.com/rpm-software-management/dnf5/issues/1949