### PR TITLE
feat: add field-specific search options (--name, --summary)

### DIFF
--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -22,11 +22,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "search_processor.hpp"
 
+#include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+
 #include <dnf5/shared_options.hpp>
+#include <libdnf5-cli/exception.hpp>
 #include <libdnf5-cli/output/search.hpp>
 #include <libdnf5/conf/option_string.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 namespace dnf5 {
 
@@ -48,9 +52,27 @@ void SearchCommand::set_argument_parser() {
 
     show_duplicates = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "showduplicates", '\0', "Show all versions of the packages, not only the latest ones.", false);
+
+    search_name = std::make_unique<libdnf5::cli::session::BoolOption>(
+        *this, "name", '\0', "Limit the search to the Name field.", false);
+
+    search_summary = std::make_unique<libdnf5::cli::session::BoolOption>(
+        *this, "summary", '\0', "Limit the search to the Summary field.", false);
 }
 
 void SearchCommand::configure() {
+    const auto name_only = search_name->get_value();
+    const auto summary_only = search_summary->get_value();
+    const auto search_all = all->get_value();
+
+    if (name_only && summary_only) {
+        throw libdnf5::cli::CommandExitError(1, M_("Options --name and --summary cannot be used together."));
+    }
+
+    if (search_all && (name_only || summary_only)) {
+        throw libdnf5::cli::CommandExitError(1, M_("Option --all cannot be used with --name or --summary."));
+    }
+
     auto & context = get_context();
     context.set_load_system_repo(true);
     context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
@@ -58,7 +80,13 @@ void SearchCommand::configure() {
 
 void SearchCommand::run() {
     auto & base = get_context().get_base();
-    SearchProcessor processor(base, patterns->get_value(), all->get_value(), show_duplicates->get_value());
+    SearchProcessor processor(
+        base,
+        patterns->get_value(),
+        all->get_value(),
+        show_duplicates->get_value(),
+        search_name->get_value(),
+        search_summary->get_value());
     libdnf5::cli::output::print_search_results(processor.get_results());
 }
 

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -44,6 +44,8 @@ private:
     std::unique_ptr<SearchAllOption> all{nullptr};
     std::unique_ptr<SearchPatternsArguments> patterns{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> show_duplicates{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> search_name{nullptr};
+    std::unique_ptr<libdnf5::cli::session::BoolOption> search_summary{nullptr};
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/search/search_processor.hpp
+++ b/dnf5/commands/search/search_processor.hpp
@@ -36,7 +36,12 @@ class SearchProcessor {
 public:
     /// Prepare the processor based on the parameters given by the user.
     explicit SearchProcessor(
-        libdnf5::Base & base, std::vector<std::string> patterns, bool search_all, bool show_duplicates);
+        libdnf5::Base & base,
+        std::vector<std::string> patterns,
+        bool search_all,
+        bool show_duplicates,
+        bool search_name,
+        bool search_summary);
 
     /// Results computation method.
     libdnf5::cli::output::SearchResults get_results();
@@ -103,6 +108,8 @@ private:
     libdnf5::rpm::PackageQuery full_package_query;
     std::unordered_map<std::string, int> packages_priorities;
     bool showdupes;
+    bool search_name;
+    bool search_summary;
 };
 
 }  // namespace dnf5

--- a/doc/commands/search.8.rst
+++ b/doc/commands/search.8.rst
@@ -35,8 +35,9 @@ The ``search`` command in ``DNF5`` is used for searching packages by matching
 given keywords from the user against various metadata.
 
 By default the command searches for all requested keys (AND operation) in
-`Name` or `Summary` fields from the RPM package metadata. Matching is
-case-insensitive and globs are supported.
+`Name` or `Summary` fields from the RPM package metadata. Users can limit
+the search to specific fields using ``--name`` or ``--summary``
+options. Matching is case-insensitive and globs are supported.
 
 
 Options
@@ -45,6 +46,15 @@ Options
 ``--all``
     | Search patterns also inside `Description` and `URL` fields.
     | By applying this option the search lists packages that match at least one of the keys (OR operation).
+    | Cannot be used with ``--name`` or ``--summary``.
+
+``--name``
+    | Limit the search to the `Name` field only.
+    | Cannot be used with ``--all`` or ``--summary``.
+
+``--summary``
+    | Limit the search to the `Summary` field only.
+    | Cannot be used with ``--all`` or ``--name``.
 
 ``--showduplicates``
     | Show all versions of packages, not only the latest ones.
@@ -61,6 +71,12 @@ Examples
 
 ``dnf5 search --all fedora gnome kde``
     | Search packages having any of given keywords in `Name`, `Summary`, `Description` or `URL` fields.
+
+``dnf5 search --name firefox``
+    | Search ``firefox`` keyword only in the `Name` field of packages.
+
+``dnf5 search --summary browser``
+    | Search ``browser`` keyword only in the `Summary` field of packages.
 
 
 See Also

--- a/include/libdnf5-cli/output/search.hpp
+++ b/include/libdnf5-cli/output/search.hpp
@@ -45,6 +45,8 @@ using matched_key_pair = std::pair<std::string, SearchKeyMatch>;
 struct SearchOptions {
     bool search_all;       ///< If we search also in description and URL fields in addition to name, summary.
     bool show_duplicates;  ///< If multiple versions of the same package are allowed in the output.
+    bool search_name;      ///< If we search only to the name field
+    bool search_summary;   ///< If we search only to the summary field
 };
 
 /// Auxiliary structure for holding the set of result packages together with their comparator.


### PR DESCRIPTION
Add options to limit search scope to specific package metadata fields with proper validation to prevent conflicting option combinations.

Add new options on documentation

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2358652