### PR TITLE
system-upgrade: Add --allowerasing switch

### DIFF
--- a/dnf5/commands/system-upgrade/system-upgrade.cpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.cpp
@@ -81,6 +81,8 @@ void SystemUpgradeDownloadCommand::set_argument_parser() {
     no_downgrade_arg->set_const_value("true");
     no_downgrade_arg->link_value(no_downgrade);
     cmd.register_named_arg(no_downgrade_arg);
+
+    allow_erasing = std::make_unique<AllowErasingOption>(*this);
 }
 
 void SystemUpgradeDownloadCommand::configure() {
@@ -110,6 +112,7 @@ void SystemUpgradeDownloadCommand::run() {
     auto & ctx = get_context();
 
     const auto & goal = ctx.get_goal();
+    goal->set_allow_erasing(allow_erasing->get_value());
 
     if (no_downgrade->get_value()) {
         goal->add_rpm_upgrade();

--- a/dnf5/commands/system-upgrade/system-upgrade.hpp
+++ b/dnf5/commands/system-upgrade/system-upgrade.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_SYSTEM_UPGRADE_HPP
 
 #include <dnf5/context.hpp>
+#include <dnf5/shared_options.hpp>
 #include <libdnf5/transaction/offline.hpp>
 
 namespace dnf5 {
@@ -43,6 +44,7 @@ public:
 
 private:
     libdnf5::OptionBool * no_downgrade{nullptr};
+    std::unique_ptr<AllowErasingOption> allow_erasing;
     std::filesystem::path datadir{libdnf5::offline::DEFAULT_DATADIR};
     std::string target_releasever;
     std::string system_releasever;

--- a/doc/commands/system-upgrade.8.rst
+++ b/doc/commands/system-upgrade.8.rst
@@ -63,6 +63,9 @@ Options
 ``--no-downgrade``
     | Behave like ``dnf5 update``: do not install packages from the new release if they are older than what is currently installed. This is the opposite of the default behavior, which behaves like ``dnf5 distro-sync``, always installing packages from the new release, even if they are older than the currently-installed version.
 
+``--allowerasing``
+    | Allow removing of installed packages to resolve any potential dependency problems.
+
 ``--number=<boot number>``
     | See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`
 


### PR DESCRIPTION
This patch adds the --allowerasing option to the `dnf system-upgrade download`
command. It helps users resolve dependency issues during the system upgrade.
The use of this option is even documented in the Fedora documentation:
https://docs.fedoraproject.org/en-US/quick-docs/upgrading-fedora-offline/

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2349754