### PR TITLE
dnf5: --no-gpgchecks overrides localpkg_gpgcheck

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -429,6 +429,7 @@ void RootCommand::set_argument_parser() {
                                           [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                           [[maybe_unused]] const char * option,
                                           [[maybe_unused]] const char * value) {
+        ctx.get_base().get_config().get_localpkg_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         ctx.get_base().get_config().get_pkg_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         ctx.get_base().get_config().get_repo_gpgcheck_option().set(libdnf5::Option::Priority::COMMANDLINE, 0);
         // Store to vector. Use it later when repositories configuration will be loaded.


### PR DESCRIPTION
When setting --no-gpgchecks, dnf5 fails to override localpkg_gpgcheck which is not the expectation.  This breaks compatibility with dnf4.

    # DNF4
    $ dnf4 --version | head -n1
    4.23.0

    # Dump the config with dnf4, showing localpkg_gpgcheck is enabled
    $ dnf4 config-manager --dump | grep gpgcheck
    gpgcheck = 1
    localpkg_gpgcheck = 1
    repo_gpgcheck = 0

    # With dnf4, --nogpgcheck overrides localpkg_gpgcheck, as expected
    $ dnf4 --nogpgcheck config-manager --dump | grep gpgcheck
    gpgcheck = 0
    localpkg_gpgcheck = 0
    repo_gpgcheck = 0

    # DNF5
    $ dnf5 --version | head -n1
    dnf5 version 5.2.13.1

    # Dump the config with dnf5, showing localpkg_gpgcheck is enabled
    $ dnf5 --dump-main-config | grep gpgcheck
    gpgcheck = 1
    localpkg_gpgcheck = 1
    pkg_gpgcheck = 1
    repo_gpgcheck = 0

    # With dnf5, --nogpgcheck fails to override localpkg_gpgcheck
    $ dnf5 --nogpgcheck --dump-main-config | grep gpgcheck
    gpgcheck = 0
    localpkg_gpgcheck = 1
    pkg_gpgcheck = 0
    repo_gpgcheck = 0

    # For good measure, use the non-compat option name
    $ dnf5 --no-gpgchecks --dump-main-config | grep gpgcheck
    gpgcheck = 0
    localpkg_gpgcheck = 1
    pkg_gpgcheck = 0
    repo_gpgcheck = 0

Override localpkg_gpgcheck as we do for the other `*_gpgcheck` flags.