### PR TITLE
expired-pgp-keys: Fix checking expiration of keys in RPM database

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -93,13 +93,13 @@ public:
         }
 
         std::cerr << libdnf5::utils::sformat(
-                         _("The following PGP key (0x{}) is about to be removed:"), key_info.get_short_key_id())
+                         _("The following OpenPGP key (0x{}) is about to be removed:"), key_info.get_short_key_id())
                   << std::endl;
         std::cerr << libdnf5::utils::sformat(_(" Reason     : {}\n"), removal_info.format(true));
         for (auto & user_id : key_info.get_user_ids()) {
             std::cerr << libdnf5::utils::sformat(_(" UserID     : \"{}\"\n"), user_id);
         }
-        std::cerr << libdnf5::utils::sformat(_(" From       : {}\n"), key_info.get_url());
+        std::cerr << libdnf5::utils::sformat(_(" Fingerprint: {}\n"), key_info.get_fingerprint());
 
         std::cerr << std::endl << _("As a result, installing packages signed with this key will fail.") << std::endl;
         std::cerr << _("It is recommended to remove the expired key to allow importing") << std::endl;
@@ -112,7 +112,8 @@ public:
     }
 
     void repokey_removed([[maybe_unused]] const libdnf5::rpm::KeyInfo & key_info) override {
-        std::cerr << _("The key was successfully removed.") << std::endl;
+        std::cerr << libdnf5::utils::sformat(_("Key 0x{} was successfully removed."), key_info.get_short_key_id())
+                  << std::endl;
     }
 
 private:


### PR DESCRIPTION
There was a flaw in what this plugin did: Instead of checking an expiration time of the keys in an RPM database, it downloaded keys of enabled repositories from the Internet and checked their expiration time. As a side effect, this plugin repeatedly downloaded the keys on every invocation.

This patch fixes both the issues by checking keys which are in the RPM database instead.

The new implementation removes all expired and confirmed keys in a single RPM transaction. It also removes the unnecessary crosscheck that a key obtained from an RPM database axtually exists in the database. All that speeds up the operation at the expense that reporting a success of the removal happens after the user selecting all the keys for the removal.

The user query now reports a fingerprint instead of a path to the key file. The reason is that a name of the key file is a temporary file now because we take the keys from the RPM database. The current API does allow importing from memory, neither changing the file attribute of KeyInfo object.

This patch intentionally does not enhance any interface, inluding newly identified bugs to be fixed independenlty later:

Respect --install-root option. We should probably move some code to libdnf5/rpm/rpm_signature.cpp, or expose more code from there.

libdnf5::repo callbacks API is badly designed as it cannot be used independetly from libdnf5::repo::RepoQuery object. That interface should be moved closer to base as it is deals with a user interface and not the repositories.

Resolves #2099
Resolves #2108