### PR TITLE
rpm: Ensure make_provides_ready always uses an up-to-date considered map

### DIFF
--- a/libdnf5/module/module_sack.cpp
+++ b/libdnf5/module/module_sack.cpp
@@ -350,6 +350,9 @@ void ModuleSack::Impl::make_provides_ready() {
         return;
     }
 
+    // before swapping the considered map make sure it's uptodate
+    recompute_considered_in_pool();
+
     // Temporarily replaces the considered map with an empty one. Ignores "excludes" during calculation provides.
     Map * considered = pool->considered;
     pool->considered = nullptr;

--- a/libdnf5/rpm/package_sack.cpp
+++ b/libdnf5/rpm/package_sack.cpp
@@ -54,6 +54,9 @@ void PackageSack::Impl::make_provides_ready() {
         return;
     }
 
+    // before swapping the considered map make sure it's uptodate
+    recompute_considered_in_pool();
+
     // Temporarily replaces the considered map with an empty one. Ignores "excludes" during calculation provides.
     libdnf5::solv::SolvMap original_considered_map(0);
     get_rpm_pool(base).swap_considered_map(original_considered_map);


### PR DESCRIPTION
The `considered_map` may not be up to date when `make_provides_ready()` is called. This patch resolves the following scenario (see related issue

- If modules are enabled and available, one of the last steps in `load_repos()` is applying module_filtering, which also recomputes the considered map.

- During the goal resolution, command-line packages are added, increasing the number of solvables in the pool. This invalidates the `considered_map`, but it is not recomputed.

- After adding command-line packages, excludes are reloaded. As part of setting versionlock excludes, `make_provides_ready()` is called (via the `PackageQuery` constructor).

- At this point, the considered map is invalid and smaller than the current number of solvables, leading to an assertion failure in `swap_considered_map`.

Debugging this issue was tricky because `considered_map` is a bitmap, where each solvable takes only one bit. Since the allocated size is rounded up to bytes, there is usually some extra space for a few additional command-line packages without requiring a resize. However, if the number of solvables before adding a package was a multiple of eight, adding another package triggers the assertion failure:

```
terminate called after throwing an instance of 'libdnf5::AssertionError'
  what():  libdnf5/./solv/pool.hpp:246: void libdnf5::solv::Pool::swap_considered_map(libdnf5::solv::SolvMap&): Assertion 'other_considered_map.allocated_size() == 0 || other_considered_map.allocated_size() >= get_nsolvables()' failed: The considered map is smaller than the number of solvables in the pool
Aborted (core dumped)
```

With this patch, `make_provides_ready()` always works with an up-to-date considered_map, ensuring correctness.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2007