### PR TITLE
cli: Fix use-after-free issue in CommandAlias

### DIFF
--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -1279,8 +1279,9 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
         auto & target_arg = owner.get_named_arg(target_named_arg.id_path, false);
         const char * args[2];
         int args_count = 1;
+        std::string value;
         if (target_arg.get_has_value()) {
-            auto value = format_string(target_named_arg.value, number_of_required_values + 1, argv);
+            value = format_string(target_named_arg.value, number_of_required_values + 1, argv);
             args[args_count++] = value.c_str();
         }
         args[0] = option;


### PR DESCRIPTION
The raw pointer to the `value` variable, which is local to the if block,
was stored in the args array and later used in the
`target_arg.parse_long(option, args_count, args);` call. Unfortunately,
by this time, the `value` variable has already been destroyed.