### PR TITLE
expired-pgp-keys: Do not use a deprecated way of removing keys with RPM v6

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -670,6 +670,9 @@ Summary:        Libdnf5 plugin for detecting and removing expired PGP keys
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       gnupg2
+%if 0%{?fedora} >= 43 || 0%{?rhel} >= 11
+Requires:       rpm-libs%{?_isa} >= 5.99.90
+%endif
 
 %description -n libdnf5-plugin-expired-pgp-keys
 Libdnf5 plugin for detecting and removing expired PGP keys.

--- a/libdnf5-plugins/expired-pgp-keys/CMakeLists.txt
+++ b/libdnf5-plugins/expired-pgp-keys/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(expired-pgp-keys PRIVATE libdnf5 libdnf5-cli)
 
 pkg_check_modules(RPM REQUIRED rpm)
 target_link_libraries(expired-pgp-keys PRIVATE ${RPM_LIBRARIES})
+if (RPM_VERSION VERSION_GREATER_EQUAL "5.99.90")
+    add_definitions(-DHAVE_RPM6)
+endif()
 
 install(TARGETS expired-pgp-keys LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/")
 


### PR DESCRIPTION
RPM 6 warns on removing a key by a gpg-pubkey package name:

    warning: erasing gpg-pubkey packages is deprecated; use rpmkeys --delete 326785684e6adf5ac523b673c77c028403690624

RPM 6 has rpmtxnDeletePubkey() as a replacement.

This patch keeps using the old way on RPM < 6 and uses
rpmtxnDeletePubkey() on RPM 6 because rpmtxnDeletePubkey() is
available since RPM 5.99.90. The RPM version is detected at build time
and enforced at run-time with a dependency on
libdnf5-plugin-expired-pgp-keys package level.

I successfully tested it on Fedora 43 and Fedora 41.