### PR TITLE
Fix D-Bus Communication Issues

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -322,8 +322,8 @@ void OfflineRebootCommand::run() {
             .storeResultsTo(unit_object_path);
 
         auto unit_proxy = sdbus::createProxy(SYSTEMD_DESTINATION_NAME, unit_object_path);
-        const auto & wants =
-            std::vector<std::string>{unit_proxy->getProperty("Wants").onInterface(SYSTEMD_UNIT_INTERFACE)};
+        const auto wants =
+            std::vector<std::string>(unit_proxy->getProperty("Wants").onInterface(SYSTEMD_UNIT_INTERFACE));
         if (std::find(wants.begin(), wants.end(), SYSTEMD_SERVICE_NAME) == wants.end()) {
             throw libdnf5::cli::CommandExitError(
                 1, M_("{} is not wanted by system-update.target."), SYSTEMD_SERVICE_NAME);


### PR DESCRIPTION
This patch resolves two issues:

- Incorrect creation of std::vector<std::string> from the D-Bus variant.
- Incorrect session handling in the offline command (notable with sdbus-cpp v2).

These issues caused the dnf offline reboot command to break.