### PR TITLE
Expose librepo max_downloads_per_mirror configuration (forward port to dnf5)

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -1037,6 +1037,15 @@ configuration.
 
     Default: ``3``.
 
+.. _max_downloads_per_mirror_options-label:
+
+``max_downloads_per_mirror``
+    :ref:`integer <integer-label>`
+
+    Maximum number of simultaneous downloads per mirror. Max is ``20``.
+
+    Default: ``3``.
+
 .. _metadata_expire_options-label:
 
 ``metadata_expire``

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -288,6 +288,8 @@ public:
     const OptionSeconds & get_timeout_option() const;
     OptionNumber<std::uint32_t> & get_max_parallel_downloads_option();
     const OptionNumber<std::uint32_t> & get_max_parallel_downloads_option() const;
+    OptionNumber<std::uint32_t> & get_max_downloads_per_mirror_option();
+    const OptionNumber<std::uint32_t> & get_max_downloads_per_mirror_option() const;
     OptionSeconds & get_metadata_expire_option();
     const OptionSeconds & get_metadata_expire_option() const;
     OptionString & get_sslcacert_option();

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -108,6 +108,8 @@ public:
     const OptionChild<OptionSeconds> & get_timeout_option() const;
     OptionChild<OptionNumber<std::uint32_t>> & get_max_parallel_downloads_option();
     const OptionChild<OptionNumber<std::uint32_t>> & get_max_parallel_downloads_option() const;
+    OptionChild<OptionNumber<std::uint32_t>> & get_max_downloads_per_mirror_option();
+    const OptionChild<OptionNumber<std::uint32_t>> & get_max_downloads_per_mirror_option() const;
     OptionChild<OptionSeconds> & get_metadata_expire_option();
     const OptionChild<OptionSeconds> & get_metadata_expire_option() const;
     OptionNumber<std::int32_t> & get_cost_option();

--- a/libdnf5-cli/output/repo_info.cpp
+++ b/libdnf5-cli/output/repo_info.cpp
@@ -186,6 +186,7 @@ general connection settings?
        bandwidth
        ip_resolve
        max_parallel_downloads
+       max_downloads_per_mirror
        minrate
        retries
        throttle

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -289,6 +289,7 @@ class ConfigMain::Impl {
 
     OptionSeconds timeout{30};
     OptionNumber<std::uint32_t> max_parallel_downloads{3, 1};
+    OptionNumber<std::uint32_t> max_downloads_per_mirror{3, 1};
     OptionSeconds metadata_expire{60 * 60 * 48};
     OptionString sslcacert{""};
     OptionBool sslverify{true};
@@ -454,6 +455,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("throttle", throttle);
     owner.opt_binds().add("timeout", timeout);
     owner.opt_binds().add("max_parallel_downloads", max_parallel_downloads);
+    owner.opt_binds().add("max_downloads_per_mirror", max_downloads_per_mirror);
     owner.opt_binds().add("metadata_expire", metadata_expire);
     owner.opt_binds().add("sslcacert", sslcacert);
     owner.opt_binds().add("sslverify", sslverify);
@@ -1249,6 +1251,13 @@ const OptionNumber<std::uint32_t> & ConfigMain::get_max_parallel_downloads_optio
     return p_impl->max_parallel_downloads;
 }
 
+OptionNumber<std::uint32_t> & ConfigMain::get_max_downloads_per_mirror_option() {
+    return p_impl->max_downloads_per_mirror;
+}
+const OptionNumber<std::uint32_t> & ConfigMain::get_max_downloads_per_mirror_option() const {
+    return p_impl->max_downloads_per_mirror;
+}
+
 OptionSeconds & ConfigMain::get_metadata_expire_option() {
     return p_impl->metadata_expire;
 }
@@ -1467,6 +1476,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(throttle, other.throttle);
     load_option(timeout, other.timeout);
     load_option(max_parallel_downloads, other.max_parallel_downloads);
+    load_option(max_downloads_per_mirror, other.max_downloads_per_mirror);
     load_option(metadata_expire, other.metadata_expire);
     load_option(sslcacert, other.sslcacert);
     load_option(sslverify, other.sslverify);

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -72,6 +72,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionNumber<float>> throttle{main_config.get_throttle_option()};
     OptionChild<OptionSeconds> timeout{main_config.get_timeout_option()};
     OptionChild<OptionNumber<std::uint32_t>> max_parallel_downloads{main_config.get_max_parallel_downloads_option()};
+    OptionChild<OptionNumber<std::uint32_t>> max_downloads_per_mirror{main_config.get_max_downloads_per_mirror_option()};
     OptionChild<OptionSeconds> metadata_expire{main_config.get_metadata_expire_option()};
     OptionNumber<std::int32_t> cost{1000};
     OptionNumber<std::int32_t> priority{99};
@@ -162,6 +163,7 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
     owner.opt_binds().add("throttle", throttle);
     owner.opt_binds().add("timeout", timeout);
     owner.opt_binds().add("max_parallel_downloads", max_parallel_downloads);
+    owner.opt_binds().add("max_downloads_per_mirror", max_downloads_per_mirror);
     owner.opt_binds().add("metadata_expire", metadata_expire);
     owner.opt_binds().add("cost", cost);
     owner.opt_binds().add("priority", priority);
@@ -409,6 +411,13 @@ OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_max_parallel_download
 }
 const OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_max_parallel_downloads_option() const {
     return p_impl->max_parallel_downloads;
+}
+
+OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_max_downloads_per_mirror_option() {
+    return p_impl->max_downloads_per_mirror;
+}
+const OptionChild<OptionNumber<std::uint32_t>> & ConfigRepo::get_max_downloads_per_mirror_option() const {
+    return p_impl->max_downloads_per_mirror;
 }
 
 OptionChild<OptionSeconds> & ConfigRepo::get_metadata_expire_option() {

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -668,6 +668,7 @@ void RepoDownloader::common_handle_setup(LibrepoHandle & h, const DownloadData &
     h.set_opt(LRO_GPGCHECK, download_data.config.get_repo_gpgcheck_option().get_value());
     h.set_opt(LRO_MAXMIRRORTRIES, static_cast<long>(download_data.max_mirror_tries));
     h.set_opt(LRO_MAXPARALLELDOWNLOADS, download_data.config.get_max_parallel_downloads_option().get_value());
+    h.set_opt(LRO_MAXDOWNLOADSPERMIRROR, download_data.config.get_max_downloads_per_mirror_option().get_value());
 
     LrUrlVars * repomd_substs = nullptr;
     repomd_substs = lr_urlvars_set(repomd_substs, MD_FILENAME_GROUP_GZ, MD_FILENAME_GROUP);


### PR DESCRIPTION
This is a forward port of the implementation in libdnf4 (libdnf4 commit [67440807f4cb7eb0887f3e08de6ea589a2e2c823](https://github.com/rpm-software-management/libdnf/commit/67440807f4cb7eb0887f3e08de6ea589a2e2c823), pull request https://github.com/rpm-software-management/libdnf/pull/1532).

In many cases the librepo default of 3 concurrent downloads per mirror is sufficient, as there are multiple mirrors, and the max of 3 per mirror is cumulative up until max_parallel_downloads. However, in some situations you don't necessarily want to have other mirrors, and want to have more than 3 parallel downloads.

Such a situation could be where not all mirrors have equal cost, and can handle more simultaneous downloads to saturate the available network bandwidth - so it's beneficial to only list the one mirror in the mirrorlist, and up the maximum number of parallel downloads.

= changelog =
msg: Expose librepo max_downloads_per_mirror config option type: enhancement

---

