### PR TITLE
Add metalink exclude options to configuration

### DIFF
--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -244,6 +244,10 @@ public:
     const OptionStringAppendList & get_exclude_from_weak_option() const;
     OptionBool & get_exclude_from_weak_autodetect_option();
     const OptionBool & get_exclude_from_weak_autodetect_option() const;
+    OptionStringAppendList & get_metalink_exclude_domain_option();
+    const OptionStringAppendList & get_metalink_exclude_domain_option() const;
+    OptionStringAppendList & get_metalink_exclude_location_option();
+    const OptionStringAppendList & get_metalink_exclude_location_option() const;
     OptionString & get_proxy_option();
     const OptionString & get_proxy_option() const;
     OptionString & get_proxy_username_option();

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -245,6 +245,8 @@ class ConfigMain::Impl {
     OptionStringAppendList includepkgs{std::vector<std::string>{}};
     OptionStringAppendList exclude_from_weak{std::vector<std::string>{}};
     OptionBool exclude_from_weak_autodetect{true};
+    OptionStringAppendList metalink_exclude_domain{std::vector<std::string>{}};
+    OptionStringAppendList metalink_exclude_location{std::vector<std::string>{}};
     OptionString proxy{""};
     OptionString proxy_username{nullptr};
     OptionString proxy_password{nullptr};
@@ -423,6 +425,8 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("includepkgs", includepkgs);
     owner.opt_binds().add("exclude_from_weak", exclude_from_weak);
     owner.opt_binds().add("exclude_from_weak_autodetect", exclude_from_weak_autodetect);
+    owner.opt_binds().add("metalink_exclude_domain", metalink_exclude_domain);
+    owner.opt_binds().add("metalink_exclude_location", metalink_exclude_location);
     owner.opt_binds().add("proxy", proxy);
     owner.opt_binds().add("proxy_username", proxy_username);
     owner.opt_binds().add("proxy_password", proxy_password);
@@ -1121,6 +1125,22 @@ const OptionBool & ConfigMain::get_exclude_from_weak_autodetect_option() const {
     return p_impl->exclude_from_weak_autodetect;
 }
 
+OptionStringAppendList & ConfigMain::get_metalink_exclude_domain_option() {
+    return p_impl->metalink_exclude_domain;
+}
+
+const OptionStringAppendList & ConfigMain::get_metalink_exclude_domain_option() const {
+    return p_impl->metalink_exclude_domain;
+}
+
+OptionStringAppendList & ConfigMain::get_metalink_exclude_location_option() {
+    return p_impl->metalink_exclude_location;
+}
+
+const OptionStringAppendList & ConfigMain::get_metalink_exclude_location_option() const {
+    return p_impl->metalink_exclude_location;
+}
+
 OptionString & ConfigMain::get_proxy_option() {
     return p_impl->proxy;
 }
@@ -1459,6 +1479,8 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(includepkgs, other.includepkgs);
     load_option(exclude_from_weak, other.exclude_from_weak);
     load_option(exclude_from_weak_autodetect, other.exclude_from_weak_autodetect);
+    load_option(metalink_exclude_domain, other.metalink_exclude_domain);
+    load_option(metalink_exclude_location, other.metalink_exclude_location);
     load_option(proxy, other.proxy);
     load_option(proxy_username, other.proxy_username);
     load_option(proxy_password, other.proxy_password);

--- a/test/libdnf5/conf/test_config_parser.hpp
+++ b/test/libdnf5/conf/test_config_parser.hpp
@@ -38,6 +38,7 @@ class ConfigParserTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_read_write_with_comments_header);
     CPPUNIT_TEST(test_read_write_crazy);
     CPPUNIT_TEST(test_read_modify_write);
+    CPPUNIT_TEST(test_metalink_exclude_options);
 #endif
 
     CPPUNIT_TEST_SUITE_END();
@@ -56,6 +57,7 @@ public:
     void test_read_write_with_comments_header();
     void test_read_write_crazy();
     void test_read_modify_write();
+    void test_metalink_exclude_options();
 };
 
 #endif


### PR DESCRIPTION
This update introduces two new configuration options: `metalink_exclude_domain` and `metalink_exclude_location`. These options allow users to specify domains and locations to exclude when using metalink sources.

Requires: https://github.com/rpm-software-management/librepo/pull/357
Fixes: https://github.com/rpm-software-management/dnf5/issues/1483
