### PR TITLE
repo: Do not fail on empty temporary files toml

### DIFF
--- a/libdnf5/repo/temp_files_memory.cpp
+++ b/libdnf5/repo/temp_files_memory.cpp
@@ -46,7 +46,7 @@ std::vector<std::string> TempFilesMemory::get_files() const {
 
     try {
         auto toml_data = toml::parse(full_memory_path);
-        return toml::get<std::vector<std::string>>(toml_data[FILE_PATHS_TOML_KEY]);
+        return toml::find_or(toml_data, FILE_PATHS_TOML_KEY, std::vector<std::string>{});
     } catch (const toml::exception & e) {
         throw libdnf5::Error(
             M_("An error occurred when parsing the temporary files memory file at '{}': {}"),

--- a/test/libdnf5/repo/test_temp_files_memory.cpp
+++ b/test/libdnf5/repo/test_temp_files_memory.cpp
@@ -49,11 +49,17 @@ void TempFilesMemoryTest::test_get_files_when_empty_storage() {
     CPPUNIT_ASSERT(memory.get_files().empty());
 }
 
-void TempFilesMemoryTest::test_get_files_throws_exception_when_invalid_format() {
+void TempFilesMemoryTest::test_get_files_returns_empty_vector_when_missing_key() {
     libdnf5::utils::fs::File(full_path, "w").write("");
     TempFilesMemory memory_empty(base.get_weak_ptr(), parent_dir_path);
-    CPPUNIT_ASSERT_THROW(memory_empty.get_files(), libdnf5::Error);
+    CPPUNIT_ASSERT(memory_empty.get_files().empty());
 
+    libdnf5::utils::fs::File(full_path, "w").write("UNKNOWN_KEY = [\"path1\", \"path2\", \"path3\"]");
+    TempFilesMemory memory_unknown_key(base.get_weak_ptr(), parent_dir_path);
+    CPPUNIT_ASSERT(memory_unknown_key.get_files().empty());
+}
+
+void TempFilesMemoryTest::test_get_files_throws_exception_when_invalid_format() {
     libdnf5::utils::fs::File(full_path, "w").write("[\"path1\", \"path2\", \"path3\"]");
     TempFilesMemory memory_invalid(base.get_weak_ptr(), parent_dir_path);
     CPPUNIT_ASSERT_THROW(memory_invalid.get_files(), libdnf5::Error);

--- a/test/libdnf5/repo/test_temp_files_memory.hpp
+++ b/test/libdnf5/repo/test_temp_files_memory.hpp
@@ -32,6 +32,7 @@ class TempFilesMemoryTest : public BaseTestCase {
     CPPUNIT_TEST(test_directory_is_created_when_not_exists);
     CPPUNIT_TEST(test_get_files_when_empty_storage);
     CPPUNIT_TEST(test_get_files_throws_exception_when_invalid_format);
+    CPPUNIT_TEST(test_get_files_returns_empty_vector_when_missing_key);
     CPPUNIT_TEST(test_get_files_returns_stored_values);
     CPPUNIT_TEST(test_add_files_when_empty_storage);
     CPPUNIT_TEST(test_add_no_files_when_empty_storage);
@@ -47,6 +48,7 @@ public:
     void test_directory_is_created_when_not_exists();
     void test_get_files_when_empty_storage();
     void test_get_files_throws_exception_when_invalid_format();
+    void test_get_files_returns_empty_vector_when_missing_key();
     void test_get_files_returns_stored_values();
     void test_add_files_when_empty_storage();
     void test_add_no_files_when_empty_storage();


### PR DESCRIPTION
Use toml::find_or to safely read file paths from temp files toml,
returning an empty vector if the "files" key is missing.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1001
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2330306