### PR TITLE
Add group ordering by orider_int to dnf5daemon

### DIFF
--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -70,7 +70,10 @@ void EnvironmentInfoCommand::run() {
     }
 
     std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
-    std::sort(environments.begin(), environments.end(), libdnf5::comps::environment_display_order_cmp);
+    std::sort(
+        environments.begin(),
+        environments.end(),
+        libdnf5::cli::output::comps_display_order_cmp<libdnf5::comps::Environment>);
 
     for (auto environment : environments) {
         libdnf5::cli::output::EnvironmentAdapter cli_env(environment);

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -68,7 +68,10 @@ void EnvironmentListCommand::run() {
     }
 
     std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
-    std::sort(environments.begin(), environments.end(), libdnf5::comps::environment_display_order_cmp);
+    std::sort(
+        environments.begin(),
+        environments.end(),
+        libdnf5::cli::output::comps_display_order_cmp<libdnf5::comps::Environment>);
 
     std::vector<std::unique_ptr<libdnf5::cli::output::IEnvironment>> cli_envs;
     for (auto & env : environments) {

--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -30,7 +30,7 @@ using namespace libdnf5::cli;
 
 void GroupInfoCommand::print(const libdnf5::comps::GroupQuery & query) {
     std::vector<libdnf5::comps::Group> groups(query.list().begin(), query.list().end());
-    std::sort(groups.begin(), groups.end(), libdnf5::comps::group_display_order_cmp);
+    std::sort(groups.begin(), groups.end(), libdnf5::cli::output::comps_display_order_cmp<libdnf5::comps::Group>);
 
     for (auto group : groups) {
         libdnf5::cli::output::GroupAdapter cli_group(group);

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -92,7 +92,7 @@ void GroupListCommand::run() {
 
 void GroupListCommand::print(const libdnf5::comps::GroupQuery & query) {
     std::vector<libdnf5::comps::Group> groups(query.list().begin(), query.list().end());
-    std::sort(groups.begin(), groups.end(), libdnf5::comps::group_display_order_cmp);
+    std::sort(groups.begin(), groups.end(), libdnf5::cli::output::comps_display_order_cmp<libdnf5::comps::Group>);
 
     std::vector<std::unique_ptr<libdnf5::cli::output::IGroup>> items;
     items.reserve(groups.size());

--- a/dnf5daemon-client/wrappers/dbus_environment_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_environment_wrapper.hpp
@@ -37,6 +37,7 @@ public:
     std::string get_name() const { return std::string{rawdata.at("name")}; }
     std::string get_description() const { return std::string{rawdata.at("description")}; }
     std::string get_order() const { return std::string{rawdata.at("order")}; }
+    int get_order_int() const { return int{rawdata.at("order_int")}; }
     // TODO(mblaha) proper installed value
     bool get_installed() const { return false; }
     std::set<std::string> get_repos() const;

--- a/dnf5daemon-client/wrappers/dbus_group_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_group_wrapper.hpp
@@ -49,6 +49,7 @@ public:
     std::string get_name() const { return std::string{rawdata.at("name")}; }
     std::string get_description() const { return std::string{rawdata.at("description")}; }
     std::string get_order() const { return std::string{rawdata.at("order")}; }
+    int get_order_int() const { return int{rawdata.at("order_int")}; }
     std::string get_langonly() const { return std::string{rawdata.at("langonly")}; }
     bool get_installed() const { return bool{rawdata.at("installed")}; }
     bool get_uservisible() const { return bool{rawdata.at("uservisible")}; }

--- a/dnf5daemon-server/group.hpp
+++ b/dnf5daemon-server/group.hpp
@@ -31,11 +31,18 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 enum class GroupAttribute {
     groupid,
     name,
-    description
+    description,
     // TODO(mblaha): translated_name, translated_description, packages, reason
+    order,
+    order_int,
+    langonly,
+    uservisible,
+    is_default,
+    packages,
+    installed,
+    repos,
 };
 
-dnfdaemon::KeyValueMap group_to_map(
-    const libdnf5::comps::Group & libdnf_group, const std::vector<std::string> & attributes);
+dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const std::vector<std::string> & attributes);
 
 #endif

--- a/dnf5daemon-server/services/comps/group.cpp
+++ b/dnf5daemon-server/services/comps/group.cpp
@@ -35,6 +35,7 @@ enum class GroupAttribute {
     description,
     // TODO(mblaha): translated name / translated description
     order,
+    order_int,
     langonly,
     uservisible,
     is_default,
@@ -49,6 +50,7 @@ const std::map<std::string, GroupAttribute> group_attributes{
     {"name", GroupAttribute::name},
     {"description", GroupAttribute::description},
     {"order", GroupAttribute::order},
+    {"order_int", GroupAttribute::order_int},
     {"langonly", GroupAttribute::langonly},
     {"uservisible", GroupAttribute::uservisible},
     {"default", GroupAttribute::is_default},
@@ -79,6 +81,9 @@ dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const 
                 break;
             case GroupAttribute::order:
                 dbus_group.emplace(attr, libdnf_group.get_order());
+                break;
+            case GroupAttribute::order_int:
+                dbus_group.emplace(attr, libdnf_group.get_order_int());
                 break;
             case GroupAttribute::langonly:
                 dbus_group.emplace(attr, libdnf_group.get_langonly());

--- a/dnf5daemon-server/services/comps/group.cpp
+++ b/dnf5daemon-server/services/comps/group.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group.hpp"
 
+#include "../../group.hpp"
 #include "dbus.hpp"
 
 #include <libdnf5/common/sack/query_cmp.hpp>
@@ -26,99 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/comps/group/query.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
-#include <iostream>
 #include <string>
-
-enum class GroupAttribute {
-    groupid,
-    name,
-    description,
-    // TODO(mblaha): translated name / translated description
-    order,
-    order_int,
-    langonly,
-    uservisible,
-    is_default,
-    packages,
-    installed,
-    repos,
-};
-
-// map string group attribute name to actual attribute
-const std::map<std::string, GroupAttribute> group_attributes{
-    {"groupid", GroupAttribute::groupid},
-    {"name", GroupAttribute::name},
-    {"description", GroupAttribute::description},
-    {"order", GroupAttribute::order},
-    {"order_int", GroupAttribute::order_int},
-    {"langonly", GroupAttribute::langonly},
-    {"uservisible", GroupAttribute::uservisible},
-    {"default", GroupAttribute::is_default},
-    {"packages", GroupAttribute::packages},
-    {"installed", GroupAttribute::installed},
-    {"repos", GroupAttribute::repos},
-};
-
-dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const std::vector<std::string> & attributes) {
-    dnfdaemon::KeyValueMap dbus_group;
-    // add group id by default
-    dbus_group.emplace(std::make_pair("groupid", libdnf_group.get_groupid()));
-    // attributes required by client
-    for (auto & attr : attributes) {
-        auto it = group_attributes.find(attr);
-        if (it == group_attributes.end()) {
-            throw std::runtime_error(fmt::format("Group attribute '{}' not supported", attr));
-        }
-        switch (it->second) {
-            case GroupAttribute::groupid:
-                // groupid is always included
-                break;
-            case GroupAttribute::name:
-                dbus_group.emplace(attr, libdnf_group.get_name());
-                break;
-            case GroupAttribute::description:
-                dbus_group.emplace(attr, libdnf_group.get_description());
-                break;
-            case GroupAttribute::order:
-                dbus_group.emplace(attr, libdnf_group.get_order());
-                break;
-            case GroupAttribute::order_int:
-                dbus_group.emplace(attr, libdnf_group.get_order_int());
-                break;
-            case GroupAttribute::langonly:
-                dbus_group.emplace(attr, libdnf_group.get_langonly());
-                break;
-            case GroupAttribute::uservisible:
-                dbus_group.emplace(attr, libdnf_group.get_uservisible());
-                break;
-            case GroupAttribute::is_default:
-                dbus_group.emplace(attr, libdnf_group.get_default());
-                break;
-            case GroupAttribute::installed:
-                dbus_group.emplace(attr, libdnf_group.get_installed());
-                break;
-            case GroupAttribute::repos: {
-                auto repos_set = libdnf_group.get_repos();
-                std::vector<std::string> repos(repos_set.begin(), repos_set.end());
-                dbus_group.emplace(attr, repos);
-                break;
-            }
-            case GroupAttribute::packages: {
-                dnfdaemon::KeyValueMapList packages;
-                for (auto pkg : libdnf_group.get_packages()) {
-                    dnfdaemon::KeyValueMap package;
-                    package.emplace("name", pkg.get_name());
-                    package.emplace("type", static_cast<int>(pkg.get_type()));
-                    package.emplace("condition", pkg.get_condition());
-                    packages.push_back(std::move(package));
-                }
-                dbus_group.emplace(attr, packages);
-                break;
-            }
-        }
-    }
-    return dbus_group;
-}
 
 
 void Group::dbus_register() {

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -237,12 +237,13 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
         std::vector<std::string> grp_attrs{"name"};
         dnfdaemon::KeyValueMap trans_item_attrs{};
         for (auto & tsgrp : transaction.get_transaction_groups()) {
+            auto group = tsgrp.get_group();
             dbus_transaction.push_back(dnfdaemon::DbusTransactionItem(
                 dbus_transaction_item_type_to_string(dnfdaemon::DbusTransactionItemType::GROUP),
                 transaction_item_action_to_string(tsgrp.get_action()),
                 transaction_item_reason_to_string(tsgrp.get_reason()),
                 trans_item_attrs,
-                group_to_map(tsgrp.get_group(), grp_attrs)));
+                group_to_map(group, grp_attrs)));
         }
         for (auto & tsenv : transaction.get_transaction_environments()) {
             dbus_transaction.push_back(dnfdaemon::DbusTransactionItem(

--- a/include/libdnf5-cli/output/adapters/comps_tmpl.hpp
+++ b/include/libdnf5-cli/output/adapters/comps_tmpl.hpp
@@ -122,6 +122,11 @@ private:
     T env;
 };
 
+template <class T>
+bool comps_display_order_cmp(T & a, T & b) {
+    return a.get_order_int() < b.get_order_int();
+}
+
 }  // namespace libdnf5::cli::output
 
 #endif  // LIBDNF5_CLI_OUTPUT_ADAPTERS_COMPS_TMPL_HPP

--- a/include/libdnf5-cli/output/adapters/comps_tmpl.hpp
+++ b/include/libdnf5-cli/output/adapters/comps_tmpl.hpp
@@ -66,6 +66,8 @@ public:
 
     std::string get_order() const override { return grp.get_order(); }
 
+    int get_order_int() const override { return grp.get_order_int(); }
+
     std::string get_langonly() const override { return grp.get_langonly(); }
 
     bool get_uservisible() const override { return grp.get_uservisible(); }
@@ -93,6 +95,8 @@ public:
     std::string get_description() const override { return env.get_description(); }
 
     std::string get_order() const override { return env.get_order(); }
+
+    int get_order_int() const override { return env.get_order_int(); }
 
     std::vector<std::string> get_groups() override {
         if constexpr (requires { env.get_groups(); }) {

--- a/include/libdnf5-cli/output/interfaces/comps.hpp
+++ b/include/libdnf5-cli/output/interfaces/comps.hpp
@@ -47,6 +47,7 @@ public:
     virtual std::string get_name() const = 0;
     virtual std::string get_description() const = 0;
     virtual std::string get_order() const = 0;
+    virtual int get_order_int() const = 0;
     virtual std::string get_langonly() const = 0;
     virtual bool get_uservisible() const = 0;
     virtual std::vector<std::unique_ptr<IGroupPackage>> get_packages() = 0;
@@ -63,6 +64,7 @@ public:
     virtual std::string get_name() const = 0;
     virtual std::string get_description() const = 0;
     virtual std::string get_order() const = 0;
+    virtual int get_order_int() const = 0;
     virtual std::vector<std::string> get_groups() = 0;
     virtual std::vector<std::string> get_optional_groups() = 0;
     virtual std::set<std::string> get_repos() const = 0;

--- a/include/libdnf5/comps/environment/environment.hpp
+++ b/include/libdnf5/comps/environment/environment.hpp
@@ -155,11 +155,6 @@ private:
 };
 
 
-inline bool environment_display_order_cmp(Environment a, Environment b) {
-    return a.get_order_int() < b.get_order_int();
-}
-
-
 }  // namespace libdnf5::comps
 
 

--- a/include/libdnf5/comps/group/group.hpp
+++ b/include/libdnf5/comps/group/group.hpp
@@ -172,11 +172,6 @@ private:
 };
 
 
-inline bool group_display_order_cmp(Group a, Group b) {
-    return a.get_order_int() < b.get_order_int();
-}
-
-
 }  // namespace libdnf5::comps
 
 


### PR DESCRIPTION
This is a follow up to: https://github.com/rpm-software-management/dnf5/pull/2164

It is also needed for: https://github.com/rpm-software-management/ci-dnf-stack/pull/1661

It also unifies duplicated handling of group attributes in the daemon which was need for it to compile after adding the `order_int`.