### PR TITLE
Fix too long line of new `max_downloads_per_mirror`

### DIFF
--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -72,7 +72,8 @@ class ConfigRepo::Impl {
     OptionChild<OptionNumber<float>> throttle{main_config.get_throttle_option()};
     OptionChild<OptionSeconds> timeout{main_config.get_timeout_option()};
     OptionChild<OptionNumber<std::uint32_t>> max_parallel_downloads{main_config.get_max_parallel_downloads_option()};
-    OptionChild<OptionNumber<std::uint32_t>> max_downloads_per_mirror{main_config.get_max_downloads_per_mirror_option()};
+    OptionChild<OptionNumber<std::uint32_t>> max_downloads_per_mirror{
+        main_config.get_max_downloads_per_mirror_option()};
     OptionChild<OptionSeconds> metadata_expire{main_config.get_metadata_expire_option()};
     OptionNumber<std::int32_t> cost{1000};
     OptionNumber<std::int32_t> priority{99};


### PR DESCRIPTION
Introduced in de8e52746eadc419c23984a9da75b99eeec93b36 (https://github.com/rpm-software-management/dnf5/pull/2457)
The `Pre Commit` hook has been failing due to this.