### PR TITLE
Fix a memory leak when looking up for an OpenPGP key in RPM database

### DIFF
--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -145,11 +145,14 @@ static bool remove_pgp_key(const libdnf5::rpm::KeyInfo & key) {
     mi = rpmtsInitIterator(ts, RPMDBI_NAME, "gpg-pubkey", 0);
     auto key_id = key.get_short_key_id();
     while ((h = rpmdbNextIterator(mi)) != nullptr) {
-        if (headerGetAsString(h, RPMTAG_VERSION) == libdnf5::utils::string::tolower(key_id)) {
+        char * version = headerGetAsString(h, RPMTAG_VERSION);
+        if (version && version == libdnf5::utils::string::tolower(key_id)) {
+            free(version);
             rpmtsAddEraseElement(ts, h, -1);
             retval = rpmtsRun(ts, nullptr, RPMPROB_FILTER_NONE) == 0;
             break;
         }
+        free(version);
     }
     rpmdbFreeIterator(mi);
     rpmtsFree(ts);

--- a/libdnf5/rpm/rpm_signature.cpp
+++ b/libdnf5/rpm/rpm_signature.cpp
@@ -73,10 +73,13 @@ static bool rpmdb_lookup(const RpmTransactionPtr & ts_ptr, const KeyInfo & key) 
     mi = rpmtsInitIterator(ts_ptr.get(), RPMDBI_NAME, "gpg-pubkey", 0);
     auto key_id = key.get_short_key_id();
     while ((h = rpmdbNextIterator(mi)) != nullptr) {
-        if (headerGetAsString(h, RPMTAG_VERSION) == utils::string::tolower(key_id)) {
+        char * version = headerGetAsString(h, RPMTAG_VERSION);
+        if (version && version == utils::string::tolower(key_id)) {
+            free(version);
             retval = true;
             break;
         }
+        free(version);
     }
     rpmdbFreeIterator(mi);
     return retval;


### PR DESCRIPTION
headerGetAsString() returns a pointer which the caller must free. Also if the call fails, it will return NULL and later std::string == operator will exhibit an undefined behviour (confirmed with an address sanitizer).

There were two places of the flawed code in
libdnf5::rpm::rpmdb_lookup() and in expired-pgp-keys plugin. This patch fixes both. Though the latter will be reimplemented later.