### PR TITLE
doc: `--use-host-config` instead of `--releasever=/`

### DIFF
--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -52,7 +52,7 @@ relative to the host.
 
 Note: You may also want to use the command-line option ``--releasever=RELEASEVER`` when creating
 the installroot, otherwise the $releasever value is taken from the rpmdb within the installroot
-(and thus it is empty at the time of creation and the transaction will fail). If ``--releasever=/``
+(and thus it is empty at the time of creation and the transaction will fail). If ``--use-host-config``
 is used, the releasever will be detected from the host (/) system. The new installroot path at the
 time of creation does not contain the repository, releasever and dnf.conf files.
 


### PR DESCRIPTION
In DNF5, we don't support `--releasever=/`, but we do have the new `--use-host-config` option which sources configuration, reposdir, and vars from the host system. `--use-host-config` is typically what you want when bootstrapping a new installroot that doesn't have a releasever set, so the docs should recommend `--use-host-config` instead of `--releasever=/`.

Resolves https://github.com/rpm-software-management/dnf5/issues/1496.