### PR TITLE
docs: Use only multiline comments in RST files

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -52,9 +52,10 @@ Changes to individual options
 ``-4/-6``
   * Dropped. Now only the ``ip_resolve`` configuration option is available.
 
-.. TODO(jkolarik): Not implemented yet
-   ``-d, --debuglevel``
-     * Dropped. Now only the ``debuglevel`` configuration option is available.
+..
+    TODO(jkolarik): Not implemented yet
+    ``-d, --debuglevel``
+      * Dropped. Now only the ``debuglevel`` configuration option is available.
 
 ``--disableexcludes`` and ``--disableexcludepkgs``
   * Dropped. Now only the ``disable_excludes`` configuration option is available.

--- a/doc/commands/advisory.8.rst
+++ b/doc/commands/advisory.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/autoremove.8.rst
+++ b/doc/commands/autoremove.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/check-upgrade.8.rst
+++ b/doc/commands/check-upgrade.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/check.8.rst
+++ b/doc/commands/check.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/clean.8.rst
+++ b/doc/commands/clean.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/debuginfo-install.rst
+++ b/doc/commands/debuginfo-install.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/distro-sync.8.rst
+++ b/doc/commands/distro-sync.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/downgrade.8.rst
+++ b/doc/commands/downgrade.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/environment.8.rst
+++ b/doc/commands/environment.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/history.8.rst
+++ b/doc/commands/history.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/info.8.rst
+++ b/doc/commands/info.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/install.8.rst
+++ b/doc/commands/install.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/leaves.8.rst
+++ b/doc/commands/leaves.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/list.8.rst
+++ b/doc/commands/list.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/makecache.8.rst
+++ b/doc/commands/makecache.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/mark.8.rst
+++ b/doc/commands/mark.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/module.8.rst
+++ b/doc/commands/module.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/offline.8.rst
+++ b/doc/commands/offline.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/provides.8.rst
+++ b/doc/commands/provides.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/reinstall.8.rst
+++ b/doc/commands/reinstall.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/replay.8.rst
+++ b/doc/commands/replay.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/repo.8.rst
+++ b/doc/commands/repo.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/search.8.rst
+++ b/doc/commands/search.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/swap.8.rst
+++ b/doc/commands/swap.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/system-upgrade.8.rst
+++ b/doc/commands/system-upgrade.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/upgrade.8.rst
+++ b/doc/commands/upgrade.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/commands/versionlock.8.rst
+++ b/doc/commands/versionlock.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5.conf-deprecated.5.rst
+++ b/doc/dnf5.conf-deprecated.5.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5.conf-todo.5.rst
+++ b/doc/dnf5.conf-todo.5.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/builddep.8.rst
+++ b/doc/dnf5_plugins/builddep.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/changelog.8.rst
+++ b/doc/dnf5_plugins/changelog.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/config-manager.8.rst
+++ b/doc/dnf5_plugins/config-manager.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/copr.8.rst
+++ b/doc/dnf5_plugins/copr.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/needs_restarting.8.rst
+++ b/doc/dnf5_plugins/needs_restarting.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/repoclosure.8.rst
+++ b/doc/dnf5_plugins/repoclosure.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/repomanage.8.rst
+++ b/doc/dnf5_plugins/repomanage.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf5_plugins/reposync.8.rst
+++ b/doc/dnf5_plugins/reposync.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf_daemon/dnf5daemon_client.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_client.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_dbus_api.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/dnf_daemon/dnf5daemon_server.8.rst
+++ b/doc/dnf_daemon/dnf5daemon_server.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/libdnf5_plugins/expired-pgp-keys.8.rst
+++ b/doc/libdnf5_plugins/expired-pgp-keys.8.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/aliases.7.rst
+++ b/doc/misc/aliases.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/caching.7.rst
+++ b/doc/misc/caching.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -18,8 +18,9 @@
     You should have received a copy of the GNU General Public License
     along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
-.. TODO(jkolarik): Add link to modularity in "What are the metadata types" when the page exists
-.. TODO(jkolarik): Add link to dnf5.conf options when the page exists
+..
+    TODO(jkolarik): Add link to modularity in "What are the metadata types" when the page exists
+    TODO(jkolarik): Add link to dnf5.conf options when the page exists
 
 
 .. _caching_misc_ref-label:

--- a/doc/misc/comps.7.rst
+++ b/doc/misc/comps.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/filtering.7.rst
+++ b/doc/misc/filtering.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/forcearch.7.rst
+++ b/doc/misc/forcearch.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/installroot.7.rst
+++ b/doc/misc/installroot.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/modularity.7.rst
+++ b/doc/misc/modularity.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/specs.7.rst
+++ b/doc/misc/specs.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/doc/misc/system-state.7.rst
+++ b/doc/misc/system-state.7.rst
@@ -1,5 +1,5 @@
-.. Copyright Contributors to the DNF5 project.
 ..
+    Copyright Contributors to the DNF5 project.
     Copyright Contributors to the libdnf project.
     SPDX-License-Identifier: GPL-2.0-or-later
 


### PR DESCRIPTION
Convert single-line comments to multiline format in all RST documentation files. RST parsers process even single-line comments, so using multiline format is more appropriate.

The `'..'` prefix is critical in reStructuredText (RST) as it defines not only a comment but also **directives** (e.g., `'.. image::'` or `'.. toctree::'`) and **footnotes**. Using a single-line `'..'` for a pure comment, especially when not separated by blank lines, increases the risk of the parser misinterpreting subsequent content as part of a directive or a structural element.