### PR TITLE
add reset method, when using sdbus

### DIFF
--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -115,6 +115,16 @@ void Goal::dbus_register() {
                 [this](sdbus::MethodCall call) -> void {
                     session.get_threads_manager().handle_method(*this, &Goal::cancel, call, session.session_locale);
                 },
+                {}},
+            sdbus::MethodVTableItem{
+                sdbus::MethodName{"reset"},
+                sdbus::Signature{""},
+                {},
+                sdbus::Signature{""},
+                {"success", "error_msg"},
+                [this](sdbus::MethodCall call) -> void {
+                    session.get_threads_manager().handle_method(*this, &Goal::reset, call, session.session_locale);
+                },
                 {}})
         .forInterface(dnfdaemon::INTERFACE_GOAL);
 #else


### PR DESCRIPTION
The reset method is not setup when sdbus is used.

This make appliactions that use this API break

https://github.com/rpm-software-management/dnf5/issues/2255

