### PR TITLE
download: Do not print "Downloading Packages:" header in quiet mode

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -311,7 +311,9 @@ void DownloadCommand::run() {
         downloader.add(pkg);
     }
 
-    std::cout << "Downloading Packages:" << std::endl;
+    if (!ctx.get_quiet()) {
+        std::cout << "Downloading Packages:" << std::endl;
+    }
     downloader.download();
 }
 


### PR DESCRIPTION
The "Downloading Packages:" header was printed irresspective of --quiet option:

    # dnf -q download dontpanic
    Downloading Packages:
    #

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2362032