### PR TITLE
pre-commit: Increase autopep8 line length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
   rev: v2.2.0
   hooks:
   - id: autopep8
+    args: [-i, --max-line-length=120]
 - repo: https://github.com/rpm-software-management/rpmlint.git
   rev: 2.5.0
   hooks:


### PR DESCRIPTION
The Python conding style for this project allows 120 characters per line, see doc/best_practices/condig_style_py.rst.