### PR TITLE
Fix dnf5 copr_plugin: always set `base` in `CoprRepo`

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_repo.cpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.cpp
@@ -578,7 +578,8 @@ void installed_copr_repositories(libdnf5::Base & base, CoprRepoCallback cb) {
             continue;
 
         warn_weird_copr_repo(repo);
-        copr_repos[repo_file_path].add_dnf_repo(repo);
+        auto [it, inserted] = copr_repos.emplace(repo_file_path, CoprRepo(base));
+        it->second.add_dnf_repo(repo);
     }
 
     for (auto & [key, copr_repo] : copr_repos)

--- a/dnf5-plugins/copr_plugin/copr_repo.hpp
+++ b/dnf5-plugins/copr_plugin/copr_repo.hpp
@@ -175,7 +175,7 @@ private:
 
 class CoprRepo {
 public:
-    CoprRepo() {};
+    explicit CoprRepo(libdnf5::Base & base) : base(&base) {}
 
     explicit CoprRepo(
         libdnf5::Base & base,


### PR DESCRIPTION
Constructing incomplete (with `base` set to `nullptr`) instances of `CoprRepo` is not a good idea. It is only a matter of time before someone uses this invalid `base`.

In fact, this is why PR https://github.com/rpm-software-management/dnf5/pull/2081 causes segfault in copr_plugin unit tests.