### PR TITLE
comps: Respect the display_order with listing groups and environments

### DIFF
--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -69,7 +69,10 @@ void EnvironmentInfoCommand::run() {
         query.filter_installed(false);
     }
 
-    for (auto environment : query.list()) {
+    std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
+    std::sort(environments.begin(), environments.end(), libdnf5::comps::environment_display_order_cmp);
+
+    for (auto environment : environments) {
         libdnf5::cli::output::EnvironmentAdapter cli_env(environment);
         libdnf5::cli::output::print_environmentinfo_table(cli_env);
         std::cout << '\n';

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -67,8 +67,11 @@ void EnvironmentListCommand::run() {
         query.filter_installed(false);
     }
 
+    std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
+    std::sort(environments.begin(), environments.end(), libdnf5::comps::environment_display_order_cmp);
+
     std::vector<std::unique_ptr<libdnf5::cli::output::IEnvironment>> cli_envs;
-    for (auto & env : query.list()) {
+    for (auto & env : environments) {
         cli_envs.emplace_back(new libdnf5::cli::output::EnvironmentAdapter(env));
     }
     libdnf5::cli::output::print_environmentlist_table(cli_envs);

--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -29,7 +29,10 @@ namespace dnf5 {
 using namespace libdnf5::cli;
 
 void GroupInfoCommand::print(const libdnf5::comps::GroupQuery & query) {
-    for (auto group : query.list()) {
+    std::vector<libdnf5::comps::Group> groups(query.list().begin(), query.list().end());
+    std::sort(groups.begin(), groups.end(), libdnf5::comps::group_display_order_cmp);
+
+    for (auto group : groups) {
         libdnf5::cli::output::GroupAdapter cli_group(group);
         libdnf5::cli::output::print_groupinfo_table(cli_group);
         std::cout << '\n';

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -91,9 +91,12 @@ void GroupListCommand::run() {
 }
 
 void GroupListCommand::print(const libdnf5::comps::GroupQuery & query) {
+    std::vector<libdnf5::comps::Group> groups(query.list().begin(), query.list().end());
+    std::sort(groups.begin(), groups.end(), libdnf5::comps::group_display_order_cmp);
+
     std::vector<std::unique_ptr<libdnf5::cli::output::IGroup>> items;
-    items.reserve(query.list().size());
-    for (auto & obj : query.list()) {
+    items.reserve(groups.size());
+    for (auto & obj : groups) {
         items.emplace_back(new libdnf5::cli::output::GroupAdapter(obj));
     }
     libdnf5::cli::output::print_grouplist_table(items);

--- a/include/libdnf5/comps/environment/environment.hpp
+++ b/include/libdnf5/comps/environment/environment.hpp
@@ -94,6 +94,10 @@ public:
     // TODO(pkratoch): respect the display_order when listing environments
     std::string get_order() const;
 
+    /// @return The Environment display order as an integer or INT_MAX if the order is invalid.
+    /// @since 5.2.12.1
+    int get_order_int() const;
+
     /// @return std::vector of Group ids belonging to the Environment.
     /// @since 5.0
     //
@@ -151,6 +155,11 @@ private:
     class LIBDNF_LOCAL Impl;
     std::unique_ptr<Impl> p_impl;
 };
+
+
+inline bool environment_display_order_cmp(Environment a, Environment b) {
+    return a.get_order_int() < b.get_order_int();
+}
 
 
 }  // namespace libdnf5::comps

--- a/include/libdnf5/comps/environment/environment.hpp
+++ b/include/libdnf5/comps/environment/environment.hpp
@@ -90,8 +90,6 @@ public:
 
     /// @return The Environment display order.
     /// @since 5.0
-    //
-    // TODO(pkratoch): respect the display_order when listing environments
     std::string get_order() const;
 
     /// @return The Environment display order as an integer or INT_MAX if the order is invalid.

--- a/include/libdnf5/comps/group/group.hpp
+++ b/include/libdnf5/comps/group/group.hpp
@@ -95,6 +95,10 @@ public:
     // TODO(pkratoch): respect the display_order when listing groups
     std::string get_order() const;
 
+    /// @return The Group display order as an integer or INT_MAX if the order is invalid.
+    /// @since 5.2.12.1
+    int get_order_int() const;
+
     /// @return The Group langonly.
     /// @since 5.0
     std::string get_langonly() const;
@@ -168,6 +172,11 @@ private:
     class LIBDNF_LOCAL Impl;
     std::unique_ptr<Impl> p_impl;
 };
+
+
+inline bool group_display_order_cmp(Group a, Group b) {
+    return a.get_order_int() < b.get_order_int();
+}
 
 
 }  // namespace libdnf5::comps

--- a/include/libdnf5/comps/group/group.hpp
+++ b/include/libdnf5/comps/group/group.hpp
@@ -91,8 +91,6 @@ public:
 
     /// @return The Group display order.
     /// @since 5.0
-    //
-    // TODO(pkratoch): respect the display_order when listing groups
     std::string get_order() const;
 
     /// @return The Group display order as an integer or INT_MAX if the order is invalid.

--- a/libdnf5-cli/output/environmentlist.cpp
+++ b/libdnf5-cli/output/environmentlist.cpp
@@ -68,8 +68,6 @@ void print_environmentlist_table(std::vector<std::unique_ptr<IEnvironment>> & en
             environment->get_name().c_str(),
             environment->get_installed());
     }
-    auto cl = scols_table_get_column(table, COL_ENVIRONMENT_ID);
-    scols_sort_table(table, cl);
     scols_print_table(table);
     scols_unref_table(table);
 }

--- a/libdnf5-cli/output/grouplist.cpp
+++ b/libdnf5-cli/output/grouplist.cpp
@@ -65,8 +65,6 @@ void print_grouplist_table(std::vector<std::unique_ptr<IGroup>> & group_list) {
         add_line_into_grouplist_table(
             table, group->get_groupid().c_str(), group->get_name().c_str(), group->get_installed());
     }
-    auto cl = scols_table_get_column(table, COL_GROUP_ID);
-    scols_sort_table(table, cl);
     scols_print_table(table);
     scols_unref_table(table);
 }

--- a/libdnf5/comps/environment/environment.cpp
+++ b/libdnf5/comps/environment/environment.cpp
@@ -35,6 +35,7 @@ extern "C" {
 }
 
 #include <libxml/tree.h>
+#include <limits.h>
 
 #include <set>
 #include <string>
@@ -155,6 +156,17 @@ std::string Environment::get_translated_description() const {
 
 std::string Environment::get_order() const {
     return get_comps_pool(p_impl->base).lookup_first_id_str<EnvironmentId>(p_impl->environment_ids, SOLVABLE_ORDER);
+}
+
+
+int Environment::get_order_int() const {
+    try {
+        return std::stoi(get_order());
+    } catch (const std::invalid_argument &) {
+        return INT_MAX;
+    } catch (const std::out_of_range &) {
+        return INT_MAX;
+    }
 }
 
 

--- a/libdnf5/comps/group/group.cpp
+++ b/libdnf5/comps/group/group.cpp
@@ -38,6 +38,7 @@ extern "C" {
 
 #include <libxml/tree.h>
 #include <libxml/xmlerror.h>
+#include <limits.h>
 
 #include <set>
 #include <string>
@@ -151,6 +152,17 @@ std::string Group::get_translated_description() const {
 
 std::string Group::get_order() const {
     return get_comps_pool(p_impl->base).lookup_first_id_str<GroupId>(p_impl->group_ids, SOLVABLE_ORDER);
+}
+
+
+int Group::get_order_int() const {
+    try {
+        return std::stoi(get_order());
+    } catch (const std::invalid_argument &) {
+        return INT_MAX;
+    } catch (const std::out_of_range &) {
+        return INT_MAX;
+    }
 }
 
 

--- a/test/libdnf5/comps/test_environment.cpp
+++ b/test/libdnf5/comps/test_environment.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "test_environment.hpp"
 
 #include <libdnf5/comps/environment/query.hpp>
+#include <limits.h>
 
 #include <filesystem>
 #include <fstream>
@@ -45,6 +46,7 @@ void CompsEnvironmentTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(std::string("Basic functionality."), minimal_env.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Grundlegende Funktionalität."), minimal_env.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("3"), minimal_env.get_order());
+    CPPUNIT_ASSERT_EQUAL(3, minimal_env.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_env.get_installed());
 }
 
@@ -61,6 +63,7 @@ void CompsEnvironmentTest::test_load_defaults() {
     CPPUNIT_ASSERT_EQUAL(std::string(""), minimal_empty.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string(""), minimal_empty.get_translated_description("ja"));
     CPPUNIT_ASSERT_EQUAL(std::string(""), minimal_empty.get_order());
+    CPPUNIT_ASSERT_EQUAL(INT_MAX, minimal_empty.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_empty.get_installed());
 }
 
@@ -80,6 +83,7 @@ void CompsEnvironmentTest::test_merge() {
     CPPUNIT_ASSERT_EQUAL(std::string("Basic functionality v2."), minimal_env.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Grundlegende Funktionalität v2."), minimal_env.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("4"), minimal_env.get_order());
+    CPPUNIT_ASSERT_EQUAL(4, minimal_env.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_env.get_installed());
 }
 
@@ -100,6 +104,7 @@ void CompsEnvironmentTest::test_merge_when_different_load_order() {
     CPPUNIT_ASSERT_EQUAL(std::string("Basic functionality v2."), minimal_env.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Grundlegende Funktionalität v2."), minimal_env.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("4"), minimal_env.get_order());
+    CPPUNIT_ASSERT_EQUAL(4, minimal_env.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_env.get_installed());
 }
 
@@ -121,6 +126,7 @@ void CompsEnvironmentTest::test_merge_with_empty() {
     CPPUNIT_ASSERT_EQUAL(std::string("Basic functionality."), minimal_empty.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Grundlegende Funktionalität."), minimal_empty.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("3"), minimal_empty.get_order());
+    CPPUNIT_ASSERT_EQUAL(3, minimal_empty.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_empty.get_installed());
 }
 
@@ -142,6 +148,7 @@ void CompsEnvironmentTest::test_merge_empty_with_nonempty() {
     CPPUNIT_ASSERT_EQUAL(std::string("Basic functionality."), minimal_env.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Grundlegende Funktionalität."), minimal_env.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("3"), minimal_env.get_order());
+    CPPUNIT_ASSERT_EQUAL(3, minimal_env.get_order_int());
     CPPUNIT_ASSERT_EQUAL(false, minimal_env.get_installed());
 }
 

--- a/test/libdnf5/comps/test_group.cpp
+++ b/test/libdnf5/comps/test_group.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf5/comps/group/package.hpp>
 #include <libdnf5/comps/group/query.hpp>
+#include <limits.h>
 
 #include <filesystem>
 
@@ -70,6 +71,7 @@ void CompsGroupTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(std::string("Smallest possible installation"), core.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Kleinstmögliche Installation"), core.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("1"), core.get_order());
+    CPPUNIT_ASSERT_EQUAL(1, core.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string("it"), core.get_langonly());
     CPPUNIT_ASSERT_EQUAL(false, core.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, core.get_default());
@@ -96,6 +98,7 @@ void CompsGroupTest::test_load() {
         std::string("最小限のインストールを拡張するユーティリティの共通セット"),
         standard.get_translated_description("ja"));
     CPPUNIT_ASSERT_EQUAL(std::string("1"), standard.get_order());
+    CPPUNIT_ASSERT_EQUAL(1, standard.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string(""), standard.get_langonly());
     CPPUNIT_ASSERT_EQUAL(false, standard.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, standard.get_default());
@@ -121,6 +124,7 @@ void CompsGroupTest::test_load_defaults() {
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_translated_description("ja"));
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_order());
+    CPPUNIT_ASSERT_EQUAL(INT_MAX, core_empty.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_langonly());
     CPPUNIT_ASSERT_EQUAL(true, core_empty.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, core_empty.get_default());
@@ -146,6 +150,7 @@ void CompsGroupTest::test_merge() {
     CPPUNIT_ASSERT_EQUAL(std::string("Smallest possible installation v2"), core2.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Kleinstmögliche Installation v2"), core2.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("2"), core2.get_order());
+    CPPUNIT_ASSERT_EQUAL(2, core2.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string("de"), core2.get_langonly());
     // When boolean attributes are missing in core-v2.xml, default values are taken
     CPPUNIT_ASSERT_EQUAL(true, core2.get_uservisible());
@@ -179,6 +184,7 @@ void CompsGroupTest::test_merge_when_different_load_order() {
     CPPUNIT_ASSERT_EQUAL(std::string("Smallest possible installation v2"), core2.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Kleinstmögliche Installation v2"), core2.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("2"), core2.get_order());
+    CPPUNIT_ASSERT_EQUAL(2, core2.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string("de"), core2.get_langonly());
     // When boolean attributes are missing in core-v2.xml, default values are taken
     CPPUNIT_ASSERT_EQUAL(true, core2.get_uservisible());
@@ -212,6 +218,7 @@ void CompsGroupTest::test_merge_with_empty() {
     CPPUNIT_ASSERT_EQUAL(std::string("Smallest possible installation"), core_empty.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Kleinstmögliche Installation"), core_empty.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("1"), core_empty.get_order());
+    CPPUNIT_ASSERT_EQUAL(1, core_empty.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string("it"), core_empty.get_langonly());
     // boolean attributes are missing in core-empty.xml -> default values are taken
     CPPUNIT_ASSERT_EQUAL(true, core_empty.get_uservisible());
@@ -237,6 +244,7 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     CPPUNIT_ASSERT_EQUAL(std::string("Smallest possible installation v2"), core.get_description());
     CPPUNIT_ASSERT_EQUAL(std::string("Kleinstmögliche Installation v2"), core.get_translated_description("de"));
     CPPUNIT_ASSERT_EQUAL(std::string("2"), core.get_order());
+    CPPUNIT_ASSERT_EQUAL(2, core.get_order_int());
     CPPUNIT_ASSERT_EQUAL(std::string("de"), core.get_langonly());
     CPPUNIT_ASSERT_EQUAL(true, core.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(true, core.get_default());


### PR DESCRIPTION
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1655