### PR TITLE
config: Add 'uninstall' alias

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/convenience.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/convenience.conf
@@ -1,0 +1,7 @@
+version = '1.0'
+
+['uninstall']
+type = 'command'
+attached_command = 'remove'
+desc = 'Alias for remove'
+complete = true


### PR DESCRIPTION
The asymmetry between "install"/"remove" can be confusing even
to long-time users[0].

Address this by aliasing "remove" to "uninstall".

[0] https://samthursfield.wordpress.com/2025/06/29/dnf-uninstall/
