### PR TITLE
Enable copying config from one `libdnf5::Base` to another

### DIFF
--- a/include/libdnf5/base/base.hpp
+++ b/include/libdnf5/base/base.hpp
@@ -82,6 +82,7 @@ public:
 
     /// @return a reference to configuration
     ConfigMain & get_config();
+    void set_config(ConfigMain config);
     LogRouterWeakPtr get_logger();
     comps::CompsSackWeakPtr get_comps_sack();
     repo::RepoSackWeakPtr get_repo_sack();

--- a/include/libdnf5/conf/config.hpp
+++ b/include/libdnf5/conf/config.hpp
@@ -37,7 +37,11 @@ public:
     OptionBinds & opt_binds() noexcept;
 
     Config();
+    Config(const Config & other);
+
     virtual ~Config();
+
+    Config & operator=(const Config & other);
 
     virtual void load_from_parser(
         const ConfigParser & parser,

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -40,7 +40,11 @@ namespace libdnf5 {
 class LIBDNF_API ConfigMain : public Config {
 public:
     ConfigMain();
+    ConfigMain(const ConfigMain & other);
+
     ~ConfigMain();
+
+    ConfigMain & operator=(const ConfigMain & other);
 
     OptionNumber<std::int32_t> & get_debuglevel_option();
     const OptionNumber<std::int32_t> & get_debuglevel_option() const;

--- a/include/libdnf5/conf/option.hpp
+++ b/include/libdnf5/conf/option.hpp
@@ -54,7 +54,11 @@ public:
 
     explicit Option(Priority priority = Priority::EMPTY);
     Option(const Option & src);
+    Option(Option && other) noexcept;
+
     virtual ~Option();
+
+    Option & operator=(const Option & other);
 
     /// Makes copy (clone) of this object.
     // @replaces libdnf:conf/Option.hpp:method:Option.clone()

--- a/include/libdnf5/conf/option_binds.hpp
+++ b/include/libdnf5/conf/option_binds.hpp
@@ -67,6 +67,8 @@ public:
     OptionBinds(const OptionBinds & src);
     ~OptionBinds();
 
+    OptionBinds & operator=(const OptionBinds & other);
+
     Item & add(
         std::string id,
         Option & option,

--- a/include/libdnf5/conf/option_enum.hpp
+++ b/include/libdnf5/conf/option_enum.hpp
@@ -40,6 +40,8 @@ public:
     OptionEnum(std::string default_value, std::vector<std::string> enum_vals);
     OptionEnum(std::string default_value, std::vector<std::string> enum_vals, FromStringFunc && from_string_func);
 
+    OptionEnum(const OptionEnum & other);
+
     ~OptionEnum() override;
 
     /// Makes copy (clone) of this object.

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -272,6 +272,9 @@ bool Base::are_repos_configured() const noexcept {
 ConfigMain & Base::get_config() {
     return p_impl->config;
 }
+void Base::set_config(ConfigMain config) {
+    this->p_impl->config = std::move(config);
+}
 LogRouterWeakPtr Base::get_logger() {
     return {&p_impl->log_router, &p_impl->log_router_guard};
 }

--- a/libdnf5/conf/config.cpp
+++ b/libdnf5/conf/config.cpp
@@ -23,6 +23,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf5 {
 
 class Config::Impl {
+public:
+    Impl() = default;
+    Impl(const Impl & other) : binds(other.binds) {}
+
+    Impl & operator=(const Impl & other) {
+        binds = other.binds;
+        return *this;
+    }
+
 private:
     friend Config;
 
@@ -33,8 +42,18 @@ OptionBinds & Config::opt_binds() noexcept {
     return p_impl->binds;
 }
 
-Config::~Config() = default;
 Config::Config() : p_impl(new Impl()) {}
+
+Config::Config(const Config & other) : p_impl(other.p_impl) {}
+
+Config::~Config() = default;
+
+Config & Config::operator=(const Config & other) {
+    if (this != &other) {
+        p_impl = other.p_impl;
+    }
+    return *this;
+}
 
 void Config::load_from_parser(
     const ConfigParser & parser,

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -110,6 +110,7 @@ class ConfigMain::Impl {
     friend class ConfigMain;
 
     explicit Impl(Config & owner);
+    explicit Impl(Config & owner, Config & other);
 
     Config & owner;
 
@@ -470,7 +471,20 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
 ConfigMain::ConfigMain() {
     p_impl = std::unique_ptr<Impl>(new Impl(*this));
 }
+
+ConfigMain::ConfigMain(const ConfigMain & other) : Config(other) {
+    p_impl = std::make_unique<Impl>(*other.p_impl);
+}
+
 ConfigMain::~ConfigMain() = default;
+
+ConfigMain & ConfigMain::operator=(const ConfigMain & other) {
+    if (this != &other) {
+        Config::operator=(other);
+        p_impl = std::make_unique<Impl>(*other.p_impl);
+    }
+    return *this;
+}
 
 OptionNumber<std::int32_t> & ConfigMain::get_debuglevel_option() {
     return p_impl->debuglevel;

--- a/libdnf5/conf/option.cpp
+++ b/libdnf5/conf/option.cpp
@@ -35,9 +35,11 @@ private:
 
 Option::Option(Priority priority) : p_impl(new Impl(priority)) {}
 
+Option::Option(const Option & src) = default;
+
 Option::~Option() = default;
 
-Option::Option(const Option & src) = default;
+Option & Option::operator=(const Option & other) = default;
 
 Option::Priority Option::get_priority() const {
     return p_impl->priority;
@@ -69,5 +71,6 @@ void Option::assert_not_locked() const {
 const std::string & Option::get_lock_comment() const noexcept {
     return p_impl->lock_comment;
 }
+
 
 }  // namespace libdnf5

--- a/libdnf5/conf/option_binds.cpp
+++ b/libdnf5/conf/option_binds.cpp
@@ -93,6 +93,12 @@ private:
 OptionBinds::OptionBinds() : p_impl(new Impl()) {}
 OptionBinds::OptionBinds(const OptionBinds & src) = default;
 OptionBinds::~OptionBinds() = default;
+OptionBinds & OptionBinds::operator=(const OptionBinds & other) {
+    if (this != &other) {
+        p_impl = other.p_impl;
+    }
+    return *this;
+}
 
 OptionBinds::Item & OptionBinds::at(const std::string & id) {
     auto item = p_impl->items.find(id);

--- a/libdnf5/conf/option_enum.cpp
+++ b/libdnf5/conf/option_enum.cpp
@@ -60,6 +60,8 @@ OptionEnum::OptionEnum(
     test(p_impl->value);
 }
 
+OptionEnum::OptionEnum(const OptionEnum & other) = default;
+
 OptionEnum::~OptionEnum() = default;
 
 void OptionEnum::test(const std::string & value) const {


### PR DESCRIPTION
Adds `void Base::set_config(ConfigMain config)` and adds missing copy constructors and/or copy assignment operators (`operator=`) for:

- `libdnf5::Config`
- `libdnf5::ConfigMain`
- `libdnf5::Option`
- `libdnf5::OptionBinds`
- `libdnf5::OptionEnum`

Correct me if I'm wrong, but ideally these classes should also have move constructors and move assignment operators (rule of five).

`set_config` is wanted by the DNF5 manifest plugin (https://github.com/rpm-software-management/dnf5/issues/2370) so we can easily create new `libdnf5::Base` objects to resolve transactions for multiple architectures (requiring distinct sets of repositories).

I think these changes are ABI-compatible since these classes were already non-trivial.