### PR TITLE
dnfdaemon: Add new History interface

### DIFF
--- a/dnf5daemon-server/dbus.hpp
+++ b/dnf5daemon-server/dbus.hpp
@@ -61,6 +61,7 @@ const SDBUS_INTERFACE_NAME_TYPE INTERFACE_REPO{"org.rpm.dnf.v0.rpm.Repo"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_RPM{"org.rpm.dnf.v0.rpm.Rpm"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_GOAL{"org.rpm.dnf.v0.Goal"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_GROUP{"org.rpm.dnf.v0.comps.Group"};
+const SDBUS_INTERFACE_NAME_TYPE INTERFACE_HISTORY{"org.rpm.dnf.v0.History"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_ADVISORY{"org.rpm.dnf.v0.Advisory"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_OFFLINE{"org.rpm.dnf.v0.Offline"};
 const SDBUS_INTERFACE_NAME_TYPE INTERFACE_SESSION_MANAGER{"org.rpm.dnf.v0.SessionManager"};

--- a/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
+++ b/dnf5daemon-server/dbus/interfaces/CMakeLists.txt
@@ -6,3 +6,4 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Advisory.xml ${CMAKE_C
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.comps.Group.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.comps.Group.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Base.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Base.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.Offline.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.Offline.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.rpm.dnf.v0.History.xml ${CMAKE_CURRENT_BINARY_DIR}/org.rpm.dnf.v0.History.xml COPYONLY)

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
@@ -1,0 +1,79 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<node>
+<!-- org.rpm.dnf.v0.History:
+   @short_description: Interface to transactions history database
+-->
+<interface name="org.rpm.dnf.v0.History">
+    <!--
+        recent_changes:
+        @options: an array of key/value pairs
+        @changeset: a dictionary {"<type_of_change>":[<package>,<package>,...]}
+
+        Get a list of packages that have been recently changed. The
+        "type_of_change" key in the output dictionary can be one of the
+        following: "installed", "removed", "upgraded", or "downgraded". The
+        packages in the output are represented as dictionaries containing the
+        requested set of attributes for the changed packages.
+
+        For installed, upgraded, and downgraded packages, the currently
+        installed version is returned.
+
+        For upgraded and downgraded packages, the "original_evr" attribute
+        is also included, containing the package EVR before the change.
+
+        If requested, upgraded packages may also include an "advisory_name"
+        field, indicating the name of the update that contains the upgraded
+        (i.e., currently installed) version of the package.
+
+        For removed packages, only the name, arch, and evr of the removed
+        version are provided.
+
+        Following options and filters are supported:
+
+            - upgraded_packages: boolean, default "true"
+                Whether to include upgraded packages in the output.
+            - downgraded_packages: boolean, default "true"
+                Whether to include downgraded packages in the output.
+            - installed_packages: boolean, default "true"
+                Whether to include installed packages in the output.
+            - removed_packages: boolean, default "true"
+                Whether to include removed packages in the output.
+            - include_advisory: boolean, default "true"
+                Whether to include "advisory_name" to upgraded packages attributes.
+            - package_attrs: list of strings, default ["name", "summary", "evr", "arch"]
+                List of package attributes that are returned for each changed
+                package. Supported attributes are the same as in list() method of
+                the Rpm interface.
+            - since: int64, unix timestamp
+                Get changes since a given point in time.
+
+        Unknown options are ignored.
+    -->
+    <method name="recent_changes">
+        <arg name="options" type="a{sv}" direction="in" />
+        <arg name="changeset" type="a{saa{sv}}" direction="out" />
+    </method>
+</interface>
+
+</node>

--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
@@ -42,9 +42,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         For upgraded and downgraded packages, the "original_evr" attribute
         is also included, containing the package EVR before the change.
 
-        If requested, upgraded packages may also include an "advisory_name"
-        field, indicating the name of the update that contains the upgraded
-        (i.e., currently installed) version of the package.
+        If requested, upgraded packages may also include an "advisories" list
+        field, indicating the name of the updates that contain the upgraded
+        (i.e., currently installed) version of the package. If the "all_advisories"
+        option is set, advisories for all versions between the original and currently
+        installed versions are also included.
 
         For removed packages, only the name, arch, and evr of the removed
         version are provided.
@@ -60,7 +62,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
             - removed_packages: boolean, default "true"
                 Whether to include removed packages in the output.
             - include_advisory: boolean, default "true"
-                Whether to include "advisory_name" to upgraded packages attributes.
+                Whether to include "advisories" to upgraded packages attributes.
+            - all_advisories: boolean, default "false"
+                Only make sense with include_advisory=true. Include also advisories
+                for all versions between the original and currently installed.
             - package_attrs: list of strings, default ["name", "summary", "evr", "arch"]
                 List of package attributes that are returned for each changed
                 package. Supported attributes are the same as in list() method of

--- a/dnf5daemon-server/services/history/history.cpp
+++ b/dnf5daemon-server/services/history/history.cpp
@@ -1,0 +1,229 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "history.hpp"
+
+#include "dbus.hpp"
+#include "package.hpp"
+
+#include <libdnf5/advisory/advisory_package.hpp>
+#include <libdnf5/advisory/advisory_query.hpp>
+#include <libdnf5/common/sack/query_cmp.hpp>
+#include <libdnf5/rpm/nevra.hpp>
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/transaction/rpm_package.hpp>
+#include <libdnf5/transaction/transaction_history.hpp>
+#include <libdnf5/utils/format.hpp>
+#include <sdbus-c++/sdbus-c++.h>
+
+void History::dbus_register() {
+    auto dbus_object = session.get_dbus_object();
+#ifdef SDBUS_CPP_VERSION_2
+    dbus_object
+        ->addVTable(sdbus::MethodVTableItem{
+            sdbus::MethodName{"recent_changes"},
+            sdbus::Signature{"a{sv}"},
+            {"options"},
+            sdbus::Signature{"a{saa{sv}}"},
+            {"changeset"},
+            [this](sdbus::MethodCall call) -> void {
+                session.get_threads_manager().handle_method(
+                    *this, &History::recent_changes, call, session.session_locale);
+            },
+            {}})
+        .forInterface(dnfdaemon::INTERFACE_HISTORY);
+#else
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_HISTORY,
+        "recent_changes",
+        sdbus::Signature{"a{sv}"},
+        {"options"},
+        sdbus::Signature{"a{saa{sv}}"},
+        {"changeset"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &History::recent_changes, call, session.session_locale);
+        });
+#endif
+}
+
+std::string get_evr(const libdnf5::transaction::Package & trans_pkg) {
+    auto epoch = trans_pkg.get_epoch();
+    if (epoch == "0") {
+        return libdnf5::utils::sformat("{}-{}", trans_pkg.get_version(), trans_pkg.get_release());
+    } else {
+        return libdnf5::utils::sformat("{}:{}-{}", epoch, trans_pkg.get_version(), trans_pkg.get_release());
+    }
+}
+
+dnfdaemon::KeyValueMap history_package_to_map(const libdnf5::transaction::Package & trans_pkg) {
+    dnfdaemon::KeyValueMap dbus_package;
+    dbus_package.emplace("name", trans_pkg.get_name());
+    dbus_package.emplace("arch", trans_pkg.get_arch());
+    dbus_package.emplace("evr", get_evr(trans_pkg));
+    return dbus_package;
+}
+
+sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
+    // TODO(mblaha): This method does not handle obsoletes because the necessary data
+    // is missing from the history database:
+    // https://github.com/rpm-software-management/dnf5/issues/2254
+    dnfdaemon::KeyValueMap options;
+    call >> options;
+    // TODO(mblaha): Automatically add "updateinfo" metadata?
+    session.fill_sack();
+
+    auto upgraded_requested = dnfdaemon::key_value_map_get<bool>(options, "upgraded_packages", true);
+    auto downgraded_requested = dnfdaemon::key_value_map_get<bool>(options, "downgraded_packages", true);
+    auto installed_requested = dnfdaemon::key_value_map_get<bool>(options, "installed_packages", true);
+    auto removed_requested = dnfdaemon::key_value_map_get<bool>(options, "removed_packages", true);
+    auto include_advisory = dnfdaemon::key_value_map_get<bool>(options, "include_advisory", true);
+    auto pkg_attrs = dnfdaemon::key_value_map_get<std::vector<std::string>>(
+        options, "package_attrs", std::vector<std::string>{"name", "summary", "evr", "arch"});
+
+    auto & base = *session.get_base();
+    libdnf5::transaction::TransactionHistory history(base);
+    std::vector<libdnf5::transaction::Transaction> transactions;
+
+    bool timestamp_used = options.contains("since");
+    int64_t timestamp;
+    if (timestamp_used) {
+        // TODO(mblaha): Add a new method TransactionHistory::list_transactions_since()
+        // to retrieve transactions newer than a given point in time
+        timestamp = dnfdaemon::key_value_map_get<int64_t>(options, "since");
+        transactions = history.list_all_transactions();
+    } else {
+        // if timestamp is not present, use only the latest transaction
+        auto trans_ids = history.list_transaction_ids();
+        transactions = history.list_transactions(std::vector<int64_t>{trans_ids.back()});
+    }
+    // the operator < for the Transaction class is kind of "reversed".
+    // transA < transB means that transA.get_id() > transB.get_id()
+    // I need the transactions in ascending order by id, thus the ">" operator is used
+    std::sort(transactions.begin(), transactions.end(), std::greater{});
+
+    // get all installed packages NAs and installonly pkgs NEVRAs
+    libdnf5::rpm::PackageQuery installed_query(base);
+    installed_query.filter_installed();
+    std::map<std::string, libdnf5::rpm::Package> installed_na;
+    for (const auto & pkg : installed_query) {
+        installed_na.emplace(pkg.get_na(), pkg);
+    }
+
+    std::unordered_set<std::string> seen_na{};
+
+    dnfdaemon::KeyValueMapList out_installed;
+    dnfdaemon::KeyValueMapList out_removed;
+    dnfdaemon::KeyValueMapList out_downgraded;
+    // pair of (old, new)
+    std::vector<std::pair<libdnf5::transaction::Package, libdnf5::rpm::Package>> upgrades;
+    using Action = libdnf5::transaction::TransactionItemAction;
+    libdnf5::rpm::PackageSet upgrades_set{base};
+    for (auto & transaction : transactions) {
+        // skip unfinished or error transactions
+        if (transaction.get_state() != libdnf5::transaction::TransactionState::OK) {
+            continue;
+        }
+        // only interested in transactions newer than the timestamp
+        if (timestamp_used && transaction.get_dt_end() <= timestamp) {
+            continue;
+        }
+        for (const auto & pkg : transaction.get_packages()) {
+            const auto action = pkg.get_action();
+            // only interested in actions on a previously installed package or
+            // installations of a new package
+            if (action != Action::INSTALL && action != Action::REMOVE && action != Action::REPLACED) {
+                continue;
+            }
+
+            std::string na = pkg.get_name() + "." + pkg.get_arch();
+            auto added = seen_na.insert(na);
+            if (!added.second) {
+                // only interested in the first occurence of given NA
+                continue;
+            }
+
+            auto installed_pkg = installed_na.find(na);
+            if (action == Action::INSTALL) {
+                // check if the package is still installed
+                if (installed_requested && installed_pkg != installed_na.end()) {
+                    out_installed.push_back(package_to_map(installed_pkg->second, pkg_attrs));
+                }
+            } else {
+                // package was REMOVEd or REPLACED
+                // check the current installed version of the package
+                if (installed_pkg != installed_na.end()) {
+                    if (libdnf5::rpm::cmp_nevra(pkg, installed_na.at(na))) {
+                        if (upgraded_requested) {
+                            upgrades_set.add(installed_pkg->second);
+                            upgrades.emplace_back(pkg, installed_pkg->second);
+                        }
+                    } else if (libdnf5::rpm::cmp_nevra(installed_na.at(na), pkg)) {
+                        if (downgraded_requested) {
+                            auto replace_pkg = package_to_map(installed_pkg->second, pkg_attrs);
+                            replace_pkg.emplace("original_evr", get_evr(pkg));
+                            out_downgraded.push_back(std::move(replace_pkg));
+                        }
+                    }
+                } else {
+                    if (removed_requested) {
+                        out_removed.push_back(history_package_to_map(pkg));
+                    }
+                }
+            }
+        }
+    }
+
+    auto reply = call.createReply();
+    std::map<std::string, dnfdaemon::KeyValueMapList> output;
+    if (upgraded_requested) {
+        // inject advisory to upgraded packages
+        std::unordered_map<std::string, libdnf5::advisory::AdvisoryPackage> advisories_by_nevra;
+        if (include_advisory) {
+            auto advisories = libdnf5::advisory::AdvisoryQuery(base);
+            for (const auto & adv_pkg :
+                 advisories.get_advisory_packages_sorted(upgrades_set, libdnf5::sack::QueryCmp::EQ)) {
+                advisories_by_nevra.emplace(adv_pkg.get_nevra(), adv_pkg);
+            }
+        }
+        dnfdaemon::KeyValueMapList out_upgraded;
+        for (const auto & [old_pkg, new_pkg] : upgrades) {
+            auto replace_pkg = package_to_map(new_pkg, pkg_attrs);
+            replace_pkg.emplace("original_evr", get_evr(old_pkg));
+            auto advisory_pkg = advisories_by_nevra.find(new_pkg.get_nevra());
+            if (advisory_pkg != advisories_by_nevra.end()) {
+                auto advisory = advisory_pkg->second.get_advisory();
+                replace_pkg.emplace("advisory_name", advisory.get_name());
+            }
+            out_upgraded.push_back(std::move(replace_pkg));
+        }
+        output["upgraded"] = out_upgraded;
+    }
+    if (downgraded_requested) {
+        output["downgraded"] = out_downgraded;
+    }
+    if (installed_requested) {
+        output["installed"] = out_installed;
+    }
+    if (removed_requested) {
+        output["removed"] = out_removed;
+    }
+
+    reply << output;
+    return reply;
+}

--- a/dnf5daemon-server/services/history/history.hpp
+++ b/dnf5daemon-server/services/history/history.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5DAEMON_SERVER_SERVICES_HISTORY_HISTORY_HPP
+#define DNF5DAEMON_SERVER_SERVICES_HISTORY_HISTORY_HPP
+
+#include "session.hpp"
+
+#include <sdbus-c++/sdbus-c++.h>
+
+class History : public IDbusSessionService {
+public:
+    using IDbusSessionService::IDbusSessionService;
+    ~History() = default;
+    void dbus_register();
+    void dbus_deregister();
+
+private:
+    sdbus::MethodReply recent_changes(sdbus::MethodCall & call);
+};
+
+#endif

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "services/base/base.hpp"
 #include "services/comps/group.hpp"
 #include "services/goal/goal.hpp"
+#include "services/history/history.hpp"
 #include "services/offline/offline.hpp"
 #include "services/repo/repo.hpp"
 #include "services/rpm/rpm.hpp"
@@ -167,6 +168,7 @@ Session::Session(
     services.emplace_back(std::make_unique<Goal>(*this));
     services.emplace_back(std::make_unique<Offline>(*this));
     services.emplace_back(std::make_unique<Group>(*this));
+    services.emplace_back(std::make_unique<History>(*this));
     services.emplace_back(std::make_unique<dnfdaemon::Advisory>(*this));
 
     // Register all provided services on d-bus

--- a/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
@@ -154,3 +154,18 @@ Interfaces
 
    .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Advisory.xml
       :language: xml
+
+
+.. only:: sphinx4
+
+   ..  dbus-doc:: dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
+
+.. only:: not sphinx4
+
+   .. warning::
+      Sphinx 4 is required to build D-Bus documentation.
+
+      This is the content of ``dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml``:
+
+   .. literalinclude:: ../../dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
+      :language: xml

--- a/include/libdnf5/advisory/advisory_query.hpp
+++ b/include/libdnf5/advisory/advisory_query.hpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf5/base/base_weak.hpp"
 #include "libdnf5/common/sack/query_cmp.hpp"
 #include "libdnf5/defs.h"
+#include "libdnf5/rpm/nevra.hpp"
 #include "libdnf5/rpm/package_set.hpp"
 
 
@@ -100,6 +101,14 @@ public:
     /// @param cmp_type     Condition to fulfill when comparing epoch-version-release of packages.
     void filter_packages(
         const libdnf5::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
+
+    /// Filter out advisories that don't contain at least one AdvisoryPackage that has a counterpart Package in nevras
+    /// such that they have matching name and architecture and also their epoch-version-release complies to cmp_type.
+    ///
+    /// @param nevras       std::vector<libdnf5::rpm::Nevra> used when filtering.
+    /// @param cmp_type     Condition to fulfill when comparing epoch-version-release of packages.
+    void filter_packages(
+        const std::vector<libdnf5::rpm::Nevra> & nevras, sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
 
     /// Get std::vector of AdvisoryPackages present in advisories from query.
     /// Each AdvisoryPackage is returned only if it has a counterpart Package in package_set such that they have matching

--- a/include/libdnf5/advisory/advisory_set.hpp
+++ b/include/libdnf5/advisory/advisory_set.hpp
@@ -126,6 +126,14 @@ public:
     /// @since 5.0
     std::vector<AdvisoryPackage> get_advisory_packages_sorted_by_name_arch_evr(bool only_applicable = false) const;
 
+    /// Gather AdvisoryPackages for each Advisory in the set.
+    /// The AdvisoryPackages are sorted by name, arch and evr. name and arch are
+    /// compared as strings, evr uses libdnf5::rpm::evrcmp() function.
+    ///
+    /// @param only_applicable Whether to return only AdvisoryPackages from applicable AdvisoryCollections.
+    std::vector<AdvisoryPackage> get_advisory_packages_sorted_by_name_arch_evr_string(
+        bool only_applicable = false) const;
+
 private:
     friend AdvisorySetIterator;
     friend class AdvisoryQuery;

--- a/libdnf5/advisory/advisory_package_private.hpp
+++ b/libdnf5/advisory/advisory_package_private.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/pool.hpp"
 
 #include "libdnf5/advisory/advisory_package.hpp"
+#include "libdnf5/rpm/nevra.hpp"
 
 #include <solv/pooltypes.h>
 #include <solv/solvable.h>
@@ -51,7 +52,7 @@ public:
     bool get_relogin_suggested() const { return relogin_suggested; };
 
     //TODO(amatej): Is this the correct name?
-    /// Compare NEVRAs of two AdvisoryPackages
+    /// Compare NEVRAs of two AdvisoryPackages using libsolv ids.
     ///
     /// @param first        First AdvisoryPackage to compare.
     /// @param second       Second AdvisoryPackage to compare.
@@ -77,6 +78,18 @@ public:
         if (adv_pkg.p_impl->name != s->name)
             return adv_pkg.p_impl->name < s->name;
         return adv_pkg.p_impl->arch < s->arch;
+    }
+
+    /// Compare Name and Architecture of AdvisoryPackage and libdnf5::rpm::Nevra
+    ///
+    /// @param adv_pkg      AdvisoryPackage to compare.
+    /// @param nevra        libdnf5::rpm::Nevra to compare.
+    /// @return True if AdvisoryPackage has smaller name or architecture than libdnf5::rpm::Nevra, False otherwise.
+    static bool name_arch_compare_lower_nevra(const AdvisoryPackage & adv_pkg, const rpm::Nevra & nevra) {
+        if (adv_pkg.get_name() != nevra.get_name()) {
+            return adv_pkg.get_name() < nevra.get_name();
+        }
+        return adv_pkg.get_arch() < nevra.get_arch();
     }
 
     //TODO(amatej): Is this the correct name?

--- a/libdnf5/advisory/advisory_set.cpp
+++ b/libdnf5/advisory/advisory_set.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/solv_map.hpp"
 
 #include "libdnf5/advisory/advisory_set_iterator.hpp"
+#include "libdnf5/rpm/nevra.hpp"
 
 
 namespace libdnf5::advisory {
@@ -132,6 +133,25 @@ std::vector<AdvisoryPackage> AdvisorySet::get_advisory_packages_sorted_by_name_a
     }
 
     std::sort(out.begin(), out.end(), AdvisoryPackage::Impl::nevra_compare_lower_id);
+
+    return out;
+}
+
+std::vector<AdvisoryPackage> AdvisorySet::get_advisory_packages_sorted_by_name_arch_evr_string(
+    bool only_applicable) const {
+    std::vector<AdvisoryPackage> out;
+    for (Id candidate_id : *p_impl) {
+        Advisory advisory2 = Advisory(p_impl->base, AdvisoryId(candidate_id));
+        auto collections = advisory2.get_collections();
+        for (auto & collection : collections) {
+            if (only_applicable && !collection.is_applicable()) {
+                continue;
+            }
+            collection.get_packages(out);
+        }
+    }
+
+    std::sort(out.begin(), out.end(), libdnf5::rpm::cmp_naevr<AdvisoryPackage>);
 
     return out;
 }

--- a/test/libdnf5/advisory/test_advisory_query.cpp
+++ b/test/libdnf5/advisory/test_advisory_query.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../shared/utils.hpp"
 
+#include <libdnf5/rpm/nevra.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
 
@@ -108,6 +109,46 @@ void AdvisoryAdvisoryQueryTest::test_filter_packages() {
 
     adv_query = AdvisoryQuery(base);
     adv_query.filter_packages(pkg_query, libdnf5::sack::QueryCmp::LT);
+    expected = {get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_filter_packages_nevra() {
+    // Tests filter_packages method
+    libdnf5::rpm::PackageQuery pkg_query(base);
+    std::vector<libdnf5::rpm::Nevra> nevras;
+    for (const auto & pkg : pkg_query) {
+        libdnf5::rpm::Nevra nevra;
+        nevra.set_name(pkg.get_name());
+        nevra.set_epoch(pkg.get_epoch());
+        nevra.set_version(pkg.get_version());
+        nevra.set_release(pkg.get_release());
+        nevra.set_arch(pkg.get_arch());
+        nevras.emplace_back(std::move(nevra));
+    }
+
+    AdvisoryQuery adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(nevras, libdnf5::sack::QueryCmp::GT);
+    std::vector<Advisory> expected = {get_advisory("PKG-NEWER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
+
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(nevras, libdnf5::sack::QueryCmp::GTE);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-NEWER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
+
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(nevras, libdnf5::sack::QueryCmp::EQ);
+    expected = {get_advisory("DNF-2019-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
+
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(nevras, libdnf5::sack::QueryCmp::LTE);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
+
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(nevras, libdnf5::sack::QueryCmp::LT);
     expected = {get_advisory("PKG-OLDER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }

--- a/test/libdnf5/advisory/test_advisory_query.hpp
+++ b/test/libdnf5/advisory/test_advisory_query.hpp
@@ -33,6 +33,7 @@ class AdvisoryAdvisoryQueryTest : public BaseTestCase {
     CPPUNIT_TEST(test_filter_name);
     CPPUNIT_TEST(test_filter_type);
     CPPUNIT_TEST(test_filter_packages);
+    CPPUNIT_TEST(test_filter_packages_nevra);
     CPPUNIT_TEST(test_filter_cve);
     CPPUNIT_TEST(test_filter_bugzilla);
     CPPUNIT_TEST(test_filter_reference);
@@ -48,6 +49,7 @@ public:
     void test_filter_name();
     void test_filter_type();
     void test_filter_packages();
+    void test_filter_packages_nevra();
     void test_filter_cve();
     void test_filter_bugzilla();
     void test_filter_reference();


### PR DESCRIPTION
Create a new D-Bus interface to retrieve information from the dnf5
transaction history. The new History interface currently supports only
one method: "recent_changes". This method retrieves information from the
history database about changes in the installed package set since the
specified point in time.

Resolves: https://github.com/rpm-software-management/dnf5/issues/773