### PR TITLE
swig: Add iterator for config options for python

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -151,5 +151,29 @@ create_config_option_attributes(ConfigMain)
 %}
 #endif
 
+// The following adds a config options iterator in Python.
+//
+%define add_config_iterator(ClassName)
+#if defined(SWIGPYTHON)
+%pythoncode %{
+import re
+
+def ClassName##__iter__(self):
+    options = {}
+    for attr in dir(ClassName):
+        option_getter_match = re.search(r'get_(\w+)_option', attr)
+        if option_getter_match:
+            option_name = option_getter_match.group(1)
+            options[option_name] = self.__getattribute__('get_{}_option'.format(option_name))()
+    return iter(options.items())
+ClassName.__iter__ = ClassName##__iter__
+del ClassName##__iter__
+
+%}
+#endif
+%enddef
+
+add_config_iterator(ConfigMain)
+
 // Deletes any previously defined catches
 %catches();

--- a/bindings/libdnf5/repo.i
+++ b/bindings/libdnf5/repo.i
@@ -169,6 +169,8 @@ add_iterator(SetRepoWeakPtr)
 %pythoncode %{
 conf.create_config_option_attributes(ConfigRepo)
 %}
+// Add configuration options iterator for Python.
+add_config_iterator(ConfigRepo)
 #endif
 
 // Add attributes for getters/setters in Python.

--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -86,3 +86,15 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
     def test_get_unknown_option_by_attribute(self):
         config = self.base.get_config()
         self.assertRaises(AttributeError, lambda: config.xyz)
+
+    def test_iterate_options(self):
+        config = self.base.get_config()
+
+        config.proxy = 'abcd'
+
+        proxy_option = None
+        for name, option in config:
+            if name == 'proxy':
+                proxy_option = (name, option.get_value())
+
+        self.assertEqual(proxy_option, ('proxy', 'abcd'))

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -106,3 +106,17 @@ class TestRepo(base_test_case.BaseTestCase):
         self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
         self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)
+
+    def test_iterate_config_options(self):
+        repoid = "repomd-repo1"
+        repo = self.add_repo_repomd(repoid, load=False)
+        config = repo.get_config()
+
+        config.proxy = 'abcd'
+
+        proxy_option = None
+        for name, option in config:
+            if name == 'proxy':
+                proxy_option = (name, option.get_value())
+
+        self.assertEqual(proxy_option, ('proxy', 'abcd'))


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/1579

Alternatively, it might be done by defining a class similar to `Iterator` in `common.i`, only for a map iterator, and then adding this iterator for `libdnf5::OptionBinds`, but I didn't find out any way how to create bindings for the template `std::map<std::string, libdnf5::OptionBinds::Item>`. Any suggestions are appreciated.