### PR TITLE
daemon: Protect libdnf5 access in D-Bus services with mutex

### DIFF
--- a/dnf5daemon-server/services/repo/repo.cpp
+++ b/dnf5daemon-server/services/repo/repo.cpp
@@ -283,7 +283,9 @@ void Repo::dbus_register() {
                 sdbus::Signature{""},
                 {},
                 [this](sdbus::MethodCall call) -> void {
-                    session.get_threads_manager().handle_method(*this, &Repo::confirm_key_with_options, call);
+                    // confirm_key_with_options method does not call any libdnf5 API. Do not use the mutex to avoid deadlocks.
+                    session.get_threads_manager().handle_method<Repo, false>(
+                        *this, &Repo::confirm_key_with_options, call);
                 },
                 {}},
             sdbus::MethodVTableItem{
@@ -293,7 +295,8 @@ void Repo::dbus_register() {
                 sdbus::Signature{""},
                 {},
                 [this](sdbus::MethodCall call) -> void {
-                    session.get_threads_manager().handle_method(*this, &Repo::confirm_key, call);
+                    // confirm_key method does not call any libdnf5 API. Do not use the mutex to avoid deadlocks.
+                    session.get_threads_manager().handle_method<Repo, false>(*this, &Repo::confirm_key, call);
                 },
                 {}},
             sdbus::MethodVTableItem{
@@ -358,7 +361,8 @@ void Repo::dbus_register() {
         "",
         {},
         [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Repo::confirm_key_with_options, call);
+            // confirm_key_with_options method does not call any libdnf5 API. Do not use the mutex to avoid deadlocks.
+            session.get_threads_manager().handle_method<Repo, false>(*this, &Repo::confirm_key_with_options, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPO,
@@ -368,7 +372,8 @@ void Repo::dbus_register() {
         "",
         {},
         [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Repo::confirm_key, call);
+            // confirm_key method does not call any libdnf5 API. Do not use the mutex to avoid deadlocks.
+            session.get_threads_manager().handle_method<Repo, false>(*this, &Repo::confirm_key, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPO,

--- a/dnf5daemon-server/session.hpp
+++ b/dnf5daemon-server/session.hpp
@@ -99,6 +99,7 @@ public:
     void set_cancel_download(CancelDownload value) { cancel_download.store(value); }
 
     std::mutex & get_transaction_mutex() { return transaction_mutex; }
+    std::mutex & get_libdnf5_mutex() { return libdnf5_mutex; }
 
     void reset_goal();
     void reset_base();
@@ -121,6 +122,9 @@ private:
     enum class KeyConfirmationStatus { PENDING, CONFIRMED, REJECTED };
     std::mutex key_import_mutex;
     std::mutex transaction_mutex;
+    // Mutex to serialize D-Bus method calls within the same session. Needed
+    // because libdnf5 and libsolv are not thread-safe.
+    std::mutex libdnf5_mutex;
     std::condition_variable key_import_condition;
     std::map<std::string, KeyConfirmationStatus> key_import_status{};  // map key_id: confirmation status
     std::atomic<CancelDownload> cancel_download{CancelDownload::NOT_RUNNING};

--- a/dnf5daemon-server/session_manager.cpp
+++ b/dnf5daemon-server/session_manager.cpp
@@ -57,7 +57,8 @@ void SessionManager::dbus_register() {
                 sdbus::Signature{"o"},
                 {"session_object_path"},
                 [this](sdbus::MethodCall call) -> void {
-                    threads_manager.handle_method(*this, &SessionManager::open_session, call);
+                    // open_session method manages sessions and does not call any libdnf5 API. Do not use the mutex.
+                    threads_manager.handle_method<SessionManager, false>(*this, &SessionManager::open_session, call);
                 },
                 {}},
             sdbus::MethodVTableItem{
@@ -67,7 +68,8 @@ void SessionManager::dbus_register() {
                 sdbus::Signature{"b"},
                 {"success"},
                 [this](sdbus::MethodCall call) -> void {
-                    threads_manager.handle_method(*this, &SessionManager::close_session, call);
+                    // close_session method manages sessions and does not call any libdnf5 API. Do not use the mutex.
+                    threads_manager.handle_method<SessionManager, false>(*this, &SessionManager::close_session, call);
                 },
                 {}})
         .forInterface(dnfdaemon::INTERFACE_SESSION_MANAGER);
@@ -80,7 +82,8 @@ void SessionManager::dbus_register() {
         "o",
         {"session_object_path"},
         [this](sdbus::MethodCall call) -> void {
-            threads_manager.handle_method(*this, &SessionManager::open_session, call);
+            // open_session method manages sessions and does not call any libdnf5 API. Do not use the mutex.
+            threads_manager.handle_method<SessionManager, false>(*this, &SessionManager::open_session, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_SESSION_MANAGER,
@@ -90,7 +93,8 @@ void SessionManager::dbus_register() {
         "b",
         {"success"},
         [this](sdbus::MethodCall call) -> void {
-            threads_manager.handle_method(*this, &SessionManager::close_session, call);
+            // close_session method manages sessions and does not call any libdnf5 API. Do not use the mutex.
+            threads_manager.handle_method<SessionManager, false>(*this, &SessionManager::close_session, call);
         });
     dbus_object->finishRegistration();
 


### PR DESCRIPTION
This change fixes race conditions in various libdnf5/libsolv calls when
multiple threads access them concurrently. It is necessary because
neither libdnf5 nor libsolv is thread-safe.

See https://github.com/rpm-software-management/dnf5/issues/2420

This is alternative to https://github.com/rpm-software-management/dnf5/pull/2440 with centralized libdnf5 calls serialization.