### PR TITLE
automatic: Expand emit_via in command_email emitter to individual arguments

### DIFF
--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -136,7 +136,7 @@ void EmitterCommandEmail::notify() {
         if (!email_to.empty()) {
             email_to += " ";
         }
-        email_to += email;
+        email_to += quote(email);
     }
     std::string subject = libdnf5::utils::sformat(
         _("[{}] dnf5-automatic: {}"), config_automatic.config_emitters.system_name.get_value(), short_message());
@@ -146,7 +146,7 @@ void EmitterCommandEmail::notify() {
         fmt::arg("body", quote(output_stream.str())),
         fmt::arg("subject", quote(subject)),
         fmt::arg("email_from", quote(email_from)),
-        fmt::arg("email_to", quote(email_to)));
+        fmt::arg("email_to", email_to));
 
     FILE * command_pipe = popen(command_string.c_str(), "w");
     if (command_pipe) {


### PR DESCRIPTION
If /etc/dnf/automatic.conf has:

    [emitters]
    emit_via = command_email
    [command_email]
    email_to = root,test

a command incompatible with s-nail-14.9.25, a "mail" command implementation, was executed:

    execve("/bin/sh", ["sh", "-c", "--", "mail -Ssendwait -s "[fedora-43] dnf5-automatic: 49 new upgrades have been downloaded." -r "root" "root test""], ...)

The cause was that s-nail does not support multiple recipients in a single argument.

This patch changes how "{email_to}" expands in command_format formatting string. Now it expands into multiple, space separated arguments. The new syntax is also accepted by mailx tool.

This patch also amends a documentation to explain how to configure multiple recipients.

A test will be added to ci-dnf-stack repository.

Resolve: #2273
Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1685