### PR TITLE
Fix: let copr plugin to respect the installroot option

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_disable.cpp
+++ b/dnf5-plugins/copr_plugin/copr_disable.cpp
@@ -30,9 +30,10 @@ namespace dnf5 {
 void CoprDisableCommand::set_argument_parser() {
     CoprSubCommandWithID::set_argument_parser();
     auto & cmd = *get_argument_parser_command();
+    auto & base = get_context().get_base();
     std::string desc = libdnf5::utils::sformat(
         _("disable specified Copr repository (if exists), keep {}/*.repo file - just mark enabled=0"),
-        copr_repo_directory().native());
+        copr_repo_directory(&base).native());
     cmd.set_description(desc);
     cmd.set_long_description(desc);
 }

--- a/dnf5-plugins/copr_plugin/copr_enable.cpp
+++ b/dnf5-plugins/copr_plugin/copr_enable.cpp
@@ -32,10 +32,11 @@ void CoprEnableCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & cmd = *get_argument_parser_command();
     auto & parser = ctx.get_argument_parser();
+    auto & base = ctx.get_base();
 
     std::string desc = libdnf5::utils::sformat(
         _("download the repository info from a Copr server and install it as a {}/*.repo file"),
-        copr_repo_directory().native());
+        copr_repo_directory(&base).native());
 
     cmd.set_description(desc);
     cmd.set_long_description(desc);

--- a/dnf5-plugins/copr_plugin/copr_remove.cpp
+++ b/dnf5-plugins/copr_plugin/copr_remove.cpp
@@ -30,9 +30,10 @@ namespace dnf5 {
 void CoprRemoveCommand::set_argument_parser() {
     CoprSubCommandWithID::set_argument_parser();
     auto & cmd = *get_argument_parser_command();
+    auto & base = get_context().get_base();
     std::string desc = libdnf5::utils::sformat(
         _("remove specified Copr repository from the system (removes the {}/*.repo file)"),
-        copr_repo_directory().native());
+        copr_repo_directory(&base).native());
     cmd.set_description(desc);
     cmd.set_long_description(desc);
 }

--- a/dnf5-plugins/copr_plugin/copr_repo.hpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.hpp
@@ -227,7 +227,7 @@ private:
 
 using CoprRepoCallback = std::function<void(CoprRepo &)>;
 void installed_copr_repositories(libdnf5::Base & base, CoprRepoCallback cb);
-std::filesystem::path copr_repo_directory();
+std::filesystem::path copr_repo_directory(libdnf5::Base * base);
 
 void copr_repo_disable(libdnf5::Base & base, const std::string & repo_spec);
 void copr_repo_remove(libdnf5::Base & base, const std::string & repo_spec);


### PR DESCRIPTION
This creates repofiles in `installroot` to respect its location. However `dnf4 copr` behaves the same way as `dnf5 copr` with `--use-host-config`:

```
[root@7223880ab7fc tmp]# dnf4 copr enable @copr/copr-ping --installroot=/tmp/dnf4 -y
...
[root@7223880ab7fc tmp]# tree
.
└── dnf4
    ├── usr
    │   └── lib
    │       └── sysimage
    │           └── rpm
    │               ├── rpmdb.sqlite
    │               ├── rpmdb.sqlite-shm
    │               └── rpmdb.sqlite-wal
    └── var
        ├── cache
        │   └── dnf
        │       └── expired_repos.json
        └── log
            ├── dnf.librepo.log
            ├── dnf.log
            └── dnf.rpm.log

10 directories, 7 files
[root@7223880ab7fc tmp]#
```

the repofile is created inside `/etc/yum.repos.d`, the installroot is ignored.

```
[root@7223880ab7fc tmp]# ls /etc/yum.repos.d/
_copr:copr.fedorainfracloud.org:group_copr:copr-ping.repo                      fedora-cisco-openh264.repo   fedora-updates.repo
_copr:copr.fedorainfracloud.org:packit:rpm-software-management-dnf5-2081.repo  fedora-updates-testing.repo  fedora.repo
```

But `dnf4 install buildtag --installroot=/tmp/dnf4` somehow uses the repofile in `/etc/yum.repos.d`. The same steps with dnf5 will result in 

```
[root@7223880ab7fc tmp]# dnf5 install buildtag --installroot=/tmp/dnf5
Updating and loading repositories:
Repositories loaded.
Failed to resolve the transaction:
No match for argument: buildtag
No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config.
```

because dnf5 by default looks to the installroot. I don't know whether we want to change the default behaviour of `dnf copr` between versions 4 and 5, but I'd expect the `dnf5 copr` command to create repofile inside `installroot`, so this PR should address this issue.  

Fix https://github.com/rpm-software-management/dnf5/issues/1497