### PR TITLE
libdnf5 and libdnf5-cli: Move exception declarations to own header files, unification

### DIFF
--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -20,8 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CLI_ARGUMENT_PARSER_HPP
 #define LIBDNF5_CLI_ARGUMENT_PARSER_HPP
 
+#include "argument_parser_errors.hpp"
+
 #include "libdnf5-cli/defs.h"
-#include "libdnf5-cli/exception.hpp"
 
 #include <libdnf5/conf/option.hpp>
 
@@ -31,125 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 namespace libdnf5::cli {
-
-/// Parent for all ArgumentsParser runtime errors.
-class ArgumentParserError : public Error {
-    using Error::Error;
-    const char * get_name() const noexcept override { return "ArgumentParserError"; }
-};
-
-/// Exception is thrown when conflicting arguments are used together.
-class ArgumentParserConflictingArgumentsError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserConflictingArgumentsError"; }
-};
-
-/// Exception is thrown when no command is found.
-class ArgumentParserMissingCommandError : public ArgumentParserError {
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserMissingCommandError"; }
-};
-
-/// Exception is thrown when a command requires a positional argument that was not found.
-class ArgumentParserMissingPositionalArgumentError : public ArgumentParserError {
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserMissingPositionalArgumentError"; }
-};
-
-/// Exception is thrown when a positional argument has invalid format.
-class ArgumentParserPositionalArgumentFormatError : public ArgumentParserError {
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserPositionalArgumentFormatError"; }
-};
-
-/// Exception is generated in the case of an unexpected argument.
-class ArgumentParserUnknownArgumentError : public ArgumentParserError {
-private:
-    std::string command;
-    std::string argument;
-
-public:
-    using ArgumentParserError::ArgumentParserError;
-
-    template <typename... Ss>
-    ArgumentParserUnknownArgumentError(
-        const std::string command, const std::string argument, const BgettextMessage & format, Ss &&... args)
-        : ArgumentParserError(format, std::forward<Ss>(args)...),
-          command(command),
-          argument(argument) {}
-    const char * get_name() const noexcept override { return "ArgumentParserUnknownArgumentError"; }
-    const std::string & get_command() const { return command; };
-    const std::string & get_argument() const { return argument; };
-};
-
-
-/// Exception is thrown when an argument with the same ID is already registered.
-class ArgumentParserGroupArgumentIdRegisteredError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserGroupArgumentIdRegisteredError"; }
-};
-
-
-/// Exception is thrown when the Argument `id` contains not allowed '.' character.
-class ArgumentParserArgumentInvalidIdError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserArgumentInvalidIdError"; }
-};
-
-
-/// Exception is thrown when there are too few values for the positional argument.
-class ArgumentParserPositionalArgFewValuesError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserPositionalArgFewValuesError"; }
-};
-
-
-/// Exception is thrown if the named argument requires a value and the value is missing.
-class ArgumentParserNamedArgMissingValueError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserNamedArgMissingValueError"; }
-};
-
-/// Exception is thrown if the named argument is defined without a value and a value is present.
-class ArgumentParserNamedArgValueNotExpectedError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserNamedArgValueNotExpectedError"; }
-};
-
-
-/// Exception is thrown when the command, named_argument, or positional argument was not found.
-class ArgumentParserNotFoundError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserNotFoundError"; }
-};
-
-/// Exception is thrown when the command, named argument, positional argument, or group with the same ID is already registered.
-class ArgumentParserIdAlreadyRegisteredError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserIdAlreadyRegisteredError"; }
-};
-
-/// Exception is thrown when the command, named argument, positiona argument, or group needs an additional argument.
-class ArgumentParserMissingDependentArgumentError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserMissingDependentArgumentError"; }
-};
-
-/// Exception is thrown when the given argument value is not valid.
-class ArgumentParserInvalidValueError : public ArgumentParserError {
-public:
-    using ArgumentParserError::ArgumentParserError;
-    const char * get_name() const noexcept override { return "ArgumentParserInvalidValueError"; }
-};
 
 /// Base class for user data used in ArgumentParser::Argument
 class ArgumentParserUserData {};

--- a/include/libdnf5-cli/argument_parser_errors.hpp
+++ b/include/libdnf5-cli/argument_parser_errors.hpp
@@ -1,0 +1,150 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_CLI_ARGUMENT_PARSER_ERRORS_HPP
+#define LIBDNF5_CLI_ARGUMENT_PARSER_ERRORS_HPP
+
+#include "libdnf5-cli/exception.hpp"
+
+#include <string>
+
+namespace libdnf5::cli {
+
+/// Parent for all ArgumentsParser runtime errors.
+class ArgumentParserError : public Error {
+    using Error::Error;
+    const char * get_name() const noexcept override { return "ArgumentParserError"; }
+};
+
+/// Exception is thrown when conflicting arguments are used together.
+class ArgumentParserConflictingArgumentsError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserConflictingArgumentsError"; }
+};
+
+/// Exception is thrown when no command is found.
+class ArgumentParserMissingCommandError : public ArgumentParserError {
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingCommandError"; }
+};
+
+/// Exception is thrown when a command requires a positional argument that was not found.
+class ArgumentParserMissingPositionalArgumentError : public ArgumentParserError {
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingPositionalArgumentError"; }
+};
+
+/// Exception is thrown when a positional argument has invalid format.
+class ArgumentParserPositionalArgumentFormatError : public ArgumentParserError {
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserPositionalArgumentFormatError"; }
+};
+
+/// Exception is generated in the case of an unexpected argument.
+class ArgumentParserUnknownArgumentError : public ArgumentParserError {
+private:
+    std::string command;
+    std::string argument;
+
+public:
+    using ArgumentParserError::ArgumentParserError;
+
+    template <typename... Ss>
+    ArgumentParserUnknownArgumentError(
+        const std::string command, const std::string argument, const BgettextMessage & format, Ss &&... args)
+        : ArgumentParserError(format, std::forward<Ss>(args)...),
+          command(command),
+          argument(argument) {}
+    const char * get_name() const noexcept override { return "ArgumentParserUnknownArgumentError"; }
+    const std::string & get_command() const { return command; };
+    const std::string & get_argument() const { return argument; };
+};
+
+
+/// Exception is thrown when an argument with the same ID is already registered.
+class ArgumentParserGroupArgumentIdRegisteredError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserGroupArgumentIdRegisteredError"; }
+};
+
+
+/// Exception is thrown when the Argument `id` contains not allowed '.' character.
+class ArgumentParserArgumentInvalidIdError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserArgumentInvalidIdError"; }
+};
+
+
+/// Exception is thrown when there are too few values for the positional argument.
+class ArgumentParserPositionalArgFewValuesError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserPositionalArgFewValuesError"; }
+};
+
+
+/// Exception is thrown if the named argument requires a value and the value is missing.
+class ArgumentParserNamedArgMissingValueError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNamedArgMissingValueError"; }
+};
+
+/// Exception is thrown if the named argument is defined without a value and a value is present.
+class ArgumentParserNamedArgValueNotExpectedError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNamedArgValueNotExpectedError"; }
+};
+
+
+/// Exception is thrown when the command, named_argument, or positional argument was not found.
+class ArgumentParserNotFoundError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNotFoundError"; }
+};
+
+/// Exception is thrown when the command, named argument, positional argument, or group with the same ID is already registered.
+class ArgumentParserIdAlreadyRegisteredError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserIdAlreadyRegisteredError"; }
+};
+
+/// Exception is thrown when the command, named argument, positiona argument, or group needs an additional argument.
+class ArgumentParserMissingDependentArgumentError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingDependentArgumentError"; }
+};
+
+/// Exception is thrown when the given argument value is not valid.
+class ArgumentParserInvalidValueError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserInvalidValueError"; }
+};
+
+}  // namespace libdnf5::cli
+
+#endif

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_BASE_TRANSACTION_HPP
 #define LIBDNF5_BASE_TRANSACTION_HPP
 
+#include "transaction_errors.hpp"
+
 #include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/log_event.hpp"
@@ -43,16 +45,6 @@ class TransactionGroup;
 class TransactionEnvironment;
 class TransactionModule;
 class TransactionPackage;
-
-/// Error related to processing transaction
-class LIBDNF_API TransactionError : public Error {
-public:
-    using Error::Error;
-    /// @return Error class' domain name"
-    const char * get_domain_name() const noexcept override { return "libdnf5::base"; }
-    /// @return Error class' name"
-    const char * get_name() const noexcept override { return "TransactionError"; }
-};
 
 
 class LIBDNF_API Transaction {

--- a/include/libdnf5/base/transaction_errors.hpp
+++ b/include/libdnf5/base/transaction_errors.hpp
@@ -17,24 +17,26 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
 
-#include "transaction_item_errors.hpp"
+#ifndef LIBDNF5_BASE_TRANSACTION_ERRORS_HPP
+#define LIBDNF5_BASE_TRANSACTION_ERRORS_HPP
 
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
 
+namespace libdnf5::base {
 
-namespace libdnf5::transaction {
+/// Error related to processing transaction
+class LIBDNF_API TransactionError : public Error {
+public:
+    using Error::Error;
+    /// @return Error class' domain name"
+    const char * get_domain_name() const noexcept override { return "libdnf5::base"; }
+    /// @return Error class' name"
+    const char * get_name() const noexcept override { return "TransactionError"; }
+};
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+}  // namespace libdnf5::base
 
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_BASE_TRANSACTION_ERRORS_HPP

--- a/include/libdnf5/comps/group/package.hpp
+++ b/include/libdnf5/comps/group/package.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_COMPS_GROUP_PACKAGE_HPP
 #define LIBDNF5_COMPS_GROUP_PACKAGE_HPP
 
+#include "package_errors.hpp"
 #include "package_type.hpp"
 
 #include "libdnf5/defs.h"

--- a/include/libdnf5/comps/group/package_errors.hpp
+++ b/include/libdnf5/comps/group/package_errors.hpp
@@ -17,24 +17,27 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_COMPS_GROUP_PACKAGE_ERRORS_HPP
+#define LIBDNF5_COMPS_GROUP_PACKAGE_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
+#include "package_type.hpp"
 
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
 #include <string>
 
+namespace libdnf5::comps {
 
-namespace libdnf5::transaction {
+class LIBDNF_API InvalidPackageType : public libdnf5::Error {
+public:
+    InvalidPackageType(const std::string & type);
+    InvalidPackageType(const PackageType type);
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+    const char * get_domain_name() const noexcept override { return "libdnf5::comps"; }
+    const char * get_name() const noexcept override { return "InvalidPackageType"; }
+};
 
+}  // namespace libdnf5::comps
 
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif

--- a/include/libdnf5/comps/group/package_type.hpp
+++ b/include/libdnf5/comps/group/package_type.hpp
@@ -35,15 +35,6 @@ enum class PackageType : int {
     OPTIONAL = 1 << 3      // not installed by default, but can be checked in the UI
 };
 
-class LIBDNF_API InvalidPackageType : public libdnf5::Error {
-public:
-    InvalidPackageType(const std::string & type);
-    InvalidPackageType(const PackageType type);
-
-    const char * get_domain_name() const noexcept override { return "libdnf5::comps"; }
-    const char * get_name() const noexcept override { return "InvalidPackageType"; }
-};
-
 inline PackageType operator|(PackageType a, PackageType b) {
     return static_cast<PackageType>(
         static_cast<std::underlying_type<PackageType>::type>(a) |

--- a/include/libdnf5/conf/config_parser.hpp
+++ b/include/libdnf5/conf/config_parser.hpp
@@ -20,56 +20,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CONF_CONFIG_PARSER_HPP
 #define LIBDNF5_CONF_CONFIG_PARSER_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "config_parser_errors.hpp"
+
 #include "libdnf5/common/preserve_order_map.hpp"
+#include "libdnf5/defs.h"
 
 #include <string>
 
 
 namespace libdnf5 {
-
-/// Error accessing config file other than ENOENT; e.g. we don't have read permission
-class LIBDNF_API InaccessibleConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "InaccessibleConfigError"; }
-};
-
-/// Configuration file is missing
-class LIBDNF_API MissingConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "MissingConfigError"; }
-};
-
-/// Configuration file is invalid
-class LIBDNF_API InvalidConfigError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "InvalidConfigError"; }
-};
-
-class LIBDNF_API ConfigParserError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "ConfigParserError"; }
-};
-
-class LIBDNF_API ConfigParserSectionNotFoundError : public ConfigParserError {
-public:
-    explicit ConfigParserSectionNotFoundError(const std::string & section);
-    const char * get_name() const noexcept override { return "ConfigParserSectionNotFoundError"; }
-};
-
-class LIBDNF_API ConfigParserOptionNotFoundError : public ConfigParserError {
-public:
-    explicit ConfigParserOptionNotFoundError(const std::string & section, const std::string & option);
-    const char * get_name() const noexcept override { return "ConfigParserOptionNotFoundError"; }
-};
 
 /**
 * @class ConfigParser

--- a/include/libdnf5/conf/config_parser_errors.hpp
+++ b/include/libdnf5/conf/config_parser_errors.hpp
@@ -1,0 +1,74 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_CONF_CONFIG_PARSER_ERRORS_HPP
+#define LIBDNF5_CONF_CONFIG_PARSER_ERRORS_HPP
+
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/defs.h"
+
+
+namespace libdnf5 {
+
+/// Error accessing config file other than ENOENT; e.g. we don't have read permission
+class LIBDNF_API InaccessibleConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "InaccessibleConfigError"; }
+};
+
+/// Configuration file is missing
+class LIBDNF_API MissingConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "MissingConfigError"; }
+};
+
+/// Configuration file is invalid
+class LIBDNF_API InvalidConfigError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "InvalidConfigError"; }
+};
+
+class LIBDNF_API ConfigParserError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "ConfigParserError"; }
+};
+
+class LIBDNF_API ConfigParserSectionNotFoundError : public ConfigParserError {
+public:
+    explicit ConfigParserSectionNotFoundError(const std::string & section);
+    const char * get_name() const noexcept override { return "ConfigParserSectionNotFoundError"; }
+};
+
+class LIBDNF_API ConfigParserOptionNotFoundError : public ConfigParserError {
+public:
+    explicit ConfigParserOptionNotFoundError(const std::string & section, const std::string & option);
+    const char * get_name() const noexcept override { return "ConfigParserOptionNotFoundError"; }
+};
+
+}  // namespace libdnf5
+
+#endif

--- a/include/libdnf5/conf/option.hpp
+++ b/include/libdnf5/conf/option.hpp
@@ -20,7 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CONF_OPTION_HPP
 #define LIBDNF5_CONF_OPTION_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "option_errors.hpp"
+
 #include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/defs.h"
 
@@ -28,36 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf5 {
-
-/// Option exception
-class LIBDNF_API OptionError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "OptionError"; }
-};
-
-/// Exception that is generated when an invalid input value is detected.
-class LIBDNF_API OptionInvalidValueError : public OptionError {
-public:
-    using OptionError::OptionError;
-    const char * get_name() const noexcept override { return "OptionInvalidValueError"; }
-};
-
-/// Exception that is generated when not allowed input value is detected.
-class LIBDNF_API OptionValueNotAllowedError : public OptionInvalidValueError {
-public:
-    using OptionInvalidValueError::OptionInvalidValueError;
-    const char * get_name() const noexcept override { return "OptionValueNotAllowedError"; }
-};
-
-/// Exception that is generated during read an empty Option.
-class LIBDNF_API OptionValueNotSetError : public OptionError {
-public:
-    using OptionError::OptionError;
-    const char * get_name() const noexcept override { return "OptionValueNotSetError"; }
-};
-
 
 /// Option class is an abstract class. Parent of all options. Options are used to store a configuration.
 // @replaces libdnf:conf/Option.hpp:class:Option

--- a/include/libdnf5/conf/option_binds.hpp
+++ b/include/libdnf5/conf/option_binds.hpp
@@ -21,30 +21,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_CONF_OPTION_BINDS_HPP
 
 #include "option.hpp"
+#include "option_binds_errors.hpp"
+
+#include "libdnf5/defs.h"
 
 #include <functional>
 #include <map>
 
 
 namespace libdnf5 {
-
-struct OptionBindsError : public Error {
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "OptionBindsError"; }
-};
-
-class OptionBindsOptionNotFoundError : public OptionBindsError {
-public:
-    explicit OptionBindsOptionNotFoundError(const std::string & id);
-    const char * get_name() const noexcept override { return "OptionBindsOptionNotFoundError"; }
-};
-
-class OptionBindsOptionAlreadyExistsError : public OptionBindsError {
-public:
-    explicit OptionBindsOptionAlreadyExistsError(const std::string & id);
-    const char * get_name() const noexcept override { return "OptionBindsOptionAlreadyExistsError"; }
-};
 
 /// Maps the options names (text names read from config file, command line, ...) to options objects.
 /// Supports user defined functions for processing new value and converting value to string.

--- a/include/libdnf5/conf/option_binds_errors.hpp
+++ b/include/libdnf5/conf/option_binds_errors.hpp
@@ -1,0 +1,51 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_CONF_OPTION_BINDS_ERRORS_HPP
+#define LIBDNF5_CONF_OPTION_BINDS_ERRORS_HPP
+
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/defs.h"
+
+#include <string>
+
+
+namespace libdnf5 {
+
+struct LIBDNF_API OptionBindsError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "OptionBindsError"; }
+};
+
+class LIBDNF_API OptionBindsOptionNotFoundError : public OptionBindsError {
+public:
+    explicit OptionBindsOptionNotFoundError(const std::string & id);
+    const char * get_name() const noexcept override { return "OptionBindsOptionNotFoundError"; }
+};
+
+class LIBDNF_API OptionBindsOptionAlreadyExistsError : public OptionBindsError {
+public:
+    explicit OptionBindsOptionAlreadyExistsError(const std::string & id);
+    const char * get_name() const noexcept override { return "OptionBindsOptionAlreadyExistsError"; }
+};
+
+}  // namespace libdnf5
+
+#endif

--- a/include/libdnf5/conf/option_binds_errors.hpp
+++ b/include/libdnf5/conf/option_binds_errors.hpp
@@ -28,7 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5 {
 
-struct LIBDNF_API OptionBindsError : public Error {
+class LIBDNF_API OptionBindsError : public Error {
     using Error::Error;
     const char * get_domain_name() const noexcept override { return "libdnf5"; }
     const char * get_name() const noexcept override { return "OptionBindsError"; }

--- a/include/libdnf5/conf/option_errors.hpp
+++ b/include/libdnf5/conf/option_errors.hpp
@@ -1,0 +1,60 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_CONF_OPTION_ERRORS_HPP
+#define LIBDNF5_CONF_OPTION_ERRORS_HPP
+
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/defs.h"
+
+
+namespace libdnf5 {
+
+/// Option exception
+class LIBDNF_API OptionError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "OptionError"; }
+};
+
+/// Exception that is generated when an invalid input value is detected.
+class LIBDNF_API OptionInvalidValueError : public OptionError {
+public:
+    using OptionError::OptionError;
+    const char * get_name() const noexcept override { return "OptionInvalidValueError"; }
+};
+
+/// Exception that is generated when not allowed input value is detected.
+class LIBDNF_API OptionValueNotAllowedError : public OptionInvalidValueError {
+public:
+    using OptionInvalidValueError::OptionInvalidValueError;
+    const char * get_name() const noexcept override { return "OptionValueNotAllowedError"; }
+};
+
+/// Exception that is generated during read an empty Option.
+class LIBDNF_API OptionValueNotSetError : public OptionError {
+public:
+    using OptionError::OptionError;
+    const char * get_name() const noexcept override { return "OptionValueNotSetError"; }
+};
+
+}  // namespace libdnf5
+
+#endif

--- a/include/libdnf5/conf/option_path.hpp
+++ b/include/libdnf5/conf/option_path.hpp
@@ -20,18 +20,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CONF_OPTION_PATH_HPP
 #define LIBDNF5_CONF_OPTION_PATH_HPP
 
+#include "option_path_errors.hpp"
 #include "option_string.hpp"
+
+#include "libdnf5/defs.h"
 
 
 namespace libdnf5 {
-
-/// Exception that is generated when input path does not exist.
-class OptionPathNotFoundError : public OptionValueNotAllowedError {
-public:
-    using OptionValueNotAllowedError::OptionValueNotAllowedError;
-    const char * get_name() const noexcept override { return "OptionPathNotFoundError"; }
-};
-
 
 /// Option that stores file/directory path.
 /// Support default value, and path verification (absolute, existence).

--- a/include/libdnf5/conf/option_path_errors.hpp
+++ b/include/libdnf5/conf/option_path_errors.hpp
@@ -17,24 +17,22 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_CONF_OPTION_PATH_ERRORS_HPP
+#define LIBDNF5_CONF_OPTION_PATH_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
+#include "option_errors.hpp"
 
 #include "libdnf5/defs.h"
 
-#include <string>
+namespace libdnf5 {
 
+/// Exception that is generated when input path does not exist.
+class LIBDNF_API OptionPathNotFoundError : public OptionValueNotAllowedError {
+public:
+    using OptionValueNotAllowedError::OptionValueNotAllowedError;
+    const char * get_name() const noexcept override { return "OptionPathNotFoundError"; }
+};
 
-namespace libdnf5::transaction {
+}  // namespace libdnf5
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
-
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -20,21 +20,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_CONF_VARS_HPP
 #define LIBDNF5_CONF_VARS_HPP
 
+#include "vars_errors.hpp"
+
 #include "libdnf5/base/base_weak.hpp"
+#include "libdnf5/defs.h"
 
 #include <map>
 #include <string>
 #include <vector>
 
+
 namespace libdnf5 {
-
-// Thrown when attempting to set a read-only variable
-class ReadOnlyVariableError : public Error {
-    using Error::Error;
-
-    const char * get_domain_name() const noexcept override { return "libdnf5"; }
-    const char * get_name() const noexcept override { return "ReadOnlyVariableError"; }
-};
 
 /// @class Vars
 ///

--- a/include/libdnf5/conf/vars_errors.hpp
+++ b/include/libdnf5/conf/vars_errors.hpp
@@ -17,24 +17,23 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_CONF_VARS_ERRORS_HPP
+#define LIBDNF5_CONF_VARS_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
 
+namespace libdnf5 {
 
-namespace libdnf5::transaction {
+// Thrown when attempting to set a read-only variable
+class LIBDNF_API ReadOnlyVariableError : public Error {
+    using Error::Error;
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+    const char * get_domain_name() const noexcept override { return "libdnf5"; }
+    const char * get_name() const noexcept override { return "ReadOnlyVariableError"; }
+};
 
+}  // namespace libdnf5
 
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif

--- a/include/libdnf5/repo/file_downloader.hpp
+++ b/include/libdnf5/repo/file_downloader.hpp
@@ -20,8 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_FILE_DOWNLOADER_HPP
 #define LIBDNF5_REPO_FILE_DOWNLOADER_HPP
 
+#include "file_downloader_errors.hpp"
+
 #include "libdnf5/base/base_weak.hpp"
-#include "libdnf5/common/exception.hpp"
 #include "libdnf5/conf/config_main.hpp"
 #include "libdnf5/defs.h"
 #include "libdnf5/repo/repo_weak.hpp"
@@ -29,13 +30,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 
 namespace libdnf5::repo {
-
-class FileDownloadError : public Error {
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
-    const char * get_name() const noexcept override { return "FileDownloadError"; }
-};
-
 
 class LIBDNF_API FileDownloader {
 public:

--- a/include/libdnf5/repo/file_downloader_errors.hpp
+++ b/include/libdnf5/repo/file_downloader_errors.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_REPO_FILE_DOWNLOADER_ERRORS_HPP
+#define LIBDNF5_REPO_FILE_DOWNLOADER_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
+namespace libdnf5::repo {
 
+class LIBDNF_API FileDownloadError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
+    const char * get_name() const noexcept override { return "FileDownloadError"; }
+};
 
-namespace libdnf5::transaction {
+}  // namespace libdnf5::repo
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
-
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_REPO_FILE_DOWNLOADER_ERRORS_HPP

--- a/include/libdnf5/repo/package_downloader.hpp
+++ b/include/libdnf5/repo/package_downloader.hpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_PACKAGE_DOWNLOADER_HPP
 #define LIBDNF5_REPO_PACKAGE_DOWNLOADER_HPP
 
+#include "package_downloader_errors.hpp"
+
 #include "libdnf5/conf/config_main.hpp"
 #include "libdnf5/defs.h"
 #include "libdnf5/rpm/package.hpp"
@@ -28,13 +30,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <optional>
 
 namespace libdnf5::repo {
-
-class PackageDownloadError : public Error {
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
-    const char * get_name() const noexcept override { return "PackageDownloadError"; }
-};
-
 
 class LIBDNF_API PackageDownloader {
 public:

--- a/include/libdnf5/repo/package_downloader_errors.hpp
+++ b/include/libdnf5/repo/package_downloader_errors.hpp
@@ -17,24 +17,21 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_REPO_PACKAGE_DOWNLOADER_ERRORS_HPP
+#define LIBDNF5_REPO_PACKAGE_DOWNLOADER_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
 
+namespace libdnf5::repo {
 
-namespace libdnf5::transaction {
+class LIBDNF_API PackageDownloadError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
+    const char * get_name() const noexcept override { return "PackageDownloadError"; }
+};
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+}  // namespace libdnf5::repo
 
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_REPO_PACKAGE_DOWNLOADER_ERRORS_HPP

--- a/include/libdnf5/repo/repo_cache.hpp
+++ b/include/libdnf5/repo/repo_cache.hpp
@@ -20,8 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_REPO_REPO_CACHE_HPP
 #define LIBDNF5_REPO_REPO_CACHE_HPP
 
+#include "repo_cache_errors.hpp"
+
 #include "libdnf5/base/base_weak.hpp"
-#include "libdnf5/common/exception.hpp"
 #include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/defs.h"
 
@@ -53,15 +54,6 @@ private:
 
     class LIBDNF_LOCAL Impl;
     ImplPtr<Impl> p_impl;
-};
-
-
-/// RepoCache exception
-class RepoCacheError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
-    const char * get_name() const noexcept override { return "RepoCacheError"; }
 };
 
 

--- a/include/libdnf5/repo/repo_cache_errors.hpp
+++ b/include/libdnf5/repo/repo_cache_errors.hpp
@@ -17,24 +17,23 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_REPO_REPO_CACHE_ERRORS_HPP
+#define LIBDNF5_REPO_REPO_CACHE_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
 
+namespace libdnf5::repo {
 
-namespace libdnf5::transaction {
+/// RepoCache exception
+class LIBDNF_API RepoCacheError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
+    const char * get_name() const noexcept override { return "RepoCacheError"; }
+};
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+}  // namespace libdnf5::repo
 
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif

--- a/include/libdnf5/repo/repo_errors.hpp
+++ b/include/libdnf5/repo/repo_errors.hpp
@@ -21,51 +21,52 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF5_RPM_REPO_ERRORS_HPP
 
 #include "libdnf5/common/exception.hpp"
+#include "libdnf5/defs.h"
 
 
 namespace libdnf5::repo {
 
-class RepoError : public Error {
+class LIBDNF_API RepoError : public Error {
     using Error::Error;
     const char * get_domain_name() const noexcept override { return "libdnf5::repo"; }
     const char * get_name() const noexcept override { return "RepoError"; }
 };
 
 
-class RepoCacheonlyError : public RepoError {
+class LIBDNF_API RepoCacheonlyError : public RepoError {
 public:
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoCacheonlyError"; }
 };
 
 
-class RepoDownloadError : public RepoError {
+class LIBDNF_API RepoDownloadError : public RepoError {
 public:
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoDownloadError"; }
 };
 
 
-class RepoPgpError : public RepoError {
+class LIBDNF_API RepoPgpError : public RepoError {
 public:
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoPgpError"; }
 };
 
 
-class RepoRpmError : public RepoError {
+class LIBDNF_API RepoRpmError : public RepoError {
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoRpmError"; }
 };
 
 
-class RepoCompsError : public RepoError {
+class LIBDNF_API RepoCompsError : public RepoError {
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoCompsError"; }
 };
 
 
-class RepoIdAlreadyExistsError : public RepoError {
+class LIBDNF_API RepoIdAlreadyExistsError : public RepoError {
     using RepoError::RepoError;
     const char * get_name() const noexcept override { return "RepoIdAlreadyExistsError"; }
 };

--- a/include/libdnf5/rpm/nevra.hpp
+++ b/include/libdnf5/rpm/nevra.hpp
@@ -21,7 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_RPM_NEVRA_HPP
 #define LIBDNF5_RPM_NEVRA_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "nevra_errors.hpp"
+
 #include "libdnf5/common/impl_ptr.hpp"
 #include "libdnf5/defs.h"
 
@@ -31,13 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf5::rpm {
-
-struct LIBDNF_API NevraIncorrectInputError : public Error {
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
-    const char * get_name() const noexcept override { return "NevraIncorrectInputError"; }
-};
-
 
 // @replaces hawkey:hawkey/__init__.py:class:Nevra
 struct LIBDNF_API Nevra {

--- a/include/libdnf5/rpm/nevra_errors.hpp
+++ b/include/libdnf5/rpm/nevra_errors.hpp
@@ -26,7 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::rpm {
 
-struct LIBDNF_API NevraIncorrectInputError : public Error {
+class LIBDNF_API NevraIncorrectInputError : public Error {
     using Error::Error;
     const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
     const char * get_name() const noexcept override { return "NevraIncorrectInputError"; }

--- a/include/libdnf5/rpm/nevra_errors.hpp
+++ b/include/libdnf5/rpm/nevra_errors.hpp
@@ -17,24 +17,21 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
 
-#include "transaction_item_errors.hpp"
+#ifndef LIBDNF5_RPM_NEVRA_ERRORS_HPP
+#define LIBDNF5_RPM_NEVRA_ERRORS_HPP
 
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
+namespace libdnf5::rpm {
 
+struct LIBDNF_API NevraIncorrectInputError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
+    const char * get_name() const noexcept override { return "NevraIncorrectInputError"; }
+};
 
-namespace libdnf5::transaction {
+}  // namespace libdnf5::rpm
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
-
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_RPM_NEVRA_ERRORS_HPP

--- a/include/libdnf5/rpm/rpm_signature.hpp
+++ b/include/libdnf5/rpm/rpm_signature.hpp
@@ -20,8 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_RPM_RPM_SIGNATURE_HPP
 #define LIBDNF5_RPM_RPM_SIGNATURE_HPP
 
+#include "rpm_signature_errors.hpp"
+
 #include "libdnf5/base/base.hpp"
-#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 #include "libdnf5/rpm/package.hpp"
 
@@ -29,20 +30,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 
 namespace libdnf5::rpm {
-
-class LIBDNF_API SignatureCheckError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
-    const char * get_name() const noexcept override { return "SignatureCheckError"; }
-};
-
-class LIBDNF_API KeyImportError : public Error {
-public:
-    using Error::Error;
-    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
-    const char * get_name() const noexcept override { return "KeyImportError"; }
-};
 
 using RpmKeyPktPtr = std::unique_ptr<uint8_t, std::function<void(uint8_t * pkt)>>;
 

--- a/include/libdnf5/rpm/rpm_signature_errors.hpp
+++ b/include/libdnf5/rpm/rpm_signature_errors.hpp
@@ -17,24 +17,28 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_RPM_RPM_SIGNATURE_ERRORS_HPP
+#define LIBDNF5_RPM_RPM_SIGNATURE_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
-#include <string>
+namespace libdnf5::rpm {
 
+class LIBDNF_API SignatureCheckError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
+    const char * get_name() const noexcept override { return "SignatureCheckError"; }
+};
 
-namespace libdnf5::transaction {
+class LIBDNF_API KeyImportError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf5::rpm"; }
+    const char * get_name() const noexcept override { return "KeyImportError"; }
+};
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+}  // namespace libdnf5::rpm
 
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
-
-}  // namespace libdnf5::transaction
-
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_RPM_RPM_SIGNATURE_ERRORS_HPP

--- a/include/libdnf5/transaction/transaction.hpp
+++ b/include/libdnf5/transaction/transaction.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "comps_environment.hpp"
 #include "comps_group.hpp"
 #include "rpm_package.hpp"
+#include "transaction_errors.hpp"
 #include "transaction_item.hpp"
 
 #include "libdnf5/base/transaction_environment.hpp"
@@ -60,14 +61,6 @@ enum class TransactionState : int { STARTED = 1, OK = 2, ERROR = 3 };
 
 LIBDNF_API std::string transaction_state_to_string(TransactionState state);
 LIBDNF_API TransactionState transaction_state_from_string(const std::string & state);
-
-class LIBDNF_API InvalidTransactionState : public libdnf5::Error {
-public:
-    InvalidTransactionState(const std::string & state);
-
-    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
-    const char * get_name() const noexcept override { return "InvalidTransactionState"; }
-};
 
 
 /// Transaction holds information about a transaction.

--- a/include/libdnf5/transaction/transaction_errors.hpp
+++ b/include/libdnf5/transaction/transaction_errors.hpp
@@ -17,11 +17,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-#define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#ifndef LIBDNF5_TRANSACTION_TRANSACTION_ERRORS_HPP
+#define LIBDNF5_TRANSACTION_TRANSACTION_ERRORS_HPP
 
-#include "transaction_item_errors.hpp"
-
+#include "libdnf5/common/exception.hpp"
 #include "libdnf5/defs.h"
 
 #include <string>
@@ -29,12 +28,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf5::transaction {
 
-enum class TransactionItemState : int { STARTED = 1, OK = 2, ERROR = 3 };
+class LIBDNF_API InvalidTransactionState : public libdnf5::Error {
+public:
+    InvalidTransactionState(const std::string & state);
 
-
-LIBDNF_API std::string transaction_item_state_to_string(TransactionItemState state);
-LIBDNF_API TransactionItemState transaction_item_state_from_string(const std::string & state);
+    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
+    const char * get_name() const noexcept override { return "InvalidTransactionState"; }
+};
 
 }  // namespace libdnf5::transaction
 
-#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
+#endif  // LIBDNF5_TRANSACTION_TRANSACTION_ERRORS_HPP

--- a/include/libdnf5/transaction/transaction_item_action.hpp
+++ b/include/libdnf5/transaction/transaction_item_action.hpp
@@ -20,7 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_TRANSACTION_ITEM_ACTION_HPP
 #define LIBDNF5_TRANSACTION_ITEM_ACTION_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "transaction_item_errors.hpp"
+
 #include "libdnf5/defs.h"
 
 #include <string>
@@ -45,15 +46,6 @@ enum class TransactionItemAction : int {
     DISABLE = 9,        // module disable
     RESET = 10,         // module reset
     SWITCH = 11         // module switch
-};
-
-
-class LIBDNF_API InvalidTransactionItemAction : public libdnf5::Error {
-public:
-    InvalidTransactionItemAction(const std::string & action);
-
-    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
-    const char * get_name() const noexcept override { return "InvalidTransactionItemAction"; }
 };
 
 

--- a/include/libdnf5/transaction/transaction_item_errors.hpp
+++ b/include/libdnf5/transaction/transaction_item_errors.hpp
@@ -1,0 +1,68 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF5_TRANSACTION_ITEM_ERRORS_HPP
+#define LIBDNF5_TRANSACTION_ITEM_ERRORS_HPP
+
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/defs.h"
+
+#include <string>
+
+
+namespace libdnf5::transaction {
+
+class LIBDNF_API InvalidTransactionItemAction : public libdnf5::Error {
+public:
+    InvalidTransactionItemAction(const std::string & action);
+
+    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
+    const char * get_name() const noexcept override { return "InvalidTransactionItemAction"; }
+};
+
+
+class LIBDNF_API InvalidTransactionItemReason : public libdnf5::Error {
+public:
+    InvalidTransactionItemReason(const std::string & reason);
+
+    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
+    const char * get_name() const noexcept override { return "InvalidTransactionItemReason"; }
+};
+
+
+class LIBDNF_API InvalidTransactionItemState : public libdnf5::Error {
+public:
+    InvalidTransactionItemState(const std::string & state);
+
+    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
+    const char * get_name() const noexcept override { return "InvalidTransactionItemState"; }
+};
+
+
+class LIBDNF_API InvalidTransactionItemType : public libdnf5::Error {
+public:
+    InvalidTransactionItemType(const std::string & type);
+
+    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
+    const char * get_name() const noexcept override { return "InvalidTransactionItemType"; }
+};
+
+}  // namespace libdnf5::transaction
+
+#endif

--- a/include/libdnf5/transaction/transaction_item_reason.hpp
+++ b/include/libdnf5/transaction/transaction_item_reason.hpp
@@ -20,7 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_TRANSACTION_TRANSACTION_ITEM_REASON_HPP
 #define LIBDNF5_TRANSACTION_TRANSACTION_ITEM_REASON_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "transaction_item_errors.hpp"
+
 #include "libdnf5/defs.h"
 
 #include <string>
@@ -36,15 +37,6 @@ enum class TransactionItemReason : int {
     WEAK_DEPENDENCY = 4,
     GROUP = 5,
     EXTERNAL_USER = 6
-};
-
-
-class LIBDNF_API InvalidTransactionItemReason : public libdnf5::Error {
-public:
-    InvalidTransactionItemReason(const std::string & reason);
-
-    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
-    const char * get_name() const noexcept override { return "InvalidTransactionItemReason"; }
 };
 
 

--- a/include/libdnf5/transaction/transaction_item_type.hpp
+++ b/include/libdnf5/transaction/transaction_item_type.hpp
@@ -20,7 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF5_TRANSACTION_ITEM_TYPE_HPP
 #define LIBDNF5_TRANSACTION_ITEM_TYPE_HPP
 
-#include "libdnf5/common/exception.hpp"
+#include "transaction_item_errors.hpp"
+
 #include "libdnf5/defs.h"
 
 #include <string>
@@ -31,18 +32,8 @@ namespace libdnf5::transaction {
 enum class TransactionItemType : int { PACKAGE, GROUP, ENVIRONMENT, MODULE };
 
 
-class LIBDNF_API InvalidTransactionItemType : public libdnf5::Error {
-public:
-    InvalidTransactionItemType(const std::string & type);
-
-    const char * get_domain_name() const noexcept override { return "libdnf5::transaction"; }
-    const char * get_name() const noexcept override { return "InvalidTransactionItemType"; }
-};
-
-
 LIBDNF_API std::string transaction_item_type_to_string(TransactionItemType action);
 LIBDNF_API TransactionItemType transaction_item_type_from_string(const std::string & action);
-
 
 }  // namespace libdnf5::transaction
 


### PR DESCRIPTION
- Some of the exceptions have already been declared in their own header files. But not all of them.  This PR unifies the approach. Separating exception declarations from other declarations simplifies their subsequent use, such as wrapping in SWIG.

- Exceptions in libdnf5 are declared as `class`. Only two (`libdnf5::OptionBindsError` and `lindnf5::rpm::NevraIncorrectInputError`) were declared as `struct`. Unification, they are now also declared as `class`.