### PR TITLE
dnf5: Support `--installed-from-repo=` for command `do`

### DIFF
--- a/dnf5/commands/do/do.cpp
+++ b/dnf5/commands/do/do.cpp
@@ -90,6 +90,7 @@ void DoCommand::set_argument_parser() {
         cmd.register_named_arg(item_type_opt);
     }
 
+    create_installed_from_repo_option(*this, installed_from_repos, false);
     create_from_repo_option(*this, from_repos, false);
 
     {
@@ -101,6 +102,7 @@ void DoCommand::set_argument_parser() {
                                        int argc,
                                        const char * const argv[]) {
             libdnf5::GoalJobSettings settings;
+            settings.set_from_repo_ids(installed_from_repos);
             settings.set_to_repo_ids(from_repos);
             switch (action) {
                 case Action::INSTALL:

--- a/dnf5/commands/do/do.hpp
+++ b/dnf5/commands/do/do.hpp
@@ -44,6 +44,7 @@ private:
 
     enum class ItemType { AUTO, PACKAGE, GROUP, ENVIRONMENT } item_type{ItemType::AUTO};
 
+    std::vector<std::string> installed_from_repos;
     std::vector<std::string> from_repos;
 
     std::string group_spec(ItemType type, const std::string & spec, libdnf5::GoalJobSettings & settings);


### PR DESCRIPTION
CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1708