### PR TITLE
Remove unused `WITH_ZCHUNK` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ option(WITH_PYTHON_PLUGINS_LOADER "Build a special dnf5 plugin that loads Python
 # build options - features
 option(WITH_COMPS "Build with comps groups and environments support" ON)
 option(WITH_MODULEMD "Build with modulemd modules support" ON)
-option(WITH_ZCHUNK "Build with zchunk delta compression support" ON)
 option(WITH_SYSTEMD "Build with systemd and D-Bus features" ON)
 option(ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 option(ENABLE_SOLV_FOCUSNEW "Build with SOLVER_FLAG_FOCUS_NEW libsolv flag enabled to ensure new dependencies are installed in latests versions?" ON)

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -87,11 +87,6 @@ Provides:       dnf5-command(versionlock)
 
 %bcond_without comps
 %bcond_without modulemd
-%if 0%{?rhel}
-%bcond_with    zchunk
-%else
-%bcond_without zchunk
-%endif
 %bcond_without systemd
 
 %bcond_with    html
@@ -135,7 +130,6 @@ Provides:       dnf5-command(versionlock)
 %endif
 %global sqlite_version 3.35.0
 %global swig_version 4
-%global zchunk_version 0.9.11
 
 
 # ========== build requires ==========
@@ -178,10 +172,6 @@ BuildRequires:  pkgconfig(libcomps)
 
 %if %{with modulemd}
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
-%endif
-
-%if %{with zchunk}
-BuildRequires:  pkgconfig(zck) >= %{zchunk_version}
 %endif
 
 %if %{with systemd}
@@ -903,7 +893,6 @@ automatically and regularly from systemd timers, cron jobs or similar.
     \
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \
     -DWITH_MODULEMD=%{?with_modulemd:ON}%{!?with_modulemd:OFF} \
-    -DWITH_ZCHUNK=%{?with_zchunk:ON}%{!?with_zchunk:OFF} \
     -DWITH_SYSTEMD=%{?with_systemd:ON}%{!?with_systemd:OFF} \
     \
     -DWITH_HTML=%{?with_html:ON}%{!?with_html:OFF} \

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -108,11 +108,6 @@ if(WITH_COMPS)
     target_link_libraries(libdnf5_iface INTERFACE ${LIBXML2_LIBRARIES})
 endif()
 
-if (WITH_ZCHUNK)
-    pkg_check_modules(ZCHUNKLIB zck>=0.9.11 REQUIRED)
-    add_definitions(-DWITH_ZCHUNK)
-endif()
-
 # GLIB librepo and libmodulemd uses glib2 in API :(
 pkg_check_modules (GLIB2 glib-2.0>=2.46.0)
 include_directories(${GLIB2_INCLUDE_DIRS})


### PR DESCRIPTION
We already require librepo 1.18.0 which contains the needed fixes related to zchunk.

https://github.com/rpm-software-management/librepo/commit/66c99da1206c96fefc1b8279f777afefb79dc614, https://github.com/rpm-software-management/librepo/commit/e2abd5dd2c1bf3a644de3bcb08c874185a0bd1e9

For: https://github.com/rpm-software-management/dnf5/issues/1233