### PR TITLE
Introduces `libdnf5` list plugins on `--version` parameter

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -234,6 +234,9 @@ public:
         return libdnf_plugins_enablement;
     }
 
+    void set_show_version(bool enable) { this->show_version = enable; }
+    bool get_show_version() const { return this->show_version; }
+
 private:
     Context & owner;
 
@@ -271,6 +274,7 @@ private:
 
     bool load_system_repo{false};
     LoadAvailableRepos load_available_repos{LoadAvailableRepos::NONE};
+    bool show_version{false};
 };
 
 // TODO(jrohel): Move logic into libdnf?
@@ -738,6 +742,14 @@ void Context::set_create_repos(bool create_repos) {
 
 bool Context::get_create_repos() const {
     return p_impl->get_create_repos();
+}
+
+void Context::set_show_version(bool show_version) {
+    p_impl->set_show_version(show_version);
+}
+
+bool Context::get_show_version() const {
+    return p_impl->get_show_version();
 }
 
 libdnf5::Base & Context::get_base() {

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -176,6 +176,10 @@ public:
     std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement();
     const std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement() const;
 
+    /// Set to true to print version information
+    void set_show_version(bool enable);
+    bool get_show_version() const;
+
 private:
     class DNF_LOCAL Impl;
     std::unique_ptr<Impl> p_impl;


### PR DESCRIPTION
Introduces `libdnf5` plugin listing on `--version`

Since `get_plugins_info()` from libdnf base requires `setup()` before, the `print_versions` calls need to postponed, which required an refactor of the `--version` parameter workflow.

Closes: #1335