### PR TITLE
Replace in-tree crc32() with a call to zlib

### DIFF
--- a/dnf5-plugins/config-manager_plugin/CMakeLists.txt
+++ b/dnf5-plugins/config-manager_plugin/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(libdnf5-cli PUBLIC ${LIBFMT_LIBRARIES})
 find_package(CURL 7.62.0 REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 
+find_package(ZLIB REQUIRED)
+
+target_link_libraries(config-manager_cmd_plugin PRIVATE ZLIB::ZLIB)
 target_link_libraries(config-manager_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(config-manager_cmd_plugin PRIVATE dnf5)
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -158,6 +158,7 @@ BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
 BuildRequires:  toml11-static
+BuildRequires:  zlib-devel
 
 %if %{with clang}
 BuildRequires:  clang


### PR DESCRIPTION
Replace the in-tree crc32() function with calls to zlib.  The only place I found the crc32 code was in was the config-manager plugin.

Fixes: SWM-1579