### PR TITLE
automatic: email emitter: Do not use fractional seconds in e-mail Date headers

### DIFF
--- a/dnf5-plugins/automatic_plugin/email_message.cpp
+++ b/dnf5-plugins/automatic_plugin/email_message.cpp
@@ -44,7 +44,8 @@ void EmailMessage::set_body(std::stringstream & body) {
 }
 
 std::string EmailMessage::str() {
-    const auto now = std::chrono::system_clock::now();
+    // RFC 5322 requires dates with integral seconds.
+    const auto now = std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now());
     std::string date = fmt::format("{:%a, %d %b %Y %H:%M:%S %z}", now);
 
     std::string to_str;

--- a/test/dnf5-plugins/CMakeLists.txt
+++ b/test/dnf5-plugins/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(automatic_plugin)
 add_subdirectory(copr_plugin)

--- a/test/dnf5-plugins/automatic_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/automatic_plugin/CMakeLists.txt
@@ -1,0 +1,17 @@
+pkg_check_modules(CPPUNIT REQUIRED cppunit)
+add_definitions(-DGETTEXT_DOMAIN=\"dnf5-plugin-automatic\")
+
+# Use all test sources in the current directory and select compilation units
+# of the plugin we want to test.
+file(GLOB TEST_AUTOMATIC_SOURCES *.cpp
+    ${PROJECT_SOURCE_DIR}/dnf5-plugins/automatic_plugin/email_message.cpp
+)
+
+include_directories(${PROJECT_SOURCE_DIR}/dnf5-plugins/automatic_plugin)
+include_directories(${PROJECT_SOURCE_DIR}/libdnf5)
+
+add_executable(run_tests_automatic ${TEST_AUTOMATIC_SOURCES})
+target_link_libraries(run_tests_automatic PRIVATE stdc++ libdnf5 libdnf5-cli test_shared)
+
+add_test(NAME test_automatic COMMAND run_tests_automatic)
+set_tests_properties(test_automatic PROPERTIES RUN_SERIAL FALSE)

--- a/test/dnf5-plugins/automatic_plugin/EmailMessage.cpp
+++ b/test/dnf5-plugins/automatic_plugin/EmailMessage.cpp
@@ -1,0 +1,57 @@
+/*
+Copyright Contributors to the DNF5 project.
+
+This file is part of DNF5: https://github.com/rpm-software-management/dnf5/
+
+DNF5 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+DNF5 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DNF5.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "EmailMessage.hpp"
+
+#include "email_message.hpp"
+
+#include <chrono>
+#include <sstream>
+#include <vector>
+
+using namespace std;
+
+// Redefine std::chrono::system_clock::now() used by dnf5::EmailMessage::str()
+// to always return fixed time 1970-01-01T00:00:00.000000.
+std::chrono::time_point<std::chrono::system_clock> std::chrono::system_clock::now() noexcept {
+    return std::chrono::time_point<std::chrono::system_clock>();
+}
+
+void EmailMessageTest::test_email_emitter() {
+    std::stringstream body{"text"};
+    dnf5::EmailMessage message;
+    message.set_subject("subject");
+    message.set_from("from@test");
+    message.set_to(std::vector<std::string>{"to1@test", "to2@test"});
+    message.set_body(body);
+    std::string got = message.str();
+
+    std::string expected{
+        "Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n"
+        "To: to1@test, to2@test\r\n"
+        "From: from@test\r\n"
+        "Subject: subject\r\n"
+        "X-Mailer: dnf5-automatic\r\n"
+        "\r\n"
+        "text\r\n"};
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Unexpectedly formatted e-mail message from dnf5::EmailMessage::str()", expected, got);
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(EmailMessageTest);

--- a/test/dnf5-plugins/automatic_plugin/EmailMessage.hpp
+++ b/test/dnf5-plugins/automatic_plugin/EmailMessage.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright Contributors to the DNF5 project.
+
+This file is part of DNF5: https://github.com/rpm-software-management/dnf5/
+
+DNF5 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+DNF5 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DNF5.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNF5_TEST_AUTOMATIC_EMAILMESSAGE_HPP
+#define DNF5_TEST_AUTOMATIC_EMAILMESSAGE_HPP
+
+// Note 1
+#include <cppunit/extensions/HelperMacros.h>
+
+class EmailMessageTest : public CPPUNIT_NS::TestFixture {
+    CPPUNIT_TEST_SUITE(EmailMessageTest);
+    CPPUNIT_TEST(test_email_emitter);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() {}
+    void tearDown() {}
+
+    void test_email_emitter();
+};
+
+#endif  // DNF5_TEST_AUTOMATIC_EMAILMESSAGE_HPP

--- a/test/dnf5-plugins/automatic_plugin/test.cpp
+++ b/test/dnf5-plugins/automatic_plugin/test.cpp
@@ -1,0 +1,31 @@
+/*
+Copyright Contributors to the DNF5 project.
+
+This file is part of DNF5: https://github.com/rpm-software-management/dnf5
+
+DNF5 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+DNF5 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DNF5.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <cppunit/CompilerOutputter.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+
+#include <iostream>
+
+int main() {
+    auto suite = CPPUNIT_NS::TestFactoryRegistry::getRegistry().makeTest();
+    CppUnit::TextUi::TestRunner runner;
+    runner.addTest(suite);
+    return !runner.run();
+}


### PR DESCRIPTION
"email" emitter produced Date: header with fractional seconds:

    Date: Sat, 31 May 2025 10:28:45.162419022 +0000

That violates RFC 5322 and some SMTP implementations reject messages with this mistake.

The cause was in fmt::format("{%S}") which formats non-integral seconds as a fractional number
<https://fmt.dev/11.1/syntax/#chrono-format-specifications>.

This patch fixes it by using std::chrono::time_point with second precision before passing it to fmt::format().