### PR TITLE
Fix conditional which assumed RHEL 10 could support SOLVER_FLAG_FOCUS_NEW

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -114,7 +114,7 @@ Provides:       dnf5-command(versionlock)
 %bcond_with    dnf5daemon_tests
 
 # Disable SOLVER_FLAG_FOCUS_NEW only for RHEL
-%if 0%{?rhel} && 0%{?rhel} < 10
+%if 0%{?rhel} && 0%{?rhel} < 11
 %bcond_with    focus_new
 %else
 %bcond_without focus_new


### PR DESCRIPTION
libsolv is currently 0.7.29 in RHEL 10 which does not support this feature

Copied from <https://src.fedoraproject.org/rpms/dnf5/pull-request/96>.