### PR TITLE
Implement libdnf5::throw_with_nested: throws our nested exception type

### DIFF
--- a/dnf5/plugins.cpp
+++ b/dnf5/plugins.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "library.hpp"
 
 #include <fmt/format.h>
+#include <libdnf5/common/exception.hpp>
 
 #include <filesystem>
 
@@ -95,10 +96,10 @@ PluginLibrary::PluginLibrary(Context & context, const std::string & library_path
                 } catch (const std::exception & ex) {
                     *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
                     logger.error("dnf5_plugin_new_instance: {}", ex.what());
-                    std::throw_with_nested(std::move(plugin_exception));
+                    libdnf5::throw_with_nested(std::move(plugin_exception));
                 } catch (...) {
                     *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
-                    std::throw_with_nested(std::move(plugin_exception));
+                    libdnf5::throw_with_nested(std::move(plugin_exception));
                 }
             }
         }
@@ -166,7 +167,7 @@ void Plugins::load_plugins(const std::string & dir_path) {
             load_plugin(path);
         } catch (const std::exception & ex) {
             logger->error("Cannot load dnf5 plugin \"{}\": {}", path.string(), ex.what());
-            std::throw_with_nested(std::runtime_error("Cannot load dnf5 plugin: " + path.string()));
+            libdnf5::throw_with_nested(std::runtime_error("Cannot load dnf5 plugin: " + path.string()));
         }
     }
 }

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -303,7 +303,7 @@ template <typename... Args>
 void process_action_error(
     Logger & log, const CommandToRun & command, const std::exception & ex, BgettextMessage msg, Args &&... args) {
     if (command.action.raise_error) {
-        std::throw_with_nested(
+        libdnf5::throw_with_nested(
             ActionsPluginActionError(command.action.file_path, command.action.line_number, msg, args...));
     } else {
         log_error(

--- a/libdnf5/conf/config_parser.cpp
+++ b/libdnf5/conf/config_parser.cpp
@@ -93,12 +93,13 @@ void ConfigParser::read(const std::string & file_path) try {
     ::libdnf5::read(*this, parser);
 } catch (const FileSystemError & e) {
     if (e.get_error_code() == ENOENT) {
-        std::throw_with_nested(MissingConfigError(M_("Configuration file \"{}\" not found"), file_path));
+        libdnf5::throw_with_nested(MissingConfigError(M_("Configuration file \"{}\" not found"), file_path));
     } else {
-        std::throw_with_nested(InaccessibleConfigError(M_("Unable to access configuration file \"{}\""), file_path));
+        libdnf5::throw_with_nested(
+            InaccessibleConfigError(M_("Unable to access configuration file \"{}\""), file_path));
     }
 } catch (const Error & e) {
-    std::throw_with_nested(InvalidConfigError(M_("Error in configuration file \"{}\""), file_path));
+    libdnf5::throw_with_nested(InvalidConfigError(M_("Error in configuration file \"{}\""), file_path));
 }
 
 

--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -99,10 +99,10 @@ PluginLibrary::PluginLibrary(Base & base, ConfigParser && parser, const std::str
                 } catch (const std::exception & ex) {
                     *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
                     logger.error("libdnf_plugin_new_instance: {}", ex.what());
-                    std::throw_with_nested(std::move(plugin_exception));
+                    libdnf5::throw_with_nested(std::move(plugin_exception));
                 } catch (...) {
                     *last_exception = nullptr;  // We no longer need to save the exception in the plugin.
-                    std::throw_with_nested(std::move(plugin_exception));
+                    libdnf5::throw_with_nested(std::move(plugin_exception));
                 }
             }
         }
@@ -250,7 +250,7 @@ void Plugins::load_plugins(
             load_plugin(path, plugin_enablement);
         } catch (const std::exception & ex) {
             logger.error("Cannot load libdnf plugin enabled from \"{}\": {}", path.string(), ex.what());
-            std::throw_with_nested(PluginError(M_("Cannot load libdnf plugin enabled from: {}"), path.string()));
+            libdnf5::throw_with_nested(PluginError(M_("Cannot load libdnf plugin enabled from: {}"), path.string()));
         }
     }
 

--- a/libdnf5/repo/file_downloader.cpp
+++ b/libdnf5/repo/file_downloader.cpp
@@ -213,7 +213,7 @@ void FileDownloader::download() try {
 } catch (const RepoCacheonlyError & e) {
     throw;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(FileDownloadError(M_("Failed to download files")));
+    libdnf5::throw_with_nested(FileDownloadError(M_("Failed to download files")));
 }
 
 void FileDownloader::set_fail_fast(bool value) {

--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -264,7 +264,7 @@ void PackageDownloader::download() try {
 } catch (const RepoCacheonlyError & e) {
     throw;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(PackageDownloadError(M_("Failed to download packages")));
+    libdnf5::throw_with_nested(PackageDownloadError(M_("Failed to download packages")));
 }
 
 void PackageDownloader::set_fail_fast(bool value) {

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -166,7 +166,7 @@ void RepoDownloader::download_metadata(const std::string & destdir) try {
     }
 } catch (const std::runtime_error & e) {
     auto src = get_source_info();
-    throw_with_nested(RepoDownloadError(
+    libdnf5::throw_with_nested(RepoDownloadError(
         M_("Failed to download metadata ({}: \"{}\") for repository \"{}\""), src.first, src.second, config.get_id()));
 }
 
@@ -237,7 +237,7 @@ bool RepoDownloader::is_metalink_in_sync() try {
     logger.debug("Sync check: repo \"{}\" in sync, metalink checksums match", config.get_id());
     return true;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(
+    libdnf5::throw_with_nested(RepoDownloadError(
         M_("Error checking if metalink \"{}\" is in sync for repository \"{}\""),
         get_source_info().second,
         config.get_id()));
@@ -267,7 +267,7 @@ bool RepoDownloader::is_repomd_in_sync() try {
     return same;
 } catch (const std::runtime_error & e) {
     auto src = get_source_info();
-    throw_with_nested(RepoDownloadError(
+    libdnf5::throw_with_nested(RepoDownloadError(
         M_("Error checking if repomd ({}: \"{}\") is in sync for repository \"{}\""),
         src.first,
         src.second,
@@ -332,7 +332,8 @@ void RepoDownloader::load_local() try {
         }
     }
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(M_("Error loading local metadata for repository \"{}\""), config.get_id()));
+    libdnf5::throw_with_nested(
+        RepoDownloadError(M_("Error loading local metadata for repository \"{}\""), config.get_id()));
 }
 
 void RepoDownloader::reset_loaded() {


### PR DESCRIPTION
Throws an exception that also stores the currently active exception.

It does the same thing as `std::throw_with_nested(TException && ex)`, except that instead of an **unspecified** type that is publicly derived from both `std::nested_exception` and `std::decay<TException>::type`, it throws a type **`NestedException<std::decay<TException>::type>`** that is publicly derived from both `std::nested_exception` and `std::decay<TException>::type`.

In other words, it replaces the unspecified type (the type defined by the implementation in the standard library) with our specification. Knowing the type can simplify exception handling in some cases. For example, avoiding the need to define another type for SWIG.