### PR TITLE
Create a pipe and open files with the close-on-exec flag

### DIFF
--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -105,7 +105,7 @@ void Rhsm::setup_enrollments() {
     bool same_content = false;
     do {
         int fd;
-        if ((fd = open(repofname, O_RDONLY)) == -1) {
+        if ((fd = open(repofname, O_RDONLY | O_CLOEXEC)) == -1) {
             break;
         }
         gsize length;

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -48,6 +48,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/utils/format.hpp"
 #include "libdnf5/utils/locker.hpp"
 
+#include <fcntl.h>
 #include <fmt/format.h>
 #include <unistd.h>
 
@@ -1081,7 +1082,7 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
 #endif
 
     int pipe_out_from_scriptlets[2];
-    if (pipe(pipe_out_from_scriptlets) == -1) {
+    if (pipe2(pipe_out_from_scriptlets, O_CLOEXEC) == -1) {
         logger->error("Transaction::Run: Cannot create pipe: {}", std::strerror(errno));
         return TransactionRunResult::ERROR_RPM_RUN;
     }

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -412,7 +412,7 @@ bool Package::is_available_locally() const {
 
 bool Package::is_cached() const {
     gboolean cached{FALSE};
-    if (auto fd = ::open(get_package_path().c_str(), O_RDONLY); fd != -1) {
+    if (auto fd = ::open(get_package_path().c_str(), O_RDONLY | O_CLOEXEC); fd != -1) {
         utils::OnScopeExit close_fd([fd]() noexcept { ::close(fd); });
         auto length = static_cast<unsigned long long>(lseek(fd, 0, SEEK_END));
         if (length == get_download_size()) {

--- a/libdnf5/utils/locker.cpp
+++ b/libdnf5/utils/locker.cpp
@@ -40,7 +40,7 @@ bool Locker::write_lock() {
 }
 
 bool Locker::lock(short int type) {
-    lock_fd = open(path.c_str(), O_CREAT | O_RDWR, 0660);
+    lock_fd = open(path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0660);
     if (lock_fd == -1) {
         throw SystemError(errno, M_("Failed to open lock file \"{}\""), path);
     }


### PR DESCRIPTION
An application that uses libdnf can create a child process (`fork`) in another thread and execute the program in it.  This will leak open descriptors to the newly executed program.

The close-on-exec flag (`O_CLOEXEC`) ensures that the descriptors are closed and not passed to the newly running program (they are closed).