### PR TITLE
fix: unify epoch display across all DNF5 commands

### DIFF
--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -329,10 +329,19 @@ std::string package_to_json(const libdnf5::rpm::Package & libdnf_package, const 
                 add_string_list(json_pkg, cattr, reldeplist_to_strings(libdnf_package.get_supplements()));
                 break;
             case PackageAttribute::evr:
-                json_object_object_add(json_pkg, cattr, json_object_new_string(libdnf_package.get_evr().c_str()));
+                // Always show epoch in EVR (epoch:version-release)
+                {
+                    std::string evr_with_epoch = libdnf_package.get_epoch();
+                    if (evr_with_epoch.empty()) {
+                        evr_with_epoch = "0";
+                    }
+                    evr_with_epoch += ":" + libdnf_package.get_version() + "-" + libdnf_package.get_release();
+                    json_object_object_add(json_pkg, cattr, json_object_new_string(evr_with_epoch.c_str()));
+                }
                 break;
             case PackageAttribute::nevra:
-                json_object_object_add(json_pkg, cattr, json_object_new_string(libdnf_package.get_nevra().c_str()));
+                json_object_object_add(
+                    json_pkg, cattr, json_object_new_string(libdnf_package.get_full_nevra().c_str()));
                 break;
             case PackageAttribute::full_nevra:
                 json_object_object_add(

--- a/include/libdnf5/rpm/package.hpp
+++ b/include/libdnf5/rpm/package.hpp
@@ -532,7 +532,7 @@ public:
     /// @since 5.0.5
     libdnf5::BaseWeakPtr get_base() const;
 
-    /// Return NEVRA -> 0 epoch is not shown in string
+    /// Return NEVRA -> always includes epoch (including 0 if epoch is empty)
     std::string to_string() const;
 
     /// Provide descriptive information about instance including NEVRA and ID

--- a/libdnf5/rpm/package.cpp
+++ b/libdnf5/rpm/package.cpp
@@ -560,7 +560,7 @@ PackageId Package::get_id() const noexcept {
 };
 
 std::string Package::to_string() const {
-    return get_nevra();
+    return get_full_nevra();
 };
 
 int Package::get_hash() const {


### PR DESCRIPTION
Always show epoch (including 0) in package NEVRA strings for consistency. Updates Package::to_string(), transaction table, daemon API, and transaction replay.

Fixes inconsistent epoch handling where some commands showed epoch and others didn't.

Closes #1175