### PR TITLE
doc: Clarify advisories filters documentation

### DIFF
--- a/doc/_shared/options/advisories.rst
+++ b/doc/_shared/options/advisories.rst
@@ -1,0 +1,4 @@
+``--advisories=ADVISORY_NAME,...``
+    | Include content contained in advisories with specified name.
+    | This is a list option.
+    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.

--- a/doc/_shared/options/advisory-severities.rst
+++ b/doc/_shared/options/advisory-severities.rst
@@ -1,0 +1,4 @@
+``--advisory-severities=ADVISORY_SEVERITY,...``
+    | Include content contained in advisories with specified severity.
+    | This is a list option.
+    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.

--- a/doc/_shared/options/bugfix.rst
+++ b/doc/_shared/options/bugfix.rst
@@ -1,0 +1,2 @@
+``--bugfix``
+    | Include content contained in bugfix advisories.

--- a/doc/_shared/options/bzs.rst
+++ b/doc/_shared/options/bzs.rst
@@ -1,0 +1,4 @@
+``--bzs=BUGZILLA_ID,...``
+    | Include content contained in advisories that fix a ticket of the given Bugzilla ID.
+    | This is a list option.
+    | Expected values are numeric IDs, e.g. `123123`.

--- a/doc/_shared/options/cves.rst
+++ b/doc/_shared/options/cves.rst
@@ -1,0 +1,4 @@
+``--cves=CVE_ID,...``
+    | Include content contained in advisories that fix a ticket of the given CVE (Common Vulnerabilities and Exposures) ID.
+    | This is a list option.
+    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.

--- a/doc/_shared/options/enhancement.rst
+++ b/doc/_shared/options/enhancement.rst
@@ -1,0 +1,2 @@
+``--enhancement``
+    | Include content contained in enhancement advisories.

--- a/doc/_shared/options/newpackage.rst
+++ b/doc/_shared/options/newpackage.rst
@@ -1,0 +1,2 @@
+``--newpackage``
+    | Include content contained in newpackage advisories.

--- a/doc/_shared/options/security.rst
+++ b/doc/_shared/options/security.rst
@@ -1,0 +1,2 @@
+``--security``
+    | Include content contained in security advisories.

--- a/doc/commands/advisory.8.rst
+++ b/doc/commands/advisory.8.rst
@@ -70,32 +70,19 @@ Options
     | This is a list option.
     | Only installed packages are matched. Globs are supported.
 
-``--security``
-    | Consider only content contained in security advisories.
+.. include:: ../_shared/options/security.rst
 
-``--bugfix``
-    | Consider only content contained in bugfix advisories.
+.. include:: ../_shared/options/bugfix.rst
 
-``--enhancement``
-    | Consider only content contained in enhancement advisories.
+.. include:: ../_shared/options/enhancement.rst
 
-``--newpackage``
-    | Consider only content contained in newpackage advisories.
+.. include:: ../_shared/options/newpackage.rst
 
-``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Consider only content contained in advisories with specified severity.
-    | This is a list option.
-    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+.. include:: ../_shared/options/advisory-severities.rst
 
-``--bzs=BUGZILLA_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID.
-    | This is a list option.
-    | Expected values are numeric IDs, e.g. `123123`.
+.. include:: ../_shared/options/bzs.rst
 
-``--cves=CVE_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
-    | This is a list option.
-    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+.. include:: ../_shared/options/cves.rst
 
 ``--with-bz``
     | Show only advisories referencing a Bugzilla ticket.

--- a/doc/commands/check-upgrade.8.rst
+++ b/doc/commands/check-upgrade.8.rst
@@ -44,37 +44,21 @@ Options
 ``--changelogs``
     | Print the package changelogs.
 
-``--advisories=ADVISORY_NAME,...``
-    | Consider only content contained in advisories with specified name.
-    | This is a list option.
-    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+.. include:: ../_shared/options/advisories.rst
 
-``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Consider only content contained in advisories with specified severity.
-    | This is a list option.
-    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+.. include:: ../_shared/options/advisory-severities.rst
 
-``--bzs=BUGZILLA_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID.
-    | This is a list option.
-    | Expected values are numeric IDs, e.g. `123123`.
+.. include:: ../_shared/options/bzs.rst
 
-``--cves=CVE_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
-    | This is a list option.
-    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+.. include:: ../_shared/options/cves.rst
 
-``--security``
-    | Consider only content contained in security advisories.
+.. include:: ../_shared/options/security.rst
 
-``--bugfix``
-    | Consider only content contained in bugfix advisories.
+.. include:: ../_shared/options/bugfix.rst
 
-``--enhancement``
-    | Consider only content contained in enhancement advisories.
+.. include:: ../_shared/options/enhancement.rst
 
-``--newpackage``
-    | Consider only content contained in newpackage advisories.
+.. include:: ../_shared/options/newpackage.rst
 
 ``--minimal``
     | Reports the lowest versions of packages that fix advisories of type bugfix, enhancement, security, or

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -70,37 +70,21 @@ Options
 ``--offline``
     | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
 
-``--advisories=ADVISORY_NAME,...``
-    | Consider only content contained in advisories with specified name.
-    | This is a list option.
-    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+.. include:: ../_shared/options/advisories.rst
 
-``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Consider only content contained in advisories with specified severity.
-    | This is a list option.
-    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+.. include:: ../_shared/options/advisory-severities.rst
 
-``--bzs=BUGZILLA_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID.
-    | This is a list option.
-    | Expected values are numeric IDs, e.g. `123123`.
+.. include:: ../_shared/options/bzs.rst
 
-``--cves=CVE_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
-    | This is a list option.
-    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+.. include:: ../_shared/options/cves.rst
 
-``--security``
-    | Consider only content contained in security advisories.
+.. include:: ../_shared/options/security.rst
 
-``--bugfix``
-    | Consider only content contained in bugfix advisories.
+.. include:: ../_shared/options/bugfix.rst
 
-``--enhancement``
-    | Consider only content contained in enhancement advisories.
+.. include:: ../_shared/options/enhancement.rst
 
-``--newpackage``
-    | Consider only content contained in newpackage advisories.
+.. include:: ../_shared/options/newpackage.rst
 
 
 Examples

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -39,15 +39,9 @@ as ``<package-file-spec>``.
 Options
 =======
 
-``--advisories=ADVISORY_NAME,...``
-    | Limit to packages in advisories with specified name.
-    | This is a list option.
-    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+.. include:: ../_shared/options/advisories.rst
 
-``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Limit to packages in advisories with specified severity.
-    | This is a list option.
-    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+.. include:: ../_shared/options/advisory-severities.rst
 
 ``--arch=ARCH,...``
     | Limit to packages of these architectures.
@@ -58,18 +52,11 @@ Options
     | This is the default behavior.
     | Can be combined with ``--installed`` to query both installed and available packages.
 
-``--bugfix``
-    | Limit to packages in bugfix advisories.
+.. include:: ../_shared/options/bugfix.rst
 
-``--bzs=BUGZILLA_ID,...``
-    | Limit to packages in advisories that fix a Bugzilla ID.
-    | This is a list option.
-    | Expected values are numeric IDs, e.g. `123123`.
+.. include:: ../_shared/options/bzs.rst
 
-``--cves=CVE_ID,...``
-    | Limit to packages in advisories that fix a CVE (Common Vulnerabilities and Exposures) ID.
-    | This is a list option.
-    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+.. include:: ../_shared/options/cves.rst
 
 ``--disable-modular-filtering``
     | Include packages of inactive module streams.
@@ -78,8 +65,7 @@ Options
     | Limit to installed duplicate packages (i.e. more package versions for  the  same  name and architecture).
     | Installonly packages are excluded from this set.
 
-``--enhancement``
-    | Limit to packages in enhancement advisories.
+.. include:: ../_shared/options/enhancement.rst
 
 ``--exactdeps``
     | Limit to packages that require <capability> specified by --whatrequires or --whatdepends.
@@ -105,8 +91,7 @@ Options
 ``--leaves``
     | Limit to groups of installed packages not required by other installed packages.
 
-``--newpackage``
-    | Limit to packages in newpackage advisories.
+.. include:: ../_shared/options/newpackage.rst
 
 ``--providers-of=PACKAGE_ATTRIBUTE``
     | After filtering is finished get selected attribute of packages and output packages that provide it.
@@ -123,8 +108,7 @@ Options
     | It repeats the output extension as long as new packages are being added.
     | The added packages are limited by ``--available``, ``--installed`` and ``--arch`` options.
 
-``--security``
-    | Limit to packages in security advisories.
+.. include:: ../_shared/options/security.rst
 
 ``--srpm``
     | After filtering is finished use packages' corresponding source RPMs for output.

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -70,37 +70,21 @@ Options
 ``--offline``
     | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
 
-``--advisories=ADVISORY_NAME,...``
-    | Consider only content contained in advisories with specified name.
-    | This is a list option.
-    | Expected values are advisory IDs, e.g. `FEDORA-2201-123`.
+.. include:: ../_shared/options/advisories.rst
 
-``--advisory-severities=ADVISORY_SEVERITY,...``
-    | Consider only content contained in advisories with specified severity.
-    | This is a list option.
-    | Accepted values are: `critical`, `important`, `moderate`, `low`, `none`.
+.. include:: ../_shared/options/advisory-severities.rst
 
-``--bzs=BUGZILLA_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given Bugzilla ID.
-    | This is a list option.
-    | Expected values are numeric IDs, e.g. `123123`.
+.. include:: ../_shared/options/bzs.rst
 
-``--cves=CVE_ID,...``
-    | Consider only content contained in advisories that fix a ticket of given CVE (Common Vulnerabilities and Exposures) ID.
-    | This is a list option.
-    | Expected values are string IDs in CVE format, e.g. `CVE-2201-0123`.
+.. include:: ../_shared/options/cves.rst
 
-``--security``
-    | Consider only content contained in security advisories.
+.. include:: ../_shared/options/security.rst
 
-``--bugfix``
-    | Consider only content contained in bugfix advisories.
+.. include:: ../_shared/options/bugfix.rst
 
-``--enhancement``
-    | Consider only content contained in enhancement advisories.
+.. include:: ../_shared/options/enhancement.rst
 
-``--newpackage``
-    | Consider only content contained in newpackage advisories.
+.. include:: ../_shared/options/newpackage.rst
 
 
 Examples


### PR DESCRIPTION
This patch slightly adjusts the wording from "Consider only content..."
to "Include content..." to avoid implying that the options produce an
intersection of advisories when combined. The new phrasing aligns with
what was used in the DNF4 documentation.

Additionally, the descriptions of these options have been moved to the
shared library to improve maintainability and reduce duplication.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1401