### PR TITLE
Adapt missing gpg key check for parallel downloading

### DIFF
--- a/libdnf5/repo/repo_sack.cpp
+++ b/libdnf5/repo/repo_sack.cpp
@@ -333,13 +333,9 @@ bool RepoSack::Impl::handle_repo_exception(const Repo * repo, std::exception_ptr
     } catch (const RepoDownloadError & rd_err) {
         exception = rd_err;
         if (report_key_err) {
-            try {
-                std::rethrow_if_nested(rd_err);
-            } catch (const LibrepoError & lr_err) {
-                if (lr_err.get_code() == LRE_BADGPG) {
-                    return true;
-                }
-            } catch (...) {
+            std::string msg = rd_err.what();
+            if (msg.ends_with("Signing key not found")) {
+                return true;
             }
         }
     } catch (const std::exception & e) {


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/issues/2323

Unfortunaly the errors from librepo parallel downloading API are reported only as strings (to improve that we would have to break librepo ABI).
https://github.com/rpm-software-management/librepo/blob/master/librepo/metadata_downloader.h#L61-L62

This approach also works with the nested exceptions (still used by local repo loading) because we check the suffix (the inner most exception).

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1692