### PR TITLE
Fix builddep command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ To setup a development environment, complete the following steps:
 1. Install build requirements:
 
    ```
-   dnf builddep dnf5.spec #[--define '_without_<option> 1 ...]
+   dnf builddep dnf5 #[--define '_without_<option> 1 ...]
    ```
 
 2. Build DNF5:


### PR DESCRIPTION
the command `dnf builddep dnf5.spec` results in the following error:

Updating and loading repositories:
Repositories loaded.
error: Unable to open dnf5.spec: No such file or directory Failed to parse spec file "dnf5.spec".
Failed to parse some inputs.