### PR TITLE
spec: Set cmake minimal version to 3.21

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -145,7 +145,7 @@ BuildRequires:  bash-completion-devel
 %else
 BuildRequires:  bash-completion
 %endif
-BuildRequires:  cmake
+BuildRequires:  cmake >= 3.21
 BuildRequires:  doxygen
 BuildRequires:  gettext
 BuildRequires:  pkgconfig(check)


### PR DESCRIPTION
To reflect changes in df97dfb075b67b206a9c06dba49d2eef43b76f4e (Increase CMake minimum required version to 3.21).