### PR TITLE
ci: Use RSM_CI_APP_PRIVATE_KEY in do-release.yaml

### DIFF
--- a/.github/workflows/do-release.yaml
+++ b/.github/workflows/do-release.yaml
@@ -12,6 +12,11 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && github.repository_owner == 'rpm-software-management'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RSM_CI_APP_ID }}
+          private-key: ${{ secrets.RSM_CI_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - name: Create GitHub release
         run: |
@@ -22,4 +27,4 @@ jobs:
           # Use the changelog re-calculated to create a new release
           gh release create ${VERSION} --draft --title ${VERSION} -n "${CHANGELOG}"
         env:
-          GH_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
`RELEASEBOT_GITHUB_TOKEN` has expired or for whatever reason no longer has access to the DNF 5 GitHub repository, so our "Create a GitHub release once a PR is merged" workflow has been failing. Instead, use a private key for the RSM CI GitHub App to dynamically create a GitHub token and use that to authenticate. The RSM CI private key should never expire [1]. This pattern is already used in `backport.yml`.

[1] https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps