### PR TITLE
Report specs filtered out by advisories

### DIFF
--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -90,7 +90,8 @@ void AdvisorySubCommand::run() {
         advisory_newpackage->get_value(),
         advisory_severity->get_value(),
         advisory_bz->get_value(),
-        advisory_cve->get_value());
+        advisory_cve->get_value(),
+        false);
 
     auto advisories = advisories_opt.value_or(libdnf5::advisory::AdvisoryQuery(ctx.get_base()));
 

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -171,7 +171,8 @@ void CheckUpgradeCommand::run() {
         advisory_newpackage->get_value(),
         advisory_severity->get_value(),
         advisory_bz->get_value(),
-        advisory_cve->get_value());
+        advisory_cve->get_value(),
+        false);
     if (advisories.has_value()) {
         upgrades_query.filter_latest_unresolved_advisories(
             std::move(advisories.value()), installed_query, libdnf5::sack::QueryCmp::GTE);

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -101,7 +101,8 @@ void InstallCommand::run() {
         advisory_newpackage->get_value(),
         advisory_severity->get_value(),
         advisory_bz->get_value(),
-        advisory_cve->get_value());
+        advisory_cve->get_value(),
+        !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
     if (advisories.has_value()) {
         settings.set_advisory_filter(std::move(advisories.value()));
     }

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -631,7 +631,8 @@ void RepoqueryCommand::run() {
         advisory_newpackage->get_value(),
         advisory_severity->get_value(),
         advisory_bz->get_value(),
-        advisory_cve->get_value());
+        advisory_cve->get_value(),
+        false);
     if (advisories.has_value()) {
         result_query.filter_advisories(advisories.value(), libdnf5::sack::QueryCmp::GTE);
     }

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -132,7 +132,8 @@ void UpgradeCommand::run() {
         advisory_newpackage->get_value(),
         advisory_severity->get_value(),
         advisory_bz->get_value(),
-        advisory_cve->get_value());
+        advisory_cve->get_value(),
+        !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
     if (advisories.has_value()) {
         settings.set_advisory_filter(std::move(advisories.value()));
     }

--- a/doc/_shared/options/advisories.rst
+++ b/doc/_shared/options/advisories.rst
@@ -2,3 +2,4 @@
     | Include content contained in advisories with specified name.
     | This is a list option.
     | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+    | Any transaction command (install, upgrade) will fail with an error if there is no existing advisory in the list; this can be bypassed by using the --skip-unavailable switch.

--- a/doc/_shared/options/bzs.rst
+++ b/doc/_shared/options/bzs.rst
@@ -2,3 +2,4 @@
     | Include content contained in advisories that fix a ticket of the given Bugzilla ID.
     | This is a list option.
     | Expected values are numeric IDs, e.g. `123123`.
+    | Any transaction command (install, upgrade) will fail with an error if there is no advisory fixing the given ticket; this can be bypassed by using the --skip-unavailable switch.

--- a/doc/_shared/options/cves.rst
+++ b/doc/_shared/options/cves.rst
@@ -2,3 +2,4 @@
     | Include content contained in advisories that fix a ticket of the given CVE (Common Vulnerabilities and Exposures) ID.
     | This is a list option.
     | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+    | Any transaction command (install, upgrade) will fail with an error if there is no advisory fixing the given ticket; this can be bypassed by using the --skip-unavailable switch.

--- a/include/libdnf5/base/goal_elements.hpp
+++ b/include/libdnf5/base/goal_elements.hpp
@@ -125,7 +125,8 @@ enum class GoalProblem : uint32_t {
     MALFORMED = (1 << 23),
     NOT_FOUND_DEBUGINFO = (1 << 24),
     NOT_FOUND_DEBUGSOURCE = (1 << 25),
-    MERGE_ERROR = (1 << 26)
+    MERGE_ERROR = (1 << 26),
+    NOT_FOUND_IN_ADVISORIES = (1 << 27)
 };
 
 /// Types of Goal actions

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -596,6 +596,16 @@ GoalProblem Goal::Impl::add_specs_to_goal(base::Transaction & transaction) {
                 if (settings.get_advisory_filter() != nullptr) {
                     filter_candidates_for_advisory_upgrade(
                         base, query, *settings.get_advisory_filter(), cfg_main.get_obsoletes_option().get_value());
+                    if (query.empty()) {
+                        transaction.p_impl->add_resolve_log(
+                            action,
+                            GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                            settings,
+                            libdnf5::transaction::TransactionItemType::PACKAGE,
+                            {},
+                            {},
+                            libdnf5::Logger::Level::WARNING);
+                    }
                 }
 
                 // Make the smallest possible upgrade

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -1419,6 +1419,18 @@ std::pair<GoalProblem, libdnf5::solv::IdQueue> Goal::Impl::add_install_to_goal(
         // Apply advisory filters
         if (settings.get_advisory_filter() != nullptr) {
             query.filter_advisories(*settings.get_advisory_filter(), libdnf5::sack::QueryCmp::EQ);
+            if (query.empty()) {
+                transaction.p_impl->add_resolve_log(
+                    action,
+                    GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                    settings,
+                    libdnf5::transaction::TransactionItemType::PACKAGE,
+                    spec,
+                    {},
+                    log_level);
+                return {
+                    skip_unavailable ? GoalProblem::NO_PROBLEM : GoalProblem::NOT_FOUND_IN_ADVISORIES, result_queue};
+            }
         }
 
         /// <name, <arch, std::vector<pkg Solvables>>>
@@ -1508,6 +1520,19 @@ std::pair<GoalProblem, libdnf5::solv::IdQueue> Goal::Impl::add_install_to_goal(
             // Apply advisory filters
             if (settings.get_advisory_filter() != nullptr) {
                 query.filter_advisories(*settings.get_advisory_filter(), libdnf5::sack::QueryCmp::EQ);
+                if (query.empty()) {
+                    transaction.p_impl->add_resolve_log(
+                        action,
+                        GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                        settings,
+                        libdnf5::transaction::TransactionItemType::PACKAGE,
+                        spec,
+                        {},
+                        log_level);
+                    return {
+                        skip_unavailable ? GoalProblem::NO_PROBLEM : GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                        result_queue};
+                }
             }
 
             rpm::PackageQuery available(query);
@@ -1584,6 +1609,19 @@ std::pair<GoalProblem, libdnf5::solv::IdQueue> Goal::Impl::add_install_to_goal(
             // Apply advisory filters
             if (settings.get_advisory_filter() != nullptr) {
                 query.filter_advisories(*settings.get_advisory_filter(), libdnf5::sack::QueryCmp::EQ);
+                if (query.empty()) {
+                    transaction.p_impl->add_resolve_log(
+                        action,
+                        GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                        settings,
+                        libdnf5::transaction::TransactionItemType::PACKAGE,
+                        spec,
+                        {},
+                        log_level);
+                    return {
+                        skip_unavailable ? GoalProblem::NO_PROBLEM : GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                        result_queue};
+                }
             }
             solv_map_to_id_queue(result_queue, *query.p_impl);
             rpm_goal.add_install(result_queue, skip_broken, best, clean_requirements_on_remove);
@@ -2291,6 +2329,17 @@ GoalProblem Goal::Impl::add_up_down_distrosync_to_goal(
     // Apply advisory filters
     if (settings.get_advisory_filter() != nullptr) {
         filter_candidates_for_advisory_upgrade(base, query, *settings.get_advisory_filter(), obsoletes);
+        if (query.empty()) {
+            transaction.p_impl->add_resolve_log(
+                action,
+                GoalProblem::NOT_FOUND_IN_ADVISORIES,
+                settings,
+                libdnf5::transaction::TransactionItemType::PACKAGE,
+                spec,
+                {},
+                libdnf5::Logger::Level::WARNING);
+            return skip_unavailable ? GoalProblem::NO_PROBLEM : GoalProblem::NOT_FOUND_IN_ADVISORIES;
+        }
     }
 
     if (minimal) {

--- a/libdnf5/base/log_event.cpp
+++ b/libdnf5/base/log_event.cpp
@@ -159,7 +159,11 @@ std::string LogEvent::to_string(
             }
             return ret.append(utils::sformat(_("No match for argument: {}"), *spec));
         case GoalProblem::NOT_FOUND_IN_ADVISORIES:
-            return ret.append(utils::sformat(_("No match for argument '{0}' in selected advisories"), *spec));
+            if (spec && !spec->empty()) {
+                return ret.append(utils::sformat(_("No match for argument '{0}' in selected advisories"), *spec));
+            } else {
+                return ret.append(_("No match in selected advisories"));
+            }
         case GoalProblem::NOT_FOUND_IN_REPOSITORIES:
             return ret.append(utils::sformat(
                 _("No match for argument '{0}' in repositories '{1}'"),

--- a/libdnf5/base/log_event.cpp
+++ b/libdnf5/base/log_event.cpp
@@ -158,6 +158,8 @@ std::string LogEvent::to_string(
                     utils::sformat(_("Cannot perform {0}, no match for: {1}."), goal_action_to_string(action), *spec));
             }
             return ret.append(utils::sformat(_("No match for argument: {}"), *spec));
+        case GoalProblem::NOT_FOUND_IN_ADVISORIES:
+            return ret.append(utils::sformat(_("No match for argument '{0}' in selected advisories"), *spec));
         case GoalProblem::NOT_FOUND_IN_REPOSITORIES:
             return ret.append(utils::sformat(
                 _("No match for argument '{0}' in repositories '{1}'"),


### PR DESCRIPTION
Resolves two use-cases:

1. The user is informed if there is no existing advisory in the `--advisories=...` list. Additionally, the transaction commands that support this option (install, upgrade) will fail with exit code 1.

```
❯ dnf5 install --advisories=foo hello
Repositories loaded.
No advisory found matching the requested name: "foo"
```

2. If the user tries to install or upgrade a package not present in the requested (and existing) advisories, the command prints a warning and fails with exit code 1 (unless the `--skip-unavailable` switch is present).

```
❯ dnf install --advisories=FEDORA-2025-77ace1a41b hello
Repositories loaded.
Failed to resolve the transaction:
No match for argument 'hello' in advisories
```

Resolves: https://github.com/rpm-software-management/dnf5/issues/784

Tests adjustments: https://github.com/rpm-software-management/ci-dnf-stack/pull/1671