### PR TITLE
Add --destdir option support to all commands with --downloadonly

### DIFF
--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -57,6 +57,7 @@ void DistroSyncCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -66,6 +67,10 @@ void DistroSyncCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void DistroSyncCommand::run() {

--- a/dnf5/commands/do/do.cpp
+++ b/dnf5/commands/do/do.cpp
@@ -173,6 +173,7 @@ void DoCommand::set_argument_parser() {
     advisory_enhancement = std::make_unique<EnhancementOption>(*this);
     advisory_newpackage = std::make_unique<NewpackageOption>(*this);
 
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -207,6 +208,10 @@ void DoCommand::configure() {
 
     context.set_load_available_repos(
         in_pkgs_count > 0 ? Context::LoadAvailableRepos::ENABLED : Context::LoadAvailableRepos::NONE);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -60,6 +60,7 @@ void DowngradeCommand::set_argument_parser() {
     create_allow_downgrade_options(*this);
     create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -69,6 +70,10 @@ void DowngradeCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void DowngradeCommand::run() {

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -160,6 +160,9 @@ void DownloadCommand::set_argument_parser() {
     cmd.register_named_arg(alldeps);
     create_from_repo_option(*this, from_repos, true);
     create_destdir_option(*this);
+    auto & destdir = parser.get_named_arg("download.destdir", false);
+    destdir.set_description(
+        "Set directory used for downloading packages to. Default location is to the current working directory.");
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     cmd.register_named_arg(srpm);
     cmd.register_named_arg(url);

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -42,6 +42,7 @@ void GroupInstallCommand::set_argument_parser() {
     auto skip_broken = std::make_unique<SkipBrokenOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -53,6 +54,10 @@ void GroupInstallCommand::configure() {
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
     context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void GroupInstallCommand::run() {

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -39,6 +39,7 @@ void GroupUpgradeCommand::set_argument_parser() {
     allow_erasing = std::make_unique<AllowErasingOption>(*this);
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -50,6 +51,10 @@ void GroupUpgradeCommand::configure() {
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
     context.get_base().get_config().get_optional_metadata_types_option().add_item(
         libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_COMPS);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void GroupUpgradeCommand::run() {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -59,6 +59,7 @@ void InstallCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_allow_downgrade_options(*this);
     create_from_repo_option(*this, from_repos, true);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
 
@@ -88,6 +89,10 @@ void InstallCommand::configure() {
         advisory_cve->get_value());
 
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void InstallCommand::run() {

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -60,6 +60,7 @@ void ReinstallCommand::set_argument_parser() {
     create_allow_downgrade_options(*this);
     create_installed_from_repo_option(*this, installed_from_repos, true);
     create_from_repo_option(*this, from_repos, true);
+    create_destdir_option(*this);
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
@@ -69,6 +70,10 @@ void ReinstallCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+
+    if (!context.get_base().get_config().get_destdir_option().empty()) {
+        context.get_base().get_config().get_downloadonly_option().set(true);
+    }
 }
 
 void ReinstallCommand::run() {

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -73,8 +73,6 @@ void UpgradeCommand::set_argument_parser() {
     create_from_repo_option(*this, from_repos, true);
     create_destdir_option(*this);
     create_downloadonly_option(*this);
-    auto & destdir = parser.get_named_arg("upgrade.destdir", false);
-    destdir.set_description(destdir.get_description() + " Automatically sets the --downloadonly option.");
     create_offline_option(*this);
 
     advisory_name = std::make_unique<AdvisoryOption>(*this);

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -87,7 +87,8 @@ void create_destdir_option(dnf5::Command & command) {
     auto destdir = parser.add_new_named_arg("destdir");
     destdir->set_long_name("destdir");
     destdir->set_description(
-        "Set directory used for downloading packages to. Default location is to the current working directory.");
+        "Set directory used for downloading packages to. Default location is to the repository cache directory. "
+        "Automatically sets the --downloadonly option.");
     destdir->set_has_value(true);
     destdir->set_arg_value_help("DESTDIR");
     destdir->link_value(&command.get_context().get_base().get_config().get_destdir_option());

--- a/doc/_shared/options/destdir.rst
+++ b/doc/_shared/options/destdir.rst
@@ -1,2 +1,2 @@
 ``--destdir=<path>``
-    | Set directory used for downloading packages to. Default location is to the repository cache directory. Automatically sets the --downloadonly option.
+    | Set directory used for downloading packages to. Default location is to the repository cache directory. Automatically sets the --downloadonly option. Packages downloaded to the destdir are not automatically removed after the next successful transaction.

--- a/doc/_shared/options/destdir.rst
+++ b/doc/_shared/options/destdir.rst
@@ -1,0 +1,2 @@
+``--destdir=<path>``
+    | Set directory used for downloading packages to. Default location is to the repository cache directory. Automatically sets the --downloadonly option.

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -54,6 +54,8 @@ Options
 
 .. include:: ../_shared/options/from-repo.rst
 
+.. include:: ../_shared/options/destdir.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -58,6 +58,8 @@ Options
 
 .. include:: ../_shared/options/from-repo.rst
 
+.. include:: ../_shared/options/destdir.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -133,6 +133,10 @@ Options for ``install``, ``remove`` and ``upgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
     | Used with ``install`` and ``upgrade`` commands.
 
+``--destdir=<path>``
+    | Set directory used for downloading packages to. Default location is to the repository cache directory. Automatically sets the --downloadonly option.
+    | Used with ``install`` and ``upgrade`` commands.
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
     | Used with ``install`` and ``upgrade`` commands.

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -76,6 +76,8 @@ Options
 
 .. include:: ../_shared/options/from-repo.rst
 
+.. include:: ../_shared/options/destdir.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 
@@ -114,6 +116,9 @@ Examples
 
 ``dnf5 install --advisory=FEDORA-2022-07aa56297a \*``
     | Install all the packages that belong to the ``FEDORA-2022-07aa56297a`` advisory.
+
+``dnf5 install --destdir /tmp/my_packages vim``
+    | Download the ``vim`` package and its dependencies to ``/tmp/my_packages`` directory without installing.
 
 
 See Also

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -57,6 +57,8 @@ Options
 
 .. include:: ../_shared/options/from-repo.rst
 
+.. include:: ../_shared/options/destdir.rst
+
 ``--downloadonly``
     | Download the resolved package set without executing an RPM transaction.
 

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -60,13 +60,11 @@ Options
 ``--no-allow-downgrade``
     | Disable downgrade of dependencies when resolving the requested operation.
 
-``--destdir=<path>``
-    | Set directory used for downloading packages to. Default location is to the current working directory.
-    | Automatically sets the ``downloadonly`` option.
-
 .. include:: ../_shared/options/installed-from-repo.rst
 
 .. include:: ../_shared/options/from-repo.rst
+
+.. include:: ../_shared/options/destdir.rst
 
 ``--downloadonly``
     | Only download packages for transaction.

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -191,7 +191,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
 ``destdir``
     :ref:`string <string-label>`
 
-    Redirect downloaded packages to provided directory.
+    Redirect downloaded packages to provided directory. If set, packages downloaded to this directory are not automatically removed after the next successful transaction. To redirect the download location while allowing DNF5 to manage downloaded packages, use the :ref:`cachedir <cachedir_options-label>` option.
 
     Default: <package repository :ref:`cachedir <cachedir_options-label>`>/packages
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -418,6 +418,11 @@ void Transaction::download() {
             downloader.add(tspkg.get_package());
         }
     }
+    // We don't want to remove downloaded transaction packages in case the
+    // destdir was changed (e.g. using --destdir, --store, --offline)
+    if (!p_impl->base->get_config().get_destdir_option().empty()) {
+        downloader.force_keep_packages(true);
+    }
     downloader.download();
 }
 


### PR DESCRIPTION
Extends `--destdir` option support from `upgrade` and `download` commands to all other commands that support `--downloadonly` option. This provides consistent behavior across all package management operations.

When `--destdir` is specified with transaction command, `--downloadonly` is automatically enabled to ensure packages are downloaded to the specified directory instead of being installed. This maintains consistency with the existing `upgrade` command behavior and also with dnf4 behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)