### PR TITLE
repoclosure: skip rich dependencies

### DIFF
--- a/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure.cpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/reldep.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/format.hpp>
 
@@ -169,6 +170,10 @@ void RepoclosureCommand::run() {
     for (const auto & pkg : to_check_query) {
         std::vector<std::string> unsatisfied;
         for (const auto & reldep : pkg.get_requires()) {
+            if (libdnf5::rpm::Reldep::is_rich_dependency(reldep.to_string())) {
+                // Rich dependencies are skipped because they are too complicated to provide correct result
+                continue;
+            };
             int reldep_id = reldep.get_id().id;
             auto resolved_it = resolved.find(reldep_id);
             bool satisfied;


### PR DESCRIPTION
Similar to autodetect_unsatisfied_installed_weak_dependencies (in fact I stole the code from there). repoclosure can give bogus failures for dependencies like (foo if bar). If nothing provides foo in the repo(s) under test, but also bar is not present, that should not be considered a repoclosure failure, but repoclosure reports it as an "unresolved dep". See:

https://github.com/rpm-software-management/dnf-plugins-core/issues/549

Ideally we should handle rich dependencies correctly, but I cannot see how to do that, so I'm sending this as an alternative that's at least less-bad than the current state.