### PR TITLE
nevra: Fix description of evrcmp and rpmvercmp functions

### DIFF
--- a/include/libdnf5/rpm/nevra.hpp
+++ b/include/libdnf5/rpm/nevra.hpp
@@ -185,12 +185,12 @@ inline void copy_nevra_attributes(const F & from, T & to) {
 
 
 /// Compare alpha and numeric segments of two versions.
-/// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
+/// @return 1 if `lhs` > `rhs`, -1 if `lhs` < `rhs`, 0 if they are equal
 LIBDNF_API int rpmvercmp(const char * lhs, const char * rhs);
 
 
 /// Compare evr part of two objects
-/// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
+/// @return 1 if `lhs` > `rhs`, -1 if `lhs` < `rhs`, 0 if they are equal
 template <typename L, typename R>
 int evrcmp(const L & lhs, const R & rhs) {
     // handle empty epoch the same way as 0 epoch


### PR DESCRIPTION
This PR adjsuts description of both functions to actual [one](https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmvercmp.cc):
```
/* return 1: a is newer than b */
/*        0: a and b are the same version */
/*       -1: b is newer than a */
int rpmvercmp(const char * a, const char * b);
```

Issue: https://github.com/rpm-software-management/dnf5/issues/2187