### PR TITLE
doc: fix references to dnf5.conf(5)

### DIFF
--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -59,7 +59,7 @@ Subcommands
     Also include optional packages of the group if the ``--with-optional`` option is
     specified. By default all `Mandatory` and `Default` packages will be installed whenever
     possible. `Conditional` packages are installed if they meet their requirement. This can
-    be configured by :manpage:`dnf5-conf(5)`, :ref:`group_package_types <group_package_types_options-label>`.
+    be configured by :manpage:`dnf5.conf(5)`, :ref:`group_package_types <group_package_types_options-label>`.
 
     If the group is already (partially) installed, the command  installs the missing
     packages from the group.

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -50,7 +50,7 @@ are considered correct, the resulting package is picked simply by lexicographica
 
 When installing groups defined in ``group-spec`` arguments, ``DNF5`` ensures that the groups and
 their packages are installed on the system. Installs only group packages matching configured package
-type. See :manpage:`dnf5-conf(5)`, :ref:`group_package_types <group_package_types_options-label>`.
+type. See :manpage:`dnf5.conf(5)`, :ref:`group_package_types <group_package_types_options-label>`.
 
 When installing environments defined in ``environment-spec`` arguments, ``DNF5`` ensures that the
 environments and their groups are installed on the system.

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -476,7 +476,7 @@ Library Plugins:
     | :manpage:`libdnf5-expired-pgp-keys(8)`, :ref:`Expired PGP keys plugin <expired-pgp-keys_plugin_ref-label>`
 
 Configuration:
-    | :manpage:`dnf5-conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`
+    | :manpage:`dnf5.conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`
 
 Miscellaneous:
     | :manpage:`dnf5-aliases(7)`, :ref:`Aliases for command line arguments <aliases_misc_ref-label>`

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -226,4 +226,4 @@ The email emitter configuration.
 ``[base]`` section
 ------------------
 
-Can be used to override settings from DNF's main configuration file. See :manpage:`dnf5-conf(5)`.
+Can be used to override settings from DNF's main configuration file. See :manpage:`dnf5.conf(5)`.

--- a/doc/dnf5_plugins/config-manager.8.rst
+++ b/doc/dnf5_plugins/config-manager.8.rst
@@ -189,4 +189,4 @@ See Also
 ========
 
 Configuration:
-    | :manpage:`dnf5-conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`
+    | :manpage:`dnf5.conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`

--- a/doc/misc/system-state.7.rst
+++ b/doc/misc/system-state.7.rst
@@ -25,7 +25,7 @@
 Description
 ===========
 
-The DNF5 system state consists of several TOML files with their location determined by the `system_state_dir` configuration option (:manpage:`dnf5-conf(5)`, :ref:`system_state_dir <system_state_dir_options-label>`). DNF5 uses the system state to:
+The DNF5 system state consists of several TOML files with their location determined by the `system_state_dir` configuration option (:manpage:`dnf5.conf(5)`, :ref:`system_state_dir <system_state_dir_options-label>`). DNF5 uses the system state to:
 
     1. Store the reasons why each installed package was added to the system. The reasons can be "user" for packages that the user explicitly asked DNF5 to install, "dependency" and "weak dependency" for packages pulled in as dependencies of another package, "group" for packages installed by a group, or "external" for packages installed by another tool (e.g. rpm).
 


### PR DESCRIPTION
Some doc pages were referring to dnf5-conf(5), which doesn't exist. Fix those references to point to dnf5.conf(5) instead.