### PR TITLE
Add missing interfaces and re-order interfaces in a more logical order

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
+++ b/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
@@ -4,3 +4,5 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.rpm.Repo.xml ${CMAKE_C
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.rpm.Rpm.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.rpm.Rpm.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Advisory.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Advisory.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.comps.Group.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.comps.Group.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Base.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Base.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Offline.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Offline.xml COPYONLY)

--- a/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
@@ -36,22 +36,6 @@ Note: While most of the following methods can be invoked successfully by a regul
 Interfaces
 ==========
 
-
-.. only:: sphinx4
-
-   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
-
-.. only:: not sphinx4
-
-   .. warning::
-      Sphinx 4 is required to build D-Bus documentation.
-
-      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml``:
-
-   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
-      :language: xml
-
-
 .. only:: sphinx4
 
    ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
@@ -66,6 +50,19 @@ Interfaces
    .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
       :language: xml
 
+.. only:: sphinx4
+
+   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+
+.. only:: not sphinx4
+
+   .. warning::
+      Sphinx 4 is required to build D-Bus documentation.
+
+      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml``:
+
+   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Base.xml
+      :language: xml
 
 .. only:: sphinx4
 
@@ -95,6 +92,38 @@ Interfaces
 
    .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
       :language: xml
+
+.. only:: sphinx4
+
+   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+
+
+.. only:: not sphinx4
+
+   .. warning::
+      Sphinx 4 is required to build D-Bus documentation.
+
+      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml``:
+
+   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+      :language: xml
+
+
+.. only:: sphinx4
+
+   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+
+
+.. only:: not sphinx4
+
+   .. warning::
+      Sphinx 4 is required to build D-Bus documentation.
+
+      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml``:
+
+   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+      :language: xml
+
 
 
 .. only:: sphinx4


### PR DESCRIPTION
Updates the dnf5daemon doc to include the missing interfaces

org.rpm.dnf.v0.Base
org.rpm.dnf.v0.Offline

Also reorded the order of the interfaces in a more logical order of how the API will med used

Ex. SessionManager is the first one to be used.

I have made a local build with
```
cmake -B .build
cmake --build .build -t doc
```
An everything looks fine.
