### PR TITLE
Fix RepoCache::Impl::remove_recursive: Do not follow symlinks

### DIFF
--- a/libdnf5/repo/repo_cache.cpp
+++ b/libdnf5/repo/repo_cache.cpp
@@ -75,7 +75,7 @@ RepoCache::RemoveStatistics RepoCache::Impl::remove_recursive(const std::filesys
     RepoCache::RemoveStatistics status{};
     std::error_code ec;
     for (const auto & dir_entry : std::filesystem::directory_iterator(dir_path, ec)) {
-        if (dir_entry.is_directory()) {
+        if (dir_entry.is_directory() && !dir_entry.is_symlink()) {
             status += remove_recursive(dir_entry, log);
             status.p_impl->dirs_removed += remove(dir_entry, status.p_impl->errors, log);
         } else {


### PR DESCRIPTION
Symlinks were followed when removing the libdnf5 cache. This is very dangerous.
Example:
A user extracted a package into the cache folder. And later runs `dnf clean all`. The package contained a recursive symlink, which terminated the deletion with a `filesystem error: status: too many levels of symbolic...` error.

Imagine what would happen if there was a symlink outside the cache. Like a link to "/home", "/"...

Closes: https://github.com/rpm-software-management/dnf5/issues/2059