### PR TITLE
swig: Add %thread directive for repo_sack.hpp for Python

### DIFF
--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -1,5 +1,6 @@
 #if defined(SWIGPYTHON)
-%module(package="libdnf5", directors="1") repo
+%module("threads"=1, package="libdnf5", directors="1") repo
+%nothread;
 #elif defined(SWIGPERL)
 %module "libdnf5::repo"
 #elif defined(SWIGRUBY)
@@ -153,6 +154,10 @@ wrap_unique_ptr(RepoCallbacksUniquePtr, libdnf5::repo::RepoCallbacks);
 
 %include "libdnf5/repo/repo_query.hpp"
 %template(SackRepoRepoQuery) libdnf5::sack::Sack<libdnf5::repo::Repo>;
+
+#if defined(SWIGPYTHON)
+%thread;
+#endif
 %include "libdnf5/repo/repo_sack.hpp"
 %template(RepoSackWeakPtr) libdnf5::WeakPtr<libdnf5::repo::RepoSack, false>;
 


### PR DESCRIPTION
The purpose is to enable multithread support in python. With the %thread directive, the Python GIL is released before entering the methods from repo_sack.hpp and acquired when exiting them. In case the methods are called in a thread, another thread is not blocked by it. This is especially important in case of loading repositories which can take a lot of time.

I am not very sure with this solution, since the documentation of this feature is very limited and I am mostly relying on testing. That said, enabling the threads for RepoSack fixes an issue in Anaconda where the UI freezes when repositories are being loaded. I ran locally Anaconda kickstart tests as well as ci-dnf-stack and they pass.