### PR TITLE
doc: Removal of send_error_messages in automatic

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -147,6 +147,7 @@ Changes to individual commands
 ``automatic``
   * Now a DNF5 plugin.
   * The specific systemd units, ``dnf-automatic-download``, ``dnf-automatic-install``, and ``dnf-automatic-notifyonly``, have been dropped. Only one ``dnf5-automatic`` timer is shipped.
+  * The ``emitters.send_error_messages`` config option has been dropped. DNF5 automatic always informs the user about failed operations using configured emitters.
   * See the :ref:`Automatic command <automatic_plugin_ref-label>` for more information.
 
 ``autoremove``


### PR DESCRIPTION
Document difference between dnf4 and dnf5 versions of the dnf automatic
behavior regarding to the `emitters.send_error_messages` configuration
option.

Fixes: https://github.com/rpm-software-management/dnf5/issues/1965