### PR TITLE
dnf5daemon-server: Correct repo::confirm_key_with_options D-Bus signature

### DIFF
--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -278,8 +278,8 @@ void Repo::dbus_register() {
                 {}},
             sdbus::MethodVTableItem{
                 sdbus::MethodName{"confirm_key_with_options"},
-                sdbus::Signature{"sb"},
-                {"key_id", "confirmed"},
+                sdbus::Signature{"sba{sv}"},
+                {"key_id", "confirmed", "options"},
                 sdbus::Signature{""},
                 {},
                 [this](sdbus::MethodCall call) -> void {


### PR DESCRIPTION
There had been missing the "options" argument declaration in the branch for the sdbus-cpp 2.

Incomplete in the https://github.com/rpm-software-management/dnf5/pull/2333