### PR TITLE
dnf5: install/upgrade/reinstall/downgrade: Argument "--from-repo"

### DIFF
--- a/dnf5/commands/do/do.cpp
+++ b/dnf5/commands/do/do.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "do.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
@@ -88,21 +90,7 @@ void DoCommand::set_argument_parser() {
         cmd.register_named_arg(item_type_opt);
     }
 
-    {
-        auto item_from_repo_opt = parser.add_new_named_arg("from-repo");
-        item_from_repo_opt->set_long_name("from-repo");
-        item_from_repo_opt->set_description(
-            _("The following items can be selected only from the specified repositories. All enabled repositories will "
-              "still be used to satisfy dependencies."));
-        item_from_repo_opt->set_has_value(true);
-        item_from_repo_opt->set_arg_value_help("<repoid>,...");
-        item_from_repo_opt->set_parse_hook_func(
-            [this](ArgumentParser::NamedArg *, [[maybe_unused]] const char * option, const char * value) {
-                from_repos = libdnf5::OptionStringList(value).get_value();
-                return true;
-            });
-        cmd.register_named_arg(item_from_repo_opt);
-    }
+    create_from_repo_option(*this, from_repos, false);
 
     {
         auto items =

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "downgrade.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 
 namespace dnf5 {
@@ -55,6 +57,7 @@ void DowngradeCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -69,8 +72,10 @@ void DowngradeCommand::configure() {
 void DowngradeCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
+    auto settings = libdnf5::GoalJobSettings();
+    settings.set_to_repo_ids(from_repos);
     for (const auto & spec : pkg_specs) {
-        goal->add_downgrade(spec);
+        goal->add_downgrade(spec, settings);
     }
 }
 

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -41,8 +41,8 @@ public:
 
 private:
     std::vector<std::string> pkg_specs;
-
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> from_repos;
 };
 
 

--- a/dnf5/commands/from_repo.cpp
+++ b/dnf5/commands/from_repo.cpp
@@ -1,0 +1,54 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "from_repo.hpp"
+
+#include <libdnf5/conf/option_string_list.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+
+
+namespace dnf5 {
+
+void create_from_repo_option(Command & command, std::vector<std::string> & from_repos, bool detect_conflict) {
+    auto & parser = command.get_context().get_argument_parser();
+    auto from_repo_opt = parser.add_new_named_arg("from-repo");
+    from_repo_opt->set_long_name("from-repo");
+    from_repo_opt->set_description(
+        _("The following items can be selected only from the specified repositories. All enabled repositories will "
+          "still be used to satisfy dependencies."));
+    from_repo_opt->set_has_value(true);
+    from_repo_opt->set_arg_value_help("REPO_ID,...");
+    from_repo_opt->set_parse_hook_func(
+        [&from_repos, detect_conflict](
+            libdnf5::cli::ArgumentParser::NamedArg *, [[maybe_unused]] const char * option, const char * value) {
+            if (!detect_conflict || from_repos.empty()) {
+                from_repos = libdnf5::OptionStringList(value).get_value();
+            } else {
+                if (from_repos != libdnf5::OptionStringList(value).get_value()) {
+                    throw libdnf5::cli::ArgumentParserConflictingArgumentsError(
+                        M_("\"--from_repo\" already defined with diferent value"));
+                }
+            }
+            return true;
+        });
+    command.get_argument_parser_command()->register_named_arg(from_repo_opt);
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/from_repo.hpp
+++ b/dnf5/commands/from_repo.hpp
@@ -1,0 +1,36 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef DNF5_COMMANDS_FROM_REPO_HPP
+#define DNF5_COMMANDS_FROM_REPO_HPP
+
+#include <dnf5/context.hpp>
+
+#include <string>
+#include <vector>
+
+
+namespace dnf5 {
+
+void create_from_repo_option(Command & command, std::vector<std::string> & from_repos, bool detect_conflict);
+
+}
+
+#endif  // DNF5_COMMANDS_FROM_REPO_HPP

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "install.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 #include <libdnf5/conf/const.hpp>
 
@@ -56,6 +58,7 @@ void InstallCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
 
@@ -92,6 +95,7 @@ void InstallCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
+    settings.set_to_repo_ids(from_repos);
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -44,6 +44,8 @@ private:
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 
+    std::vector<std::string> from_repos;
+
     std::unique_ptr<AdvisoryOption> advisory_name;
     std::unique_ptr<SecurityOption> advisory_security;
     std::unique_ptr<BugfixOption> advisory_bugfix;

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "reinstall.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 
 namespace dnf5 {
@@ -55,6 +57,7 @@ void ReinstallCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -69,8 +72,10 @@ void ReinstallCommand::configure() {
 void ReinstallCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
+    auto settings = libdnf5::GoalJobSettings();
+    settings.set_to_repo_ids(from_repos);
     for (const auto & spec : pkg_specs) {
-        goal->add_reinstall(spec);
+        goal->add_reinstall(spec, settings);
     }
 }
 

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -42,6 +42,7 @@ public:
 private:
     std::vector<std::string> pkg_specs;
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> from_repos;
 };
 
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "upgrade.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 #include <libdnf5/conf/const.hpp>
 
@@ -67,6 +69,7 @@ void UpgradeCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_from_repo_option(*this, from_repos, true);
     create_destdir_option(*this);
     create_downloadonly_option(*this);
     auto & destdir = parser.get_named_arg("upgrade.destdir", false);
@@ -122,6 +125,8 @@ void UpgradeCommand::run() {
             advisory_newpackage->set(libdnf5::Option::Priority::RUNTIME, true);
         }
     }
+
+    settings.set_to_repo_ids(from_repos);
 
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -45,6 +45,8 @@ protected:
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 
+    std::vector<std::string> from_repos;
+
     std::unique_ptr<AdvisoryOption> advisory_name;
     std::unique_ptr<SecurityOption> advisory_security;
     std::unique_ptr<BugfixOption> advisory_bugfix;

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -54,6 +54,8 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+.. include:: ../_shared/options/from-repo.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -64,6 +64,8 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+.. include:: ../_shared/options/from-repo.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -53,6 +53,8 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+.. include:: ../_shared/options/from-repo.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -64,6 +64,8 @@ Options
     | Set directory used for downloading packages to. Default location is to the current working directory.
     | Automatically sets the ``downloadonly`` option.
 
+.. include:: ../_shared/options/from-repo.rst
+
 ``--downloadonly``
     | Only download packages for transaction.
 


### PR DESCRIPTION
The `--from-repo` argument allows the user to run actions on packages in the specified repositories. However, any dependency resolution takes into account packages from all allowed repositories.

Multiple repository ids can be specified, separated by commas, and globs can be used.

This represents a simplified usage compared to the "do" command. Unlike the "do" command, the option is applied to all arguments and cannot be defined multiple times with different values.

Example:
dnf install --from-repo=fedora pkg1 pkg2

The `--from-repo` argument implements part of the functionality of the `repo-packages` command known from dnf4, but more generally. The dnf4 `repo-packages` command allows only one repoid to be specified.