### PR TITLE
Add dnf5daemon-server requirement for polkit subpkg

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -785,6 +785,7 @@ Package management service with a DBus interface.
 Summary:        Polkit rule to allow wheel group members install trusted packages
 License:        GPL-2.0-or-later
 Requires:       polkit
+Requires:       dnf5daemon-server = %{version}-%{release}
 BuildArch:      noarch
 
 %description -n dnf5daemon-server-polkit


### PR DESCRIPTION
Add the base package dependency for the dnf5daemon-server-polkit
subpackage to ensure that dnf5daemon-server also gets updated when the
polkit rule changes.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2313