### PR TITLE
Transaction table: Omit redundant package names

### DIFF
--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -363,14 +363,21 @@ TransactionTable::Impl::Impl(ITransaction & transaction) {
         }
         for (auto & replaced : tspkg->get_replaces()) {
             // highlight incoming packages with epoch/version change
-            if (tspkg->get_package()->get_epoch() != replaced->get_epoch() ||
-                tspkg->get_package()->get_version() != replaced->get_version()) {
+            if (pkg->get_epoch() != replaced->get_epoch() ||
+                pkg->get_version() != replaced->get_version()) {
                 auto cl_evr = scols_line_get_cell(ln, COL_EVR);
                 scols_cell_set_color(cl_evr, "bold");
             }
 
             struct libscols_line * ln_replaced = scols_table_new_line(*tb, ln);
-            std::string name(libdnf5::utils::sformat(_("replacing {}"), replaced->get_name()));
+
+            std::string name;
+            if (pkg->get_name() == replaced->get_name()) {
+                // Abbreviated format for simple version upgrades
+                name = _("replacing");
+            } else {
+                name = libdnf5::utils::sformat(_("replacing {}"), replaced->get_name());
+            }
             scols_line_set_data(ln_replaced, COL_NAME, ("   " + name).c_str());
             scols_line_set_data(ln_replaced, COL_ARCH, replaced->get_arch().c_str());
             scols_line_set_data(ln_replaced, COL_EVR, replaced->get_evr().c_str());

--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -363,8 +363,7 @@ TransactionTable::Impl::Impl(ITransaction & transaction) {
         }
         for (auto & replaced : tspkg->get_replaces()) {
             // highlight incoming packages with epoch/version change
-            if (pkg->get_epoch() != replaced->get_epoch() ||
-                pkg->get_version() != replaced->get_version()) {
+            if (pkg->get_epoch() != replaced->get_epoch() || pkg->get_version() != replaced->get_version()) {
                 auto cl_evr = scols_line_get_cell(ln, COL_EVR);
                 scols_cell_set_color(cl_evr, "bold");
             }


### PR DESCRIPTION
When possible (that is, when the name of the package being replaced is the same as the name of the package replacing it), omit the old package name on the 'replacing' line to save some column width.

This PR implements one of my suggestions from #785 (also mentioned at https://github.com/rpm-software-management/dnf5/pull/1574#issuecomment-2597737679), and might be more palatable than #1574 as it doesn't remove any _actual_ information from the output — only redundancy.

With a terminal column with of 87 (arbitrarily chosen to illustrate the differences in output with an available set of package upgrades), standard `dnf5` formats like this:

```console
$ sudo dnf --enable-repo=updates-testing upgrade java\* cockpit\*
Updating and loading repositories:
Repositories loaded.
Package                                   Arch   Version                   Reposit     
 Size
Upgrading:
 cockpit-machines                         noarch 333-1.fc42                updates 991.
6 KiB
   replacing cockpit-machines             noarch 332-1.fc42                updates 992.
3 KiB
 cockpit-podman                           noarch 107-1.fc42                updates 575.
0 KiB
   replacing cockpit-podman               noarch 106-1.fc42                updates 574.
7 KiB
 java-latest-openjdk                      x86_64 1:24.0.1.0.9-3.rolling.fc updates   1.
0 MiB
   replacing java-latest-openjdk          x86_64 1:24.0.1.0.9-1.rolling.fc updates   1.
0 MiB
 java-latest-openjdk-devel                x86_64 1:24.0.1.0.9-3.rolling.fc updates  11.
5 MiB
   replacing java-latest-openjdk-devel    x86_64 1:24.0.1.0.9-1.rolling.fc updates  11.
4 MiB
 java-latest-openjdk-headless             x86_64 1:24.0.1.0.9-3.rolling.fc updates 233.
3 MiB
   replacing java-latest-openjdk-headless x86_64 1:24.0.1.0.9-1.rolling.fc updates 238.
5 MiB
Installing:
 cockpit-files                            noarch 22-1.fc42                 updates 356.
7 KiB
   replacing cockpit-navigator            noarch 0.5.10-6.fc42             fedora    3.
1 MiB

Transaction Summary:
 Installing:         1 package
 Upgrading:          5 packages
 Replacing:          6 packages

Total size of inbound packages is 65 MiB. Need to download 65 MiB.
After this operation, 8 MiB will be freed (install 248 MiB, remove 256 MiB).
Is this ok [y/N]: n
```

Built from this branch, the output fails to wrap, and the fact that the upgrades are coming from `updates-testing` is also visible (where the `-testing` was entirely cut off, previously):

```console
$ sudo ./_build_cmake/dnf5/dnf5 --disable-plugin=expired\* --enable-repo=updates-testing upgrade java\* cockpit\*
Updating and loading repositories:
Repositories loaded.
Package                        Arch   Version                   Repository         Size
Upgrading:
 cockpit-machines              noarch 333-1.fc42                updates-testi 991.6 KiB
   replacing                   noarch 332-1.fc42                updates       992.3 KiB
 cockpit-podman                noarch 107-1.fc42                updates-testi 575.0 KiB
   replacing                   noarch 106-1.fc42                updates       574.7 KiB
 java-latest-openjdk           x86_64 1:24.0.1.0.9-3.rolling.fc updates-testi   1.0 MiB
   replacing                   x86_64 1:24.0.1.0.9-1.rolling.fc updates         1.0 MiB
 java-latest-openjdk-devel     x86_64 1:24.0.1.0.9-3.rolling.fc updates-testi  11.5 MiB
   replacing                   x86_64 1:24.0.1.0.9-1.rolling.fc updates        11.4 MiB
 java-latest-openjdk-headless  x86_64 1:24.0.1.0.9-3.rolling.fc updates-testi 233.3 MiB
   replacing                   x86_64 1:24.0.1.0.9-1.rolling.fc updates       238.5 MiB
Installing:
 cockpit-files                 noarch 22-1.fc42                 updates       356.7 KiB
   replacing cockpit-navigator noarch 0.5.10-6.fc42             fedora          3.1 MiB

Transaction Summary:
 Installing:         1 package
 Upgrading:          5 packages
 Replacing:          6 packages

Total size of inbound packages is 65 MiB. Need to download 65 MiB.
After this operation, 8 MiB will be freed (install 248 MiB, remove 256 MiB).
Is this ok [y/N]: n
```

The output will still often wrap, especially when the terminal width is only 80 columns, but it'll wrap _less_ and at least that's something, given that this relatively-conservative output change involves zero pain or information loss.