### PR TITLE
dnf5: distro-sync: Argument "--from-repo"

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -43,6 +43,7 @@ public:
     std::vector<std::unique_ptr<libdnf5::Option>> * patterns_to_distro_sync_options{nullptr};
 
     std::unique_ptr<AllowErasingOption> allow_erasing;
+    std::vector<std::string> from_repos;
 };
 
 

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -50,6 +50,8 @@ Options
 ``--skip-unavailable``
     | Allow skipping packages that are not possible to synchronize. All remaining packages will be synchronized.
 
+.. include:: ../_shared/options/from-repo.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2333,7 +2333,6 @@ GoalProblem Goal::Impl::add_up_down_distrosync_to_goal(
                 libdnf5::Logger::Level::WARNING);
             return skip_unavailable ? GoalProblem::NO_PROBLEM : GoalProblem::NOT_FOUND_IN_REPOSITORIES;
         }
-        query |= installed;
     }
 
     // Apply advisory filters


### PR DESCRIPTION
The `--from-repo` argument allows the user to run `distro-sync` on packages in the specified repositories. However, any dependency resolution takes into account packages from all allowed repositories.

Multiple repository ids can be specified, separated by commas, and globs can be used. Usage is similar to the `install` command.

Unit tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1695