### PR TITLE
Explicit 64->32 bit conversion in repo_cache.cpp

### DIFF
--- a/include/libdnf5/repo/repo_cache.hpp
+++ b/include/libdnf5/repo/repo_cache.hpp
@@ -45,8 +45,9 @@ struct LIBDNF_API RepoCacheRemoveStatistics {
 
     std::size_t get_files_removed();  // Number of removed files and links.
     std::size_t get_dirs_removed();   // Number of removed directorires.
-    std::size_t get_bytes_removed();  // Number of removed bytes.
-    std::size_t get_errors();         // Numbes of errors.
+    std::size_t
+    get_bytes_removed();  // Number of removed bytes. Note: will overflow on 32-bit systems if the total space removed exceeds 4GiB.
+    std::size_t get_errors();  // Numbes of errors.
 
     RepoCacheRemoveStatistics & operator+=(const RepoCacheRemoveStatistics & rhs) noexcept;
 

--- a/libdnf5/repo/repo_cache.cpp
+++ b/libdnf5/repo/repo_cache.cpp
@@ -50,7 +50,8 @@ std::size_t remove(
             size = 0;
         }
         if (std::filesystem::remove(path)) {
-            bytes_count += size;
+            // Note: bytes_count will overflow on 32-bit systems if the total space removed exceeds 4GiB.
+            bytes_count += static_cast<std::size_t>(size);
             return 1;
         }
     } catch (const std::filesystem::filesystem_error & ex) {


### PR DESCRIPTION
On Fedora 41 i686, this conversion causes a warning which prevents compiling, so we need to make it explicit with static_cast. I'm not sure why the warning is thrown on F41 but not F42+.

Unfortuntaely, this warning represents a real bug: get_bytes_removed() can overflow on 32-bit systems if over 4GiB is removed. We should use a 64-bit integer for get_bytes_removed(), but changing this would break ABI compatibility since the just-released DNF 5.2.13.0.

I have included this patch downstream for DNF 5.2.13.0 on Fedora 41. I think we should merge it upstream as well, for now. Perhaps we should then fix the underlying issue by breaking ABI and making `get_bytes_removed` always return a u64. If we followed procedure, I believe that would mean bumping to DNF 5.3. But the 5.2.13.0 release has only been out for a couple days, and the ABI would only change on 32-bit platforms.