### PR TITLE
pre-commit: Exclude .tito/tito.props from check-xml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
        test/libdnf5/iniparser/test_iniparser.cpp
   - id: end-of-file-fixer
   - id: check-xml
+    exclude: \.tito/tito\.props
   - id: check-added-large-files
   - id: check-merge-conflict
 - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
This file is not intended to be an XML file, although it is identified
as one by identify-2.6.12.
This should fix the failing github pre-commit checks.