### PR TITLE
Bindings: add iterator to `libdnf5::OptionBinds`

### DIFF
--- a/bindings/libdnf5/conf.i
+++ b/bindings/libdnf5/conf.i
@@ -14,6 +14,12 @@
 %import "exception.i"
 %import "logger.i"
 
+// This is required because `libdnf5::OptionBinds::Item` is nested
+// inside `libdnf5::OptionBinds` class.
+// While swig claims it shoudn't be needed for Python it seems it is:
+// https://www.swig.org/Doc4.3/SWIGDocumentation.html#SWIGPlus_nested_classes
+%feature("flatnested");
+
 %{
     #include "bindings/libdnf5/exception.hpp"
 
@@ -85,18 +91,10 @@ wrap_unique_ptr(StringUniquePtr, std::string);
 %template(OptionChildSeconds) libdnf5::OptionChild<libdnf5::OptionSeconds>;
 
 
-%rename (OptionBinds_Item) libdnf5::OptionBinds::Item;
-%ignore libdnf5::OptionBindsError;
-%ignore libdnf5::OptionBindsOptionNotFoundError;
-%ignore libdnf5::OptionBindsOptionAlreadyExistsError;
-%ignore libdnf5::OptionBinds::add(const std::string & id, Option & option,
-    Item::NewStringFunc new_string_func, Item::GetValueStringFunc get_value_string_func, bool add_value);
-%ignore libdnf5::OptionBinds::begin;
-%ignore libdnf5::OptionBinds::cbegin;
-%ignore libdnf5::OptionBinds::end;
-%ignore libdnf5::OptionBinds::cend;
-%ignore libdnf5::OptionBinds::find;
+%template(MapStringItem) std::map<std::string, libdnf5::OptionBinds::Item>;
 %include "libdnf5/conf/option_binds.hpp"
+
+add_iterator(OptionBinds)
 
 %ignore libdnf5::ConfigParserError;
 %ignore libdnf5::InaccessibleConfigError;

--- a/include/libdnf5/conf/option_binds.hpp
+++ b/include/libdnf5/conf/option_binds.hpp
@@ -42,6 +42,10 @@ public:
         using NewStringFunc = std::function<void(Option::Priority, const std::string &)>;
         using GetValueStringFunc = std::function<const std::string &()>;
 
+        Item();
+        Item(const Item & src);
+        Item & operator=(const Item & src);
+
         ~Item();
         Option::Priority get_priority() const;
         void new_string(Option::Priority priority, const std::string & value);

--- a/libdnf5/conf/option_binds.cpp
+++ b/libdnf5/conf/option_binds.cpp
@@ -58,6 +58,10 @@ OptionBinds::Item::Item(Option & option) : p_impl(new Impl(option)) {}
 
 OptionBinds::Item::~Item() = default;
 
+OptionBinds::Item::Item() = default;
+OptionBinds::Item::Item(const Item & src) = default;
+OptionBinds::Item & OptionBinds::Item::operator=(const Item & src) = default;
+
 Option::Priority OptionBinds::Item::get_priority() const {
     return p_impl->option->get_priority();
 }


### PR DESCRIPTION
This requires to instantiate `std::map<std::string, libdnf5::OptionBinds::Item>` template because `libdnf5::OptionBinds` uses its iterator.

To instantiate the template we need to add constructors to `libdnf5::OptionBinds::Item`. I think this is needed beacuse because `Item` contains an Impl ptr and swig doesn't know how to create that (because it is hidden).

Finally to wrap the `libdnf5::OptionBinds::Item` we need to flatten the class hierarchy.

This is an alternative approach to https://github.com/rpm-software-management/dnf5/pull/2369.