### PR TITLE
offline: Store downloaded packages in /var/lib/dnf

### DIFF
--- a/dnf5/commands/offline/offline.hpp
+++ b/dnf5/commands/offline/offline.hpp
@@ -47,10 +47,12 @@ public:
 
 protected:
     std::filesystem::path get_datadir() const { return datadir; };
+    std::filesystem::path get_destdir() const { return destdir; };
     std::optional<libdnf5::offline::OfflineTransactionState> state;
 
 private:
     std::filesystem::path datadir;
+    std::filesystem::path destdir;
 };
 
 class OfflineRebootCommand : public OfflineSubcommand {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -393,10 +393,11 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     // Serialize the transaction
     const auto & installroot = base.get_config().get_installroot_option().get_value();
     const auto & offline_datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
+    const auto & offline_destdir = installroot / libdnf5::offline::DEFAULT_DESTDIR.relative_path();
     std::filesystem::create_directories(offline_datadir);
-    constexpr const char * packages_in_trans_dir{"./packages"};
-    constexpr const char * comps_in_trans_dir{"./comps"};
-    const auto & comps_location = offline_datadir / comps_in_trans_dir;
+    std::filesystem::create_directories(offline_destdir);
+    const auto & packages_location = offline_destdir / "packages";
+    const auto & comps_location = offline_destdir / "comps";
 
     const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
     libdnf5::offline::OfflineTransactionState state{state_path};
@@ -409,7 +410,7 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
 
     const auto transaction_json_path = offline_datadir / TRANSACTION_JSON;
     libdnf5::utils::fs::File transaction_json_file{transaction_json_path, "w"};
-    transaction_json_file.write(transaction.serialize(packages_in_trans_dir, comps_in_trans_dir));
+    transaction_json_file.write(transaction.serialize(packages_location, comps_location));
     transaction_json_file.close();
 
     // Download and transaction test complete. Fill out entries in offline
@@ -475,7 +476,9 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     if (should_store_offline) {
         const auto & installroot = base.get_config().get_installroot_option().get_value();
         const auto & offline_datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
+        const auto & offline_destdir = installroot / libdnf5::offline::DEFAULT_DESTDIR.relative_path();
         std::filesystem::create_directories(offline_datadir);
+        std::filesystem::create_directories(offline_destdir);
         const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
         libdnf5::offline::OfflineTransactionState state{state_path};
 
@@ -489,8 +492,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
                 throw libdnf5::cli::AbortedByUserError();
             }
         }
-
-        base.get_config().get_destdir_option().set(offline_datadir / "packages");
+        base.get_config().get_destdir_option().set(offline_destdir / "packages");
         transaction.set_download_local_pkgs(true);
     }
 

--- a/dnf5daemon-server/services/offline/offline.hpp
+++ b/dnf5daemon-server/services/offline/offline.hpp
@@ -49,6 +49,7 @@ private:
     enum class Scheduled { NOT_SCHEDULED, ANOTHER_TOOL, SCHEDULED };
     Scheduled offline_transaction_scheduled();
     std::filesystem::path get_datadir();
+    std::filesystem::path get_destdir();
 };
 
 #endif

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -348,6 +348,7 @@ void Session::download_transaction_packages() {
 void Session::store_transaction_offline(bool downloadonly) {
     const auto & installroot = base->get_config().get_installroot_option().get_value();
     const auto & offline_datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
+    const auto & offline_destdir = installroot / libdnf5::offline::DEFAULT_DESTDIR.relative_path();
     std::filesystem::create_directories(offline_datadir);
     const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
     libdnf5::offline::OfflineTransactionState state{state_path};
@@ -356,7 +357,7 @@ void Session::store_transaction_offline(bool downloadonly) {
     state.write();
 
     // Download transaction packages
-    const auto & dest_dir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path() / "packages";
+    const auto & dest_dir = offline_destdir / "packages";
     std::filesystem::create_directories(dest_dir);
     base->get_config().get_destdir_option().set(dest_dir);
     download_transaction_packages();
@@ -376,15 +377,13 @@ void Session::store_transaction_offline(bool downloadonly) {
     }
 
     // Serialize the transaction
-    constexpr const char * packages_in_trans_dir{"./packages"};
-    constexpr const char * comps_in_trans_dir{"./comps"};
-    const auto & comps_location = offline_datadir / comps_in_trans_dir;
+    const auto & comps_location = offline_destdir / "comps";
 
     transaction->store_comps(comps_location);
 
     const auto transaction_json_path = offline_datadir / "transaction.json";
     libdnf5::utils::fs::File transaction_json_file{transaction_json_path, "w"};
-    transaction_json_file.write(transaction->serialize(packages_in_trans_dir, comps_in_trans_dir));
+    transaction_json_file.write(transaction->serialize(dest_dir, comps_location));
     transaction_json_file.close();
 
     // Download and transaction test complete. Fill out entries in offline

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -47,6 +47,7 @@ const std::string STATUS_TRANSACTION_INCOMPLETE{"transaction-incomplete"};
 const std::filesystem::path MAGIC_SYMLINK{"/system-update"};
 
 const std::filesystem::path DEFAULT_DATADIR{std::filesystem::path(libdnf5::SYSTEM_STATE_DIR) / "offline"};
+const std::filesystem::path DEFAULT_DESTDIR{std::filesystem::path(libdnf5::PERSISTDIR) / "offline"};
 const std::filesystem::path TRANSACTION_STATE_FILENAME{"offline-transaction-state.toml"};
 
 class OfflineTransactionState;


### PR DESCRIPTION
The persistdir is better than system_state_dir, which should be used only for storing system state, or than system_cachedir, which might not be guaranteed to survive reboot.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2398