### PR TITLE
Revert "Packit: use GH's release notes for downstream changelog"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -38,7 +38,7 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-rawhide
-    copy_upstream_release_description: true
+    copy_upstream_release_description: false
     packages: [dnf5]
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
This reverts commit b1b72a245f9fa30a378a78ca74007965a78b739a.

We use GitHub to autogenerate upstream release notes that list the PRs that were merged since the last release. But these release notes are not appropriate to include in downstream RPM changelogs; they include GitHub usernames, links to pull requests, possibly special characters that could be interpreted as RPM macros [1], and are long.

Let's use `copy_upstream_release_description: false` which will make a one-line changelog entry with `Update to version x.y.z.p` which is what you see on Fedora packages that use %autochangelog, which is recommended by the Fedora packaging guidelines.

[1] https://packit.dev/docs/configuration#copy_upstream_release_description