### PR TITLE
FindRuby no longer provides upper-case RUBY_* variables

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -7,7 +7,7 @@ message("Building bindings for ruby")
 
 
 find_package(Ruby REQUIRED)
-include_directories(${RUBY_INCLUDE_DIRS})
+include_directories(${Ruby_INCLUDE_DIRS})
 
 
 function(add_ruby_module LIBRARY_NAME MODULE_NAME)
@@ -20,9 +20,9 @@ function(add_ruby_module LIBRARY_NAME MODULE_NAME)
 
     string(REPLACE "_" "-" C_LIBRARY_NAME ${LIBRARY_NAME})
     target_link_libraries(${TARGET_NAME} PRIVATE ${C_LIBRARY_NAME})
-    target_link_libraries(${TARGET_NAME} PRIVATE ${RUBY_LIBRARY})
+    target_link_libraries(${TARGET_NAME} PRIVATE ${Ruby_LIBRARY})
 
-    install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION "${RUBY_VENDORARCH_DIR}/${LIBRARY_NAME}")
+    install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION "${Ruby_VENDORARCH_DIR}/${LIBRARY_NAME}")
 endfunction()
 
 

--- a/test/ruby/CMakeLists.txt
+++ b/test/ruby/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(add_ruby_test)
     set(target "test_ruby_${ARGV0}_${ARGV1}")
     add_test(
         NAME "${target}"
-        COMMAND "${RUBY_EXECUTABLE}" "-I${CMAKE_BINARY_DIR}/bindings/ruby" "-I${CMAKE_CURRENT_SOURCE_DIR}" "${ARGV1}"
+        COMMAND "${Ruby_EXECUTABLE}" "-I${CMAKE_BINARY_DIR}/bindings/ruby" "-I${CMAKE_CURRENT_SOURCE_DIR}" "${ARGV1}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 


### PR DESCRIPTION
Since cmake 4.0.0 version.

https://cmake.org/cmake/help/git-stage/policy/CMP0185.html
https://cmake.org/cmake/help/latest/module/FindRuby.html