### PR TITLE
dnfdaemon: Obey downloader D-Bus signal signature

### DIFF
--- a/dnf5daemon-server/callbacks.cpp
+++ b/dnf5daemon-server/callbacks.cpp
@@ -51,6 +51,9 @@ sdbus::Signal DownloadCB::create_signal_download(const SDBUS_SIGNAL_NAME_TYPE & 
     if (user_data) {
         auto * data = reinterpret_cast<DownloadUserData *>(user_data);
         signal << data->download_id;
+    } else {
+        // it can happen for example when downloading OpenPGP keys
+        signal << "";
     }
     return signal;
 }


### PR DESCRIPTION
While the DownloadCB::create_signal_download() may not always have set the `user_data`, the D-Bus signal signature is not that flexible and requires to be always the same, with all the declared arguments, thus pass an empty string as the `download_id` when it's not available.

Fixes https://github.com/rpm-software-management/dnf5/issues/2338