### PR TITLE
Fix package build workflow: use code from the tested PR

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure CC CXX env variables
         id: configure_compiler


### PR DESCRIPTION
In https://github.com/rpm-software-management/dnf5/pull/2237 I have discovered that the github actions builds don't use code from the PR.

We can verify this by inspecting any of the `ccache builds` actions, for example: https://github.com/rpm-software-management/dnf5/actions/runs/14829865860/job/41631948613. Expand the `Run actions/checkout@v4` step and in it expand `Checking out the ref`. We can see: `/usr/sbin/git checkout --progress --force -B main refs/remotes/origin/main` so it is checkout out the main branch.

Add needed `ref` to the `checkout` action so that we build the new code.

Once this is merged we can verify that rerunning the https://github.com/rpm-software-management/dnf5/pull/2237 clang build passes.

(Note that in this PR the actions will still be broken.)