### PR TITLE
bindings: Add Python cmp_nevra binding

### DIFF
--- a/bindings/libdnf5/rpm.i
+++ b/bindings/libdnf5/rpm.i
@@ -61,6 +61,7 @@
 %template(VectorNevra) std::vector<libdnf5::rpm::Nevra>;
 %template(VectorNevraForm) std::vector<libdnf5::rpm::Nevra::Form>;
 %template(PairBoolNevra) std::pair<bool, libdnf5::rpm::Nevra>;
+%template(cmp_nevra) libdnf5::rpm::cmp_nevra<libdnf5::rpm::Nevra>;
 
 %include "libdnf5/rpm/versionlock_config.hpp"
 


### PR DESCRIPTION
This would simplify comparison of Nevra objects:
```python
import libdnf5

def parse_nevra(nevra_str):
    form_nevra = libdnf5.rpm.VectorNevraForm(1, libdnf5.rpm.Nevra.Form_NEVRA)
    nevra = libdnf5.rpm.Nevra.parse(nevra_str, form_nevra)[0]
    return nevra

# This is how we can compare today (similar to C++ code)
def less(lhs, rhs):
    for attr in ["get_epoch", "get_version", "get_release"]:
        r = libdnf5.rpm.rpmvercmp(getattr(lhs, attr)(), getattr(rhs, attr)())
        if r != 0:
            return r == -1
    return False

if __name__ == "__main__":
    old = parse_nevra("foo-1.2.2-1.fc41.x86_64")
    new = parse_nevra("foo-1.2.3-2.fc41.x86_64")
    
    assert(less(old, new) and libdnf5.rpm.cmp_nevra(old, new) == True)
    assert(less(old, old) or libdnf5.rpm.cmp_nevra(old, old) == False)
    assert(less(new, old) or libdnf5.rpm.cmp_nevra(new, old) == False)
```
