### PR TITLE
dnfdaemon: Removed incorrect output parameter names

### DIFF
--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -121,7 +121,7 @@ void Goal::dbus_register() {
                 sdbus::Signature{""},
                 {},
                 sdbus::Signature{""},
-                {"success", "error_msg"},
+                {},
                 [this](sdbus::MethodCall call) -> void {
                     session.get_threads_manager().handle_method(*this, &Goal::reset, call, session.session_locale);
                 },


### PR DESCRIPTION
The method does not return any output parameters.

Resolves: https://github.com/rpm-software-management/dnf5/pull/2317