### PR TITLE
search: Do not separate a package from a summary with a colon

### DIFF
--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -107,7 +107,7 @@ void print_search_results(const SearchResults & results) {
             } else {
                 std::cout << highlight(package.get_name()) << "." << package.get_arch();
             }
-            std::cout << ": " << highlight(package.get_summary()) << std::endl;
+            std::cout << "\t" << highlight(package.get_summary()) << std::endl;
         }
     }
 }


### PR DESCRIPTION
It was reported that selecting a package name from an output of "dnf5 search" command was difficult because of a colon adjacent to the pacakge name:

    $ dnf5 search dontpanic
    Updating and loading repositories:
    Repositories loaded.
    Matched fields: name (exact)
    dontpanic.i686: Very simple library and executable used in testing Alien::Base

Double-clicking on "dontpanic" word selected "dontpanic.i686:", including the colon character. That made dificult to copy and paste the found packages.

While this is a problem of the terminal emulator and later the reporter found a setttings of his terminal not to do it, I think we should use a pure white-space separator to help people with not so advanced terminals.

This patch replaces the ": " separator with a single tabulation character:

    $ dnf5 search dontpanic
    Updating and loading repositories:
    Repositories loaded.
    Matched fields: name (exact)
    dontpanic.i686	Very simple library and executable used in testing Alien::Base

Resolves #2166

Do we want this change?
I guess we will need to adjust dnf-behave-tests/dnf/search.feature which again matches output literally.