### PR TITLE
dnfdaemon: Configure separate cache directory

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -771,6 +771,7 @@ Package management service with a DBus interface.
 %systemd_postun_with_restart dnf5daemon-server.service
 
 %files -n dnf5daemon-server -f dnf5daemon-server.lang
+%config(noreplace) %{_sysconfdir}/dnf/dnf5daemon-server.conf
 %{_sbindir}/dnf5daemon-server
 %{_unitdir}/dnf5daemon-server.service
 %{_datadir}/dbus-1/system.d/org.rpm.dnf.v0.conf

--- a/dnf5daemon-server/CMakeLists.txt
+++ b/dnf5daemon-server/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(
 )
 
 install(TARGETS ${DNF5DAEMON_SERVER_BIN} RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})
-
+install(DIRECTORY "config/etc/" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}" PATTERN ".gitkeep" EXCLUDE)
 
 add_subdirectory(polkit)
 add_subdirectory(dbus)

--- a/dnf5daemon-server/config/etc/dnf/dnf5daemon-server.conf
+++ b/dnf5daemon-server/config/etc/dnf/dnf5daemon-server.conf
@@ -1,0 +1,4 @@
+[main]
+# This section is used for overriding main configuration options.
+# See `man dnf.conf` for defaults and possible options.
+cachedir = /var/cache/dnf5daemon-server

--- a/dnf5daemon-server/const.hpp
+++ b/dnf5daemon-server/const.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5DAEMON_SERVER_CONST_HPP
+#define DNF5DAEMON_SERVER_CONST_HPP
+
+namespace dnfdaemon {
+
+constexpr const char * CONF_FILENAME = "/etc/dnf/dnf5daemon-server.conf";
+
+}  // namespace dnfdaemon
+
+#endif

--- a/doc/dnf_daemon/dnf5daemon_server.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_server.8.rst
@@ -30,3 +30,14 @@ Synopsis
 
 Description
 ===========
+
+dnf5daemon-server is D-Bus interface for libdnf5 package manager.
+
+
+Files
+=====
+
+``dnf5daemon-server configuration``
+    /etc/dnf/dnf5daemon-server.conf
+
+    Use the ``[main]`` section to override any main DNF5 configuration option. See :manpage:`dnf5.conf(5)`, :ref:`Main configuration options <conf_main_options-label>`.

--- a/include/libdnf5/conf/option.hpp
+++ b/include/libdnf5/conf/option.hpp
@@ -40,6 +40,9 @@ public:
         EMPTY = 0,
         DEFAULT = 10,
         MAINCONFIG = 20,
+        // TODO(mblaha): we should have named this priority differently. This level is
+        // useful anytime an app needs to read main config options from multiple
+        // sources - e.g. automatic, dnf5daemon-server
         AUTOMATICCONFIG = 30,
         REPOCONFIG = 40,
         INSTALLROOT = 45,

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -520,6 +520,14 @@ bool Repo::clone_root_metadata() {
 
     auto repo_cachedir = p_impl->config.get_cachedir();
     auto base_cachedir = p_impl->config.get_basecachedir_option().get_value();
+    auto system_cachedir = p_impl->config.get_main_config().get_system_cachedir_option().get_value();
+
+    // return fast if the system_cachedir does not exist or is equivelent to base_cachedir
+    std::error_code ec;
+    if (!std::filesystem::exists(system_cachedir, ec) ||
+        std::filesystem::equivalent(base_cachedir, system_cachedir, ec)) {
+        return false;
+    }
 
     auto base_path_pos = repo_cachedir.find(base_cachedir);
     libdnf_assert(
@@ -529,8 +537,7 @@ bool Repo::clone_root_metadata() {
         base_cachedir);
 
     auto root_repo_cachedir = repo_cachedir;
-    root_repo_cachedir.replace(
-        base_path_pos, base_cachedir.size(), p_impl->config.get_main_config().get_system_cachedir_option().get_value());
+    root_repo_cachedir.replace(base_path_pos, base_cachedir.size(), system_cachedir);
 
     auto root_repodata_cachedir = std::filesystem::path(root_repo_cachedir) / CACHE_METADATA_DIR;
     try {

--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -565,7 +565,7 @@ void RepoSack::Impl::update_and_load_repos(libdnf5::repo::RepoQuery & repos, boo
                     send_to_sack_loader(repo);
                 } else {
                     // Try reusing the root cache
-                    if (!root_cache_tried && !libdnf5::utils::am_i_root() && repo->clone_root_metadata()) {
+                    if (!root_cache_tried && repo->clone_root_metadata()) {
                         root_cache_tried = true;
                         continue;
                     }


### PR DESCRIPTION
Introduce a separate dnfdaemon configuration file for daemon specific config overrides - currently it overrides only the `cachedir` option.