### PR TITLE
dnfdaemon: Make permission check more consistent

### DIFF
--- a/dnf5daemon-server/services/base/base.cpp
+++ b/dnf5daemon-server/services/base/base.cpp
@@ -172,7 +172,7 @@ sdbus::MethodReply Base::clean(sdbus::MethodCall & call) {
     call >> cache_type;
 
     if (cache_type != "expire-cache" &&
-        !session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+        !session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION, call.getSender())) {
         throw std::runtime_error("Not authorized");
     }
 

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -168,7 +168,7 @@ sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
 }
 
 sdbus::MethodReply Offline::cancel(sdbus::MethodCall & call) {
-    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION, call.getSender())) {
         throw std::runtime_error("Not authorized");
     }
     bool success = true;
@@ -195,7 +195,7 @@ sdbus::MethodReply Offline::cancel(sdbus::MethodCall & call) {
 }
 
 sdbus::MethodReply Offline::clean(sdbus::MethodCall & call) {
-    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION, call.getSender())) {
         throw std::runtime_error("Not authorized");
     }
     std::vector<std::string> error_msgs;
@@ -224,7 +224,7 @@ sdbus::MethodReply Offline::clean(sdbus::MethodCall & call) {
 }
 
 sdbus::MethodReply Offline::set_finish_action(sdbus::MethodCall & call) {
-    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
+    if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION, call.getSender())) {
         throw std::runtime_error("Not authorized");
     }
     bool success{false};


### PR DESCRIPTION
Change permissions required for:
- clean cache
- clean or cancel offline transaction (only before the rpm transaction begins)
- set finish action after offline transaction (reboot or poweroff)

Currently the main user of these APIs is gnome software which can (if
the dnf5daemon-server-polkit package is installed) allow wheel group
users to install/upgrade packages from configured repositories without
being prompted for passwords. We need to set the same checks also for
offline transaction management APIs. Otherwise the user is allowed to
prepare an offline transaction, but is prompted for a password anyway
due to the `set_finish_action()` call that is executed after the
packages are downloaded and the offline transaction is prepared and
stored.

This change is needed to unblock gnome software transition to dnf5.