### PR TITLE
doc: document output of `--json` for `repo` command

### DIFF
--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -73,3 +73,65 @@ Examples
 ``dnf5 config-manager setopt repo_id.enabled=0``
     | Persistently disable repository using the config-manager plugin command.
     | See :manpage:`dnf5-config-manager(8)` for more details.
+
+JSON Output
+===========
+
+* ``dnf5 repo list --json``
+
+  The command returns a JSON array of objects, each describing one repository.
+  Each object contains the following fields:
+
+  - ``id`` (string) - Repository ID.
+  - ``name`` (string) - Repository name.
+  - ``is_enabled`` (boolean) - Repository status, either ``true`` (enabled),
+    or ``false`` (disabled).
+
+* ``dnf5 repo info --json``
+
+  The command returns a JSON array of objects, each describing one repository.
+  Each object contains the following fields:
+
+  - ``id`` (string) - Repository ID.
+  - ``name`` (string) - Repository name.
+  - ``is_enabled`` (boolean) - Repository status, either ``true`` (enabled),
+    or ``false`` (disabled).
+  - ``priority`` (integer) - Repository priority.
+  - ``cost`` (integer) - Repository cost.
+  - ``type`` (string) - Repository type.
+  - ``exclude_pkgs`` (array of strings) - List of excluded packages.
+  - ``include_pkgs`` (array of strings) - List of included packages.
+  - ``timestamp`` (integer) - Timestamp of the last metadata update,
+    UNIX time.
+  - ``metadata_expire`` (integer) - Metadata expiration time. If not set, value
+    is taken from global config.
+  - ``skip_if_unavailable`` (boolean) - Whether to skip the repository
+    if it is unavailable.
+  - ``repo_file_path`` (string) - Path to the repository file.
+  - ``base_url`` (array of strings) - List of base URLs. They are “effective”
+    base URLs, i.e., after expanding any variables included.
+  - ``metalink`` (string) - Metalink URL.
+  - ``mirrorlist`` (string) - Mirrorlist URL.
+  - ``gpg_key`` (array of strings) - List of OpenPGP keys.
+  - ``repo_gpgcheck`` (boolean) - Whether to perform GPG check
+    of the repository metadata.
+  - ``pkg_gpgcheck`` (boolean) - Whether to perform GPG check
+    of the packages.
+  - ``available_pkgs`` (integer) - Number of available packages
+    in the repository.
+  - ``pkgs`` (integer) - Number of packages
+    in the repository.
+  - ``size`` (integer) - Total size of packages
+    in the repository, in bytes.
+  - ``content_tags`` (array of strings) - List of content tags.
+  - ``distro_tags`` (array of strings) - List of distro tags.
+  - ``revision`` (string) - Repository revision.
+  - ``max_timestamp`` (integer) - Maximum timestamp from repomd records;
+    UNIX time.
+
+For more details about the fields, see the ``REPO OPTIONS`` section in dnf5.conf(5).
+
+See Also
+========
+
+      :manpage:`dnf5.conf(5)`, :ref:`Repo options <_repo_options-label>`

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -710,6 +710,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``bold,magenta``.
 
+.. _repo_options-label:
 
 Repo Options
 ============

--- a/libdnf5-cli/output/repo_info.cpp
+++ b/libdnf5-cli/output/repo_info.cpp
@@ -208,6 +208,7 @@ void RepoInfo::print() {
     p_impl->print();
 }
 
+// [NOTE] When editing, do not forget to update the docs at docs/commands/repo.8.rst
 void print_repoinfo_json([[maybe_unused]] const std::vector<std::unique_ptr<IRepoInfo>> & repos) {
     json_object * json_repos = json_object_new_array();
     for (const auto & repo : repos) {

--- a/libdnf5-cli/output/repolist.cpp
+++ b/libdnf5-cli/output/repolist.cpp
@@ -79,6 +79,7 @@ void print_repolist_table(const std::vector<std::unique_ptr<IRepo>> & repos, boo
 }
 
 
+// [NOTE] When editing, do not forget to update the docs at docs/commands/repo.8.rst
 void print_repolist_json([[maybe_unused]] const std::vector<std::unique_ptr<IRepo>> & repos) {
     json_object * json_repos = json_object_new_array();
     for (const auto & repo : repos) {


### PR DESCRIPTION
TODO:

- [ ] There's also
      https://github.com/rpm-software-management/dnf5/blob/2d2b92692411cbaedd589aedc37079f53198fbb4/dnf5daemon-server/package.cpp#L212
      I'm not sure how relevant is this for the documentation…
- [x] Additionally I've found `advisory` command that also supports `--json` switch, but it's not even mentioned in the docs in general that it's supported, so I'm not sure whether I should proceed with that too, or not.
- [ ] One more additional question, since there **is** an interface for printing:
     https://github.com/rpm-software-management/dnf5/blob/c87ee298457b1f19b156a776d4cb1872ae5ff7ba/include/libdnf5-cli/output/repo_info.hpp#L38
     I wonder why the JSON output is also not part of the interface

Fixes #2428