### PR TITLE
Improve "--from-repo="; Introduce "--installed-from-repo=" support for repoquery/list/info/remove/reinstall/upgrade/downgrade/distro-sync/swap

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -71,10 +71,13 @@ void DistroSyncCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
-    settings.set_to_repo_ids(from_repos);
     if (patterns_to_distro_sync_options->empty()) {
         goal->add_rpm_distro_sync(settings);
     } else {
+        // The "--from-repo" option only applies to packages explicitly listed on the command line.
+        // Other packages can be used from any enabled repository.
+        settings.set_to_repo_ids(from_repos);
+
         for (auto & pattern : *patterns_to_distro_sync_options) {
             auto option = dynamic_cast<libdnf5::OptionString *>(pattern.get());
             goal->add_rpm_distro_sync(option->get_value(), settings);

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -55,6 +55,7 @@ void DistroSyncCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
+    create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
@@ -71,6 +72,7 @@ void DistroSyncCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
+    settings.set_from_repo_ids(installed_from_repos);
     if (patterns_to_distro_sync_options->empty()) {
         goal->add_rpm_distro_sync(settings);
     } else {

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -43,6 +43,7 @@ public:
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_to_distro_sync_options{nullptr};
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 };
 

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -58,6 +58,7 @@ void DowngradeCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
@@ -74,6 +75,7 @@ void DowngradeCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
+    settings.set_from_repo_ids(installed_from_repos);
     settings.set_to_repo_ids(from_repos);
     for (const auto & spec : pkg_specs) {
         goal->add_downgrade(spec, settings);

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -42,6 +42,7 @@ public:
 private:
     std::vector<std::string> pkg_specs;
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 };
 

--- a/dnf5/commands/from_repo.hpp
+++ b/dnf5/commands/from_repo.hpp
@@ -35,6 +35,13 @@ namespace dnf5 {
 // if "--from-repo" was already defined with a different value.
 void create_from_repo_option(Command & command, std::vector<std::string> & from_repos, bool detect_conflict);
 
+// Creates a new named argument "--installed-from-repo=REPO_ID,...".
+// When the argument is used, the list of REPO_IDs is split and the items are stored in the `from_repos` vector.
+// If `detect_conflict` is true, a `libdnf5::cli::ArgumentParserConflictingArgumentsError` exception is thrown
+// if "--from-repo" was already defined with a different value.
+libdnf5::cli::ArgumentParser::NamedArg * create_installed_from_repo_option(
+    Command & command, std::vector<std::string> & from_repos, bool detect_conflict);
+
 }  // namespace dnf5
 
 #endif  // DNF5_COMMANDS_FROM_REPO_HPP

--- a/dnf5/commands/list/list.hpp
+++ b/dnf5/commands/list/list.hpp
@@ -63,6 +63,8 @@ private:
 
     // show all NEVRAs, not only the latest one
     std::unique_ptr<libdnf5::cli::session::BoolOption> show_duplicates{nullptr};
+
+    std::vector<std::string> installed_from_repos;
 };
 
 

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -58,6 +58,7 @@ void ReinstallCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
     create_downloadonly_option(*this);
     create_offline_option(*this);
@@ -74,6 +75,7 @@ void ReinstallCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
+    settings.set_from_repo_ids(installed_from_repos);
     settings.set_to_repo_ids(from_repos);
     for (const auto & spec : pkg_specs) {
         goal->add_reinstall(spec, settings);

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -42,6 +42,7 @@ public:
 private:
     std::vector<std::string> pkg_specs;
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 };
 

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "remove.hpp"
 
+#include "../from_repo.hpp"
+
 #include <dnf5/shared_options.hpp>
 
 namespace dnf5 {
@@ -38,6 +40,8 @@ void RemoveCommand::set_argument_parser() {
 
     auto & cmd = *get_argument_parser_command();
     cmd.set_description(_("Remove (uninstall) software"));
+
+    create_installed_from_repo_option(*this, installed_from_repos, true);
 
     auto noautoremove = parser.add_new_named_arg("no-autoremove");
     noautoremove->set_long_name("no-autoremove");
@@ -74,6 +78,7 @@ void RemoveCommand::run() {
     // Limit remove spec capabity to prevent multiple matches. Remove command should not match anything after performing
     // a remove action with the same spec. NEVRA and filenames are the only types that have no overlaps.
     libdnf5::GoalJobSettings settings;
+    settings.set_from_repo_ids(installed_from_repos);
     settings.set_with_nevra(true);
     settings.set_with_provides(false);
     settings.set_with_filenames(true);

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -38,6 +38,7 @@ public:
 
 private:
     std::vector<std::string> pkg_specs;
+    std::vector<std::string> installed_from_repos;
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -91,6 +91,8 @@ private:
     std::unique_ptr<AdvisorySeverityOption> advisory_severity{nullptr};
     std::unique_ptr<BzOption> advisory_bz{nullptr};
     std::unique_ptr<CveOption> advisory_cve{nullptr};
+
+    std::vector<std::string> installed_from_repos;
 };
 
 

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -71,6 +71,7 @@ void SwapCommand::set_argument_parser() {
 
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
 
+    create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
 
     create_offline_option(*this);
@@ -87,9 +88,10 @@ void SwapCommand::run() {
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
+    settings.set_from_repo_ids(installed_from_repos);
     settings.set_to_repo_ids(from_repos);
     goal->add_install(install_pkg_spec, settings);
-    goal->add_rpm_remove(remove_pkg_spec);
+    goal->add_rpm_remove(remove_pkg_spec, settings);
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -43,6 +43,7 @@ private:
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 };
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -69,6 +69,7 @@ void UpgradeCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
     create_destdir_option(*this);
     create_downloadonly_option(*this);
@@ -126,6 +127,7 @@ void UpgradeCommand::run() {
         }
     }
 
+    settings.set_from_repo_ids(installed_from_repos);
 
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -126,7 +126,6 @@ void UpgradeCommand::run() {
         }
     }
 
-    settings.set_to_repo_ids(from_repos);
 
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
@@ -146,6 +145,10 @@ void UpgradeCommand::run() {
     if (pkg_specs.empty()) {
         goal->add_rpm_upgrade(settings, minimal->get_value());
     } else {
+        // The "--from-repo" option only applies to packages explicitly listed on the command line.
+        // Other packages can be used from any enabled repository.
+        settings.set_to_repo_ids(from_repos);
+
         for (const auto & spec : pkg_specs) {
             goal->add_upgrade(spec, settings, minimal->get_value());
         }

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -45,6 +45,7 @@ protected:
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
 
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 
     std::unique_ptr<AdvisoryOption> advisory_name;

--- a/doc/_shared/options/from-repo.rst
+++ b/doc/_shared/options/from-repo.rst
@@ -1,3 +1,4 @@
 ``--from-repo=REPO_ID,...``
     | Packages (or their provides) explicitly specified on the command line will only be looked up in the specified repositories.
+    | These repositories are automatically enabled.
     | Repository enabling and disabling still applies. Dependencies of these packages will be resolved from any enabled repository.

--- a/doc/_shared/options/installed-from-repo.rst
+++ b/doc/_shared/options/installed-from-repo.rst
@@ -1,0 +1,2 @@
+``--installed-from-repo=REPO_ID,...``
+    | Filters installed packages by the ID of the repository they were installed from.

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -50,6 +50,8 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to synchronize. All remaining packages will be synchronized.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 .. include:: ../_shared/options/from-repo.rst
 
 ``--downloadonly``

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -54,6 +54,8 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 .. include:: ../_shared/options/from-repo.rst
 
 ``--downloadonly``

--- a/doc/commands/info.8.rst
+++ b/doc/commands/info.8.rst
@@ -40,6 +40,8 @@ Options
 ``--showduplicates``
     | Show all versions of the packages, not only the latest one.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 ``--installed``
     | List only installed packages.
 

--- a/doc/commands/list.8.rst
+++ b/doc/commands/list.8.rst
@@ -40,6 +40,8 @@ Options
 ``--showduplicates``
     | Show all versions of the packages, not only the latest one.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 ``--installed``
     | List only installed packages.
 

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -53,6 +53,8 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 .. include:: ../_shared/options/from-repo.rst
 
 ``--downloadonly``

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -41,6 +41,8 @@ set the ``clean_requirements_on_remove`` configuration option to ``False``.
 Options
 =======
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 ``--no-autoremove``
     | Disable removal of dependencies that are no longer used.
 

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -82,6 +82,8 @@ Options
     | Query installed packages.
     | Can be combined with ``--available`` to query both installed and available packages.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 ``--installonly``
     | Limit to installed installonly packages.
 

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -42,6 +42,8 @@ Options
 ``--allowerasing``
     | Allow removing of installed packages to resolve any potential dependency problems.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 .. include:: ../_shared/options/from-repo.rst
 
 ``--offline``

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -64,6 +64,8 @@ Options
     | Set directory used for downloading packages to. Default location is to the current working directory.
     | Automatically sets the ``downloadonly`` option.
 
+.. include:: ../_shared/options/installed-from-repo.rst
+
 .. include:: ../_shared/options/from-repo.rst
 
 ``--downloadonly``

--- a/include/libdnf5/rpm/package_query.hpp
+++ b/include/libdnf5/rpm/package_query.hpp
@@ -822,6 +822,30 @@ public:
     void filter_repo_id(
         const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
 
+    /// Filters packages by the `id` of the repository they were installed from.
+    /// This also removes any packages from the query that are not currently installed.
+    ///
+    /// @param pattern          A string the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2.14
+    //
+    void filter_from_repo_id(
+        const std::string & pattern, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ) {
+        filter_from_repo_id(std::vector<std::string>{pattern}, cmp_type);
+    };
+
+    /// Filters packages by the `id` of the repository they were installed from.
+    /// This also removes any packages from the query that are not currently installed.
+    ///
+    /// @param patterns         A vector of strings the filter is matched against.
+    /// @param cmp_type         A comparison (match) operator, defaults to `QueryCmp::EQ`.
+    ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
+    /// @since 5.2.14
+    //
+    void filter_from_repo_id(
+        const std::vector<std::string> & patterns, libdnf5::sack::QueryCmp cmp_type = libdnf5::sack::QueryCmp::EQ);
+
     /// Filter packages by advisories they are included in.
     ///
     /// @param advisory_query   AdvisoryQuery with Advisories that contain package lists the filter is matched against.

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -612,6 +612,10 @@ GoalProblem Goal::Impl::add_specs_to_goal(base::Transaction & transaction) {
                     }
                 }
 
+                if (query.empty()) {
+                    return GoalProblem::NO_PROBLEM;
+                }
+
                 // Make the smallest possible upgrade
                 if (action == GoalAction::UPGRADE_ALL_MINIMAL) {
                     query.filter_earliest_evr();
@@ -635,6 +639,10 @@ GoalProblem Goal::Impl::add_specs_to_goal(base::Transaction & transaction) {
                 } else {
                     // Keep only the packages available in the specified repositories.
                     query.filter_repo_id(settings.get_to_repo_ids(), sack::QueryCmp::GLOB);
+                }
+
+                if (query.empty()) {
+                    return GoalProblem::NO_PROBLEM;
                 }
 
                 libdnf5::solv::IdQueue upgrade_ids;


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/dnf5/issues/2315
Closes: https://github.com/rpm-software-management/dnf5/issues/381
Closes: https://github.com/rpm-software-management/dnf5/issues/1837
Resolves a significant portion of https://github.com/rpm-software-management/dnf5/issues/915.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1705

libdnf5:
-  Goal::Impl::add_specs_to_goal: Apply to_repo_ids settings in actions UPGRADE_ALL, UPGRADE_ALL_MINIMAL, and DISTRO_SYNC_ALL
- Goal::Impl::add_install_to_goal: Fix to_repo_ids handling 
- rpm::PackageQuery: New filter `filter_from_repo_id` 
- Goal: Honor set_from_repo_ids in `add_remove_to_goal`, `add_reinstall_to_goal`, `add_up_down_distrosync_to_goal` 

dnf5:
- dnf5: "--from-repo=" option enables and validates source repositories 
- Introduce "--installed-from-repo=" support for repoquery/list/info/remove/reinstall/upgrade/downgrade/distro-sync/swap