### PR TITLE
doc: Document dropping of makecache --timer option

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -394,6 +394,9 @@ To address this, the functionality has been split into two configuration options
 
 Additionally, corresponding command-line options ``--skip-broken`` and ``--skip-unavailable`` have been introduced for commands where applicable.
 
+Deprecation of the ``metadata_timer_sync`` option
+-------------------------------------------------
+The ``metadata_timer_sync`` configuration option is now obsoleted by the ``dnf5-makecache.timer`` systemd timer settings.
 
 Changes to individual options
 -----------------------------

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -237,6 +237,7 @@ Changes to individual commands
 
 ``makecache``
   * Metadata is now stored in different directories, see the ``cachedir`` configuration option :ref:`changes <cachedir_option_conf_changes_ref-label>` for more details.
+  * The ``--timer`` option has been dropped in favor of the systemd ``OnUnitInactiveSec`` setting in ``dnf5-makecache.timer`` and the ``ConditionACPower`` setting in ``dnf5-makecache.service``.
 
 ``mark``
   * Renaming subcommands to be more intuitive: ``install`` -> ``user``, ``remove`` -> ``dependency``.

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -218,10 +218,6 @@ This section does not track any deprecated option. For such options see :ref:`De
 Repo Options
 ============
 
-.. _metadata_timer_sync_options-label:
-
-``metadata_timer_sync``
-
 .. _module_hotfixes_repo_options-label:
 
 ``module_hotfixes``

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -128,8 +128,11 @@ public:
     const OptionBool & get_exit_on_lock_option() const;
     OptionBool & get_allow_vendor_change_option();
     const OptionBool & get_allow_vendor_change_option() const;
-    OptionSeconds & get_metadata_timer_sync_option();
-    const OptionSeconds & get_metadata_timer_sync_option() const;
+    /// @deprecated The metadata_timer_sync option does nothing
+    [[deprecated("The metadata_timer_sync option does nothing")]] OptionSeconds & get_metadata_timer_sync_option();
+    /// @deprecated The metadata_timer_sync option does nothing
+    [[deprecated("The metadata_timer_sync option does nothing")]] const OptionSeconds & get_metadata_timer_sync_option()
+        const;
     OptionStringList & get_disable_excludes_option();
     const OptionStringList & get_disable_excludes_option() const;
     OptionEnum & get_multilib_policy_option();  // :api

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -747,9 +747,11 @@ const OptionBool & ConfigMain::get_allow_vendor_change_option() const {
 }
 
 OptionSeconds & ConfigMain::get_metadata_timer_sync_option() {
+    LIBDNF5_DEPRECATED("The metadata_timer_sync option does nothing");
     return p_impl->metadata_timer_sync;
 }
 const OptionSeconds & ConfigMain::get_metadata_timer_sync_option() const {
+    LIBDNF5_DEPRECATED("The metadata_timer_sync option does nothing");
     return p_impl->metadata_timer_sync;
 }
 


### PR DESCRIPTION
The option (along with the metadata_timer_sync config option) was dropped in favor of systemd settings.

Fixes: https://github.com/rpm-software-management/dnf5/issues/812