### PR TITLE
GHA: Fix weblate-sync-pot workflow

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           app-id: ${{ vars.RSM_CI_APP_ID }}
           private-key: ${{ secrets.RSM_CI_APP_PRIVATE_KEY }}
-          permissions:
+          permissions: |
             contents: "write"
           repositories: "rpm-software-management/dnf5-l10n"
 


### PR DESCRIPTION
This should fix the `weblate-sync-pot.yml` workflow which has been failing since... https://github.com/rpm-software-management/dnf5/pull/2330. Sorry for all the "PR run failed" emails that has caused.