### PR TITLE
dnf5daemon-server: Allow RPM key import without password prompt for wheel users

### DIFF
--- a/dnf5daemon-server/polkit/org.rpm.dnf.v0.rules
+++ b/dnf5daemon-server/polkit/org.rpm.dnf.v0.rules
@@ -1,5 +1,6 @@
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.rpm.dnf.v0.rpm.execute_trusted_transaction" &&
+    if ((action.id == "org.rpm.dnf.v0.rpm.execute_trusted_transaction" ||
+         action.id == "org.rpm.dnf.v0.rpm.Repo.confirm_key") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("wheel")) {
             return polkit.Result.YES;


### PR DESCRIPTION
Similar to trusted RPM transaction, an RPM key import can be done silently, without asking root/admin password, when it's done by a user in the 'wheel' group.