### PR TITLE
solv: Drop the size check from swap_considered_map

### DIFF
--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -240,12 +240,7 @@ public:
     const SolvMap & get_considered_map() const noexcept { return considered; }
 
     /// Exchanges the internal map `considered` with `other_considered_map`.
-    /// The allocated size of `other_considered_map` must be >= nsolvables,
-    /// or 0 if we want to disable the use of the considered map.
     void swap_considered_map(SolvMap & other_considered_map) {
-        libdnf_assert(
-            other_considered_map.allocated_size() == 0 || other_considered_map.allocated_size() >= get_nsolvables(),
-            "The considered map is smaller than the number of solvables in the pool");
         considered.swap(other_considered_map);
         if (considered.allocated_size() == 0) {
             pool->considered = nullptr;


### PR DESCRIPTION
There is no guarantee that the considered map is valid during the swap. For example, in this scenario, the already invalid considered map is swapped to a nullptr and later restored to its original (invalid) value:

- If modules are enabled and available, one of the last steps in `load_repos()` is applying module_filtering, which also recomputes the considered map.

- During the goal resolution, command-line packages are added, increasing the number of solvables in the pool. This invalidates the `considered_map`, but it is not recomputed.

- After adding command-line packages, excludes are reloaded. As part of setting versionlock excludes, `make_provides_ready()` is called (via the `PackageQuery` constructor).

- At this point, the considered map is invalid and smaller than the current number of solvables, leading to an assertion failure in `swap_considered_map`.

Debugging this issue was tricky because `considered_map` is a bitmap, where each solvable takes only one bit. Since the allocated size is rounded up to bytes, there is usually some extra space for a few additional command-line packages without requiring a resize. However, if the number of solvables before adding a package was a multiple of eight, adding another package triggers the assertion failure:

```
terminate called after throwing an instance of 'libdnf5::AssertionError'
  what():  libdnf5/./solv/pool.hpp:246: void libdnf5::solv::Pool::swap_considered_map(libdnf5::solv::SolvMap&): Assertion 'other_considered_map.allocated_size() == 0 || other_considered_map.allocated_size() >= get_nsolvables()' failed: The considered map is smaller than the number of solvables in the pool
Aborted (core dumped)
```

Resolves: https://github.com/rpm-software-management/dnf5/issues/2007

This is an alternative to PR https://github.com/rpm-software-management/dnf5/pull/2159