### PR TITLE
Use actual repository ID in stored transactions v2

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -392,6 +392,13 @@ void OfflineExecuteCommand::pre_configure() {
     // checked when the transaction was prepared and serialized. This way, we
     // don't need to keep track of which packages need to be gpgchecked.
     ctx.get_base().get_config().get_pkg_gpgcheck_option().set(false);
+
+    // Do not create repositories from the system configuration.
+    // They would be created as the AVAILABLE type, which is not suitable for
+    // adding packages from local RPM files. Libdnf5 will instead create
+    // COMMANDLINE-type repositories as needed based on the packages from the
+    // stored offline transaction.
+    ctx.set_create_repos(false);
 }
 
 void OfflineExecuteCommand::configure() {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -215,6 +215,9 @@ public:
     }
     bool get_json_output_requested() const { return json_output; }
 
+    void set_create_repos(bool create_repos) { this->create_repos = create_repos; }
+    bool get_create_repos() const { return create_repos; }
+
     libdnf5::Base & get_base() { return base; };
 
     std::vector<std::pair<std::string, std::string>> & get_setopts() { return setopts; }
@@ -249,6 +252,7 @@ private:
 
     bool should_store_offline = false;
     bool json_output = false;
+    bool create_repos = true;
 
     bool quiet{false};
     bool dump_main_config{false};
@@ -720,6 +724,14 @@ void Context::set_json_output_requested(bool json_output) {
 
 bool Context::get_json_output_requested() const {
     return p_impl->get_json_output_requested();
+}
+
+void Context::set_create_repos(bool create_repos) {
+    p_impl->set_create_repos(create_repos);
+}
+
+bool Context::get_create_repos() const {
+    return p_impl->get_create_repos();
 }
 
 libdnf5::Base & Context::get_base() {

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -161,6 +161,10 @@ public:
     void set_json_output_requested(bool json_output);
     bool get_json_output_requested() const;
 
+    // Determines whether repositories from the system configuration should be created. The default value is `true`.
+    void set_create_repos(bool create_repos);
+    bool get_create_repos() const;
+
     libdnf5::Base & get_base();
 
     std::vector<std::pair<std::string, std::string>> & get_setopts();

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1407,20 +1407,24 @@ int main(int argc, char * argv[]) try {
             }
 
             auto repo_sack = base.get_repo_sack();
-            repo_sack->create_repos_from_system_configuration();
-            any_repos_from_system_configuration = repo_sack->size() > 0;
 
-            auto vars = base.get_vars();
-            for (auto & id_path_pair : context.get_repos_from_path()) {
-                id_path_pair.first = vars->substitute(id_path_pair.first);
-                id_path_pair.second = vars->substitute(id_path_pair.second);
-            }
-            repo_sack->create_repos_from_paths(context.get_repos_from_path(), libdnf5::Option::Priority::COMMANDLINE);
-            for (const auto & [id, path] : context.get_repos_from_path()) {
-                context.get_setopts().emplace_back(id + ".enabled", "1");
-            }
+            if (context.get_create_repos()) {
+                repo_sack->create_repos_from_system_configuration();
+                any_repos_from_system_configuration = repo_sack->size() > 0;
 
-            context.apply_repository_setopts();
+                auto vars = base.get_vars();
+                for (auto & id_path_pair : context.get_repos_from_path()) {
+                    id_path_pair.first = vars->substitute(id_path_pair.first);
+                    id_path_pair.second = vars->substitute(id_path_pair.second);
+                }
+                repo_sack->create_repos_from_paths(
+                    context.get_repos_from_path(), libdnf5::Option::Priority::COMMANDLINE);
+                for (const auto & [id, path] : context.get_repos_from_path()) {
+                    context.get_setopts().emplace_back(id + ".enabled", "1");
+                }
+
+                context.apply_repository_setopts();
+            }
 
             // Run selected command
             command->configure();

--- a/include/libdnf5/repo/repo_sack.hpp
+++ b/include/libdnf5/repo/repo_sack.hpp
@@ -172,18 +172,18 @@ private:
 
     /// If not created yet, creates the stored transaction repository and returns it.
     /// @return The stored transaction repository.
-    LIBDNF_LOCAL libdnf5::repo::RepoWeakPtr get_stored_transaction_repo();
+    LIBDNF_LOCAL libdnf5::repo::RepoWeakPtr get_stored_transaction_repo(const std::string & repo_id);
 
     /// Add given path to comps to the stored_transaction repository.
     /// @param path Path to a local xml comps file to be inserted to stored_transaction repo.
-    LIBDNF_LOCAL void add_stored_transaction_comps(const std::string & path);
+    LIBDNF_LOCAL void add_stored_transaction_comps(const std::string & path, const std::string & repo_id);
 
     /// Add given path to rpm to the stored_transaction repository.
     /// @param path Path to a local rpm file to be inserted to stored_transaction repo.
     /// @param calculate_checksum Whether libsolv should calculate and store checksum of added packages. Setting to true significantly reduces performance.
     /// @return Newly created rpm::Package object in cmdline repo
     LIBDNF_LOCAL libdnf5::rpm::Package add_stored_transaction_package(
-        const std::string & path, bool calculate_checksum = false);
+        const std::string & path, const std::string & repo_id, bool calculate_checksum = false);
 
     LIBDNF_LOCAL void internalize_repos();
 

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -791,8 +791,8 @@ GoalProblem Goal::Impl::add_replay_to_goal(
         std::optional<libdnf5::rpm::Package> local_pkg;
         if (!package_replay.package_path.empty()) {
             // Package paths are relative to replay location
-            local_pkg =
-                base->get_repo_sack()->add_stored_transaction_package(replay_location / package_replay.package_path);
+            local_pkg = base->get_repo_sack()->add_stored_transaction_package(
+                replay_location / package_replay.package_path, package_replay.repo_id);
         }
 
         const auto nevras = rpm::Nevra::parse(package_replay.nevra, {rpm::Nevra::Form::NEVRA});
@@ -1043,7 +1043,8 @@ GoalProblem Goal::Impl::add_replay_to_goal(
         }
         if (!group_replay.group_path.empty()) {
             // Group paths are relative to replay location
-            base->get_repo_sack()->add_stored_transaction_comps(replay_location / group_replay.group_path);
+            base->get_repo_sack()->add_stored_transaction_comps(
+                replay_location / group_replay.group_path, group_replay.repo_id);
         }
 
         comps::GroupQuery group_query_installed(base);
@@ -1116,7 +1117,8 @@ GoalProblem Goal::Impl::add_replay_to_goal(
 
         if (!env_replay.environment_path.empty()) {
             // Environment paths are relative to replay location
-            base->get_repo_sack()->add_stored_transaction_comps(replay_location / env_replay.environment_path);
+            base->get_repo_sack()->add_stored_transaction_comps(
+                replay_location / env_replay.environment_path, env_replay.repo_id);
         }
         if (env_replay.action == transaction::TransactionItemAction::INSTALL) {
             group_specs.emplace_back(

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -482,6 +482,7 @@ void Repo::add_xml_comps(const std::string & path) {
         throw RepoCompsError(
             M_("Failed to load xml Comps \"{}\": {}"), path, std::string(pool_errstr(p_impl->solv_repo->repo->pool)));
     }
+    p_impl->base->get_rpm_package_sack()->p_impl->invalidate_provides();
 }
 
 rpm::Package Repo::add_rpm_package(const std::string & path, bool with_hdrid) {

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -128,7 +128,6 @@ private:
     WeakPtrGuard<RepoSack, false> sack_guard;
     repo::Repo * system_repo{nullptr};
     repo::Repo * cmdline_repo{nullptr};
-    repo::Repo * stored_transaction_repo{nullptr};
     bool repos_updated_and_loaded{false};
     friend RepoSack;
 };
@@ -173,27 +172,35 @@ RepoWeakPtr RepoSack::get_cmdline_repo() {
 }
 
 
-RepoWeakPtr RepoSack::get_stored_transaction_repo() {
-    if (!p_impl->stored_transaction_repo) {
+RepoWeakPtr RepoSack::get_stored_transaction_repo(const std::string & repo_id) {
+    std::string real_repo_id = repo_id.empty() ? STORED_TRANSACTION_NAME : repo_id;
+    RepoWeakPtr stored_repo;
+    for (const auto & existing_repo : get_data()) {
+        if (existing_repo->get_id() == real_repo_id) {
+            stored_repo = existing_repo->get_weak_ptr();
+            break;
+        }
+    }
+    if (!stored_repo.is_valid()) {
         // Repo type is COMMANDLINE because we don't want to download download any packages. We want it to behave like commandline repo.
-        std::unique_ptr<Repo> repo(new Repo(p_impl->base, STORED_TRANSACTION_NAME, Repo::Type::COMMANDLINE));
+        std::unique_ptr<Repo> repo(new Repo(p_impl->base, real_repo_id, Repo::Type::COMMANDLINE));
         repo->get_config().get_build_cache_option().set(libdnf5::Option::Priority::RUNTIME, false);
-        p_impl->stored_transaction_repo = repo.get();
-        add_item(std::move(repo));
+        stored_repo = add_item_with_return(std::move(repo));
     }
 
-    return p_impl->stored_transaction_repo->get_weak_ptr();
+    return stored_repo;
 }
 
 
-void RepoSack::add_stored_transaction_comps(const std::string & path) {
-    auto stored_repo = get_stored_transaction_repo();
+void RepoSack::add_stored_transaction_comps(const std::string & path, const std::string & repo_id) {
+    auto stored_repo = get_stored_transaction_repo(repo_id);
     stored_repo->add_xml_comps(path);
 }
 
 
-libdnf5::rpm::Package RepoSack::add_stored_transaction_package(const std::string & path, bool calculate_checksum) {
-    auto stored_repo = get_stored_transaction_repo();
+libdnf5::rpm::Package RepoSack::add_stored_transaction_package(
+    const std::string & path, const std::string & repo_id, bool calculate_checksum) {
+    auto stored_repo = get_stored_transaction_repo(repo_id);
 
     auto pkg = stored_repo->add_rpm_package(path, calculate_checksum);
 
@@ -840,10 +847,6 @@ void RepoSack::internalize_repos() {
 
     if (p_impl->cmdline_repo) {
         p_impl->cmdline_repo->internalize();
-    }
-
-    if (p_impl->stored_transaction_repo) {
-        p_impl->stored_transaction_repo->internalize();
     }
 }
 


### PR DESCRIPTION
This is alternative solution to https://github.com/rpm-software-management/dnf5/pull/2061

Currently, when replaying a stored transaction, all RPM files are placed
into a single `@stored_transaction` repository. The user can see this
artifitial repository when checking from which repositories the installed
packages came:

❯ dnf repoquery --installed --queryformat="%{full_nevra} %{from_repo}\n" 
vlc-plugin-gstreamer-1:3.0.21-15.fc40.x86_64 @stored_transaction

This can be confusing, especially during a system upgrade, which also uses
stored transactions.

With this patch, local RPM files from stored transactions are placed to the
repository they originally came from:

❯ dnf repoquery --installed --queryformat="%{full_nevra} %{from_repo}\n" 
vlc-plugin-gstreamer-1:3.0.21-15.fc40.x86_64 updates

Fixes: https://github.com/rpm-software-management/dnf5/issues/1851
tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1644