### PR TITLE
Deprecate deltarpm support in dnf5

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -397,6 +397,11 @@ Deprecation of the ``metadata_timer_sync`` option
 -------------------------------------------------
 The ``metadata_timer_sync`` configuration option is now obsoleted by the |DNF_MAKECACHE_TIMER_NAME_INLINE_LITERAL| systemd timer settings.
 
+Deprecation of the ``retries`` option
+-------------------------------------
+The ``retries`` configuration option is now deprecated. In dnf4, despite being documented as the number of retries for downloading packages, it was only used to limit the number of package re-downloads due to deltarpm errors. Deltarpm is currently not implemented in DNF5.
+
+
 Changes to individual options
 -----------------------------
 ``best``

--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -399,7 +399,11 @@ The ``metadata_timer_sync`` configuration option is now obsoleted by the |DNF_MA
 
 Deprecation of the ``retries`` option
 -------------------------------------
-The ``retries`` configuration option is now deprecated. In dnf4, despite being documented as the number of retries for downloading packages, it was only used to limit the number of package re-downloads due to deltarpm errors. Deltarpm is currently not implemented in DNF5.
+The ``retries`` configuration option is now deprecated. In dnf4, despite being documented as the number of retries for downloading packages, it was only used to limit the number of package re-downloads due to deltarpm errors. Deltarpm support is currently not planned for DNF5.
+
+Deprecation of the ``deltarpm`` and ``deltarpm_percentage`` options
+-------------------------------------------------------------------
+Support for delta RPMs is not planned for DNF5.
 
 
 Changes to individual options
@@ -420,10 +424,6 @@ Changes to individual options
   * The option was changed from ``bool`` to ``enum`` with options ``all``, ``metadata`` and ``none``.
 
     * This enables users to specify whether to use the cache exclusively for metadata or for both metadata and packages.
-
-``deltarpm``
-  * Default value is changed to ``false``.
-  * The support for delta RPMs is not implemented for now.
 
 ``disable_excludes``
   * To disable all configuration file excludes, the ``*`` glob character is used now instead of the ``all`` to unify the behavior with query objects on the API.

--- a/doc/dnf5.conf-deprecated.5.rst
+++ b/doc/dnf5.conf-deprecated.5.rst
@@ -43,3 +43,20 @@ If you find any issue, please, open a ticket at https://github.com/rpm-software-
     Currently works for install command only.
 
     Default: ``True``.
+
+
+Options for both [main] and Repo
+================================
+
+.. _retries_options-label:
+
+``retries``
+    :ref:`integer <integer-label>`
+
+    Set the number of total retries for downloading packages.
+    The number is cumulative, so e.g. for ``retries=10``, DNF5 will fail after any package
+    download fails for eleventh time.
+
+    Setting this to ``0`` makes DNF5 try forever.
+
+    Default: ``10``.

--- a/doc/dnf5.conf-deprecated.5.rst
+++ b/doc/dnf5.conf-deprecated.5.rst
@@ -48,6 +48,29 @@ If you find any issue, please, open a ticket at https://github.com/rpm-software-
 Options for both [main] and Repo
 ================================
 
+.. _deltarpm_options-label:
+
+``deltarpm``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will save bandwidth by downloading much smaller delta RPM
+    files, rebuilding them to RPM locally. However, this is quite CPU and I/O
+    intensive.
+
+    Default: ``False``.
+
+.. _deltarpm_percentage_options-label:
+
+``deltarpm_percentage``
+    :ref:`integer <integer-label>`
+
+    When the relative size of delta vs pkg is larger than this, delta is not used.
+    (Deltas must be at least 25% smaller than the pkg).
+    Use ``0`` to turn off delta rpm processing. Local repositories (with
+    file:// baseurl) have delta rpms turned off by default.
+
+    Default: ``75``
+
 .. _retries_options-label:
 
 ``retries``

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -935,29 +935,6 @@ configuration.
 
     Default: ``False``.
 
-.. _deltarpm_options-label:
-
-``deltarpm``
-    :ref:`boolean <boolean-label>`
-
-    If enabled, DNF5 will save bandwidth by downloading much smaller delta RPM
-    files, rebuilding them to RPM locally. However, this is quite CPU and I/O
-    intensive.
-
-    Default: ``False``.
-
-.. _deltarpm_percentage_options-label:
-
-``deltarpm_percentage``
-    :ref:`integer <integer-label>`
-
-    When the relative size of delta vs pkg is larger than this, delta is not used.
-    (Deltas must be at least 25% smaller than the pkg).
-    Use ``0`` to turn off delta rpm processing. Local repositories (with
-    file:// baseurl) have delta rpms turned off by default.
-
-    Default: ``75``
-
 .. _disable_excludes_options-label:
 ``disable_excludes``
     :ref:`list <list-label>`

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -1207,19 +1207,6 @@ configuration.
 
     Default: ``False``.
 
-.. _retries_options-label:
-
-``retries``
-    :ref:`integer <integer-label>`
-
-    Set the number of total retries for downloading packages.
-    The number is cumulative, so e.g. for ``retries=10``, DNF5 will fail after any package
-    download fails for eleventh time.
-
-    Setting this to ``0`` makes DNF5 try forever.
-
-    Default: ``10``.
-
 .. _skip_if_unavailable_options-label:
 
 ``skip_if_unavailable``

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -302,10 +302,15 @@ public:
     const OptionString & get_proxy_sslclientcert_option() const;
     OptionString & get_proxy_sslclientkey_option();
     const OptionString & get_proxy_sslclientkey_option() const;
-    OptionBool & get_deltarpm_option();
-    const OptionBool & get_deltarpm_option() const;
-    OptionNumber<std::uint32_t> & get_deltarpm_percentage_option();
-    const OptionNumber<std::uint32_t> & get_deltarpm_percentage_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionBool & get_deltarpm_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionBool & get_deltarpm_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionNumber<std::uint32_t> & get_deltarpm_percentage_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionNumber<std::uint32_t> & get_deltarpm_percentage_option()
+        const;
     OptionBool & get_skip_if_unavailable_option();
     const OptionBool & get_skip_if_unavailable_option() const;
 

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -224,8 +224,10 @@ public:
     const OptionBool & get_build_cache_option() const;
 
     // Repo main config
-    OptionNumber<std::uint32_t> & get_retries_option();
-    const OptionNumber<std::uint32_t> & get_retries_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionNumber<std::uint32_t> & get_retries_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionNumber<std::uint32_t> & get_retries_option() const;
     OptionPath & get_cachedir_option();
     const OptionPath & get_cachedir_option() const;
     OptionBool & get_fastestmirror_option();

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -91,8 +91,11 @@ public:
     const OptionChild<OptionBool> & get_repo_gpgcheck_option() const;
     OptionChild<OptionBool> & get_enablegroups_option();
     const OptionChild<OptionBool> & get_enablegroups_option() const;
-    OptionChild<OptionNumber<std::uint32_t>> & get_retries_option();
-    const OptionChild<OptionNumber<std::uint32_t>> & get_retries_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionChild<OptionNumber<std::uint32_t>> & get_retries_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionChild<OptionNumber<std::uint32_t>> & get_retries_option()
+        const;
     OptionChild<OptionNumber<std::uint32_t>> & get_bandwidth_option();
     const OptionChild<OptionNumber<std::uint32_t>> & get_bandwidth_option() const;
     OptionChild<OptionNumber<std::uint32_t>> & get_minrate_option();

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -132,10 +132,16 @@ public:
     const OptionChild<OptionString> & get_proxy_sslclientcert_option() const;
     OptionChild<OptionString> & get_proxy_sslclientkey_option();
     const OptionChild<OptionString> & get_proxy_sslclientkey_option() const;
-    OptionChild<OptionBool> & get_deltarpm_option();
-    const OptionChild<OptionBool> & get_deltarpm_option() const;
-    OptionChild<OptionNumber<std::uint32_t>> & get_deltarpm_percentage_option();
-    const OptionChild<OptionNumber<std::uint32_t>> & get_deltarpm_percentage_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionChild<OptionBool> & get_deltarpm_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionChild<OptionBool> & get_deltarpm_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionChild<OptionNumber<std::uint32_t>> &
+    get_deltarpm_percentage_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionChild<OptionNumber<std::uint32_t>> &
+    get_deltarpm_percentage_option() const;
     OptionChild<OptionBool> & get_skip_if_unavailable_option();
     const OptionChild<OptionBool> & get_skip_if_unavailable_option() const;
     /// If true it will create libsolv cache that will speed up the next loading process

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -84,8 +84,11 @@ class ConfigRepo::Impl {
     OptionChild<OptionBool> proxy_sslverify{main_config.get_proxy_sslverify_option()};
     OptionChild<OptionString> proxy_sslclientcert{main_config.get_proxy_sslclientcert_option()};
     OptionChild<OptionString> proxy_sslclientkey{main_config.get_proxy_sslclientkey_option()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     OptionChild<OptionBool> deltarpm{main_config.get_deltarpm_option()};
     OptionChild<OptionNumber<std::uint32_t>> deltarpm_percentage{main_config.get_deltarpm_percentage_option()};
+#pragma GCC diagnostic pop
     OptionChild<OptionBool> skip_if_unavailable{main_config.get_skip_if_unavailable_option()};
     OptionString enabled_metadata{""};
     OptionChild<OptionString> user_agent{main_config.get_user_agent_option()};
@@ -497,16 +500,20 @@ const OptionChild<OptionString> & ConfigRepo::get_proxy_sslclientkey_option() co
 }
 
 OptionChild<OptionBool> & ConfigRepo::get_deltarpm_option() {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->deltarpm;
 }
 const OptionChild<OptionBool> & ConfigRepo::get_deltarpm_option() const {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->deltarpm;
 }
 
 OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_deltarpm_percentage_option() {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->deltarpm_percentage;
 }
 const OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_deltarpm_percentage_option() const {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->deltarpm_percentage;
 }
 

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -62,7 +62,10 @@ class ConfigRepo::Impl {
     OptionChild<OptionBool> pkg_gpgcheck{main_config.get_pkg_gpgcheck_option()};
     OptionChild<OptionBool> repo_gpgcheck{main_config.get_repo_gpgcheck_option()};
     OptionChild<OptionBool> enablegroups{main_config.get_enablegroups_option()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     OptionChild<OptionNumber<std::uint32_t>> retries{main_config.get_retries_option()};
+#pragma GCC diagnostic pop
     OptionChild<OptionNumber<std::uint32_t>> bandwidth{main_config.get_bandwidth_option()};
     OptionChild<OptionNumber<std::uint32_t>> minrate{main_config.get_minrate_option()};
     OptionChild<OptionEnum> ip_resolve{main_config.get_ip_resolve_option()};
@@ -355,9 +358,11 @@ const OptionChild<OptionBool> & ConfigRepo::get_enablegroups_option() const {
 }
 
 OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_retries_option() {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->retries;
 }
 const OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_retries_option() const {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->retries;
 }
 


### PR DESCRIPTION
Following options are deprecated: `retries`, `deltarpm`, `deltarpm_percentage`.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1928