### PR TITLE
Override releasever_{major,minor} with system-release provides

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -520,10 +520,36 @@ void RootCommand::set_argument_parser() {
     releasever->set_parse_hook_func(
         [&ctx](
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
-            ctx.get_base().get_vars()->set("releasever", value);
+            ctx.get_base().get_vars()->set("releasever", value, libdnf5::Vars::Priority::COMMANDLINE);
             return true;
         });
     global_options_group->register_argument(releasever);
+
+    auto releasever_major = parser.add_new_named_arg("releasever-major");
+    releasever_major->set_long_name("releasever-major");
+    releasever_major->set_has_value(true);
+    releasever_major->set_arg_value_help("RELEASEVER_MAJOR");
+    releasever_major->set_description(_("override the value of $releasever_major in config and repo files"));
+    releasever_major->set_parse_hook_func(
+        [&ctx](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            ctx.get_base().get_vars()->set("releasever_major", value, libdnf5::Vars::Priority::COMMANDLINE);
+            return true;
+        });
+    global_options_group->register_argument(releasever_major);
+
+    auto releasever_minor = parser.add_new_named_arg("releasever-minor");
+    releasever_minor->set_long_name("releasever-minor");
+    releasever_minor->set_has_value(true);
+    releasever_minor->set_arg_value_help("RELEASEVER_MINOR");
+    releasever_minor->set_description(_("override the value of $releasever_minor in config and repo files"));
+    releasever_minor->set_parse_hook_func(
+        [&ctx](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            ctx.get_base().get_vars()->set("releasever_minor", value, libdnf5::Vars::Priority::COMMANDLINE);
+            return true;
+        });
+    global_options_group->register_argument(releasever_minor);
 
     {
         auto show_new_leaves = parser.add_new_named_arg("show-new-leaves");

--- a/dnf5daemon-client/context.cpp
+++ b/dnf5daemon-client/context.cpp
@@ -54,6 +54,12 @@ void Context::init_session(sdbus::IConnection & connection) {
     if (!releasever.get_value().empty()) {
         cfg["releasever"] = sdbus::Variant(releasever.get_value());
     }
+    if (!releasever_major.get_value().empty()) {
+        cfg["releasever_major"] = sdbus::Variant(releasever_major.get_value());
+    }
+    if (!releasever_minor.get_value().empty()) {
+        cfg["releasever_minor"] = sdbus::Variant(releasever_minor.get_value());
+    }
     cfg["locale"] = sdbus::Variant(setlocale(LC_MESSAGES, nullptr));
 
     session_manager_proxy->callMethod("open_session")

--- a/dnf5daemon-client/context.hpp
+++ b/dnf5daemon-client/context.hpp
@@ -66,6 +66,8 @@ public:
     libdnf5::OptionBool allow_erasing{false};
     libdnf5::OptionString installroot{"/"};
     libdnf5::OptionString releasever{""};
+    libdnf5::OptionString releasever_major{""};
+    libdnf5::OptionString releasever_minor{""};
 
     void reset_download_cb();
     void set_download_cb(DownloadCB * download_cb) { this->download_cb = download_cb; }

--- a/dnf5daemon-client/main.cpp
+++ b/dnf5daemon-client/main.cpp
@@ -131,6 +131,20 @@ void RootCommand::set_argument_parser() {
     releasever->link_value(&ctx.releasever);
     cmd.register_named_arg(releasever);
 
+    auto releasever_major = ctx.get_argument_parser().add_new_named_arg("releasever-major");
+    releasever_major->set_long_name("releasever-major");
+    releasever_major->set_has_value(true);
+    releasever_major->set_description("override the $releasever_major variable value");
+    releasever_major->link_value(&ctx.releasever_major);
+    cmd.register_named_arg(releasever_major);
+
+    auto releasever_minor = ctx.get_argument_parser().add_new_named_arg("releasever-minor");
+    releasever_minor->set_long_name("releasever-minor");
+    releasever_minor->set_has_value(true);
+    releasever_minor->set_description("override the $releasever_minor variable value");
+    releasever_minor->link_value(&ctx.releasever_minor);
+    cmd.register_named_arg(releasever_minor);
+
     auto setopt = ctx.get_argument_parser().add_new_named_arg("setopt");
     setopt->set_long_name("setopt");
     setopt->set_has_value(true);

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -131,6 +131,14 @@ void Session::setup_base() {
         auto releasever = session_configuration_value<std::string>("releasever");
         base->get_vars()->set("releasever", releasever);
     }
+    if (session_configuration.find("releasever_major") != session_configuration.end()) {
+        auto releasever_major = session_configuration_value<std::string>("releasever_major");
+        base->get_vars()->set("releasever_major", releasever_major);
+    }
+    if (session_configuration.find("releasever_minor") != session_configuration.end()) {
+        auto releasever_minor = session_configuration_value<std::string>("releasever_minor");
+        base->get_vars()->set("releasever_minor", releasever_minor);
+    }
 
     base->setup();
 

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -298,8 +298,19 @@ Following options are applicable in the general context for any ``dnf5`` command
     If you want only packages from this repository to be available, combine this option with ``--repo=REPO_ID`` switch.
 
 ``--releasever=RELEASEVER``
-    | Override the value of the distribution release in configuration files.
-    | This can affect cache paths, values in configuration files and mirrorlist URLs.
+    Override the value of the distribution release (the ``releasever`` variable) in configuration files.
+    This can affect cache paths, values in configuration files and mirrorlist URLs.
+    Whenever ``releasever`` is set, ``releasever_major`` and ``releasever_minor`` will also be set by splitting ``releasever`` on the first ``.``.
+
+``--releasever-major=RELEASEVER_MAJOR``
+    Override the ``releasever_major`` variable, which is usually automatically detected or taken from the part of ``$releasever`` before the first ``.``.
+    Does not affect the setting of the ``releasever`` variable.
+    Must be specified after ``--releasever`` on the command line, otherwise the major part of the ``--releasever`` will take precedent.
+
+``--releasever-minor=RELEASEVER_MINOR``
+    Override the ``releasever_minor`` variable, which is usually automatically detected or taken from the part of ``$releasever`` after the first ``.``.
+    Does not affect the setting of the ``releasever`` variable.
+    Must be specified after ``--releasever`` on the command line, otherwise the minor part of the ``--releasever`` will take precedent.
 
 ``--setopt=[REPO_ID.]OPTION=VALUE``
     | Override a configuration option from the configuration file.

--- a/doc/dnf5_plugins/config-manager.8.rst
+++ b/doc/dnf5_plugins/config-manager.8.rst
@@ -110,7 +110,7 @@ Subcommands
     directories. In other words, the last directory has the highest priority.
 
     Note:
-    The variables ``releasever_major`` and ``releasever_minor`` are read-only. Their values are generated from the ``releasever`` variable.
+    The variables ``releasever_major`` and ``releasever_minor`` are automatically derived from the ``releasever`` variable whenever it is set.
 
 ``unsetvar <variable>+``
     Removes variables.
@@ -118,9 +118,6 @@ Subcommands
     Variables are loaded from multiple directories. The list of directory paths is taken from the ``varsdir`` option.
     The ``unsetvar`` command removes variables from the last directory in the list (by default ``/etc/dnf/vars``).
     So, the variable may still exist in another directory in the list (for example, the default distribution value).
-
-    Note:
-    The variables ``releasever_major`` and ``releasever_minor`` are generated automatically and cannot be removed.
 
 
 .. note::

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -106,8 +106,22 @@ public:
     /// @param name Name of the variable
     const Variable & get(const std::string & name) const;
 
+    /// @brief Detects the releasever of the system
+    ///
+    /// Returns the release name of the distribution of the tree rooted at `installroot`.
+    /// This function uses information from RPMDB found under the tree.
+    /// It's preferred to use ``detect_releasevers`` over ``detect_release``; if you use the latter, you will not be aware of distribution overrides for the major and minor release versions.
+    ///
+    /// @return the detected releasever, or nullptr if the releasever could not be determined (perhaps because the tree has no RPMDB).
     static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
+    /// @brief Detect the releasever, overridden major release, and overridden minor release for the system
+    ///
+    /// Returns a tuple of the release name, overridden major release, and overridden minor release of the distribution of the tree rooted at `installroot`.
+    /// This function uses information from RPMDB found under the tree.
+    /// The major and minor release versions are usually derived from the release version by splitting it on the first ``.``, but distributions can override the derived major and minor versions.
+    ///
+    /// @return a tuple of the releasever, overridden releasever_major, and overridden releasever_minor. Each member of the tuple can be nullptr if not provided by the system.
     static std::tuple<std::unique_ptr<std::string>, std::unique_ptr<std::string>, std::unique_ptr<std::string>>
     detect_releasevers(const BaseWeakPtr & base, const std::string & install_root_path);
 

--- a/include/libdnf5/conf/vars.hpp
+++ b/include/libdnf5/conf/vars.hpp
@@ -108,6 +108,9 @@ public:
 
     static std::unique_ptr<std::string> detect_release(const BaseWeakPtr & base, const std::string & install_root_path);
 
+    static std::tuple<std::unique_ptr<std::string>, std::unique_ptr<std::string>, std::unique_ptr<std::string>>
+    detect_releasevers(const BaseWeakPtr & base, const std::string & install_root_path);
+
 private:
     friend class Base;
 

--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -52,7 +52,7 @@ extern char ** environ;
 
 namespace libdnf5 {
 
-static const std::unordered_set<std::string> READ_ONLY_VARIABLES = {"releasever_major", "releasever_minor"};
+static const std::unordered_set<std::string> READ_ONLY_VARIABLES = {};
 
 static constexpr const char * DISTROVERPKGS[] = {
     "system-release(releasever)",

--- a/test/libdnf5/conf/test_vars.cpp
+++ b/test/libdnf5/conf/test_vars.cpp
@@ -230,22 +230,12 @@ void VarsTest::test_vars_api_releasever() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE("priority returned by vars->get()", libdnf5::Vars::Priority::PLUGIN, prioriry);
     }
 
-    // the "releasever" variable is read-write
+    // the "releasever", "releasever_major", and "releasever_minor" variables are read-write
     CPPUNIT_ASSERT(!vars->is_read_only("releasever"));
+    CPPUNIT_ASSERT(!vars->is_read_only("releasever_major"));
+    CPPUNIT_ASSERT(!vars->is_read_only("releasever_minor"));
 
-    // auto-created variables "releasever_major" and "releasever_minor" are read-only
-    CPPUNIT_ASSERT(vars->is_read_only("releasever_major"));
-    CPPUNIT_ASSERT(vars->is_read_only("releasever_minor"));
-
-    // setting the value of a read-only variable throws exception
-    CPPUNIT_ASSERT_THROW(
-        vars->set("releasever_major", "40", libdnf5::Vars::Priority::PLUGIN), libdnf5::ReadOnlyVariableError);
-
-    // removing read-only variable throws exception
-    CPPUNIT_ASSERT_THROW(
-        vars->unset("releasever_major", libdnf5::Vars::Priority::PLUGIN), libdnf5::ReadOnlyVariableError);
-
-    // because the variable "releaver" is read-write, it can be removed
+    // because the variable "releasever" is read-write, it can be removed
     CPPUNIT_ASSERT(vars->unset("releasever", libdnf5::Vars::Priority::PLUGIN));
     CPPUNIT_ASSERT_MESSAGE("after vars->unset(\"test_var3\")", !vars->contains("releasever"));
 }


### PR DESCRIPTION
Resolves https://github.com/rpm-software-management/dnf5/issues/2400.

DNF5 counterpart to https://github.com/rpm-software-management/dnf/pull/2198. See that PR for more background information.

@m-blaha are the dnf5daemon changes I made here correct? It's not clear to me how `cfg["releasever_major"]` and `cfg["releasever_minor"]` will be eventually used. 