### PR TITLE
libdnf5: Don't double format a transaction error

### DIFF
--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -356,9 +356,8 @@ void Transaction::Impl::add_resolve_log(
     const std::set<std::string> & additional_data,
     libdnf5::Logger::Level log_level) {
     resolve_logs.emplace_back(LogEvent(action, problem, additional_data, settings, spec_type, spec));
-    // TODO(jmracek) Use a logger properly
     auto & logger = *base->get_logger();
-    logger.log(log_level, resolve_logs.back().to_string());
+    logger.log_line(log_level, resolve_logs.back().to_string());
 }
 
 void Transaction::Impl::add_resolve_log(
@@ -369,9 +368,8 @@ void Transaction::Impl::add_resolve_log(
 
 void Transaction::Impl::add_resolve_log(GoalProblem problem, const SolverProblems & problems) {
     resolve_logs.emplace_back(LogEvent(problem, problems));
-    // TODO(jmracek) Use a logger properly
     auto & logger = *base->get_logger();
-    logger.error(resolve_logs.back().to_string());
+    logger.log_line(libdnf5::Logger::Level::ERROR, resolve_logs.back().to_string());
 }
 
 const std::vector<LogEvent> & Transaction::get_resolve_logs() const {


### PR DESCRIPTION
If a package requires a dependency which cannot be satisfied, a transaction error is formatted and printed to an error output and a log file.

If the error message contained curly brackets, e.g. the dependency was "a{}", "argument not found" was printed instead of the transaction error:

    # dnf5 install ~test/rpmbuild/RPMS/noarch/test2-0-0.fc44.noarch.rpm
    Updating and loading repositories:
    Repositories loaded.
    argument not found

Expected output:

    Updating and loading repositories:
    Repositories loaded.
    Failed to resolve the transaction:
    Problem: conflicting requests
      - nothing provides a{} needed by test2-0-0.fc44.noarch from @commandline You can try to add to command line: --skip-broken to skip uninstallable packages

The cause was formatting the transaction error twice: An already formatted output from LogEvent.to_string() was passed again to logger.log() which expected a formatting string. The "argument not found" message was an exception from fmt library.

This patch fixes is by logging the already formatted transaction error as a literal string.

Resolve: #2403