### PR TITLE
spec: Package CHANGELOG and other project documentation files

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -309,6 +309,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %verify(not md5 size mtime) %ghost %{_prefix}/lib/sysimage/libdnf5/*
 %license COPYING.md
 %license gpl-2.0.txt
+%doc AUTHORS.md CHANGELOG.md CONTRIBUTING.md README.md
 %{_mandir}/man8/dnf5.8.*
 %if %{with dnf5_obsoletes_dnf}
 %{_mandir}/man8/dnf.8.*


### PR DESCRIPTION
Those files brings a value for users wanting to know what has changed between DNF5 releases, or where to find more help.

I placed them into dnf5 binary package instead of libdnf5 binary package to minimize libdnf5 footprint and because /usr/share/doc/dnf5 is probably the first directory people search.