### PR TITLE
Rename dnf5-makecache timer to dnf-makecache when dnf5_obsoletes_dnf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(WITH_DNF5DAEMON_SERVER "Build package management service with a DBus inte
 option(WITH_LIBDNF5_CLI "Build library for working with a terminal in a command-line package manager" ON)
 option(WITH_DNF5 "Build dnf5 command-line package manager" ON)
 option(WITH_DNF5_PLUGINS "Build plugins for dnf5 command-line package manager" ON)
+option(WITH_DNF5_OBSOLETES_DNF "Build with DNF 5 providing files that may conflict with DNF 4" ON)
 option(WITH_PLUGIN_ACTIONS "Build a dnf5 actions plugin" ON)
 option(WITH_PLUGIN_APPSTREAM "Build with plugin to install repo's Appstream metadata" ON)
 option(WITH_PLUGIN_EXPIRED_PGP_KEYS "Build a libdnf5 expired pgp keys plugin" ON)

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -858,6 +858,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
     -DWITH_DNF5DAEMON_SERVER=%{?with_dnf5daemon_server:ON}%{!?with_dnf5daemon_server:OFF} \
     -DWITH_LIBDNF5_CLI=%{?with_libdnf_cli:ON}%{!?with_libdnf_cli:OFF} \
     -DWITH_DNF5=%{?with_dnf5:ON}%{!?with_dnf5:OFF} \
+    -DWITH_DNF5_OBSOLETES_DNF=%{?with_dnf5_obsoletes_dnf:ON}%{!?with_dnf5_obsoletes_dnf:OFF} \
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
     -DWITH_PLUGIN_APPSTREAM=%{?with_plugin_appstream:ON}%{!?with_plugin_appstream:OFF} \
     -DWITH_PLUGIN_EXPIRED_PGP_KEYS=%{?with_plugin_expired_pgp_keys:ON}%{!?with_plugin_expired_pgp_keys:OFF} \

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -271,13 +271,25 @@ upgrading, configuring, and removing computer programs in a consistent manner.
 It supports RPM packages, modulemd modules, and comps groups & environments.
 
 %post
+%if %{with dnf5_obsoletes_dnf}
+%systemd_post dnf-makecache.timer
+%else
 %systemd_post dnf5-makecache.timer
+%endif
 
 %preun
+%if %{with dnf5_obsoletes_dnf}
+%systemd_preun dnf-makecache.timer
+%else
 %systemd_preun dnf5-makecache.timer
+%endif
 
 %postun
+%if %{with dnf5_obsoletes_dnf}
+%systemd_postun_with_restart dnf-makecache.timer
+%else
 %systemd_postun_with_restart dnf5-makecache.timer
+%endif
 
 %files -f dnf5.lang
 %{_bindir}/dnf5
@@ -285,8 +297,8 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_bindir}/dnf
 %{_bindir}/yum
 %endif
-%{_unitdir}/dnf5-makecache.service
-%{_unitdir}/dnf5-makecache.timer
+%{_unitdir}/dnf*-makecache.service
+%{_unitdir}/dnf*-makecache.timer
 
 %if 0%{?fedora} || 0%{?rhel} > 10
 %{_bindir}/microdnf
@@ -898,6 +910,11 @@ for file in %{buildroot}%{_mandir}/man[578]/dnf5[-.]*; do
     filename=$(basename $file)
     ln -sr $file $dir/${filename/dnf5/dnf}
 done
+# Make "dnf-makecache" the "real" unit name, but keep compatibility for playbooks that refer to dnf5-makecache
+mv %{buildroot}%{_unitdir}/dnf5-makecache.service %{buildroot}%{_unitdir}/dnf-makecache.service
+mv %{buildroot}%{_unitdir}/dnf5-makecache.timer %{buildroot}%{_unitdir}/dnf-makecache.timer
+ln -s dnf-makecache.service %{buildroot}%{_unitdir}/dnf5-makecache.service
+ln -s dnf-makecache.timer %{buildroot}%{_unitdir}/dnf5-makecache.timer
 %endif
 
 # own dirs and files that dnf5 creates on runtime

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -237,7 +237,7 @@ Changes to individual commands
 
 ``makecache``
   * Metadata is now stored in different directories, see the ``cachedir`` configuration option :ref:`changes <cachedir_option_conf_changes_ref-label>` for more details.
-  * The ``--timer`` option has been dropped in favor of the systemd ``OnUnitInactiveSec`` setting in ``dnf5-makecache.timer`` and the ``ConditionACPower`` setting in ``dnf5-makecache.service``.
+  * The ``--timer`` option has been dropped in favor of the systemd ``OnUnitInactiveSec`` setting in ``dnf-makecache.timer`` and the ``ConditionACPower`` setting in ``dnf-makecache.service`` (these files are named ``dnf5-makecache.timer`` and ``dnf5-makecache.service`` on some systems).
 
 ``mark``
   * Renaming subcommands to be more intuitive: ``install`` -> ``user``, ``remove`` -> ``dependency``.
@@ -397,7 +397,7 @@ Additionally, corresponding command-line options ``--skip-broken`` and ``--skip-
 
 Deprecation of the ``metadata_timer_sync`` option
 -------------------------------------------------
-The ``metadata_timer_sync`` configuration option is now obsoleted by the ``dnf5-makecache.timer`` systemd timer settings.
+The ``metadata_timer_sync`` configuration option is now obsoleted by the ``dnf-makecache.timer`` systemd timer settings (named ``dnf5-makecache.timer`` on some systems).
 
 Changes to individual options
 -----------------------------

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -237,7 +237,8 @@ Changes to individual commands
 
 ``makecache``
   * Metadata is now stored in different directories, see the ``cachedir`` configuration option :ref:`changes <cachedir_option_conf_changes_ref-label>` for more details.
-  * The ``--timer`` option has been dropped in favor of the systemd ``OnUnitInactiveSec`` setting in ``dnf-makecache.timer`` and the ``ConditionACPower`` setting in ``dnf-makecache.service`` (these files are named ``dnf5-makecache.timer`` and ``dnf5-makecache.service`` on some systems).
+
+  * The ``--timer`` option has been dropped in favor of the systemd ``OnUnitInactiveSec`` setting in |DNF_MAKECACHE_TIMER_NAME_INLINE_LITERAL| and the ``ConditionACPower`` setting in |DNF_MAKECACHE_SERVICE_NAME_INLINE_LITERAL|.
 
 ``mark``
   * Renaming subcommands to be more intuitive: ``install`` -> ``user``, ``remove`` -> ``dependency``.
@@ -397,7 +398,7 @@ Additionally, corresponding command-line options ``--skip-broken`` and ``--skip-
 
 Deprecation of the ``metadata_timer_sync`` option
 -------------------------------------------------
-The ``metadata_timer_sync`` configuration option is now obsoleted by the ``dnf-makecache.timer`` systemd timer settings (named ``dnf5-makecache.timer`` on some systems).
+The ``metadata_timer_sync`` configuration option is now obsoleted by the |DNF_MAKECACHE_TIMER_NAME_INLINE_LITERAL| systemd timer settings.
 
 Changes to individual options
 -----------------------------

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -170,7 +170,12 @@ man_pages = [
     ('dnf5.conf-deprecated.5', 'dnf5.conf-deprecated', 'Config Options that are deprecated in DNF5', AUTHORS, 5),
 ]
 
-rst_prolog = """
+dnf_makecache_timer_name = "dnf-makecache.timer" if "@WITH_DNF5_OBSOLETES_DNF@" == "ON" else "dnf5-makecache.timer"
+dnf_makecache_service_name = "dnf-makecache.service" if "@WITH_DNF5_OBSOLETES_DNF@" == "ON" else "dnf5-makecache.service"
+
+rst_prolog = f"""
 .. _DNF: https://github.com/rpm-software-management/dnf/
 .. _DNF5: https://github.com/rpm-software-management/dnf5/
+.. |DNF_MAKECACHE_TIMER_NAME_INLINE_LITERAL| replace:: ``{dnf_makecache_timer_name}``
+.. |DNF_MAKECACHE_SERVICE_NAME_INLINE_LITERAL| replace:: ``{dnf_makecache_service_name}``
 """


### PR DESCRIPTION
Some maintainers of Fedora presets would prefer that the dnf-makecache timer use the unversioned name so that the presets (and Ansible playbooks, etc) do not need to be updated to account for renaming it. This change would create a file conflict between the "dnf" and "dnf5" packages in Fedora, but it's already impossible to install them simultaneously because dnf5 "obsoletes" the old dnf package.

This PR will use the unit name "dnf-makecache" when "dnf5_obsoletes_dnf", and "dnf5-makecache" when it does not obsolete dnf.

@keszybz @Conan-Kudo
