### PR TITLE
repo: fix bad GPG error handling

### DIFF
--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -400,28 +400,31 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
 
     auto handle_repo_exception = [&](const Repo * repo, std::exception_ptr ep, bool report_key_err) {
         // Use an exception_ptr to preserve the original type of the exception, in case we re-throw it.
-        std::exception e;
+        std::exception exception;
         try {
             std::rethrow_exception(ep);
-        } catch (const std::exception & exception) {
-            e = exception;
-        }
-        if (report_key_err) {
-            try {
-                std::rethrow_if_nested(e);
-            } catch (const LibrepoError & lr_err) {
-                if (lr_err.get_code() == LRE_BADGPG) {
-                    return true;
+        } catch (const RepoDownloadError & rd_err) {
+            exception = rd_err;
+            if (report_key_err) {
+                try {
+                    std::rethrow_if_nested(rd_err);
+                } catch (const LibrepoError & lr_err) {
+                    if (lr_err.get_code() == LRE_BADGPG) {
+                        return true;
+                    }
+                } catch (...) {
                 }
-            } catch (...) {
             }
+        } catch (const std::exception & e) {
+            exception = e;
         }
+
         if (!repo->get_config().get_skip_if_unavailable_option().get_value()) {
             std::rethrow_exception(ep);
         }
         base->get_logger()->warning(
             "Error loading repo \"{}\" (skipping due to \"skip_if_unavailable=true\"):", repo->get_id());
-        const auto & error_lines = utils::string::split(format(e, FormatDetailLevel::Plain), "\n");
+        const auto & error_lines = utils::string::split(format(exception, FormatDetailLevel::Plain), "\n");
         for (const auto & line : error_lines) {
             if (!line.empty()) {
                 base->get_logger()->warning(" {}", line);

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -433,7 +433,7 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
         return false;
     };
 
-    std::vector<Repo *> repos_with_bad_signature;
+    std::map<Repo *, std::exception_ptr> repo_signature_errors;
 
     for (int run_count = 0; run_count < 2; ++run_count) {
         // Set of repositories for processing. Use a set here since we don't want duplicate entries.
@@ -459,14 +459,14 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
             // It will try to download and import keys for repositories with a bad signature.
             // Repositories with a bad signature are moved to the array of repositories for processing.
 
-            if (!import_keys || repos_with_bad_signature.empty()) {
+            if (!import_keys || repo_signature_errors.empty()) {
                 break;
             }
 
             // Separates local and remote key files. Prepares local temporary files for storing downloaded remote keys.
             std::vector<std::tuple<Repo *, std::string>> local_keys_files;
             std::vector<std::tuple<Repo *, std::string, utils::fs::TempFile>> remote_keys_files;
-            for (auto * repo : repos_with_bad_signature) {
+            for (const auto & [repo, _] : repo_signature_errors) {
                 for (const auto & key_url : repo->get_config().get_gpgkey_option().get_value()) {
                     if (key_url.starts_with("file:/")) {
                         local_keys_files.emplace_back(repo, key_url);
@@ -521,6 +521,13 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
                             e.what()));
                         handle_repo_exception(repo, std::make_exception_ptr(wrapping_error), false);
                     }
+                }
+            }
+
+            // If we couldn't import any keys to resolve the signature error, re-handle the error.
+            for (const auto & [repo, ep] : repo_signature_errors) {
+                if (!repos_for_processing_set.contains(repo)) {
+                    handle_repo_exception(repo, ep, false);
                 }
             }
 
@@ -599,8 +606,9 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
                 }
 
             } catch (const RepoDownloadError &) {
-                if (handle_repo_exception(repo, std::current_exception(), import_keys)) {
-                    repos_with_bad_signature.emplace_back(repo);
+                const auto & ep = std::current_exception();
+                if (handle_repo_exception(repo, ep, import_keys)) {
+                    repo_signature_errors.insert({repo, ep});
                 }
                 repos_for_processing.erase(repos_for_processing.begin() + static_cast<ssize_t>(idx));
             }
@@ -620,9 +628,10 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
 
                 repos_for_processing.erase(repos_for_processing.begin() + static_cast<ssize_t>(idx));
                 send_to_sack_loader(repo);
-            } catch (const RepoDownloadError & e) {
-                if (handle_repo_exception(repo, std::current_exception(), import_keys)) {
-                    repos_with_bad_signature.emplace_back(repo);
+            } catch (const RepoDownloadError &) {
+                const auto & ep = std::current_exception();
+                if (handle_repo_exception(repo, ep, import_keys)) {
+                    repo_signature_errors.insert({repo, ep});
                 }
                 repos_for_processing.erase(repos_for_processing.begin() + static_cast<ssize_t>(idx));
             }


### PR DESCRIPTION
Resolves https://github.com/rpm-software-management/dnf5/issues/2134, which is a regression caused by commit 0f1242b0.

`std::rethrow_if_nested` is useless if we first slice the `std::nested_exception` to a `std::exception`. We must call `std::rethrow_if_nested` on a instance of a type derived from (or convertible to?) `std::nested_exception` [1].

[1] https://en.cppreference.com/w/cpp/error/rethrow_if_nested

We are still missing tests for repo_gpgcheck in ci-dnf-stack, but we should fix https://github.com/rpm-software-management/dnf5/issues/2134 and cut a new release ASAP.