### PR TITLE
expired-pgp-keys: Recommend the plugin only if gpg is already installed

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -22,7 +22,7 @@ Recommends:     (dnf5-plugins if dnf-plugins-core)
 Recommends:     bash-completion
 Requires:       coreutils
 %if 0%{?fedora} > 41
-Recommends:     libdnf5-plugin-expired-pgp-keys
+Recommends:     (libdnf5-plugin-expired-pgp-keys if gnupg2)
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} > 10


### PR DESCRIPTION
Since the gnupg2 package is a large binary (around 10MB), it would be preferable to install the plugin only on systems where gpg command is already present.