### PR TITLE
Remove a warning from a code about an internal use of "dnf5 offline _execute"

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -470,11 +470,6 @@ void OfflineExecuteCommand::run() {
     plymouth.progress(0);
     plymouth.message(message.c_str());
 
-    std::cout
-        << _("Warning: the `_execute` command is for internal use only and is not intended to be run directly by "
-             "the user. To initiate the system upgrade/offline transaction, you should run `dnf5 offline reboot`.")
-        << std::endl;
-
     std::filesystem::remove(libdnf5::offline::MAGIC_SYMLINK);
 
     if (offline_data.get_status() != libdnf5::offline::STATUS_READY) {


### PR DESCRIPTION
The warning was added in aa5492a7facd0d881001cc3623b82cbd80dd66a3 (system-upgrade: Add warning to `dnf5 offline _execute`). But it abuses uses when performing legitimate offline upgrade by systemd:

    Mar 09 11:25:00 oldhome dnf5[1974]: Starting offline transaction. This will take a while.
    Mar 09 11:25:00 oldhome dnf5[1974]: Warning: the `_execute` command is for internal use only and is not intended to be run directly by the user. To initiate the system upgrade/offline transaction, you should run `dnf5 offline reboot`.
    Mar 09 11:25:00 oldhome dnf5[1974]: Package                                                  Arch   Version           Repository               Size
    Mar 09 11:25:00 oldhome dnf5[1974]: Upgrading:
    Mar 09 11:25:00 oldhome dnf5[1974]:  SDL2_image                                              x86_64 2.8.6-1.fc41      @stored_transaction 217.9 KiB

I think it's better to remove the warning than detecting legitimate uses the _execute subcommand. The warning remains in a usage text and a manual.

Resolves #2121