### PR TITLE
RepoCacheRemoveStatistics::get_bytes_removed return uintmax_t

### DIFF
--- a/include/libdnf5/repo/repo_cache.hpp
+++ b/include/libdnf5/repo/repo_cache.hpp
@@ -43,10 +43,10 @@ struct LIBDNF_API RepoCacheRemoveStatistics {
     RepoCacheRemoveStatistics(RepoCacheRemoveStatistics && src) noexcept;
     RepoCacheRemoveStatistics & operator=(RepoCacheRemoveStatistics && src) noexcept;
 
-    std::size_t get_files_removed();  // Number of removed files and links.
-    std::size_t get_dirs_removed();   // Number of removed directorires.
-    std::size_t get_bytes_removed();  // Number of removed bytes.
-    std::size_t get_errors();         // Numbes of errors.
+    std::size_t get_files_removed();     // Number of removed files and links.
+    std::size_t get_dirs_removed();      // Number of removed directorires.
+    std::uintmax_t get_bytes_removed();  // Number of removed bytes.
+    std::size_t get_errors();            // Numbes of errors.
 
     RepoCacheRemoveStatistics & operator+=(const RepoCacheRemoveStatistics & rhs) noexcept;
 

--- a/libdnf5/repo/repo_cache.cpp
+++ b/libdnf5/repo/repo_cache.cpp
@@ -38,7 +38,10 @@ constexpr const char * CACHE_ATTRS_DIR = "attrs";
 // In case of an error, the error_count increases by one.
 // Returns number of removed items (0 or 1).
 std::size_t remove(
-    const std::filesystem::path & path, std::size_t & error_count, std::size_t & bytes_count, Logger & log) noexcept {
+    const std::filesystem::path & path,
+    std::size_t & error_count,
+    std::uintmax_t & bytes_count,
+    Logger & log) noexcept {
     try {
         std::error_code ec;
         auto size = std::filesystem::file_size(path, ec);
@@ -123,7 +126,7 @@ std::size_t RepoCacheRemoveStatistics::get_files_removed() {
 std::size_t RepoCacheRemoveStatistics::get_dirs_removed() {
     return p_impl->dirs_removed;
 }
-std::size_t RepoCacheRemoveStatistics::get_bytes_removed() {
+std::uintmax_t RepoCacheRemoveStatistics::get_bytes_removed() {
     return p_impl->bytes_removed;
 }
 std::size_t RepoCacheRemoveStatistics::get_errors() {

--- a/libdnf5/repo/repo_cache_private.hpp
+++ b/libdnf5/repo/repo_cache_private.hpp
@@ -44,10 +44,10 @@ private:
     friend RepoCacheRemoveStatistics;
     friend RepoCache;
 
-    std::size_t files_removed;  // Number of removed files and links.
-    std::size_t dirs_removed;   // Number of removed directorires.
-    std::size_t bytes_removed;  // Number of removed bytes.
-    std::size_t errors;         // Numbes of errors.
+    std::size_t files_removed;     // Number of removed files and links.
+    std::size_t dirs_removed;      // Number of removed directorires.
+    std::uintmax_t bytes_removed;  // Number of removed bytes.
+    std::size_t errors;            // Numbes of errors.
 };
 
 class RepoCache::Impl {


### PR DESCRIPTION
On 32-bit systems, size_t is not large enough to represent the amount of freed space if it exceeds 4GiB. We should use a uintmax_t here instead.

Supersedes https://github.com/rpm-software-management/dnf5/pull/2213.