### PR TITLE
manifest docs: mark as experimental

### DIFF
--- a/doc/dnf5_plugins/manifest.8.rst
+++ b/doc/dnf5_plugins/manifest.8.rst
@@ -9,6 +9,10 @@
  Manifest Command
 ##################
 
+.. warning::
+   The manifest plugin is under development and considered experimental. The
+   interface and behavior may change.
+
 Synopsis
 ========
 


### PR DESCRIPTION
I would still like the opportunity to modify the interface and behavior here. Let's mark the manifest plugin as experimental for now.