### PR TITLE
advisory: Add JSON documentation, standardize timestamps, and suppress error messages in JSON format

### DIFF
--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -68,7 +68,6 @@ void AdvisoryInfoCommand::process_and_print_queries(
             advisory_info.add_advisory(cli_advisory);
         }
         advisory_info.print();
-        std::cout << std::endl;
     } else {
         for (auto advisory : advisories) {
             libdnf5::cli::output::AdvisoryInfo advisory_info;

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -81,6 +81,7 @@ void AdvisorySubCommand::configure() {
 void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
+    ErrorHandling error_mode = determine_error_mode(ctx, false);
     auto advisories_opt = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_specs->get_value(),
@@ -91,7 +92,7 @@ void AdvisorySubCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        false);
+        error_mode);
 
     auto advisories = advisories_opt.value_or(libdnf5::advisory::AdvisoryQuery(ctx.get_base()));
 

--- a/dnf5/commands/check-upgrade/check-upgrade.cpp
+++ b/dnf5/commands/check-upgrade/check-upgrade.cpp
@@ -163,6 +163,7 @@ void CheckUpgradeCommand::run() {
 
     // filter by advisory flags, e.g. `--security`
     size_t size_before_filter_advisories = upgrades_query.size();
+    ErrorHandling error_mode = determine_error_mode(ctx, false);
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),
@@ -173,7 +174,7 @@ void CheckUpgradeCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        false);
+        error_mode);
     if (advisories.has_value()) {
         upgrades_query.filter_latest_unresolved_advisories(
             std::move(advisories.value()), installed_query, libdnf5::sack::QueryCmp::GTE);

--- a/dnf5/commands/do/do.cpp
+++ b/dnf5/commands/do/do.cpp
@@ -233,6 +233,8 @@ void DoCommand::run() {
     auto & ctx = get_context();
     auto goal = get_context().get_goal();
     goal->set_allow_erasing(allow_erasing->get_value());
+    ErrorHandling error_mode =
+        determine_error_mode(ctx, !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),
@@ -243,7 +245,7 @@ void DoCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
+        error_mode);
 
     for (auto & item : install_items) {
         if (advisories) {

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -94,6 +94,8 @@ void InstallCommand::run() {
     goal->set_allow_erasing(allow_erasing->get_value());
     auto settings = libdnf5::GoalJobSettings();
     settings.set_to_repo_ids(from_repos);
+    ErrorHandling error_mode =
+        determine_error_mode(ctx, !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),
@@ -104,7 +106,7 @@ void InstallCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
+        error_mode);
     if (advisories.has_value()) {
         settings.set_advisory_filter(std::move(advisories.value()));
     }

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -632,6 +632,7 @@ void RepoqueryCommand::run() {
 
     // APPLY SIMPLE FILTERS - It doesn't matter if the packages are from system or available repo
 
+    ErrorHandling error_mode = determine_error_mode(ctx, false);
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),
@@ -642,7 +643,7 @@ void RepoqueryCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        false);
+        error_mode);
     if (advisories.has_value()) {
         result_query.filter_advisories(advisories.value(), libdnf5::sack::QueryCmp::GTE);
     }

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -127,6 +127,8 @@ void UpgradeCommand::run() {
 
     settings.set_from_repo_ids(installed_from_repos);
 
+    ErrorHandling error_mode =
+        determine_error_mode(ctx, !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
     auto advisories = advisory_query_from_cli_input(
         ctx.get_base(),
         advisory_name->get_value(),
@@ -137,7 +139,7 @@ void UpgradeCommand::run() {
         advisory_severity->get_value(),
         advisory_bz->get_value(),
         advisory_cve->get_value(),
-        !ctx.get_base().get_config().get_skip_unavailable_option().get_value());
+        error_mode);
     if (advisories.has_value()) {
         settings.set_advisory_filter(std::move(advisories.value()));
     }

--- a/doc/commands/advisory.8.rst
+++ b/doc/commands/advisory.8.rst
@@ -92,6 +92,10 @@ Options
 ``--with-cve``
     | Show only advisories referencing a CVE ticket.
 
+``--json``
+    | Request JSON output format for machine-readable results.
+    | Available for ``list`` and ``info`` subcommands only.
+
 
 Examples
 ========
@@ -104,3 +108,72 @@ Examples
 
 ``dnf5 advisory list --security --advisory-severities=important``
     | Show a list of security advisories or advisories with ``important`` severity.
+
+``dnf5 advisory list --json``
+    | List all advisories in JSON format for programmatic processing.
+
+``dnf5 advisory list --json --with-cve``
+    | List advisories with CVE references in JSON format (extended format).
+
+``dnf5 advisory info FEDORA-2022-07aa56297a --json``
+    | Show detailed info about advisory in JSON format.
+
+
+JSON Output
+===========
+
+* ``dnf5 advisory list --json``
+
+The command returns a JSON array, each element describing one advisory.
+
+**Basic format** (without ``--with-cve`` or ``--with-bz``):
+
+- ``name`` (string) - Advisory identifier.
+- ``type`` (string) - Advisory type (security, bugfix, enhancement).
+- ``severity`` (string) - Advisory severity level.
+- ``nevra`` (string) - Package name-epoch:version-release.architecture.
+- ``buildtime`` (integer) - Advisory build time, UNIX time.
+
+**Extended format** (with ``--with-cve`` or ``--with-bz``):
+
+- ``advisory_name`` (string) - Advisory identifier.
+- ``advisory_type`` (string) - Advisory type (security, bugfix, enhancement).
+- ``advisory_severity`` (string) - Advisory severity level.
+- ``advisory_buildtime`` (integer) - Advisory build time, UNIX time.
+- ``nevra`` (string) - Package name-epoch:version-release.architecture.
+- ``references`` (array) - List of references (CVE/Bugzilla). Each reference contains:
+
+  - ``reference_id`` (string) - Reference identifier (e.g., CVE-2024-1234).
+  - ``reference_type`` (string) - Reference type (cve or bugzilla).
+
+* ``dnf5 advisory info --json``
+
+The command returns a JSON array, each element containing detailed advisory information.
+Each advisory object contains the following fields:
+
+- ``Name`` (string) - Advisory name/identifier.
+- ``Title`` (string) - Advisory title.
+- ``Type`` (string) - Advisory type (security, bugfix, enhancement).
+- ``Severity`` (string) - Advisory severity level.
+- ``Status`` (string) - Advisory status.
+- ``Vendor`` (string) - Advisory vendor.
+- ``Issued`` (integer) - Advisory issue time, UNIX time.
+- ``Description`` (string) - Detailed advisory description.
+- ``Message`` (string) - Advisory message.
+- ``Rights`` (string) - Advisory rights/copyright information.
+- ``references`` (array) - List of references (CVE, Bugzilla, etc.). Each reference contains:
+
+  - ``Title`` (string) - Reference title.
+  - ``Id`` (string) - Reference identifier (e.g., CVE-2024-1234).
+  - ``Type`` (string) - Reference type (cve, bugzilla, etc.).
+  - ``Url`` (string) - Reference URL.
+
+- ``collections`` (object) - Package and module collections affected by the advisory:
+
+  - ``packages`` (array) - List of affected package NEVRAs (only present if packages exist).
+  - ``modules`` (array) - List of affected module NSVCAs (only present if modules exist).
+
+For empty results:
+
+- ``dnf5 advisory list --json`` returns ``[]`` (empty array).
+- ``dnf5 advisory info --json`` returns ``[]`` (empty array).

--- a/libdnf5-cli/output/advisoryinfo.cpp
+++ b/libdnf5-cli/output/advisoryinfo.cpp
@@ -35,7 +35,7 @@ public:
 
 class AdvisoryInfoJSON::Impl {
 public:
-    Impl() { json_advisories = json_object_new_object(); };
+    Impl() { json_advisories = json_object_new_array(); };
     ~Impl() { json_object_put(json_advisories); };
     void add_advisory(IAdvisory & advisory);
     void print() {
@@ -96,6 +96,7 @@ void AdvisoryInfo::Impl::add_advisory(IAdvisory & advisory) {
     }
 }
 
+// [NOTE] When editing JSON output format, do not forget to update the docs at doc/commands/advisory.8.rst
 void AdvisoryInfoJSON::Impl::add_advisory(IAdvisory & advisory) {
     json_object * json_advisory = json_object_new_object();
     json_object_object_add(json_advisory, "Name", json_object_new_string(advisory.get_name().c_str()));
@@ -105,9 +106,7 @@ void AdvisoryInfoJSON::Impl::add_advisory(IAdvisory & advisory) {
     json_object_object_add(json_advisory, "Status", json_object_new_string(advisory.get_status().c_str()));
     json_object_object_add(json_advisory, "Vendor", json_object_new_string(advisory.get_vendor().c_str()));
     json_object_object_add(
-        json_advisory,
-        "Issued",
-        json_object_new_string(libdnf5::utils::string::format_epoch(advisory.get_buildtime()).c_str()));
+        json_advisory, "Issued", json_object_new_int64(static_cast<int64_t>(advisory.get_buildtime())));
     json_object_object_add(json_advisory, "Description", json_object_new_string(advisory.get_description().c_str()));
     json_object_object_add(json_advisory, "Message", json_object_new_string(advisory.get_message().c_str()));
     json_object_object_add(json_advisory, "Rights", json_object_new_string(advisory.get_rights().c_str()));
@@ -148,7 +147,7 @@ void AdvisoryInfoJSON::Impl::add_advisory(IAdvisory & advisory) {
         }
         json_object_object_add(json_advisory, "collections", json_collections);
     }
-    json_object_object_add(json_advisories, advisory.get_name().c_str(), json_advisory);
+    json_object_array_add(json_advisories, json_advisory);
 }
 
 

--- a/libdnf5-cli/output/advisorylist.cpp
+++ b/libdnf5-cli/output/advisorylist.cpp
@@ -123,8 +123,7 @@ static json_object * adv_pkg_as_json(auto & adv_pkg) {
     json_object_object_add(json_advisory, "severity", json_object_new_string(advisory->get_severity().c_str()));
     json_object_object_add(json_advisory, "nevra", json_object_new_string(adv_pkg->get_nevra().c_str()));
     unsigned long long buildtime = advisory->get_buildtime();
-    json_object_object_add(
-        json_advisory, "buildtime", json_object_new_string(libdnf5::utils::string::format_epoch(buildtime).c_str()));
+    json_object_object_add(json_advisory, "buildtime", json_object_new_int64(static_cast<int64_t>(buildtime)));
     return json_advisory;
 }
 
@@ -134,10 +133,7 @@ static json_object * adv_refs_as_json(auto & reference_type, auto & adv_pkg, aut
     json_object_object_add(json_advisory, "advisory_type", json_object_new_string(advisory.get_type().c_str()));
     json_object_object_add(json_advisory, "advisory_severity", json_object_new_string(advisory.get_type().c_str()));
     unsigned long long buildtime = advisory.get_buildtime();
-    json_object_object_add(
-        json_advisory,
-        "advisory_buildtime",
-        json_object_new_string(libdnf5::utils::string::format_epoch(buildtime).c_str()));
+    json_object_object_add(json_advisory, "advisory_buildtime", json_object_new_int64(static_cast<int64_t>(buildtime)));
     json_object_object_add(json_advisory, "nevra", json_object_new_string(adv_pkg.get_nevra().c_str()));
 
     json_object * json_adv_references = json_object_new_array();
@@ -153,6 +149,7 @@ static json_object * adv_refs_as_json(auto & reference_type, auto & adv_pkg, aut
 }
 
 
+// [NOTE] When editing JSON output format, do not forget to update the docs at doc/commands/advisory.8.rst
 void print_advisorylist_json(
     std::vector<std::unique_ptr<IAdvisoryPackage>> & advisory_package_list_not_installed,
     std::vector<std::unique_ptr<IAdvisoryPackage>> & advisory_package_list_installed) {
@@ -207,6 +204,7 @@ void print_advisorylist_references_table(
     scols_unref_table(table);
 }
 
+// [NOTE] When editing JSON output format, do not forget to update the docs at doc/commands/advisory.8.rst
 void print_advisorylist_references_json(
     std::vector<libdnf5::advisory::AdvisoryPackage> & advisory_package_list_not_installed,
     std::vector<libdnf5::advisory::AdvisoryPackage> & advisory_package_list_installed,


### PR DESCRIPTION
Add JSON format documentation for advisory commands, standardize timestamp
format, and implement enum-based error handling to maintain consistency
 with other JSON command outputs.

 Changes:
- Add JSON documentation for advisory list and info commands
- Change timestamps from ISO strings to UNIX integers for consistency
- Change advisory info JSON output from object to array format
- Replace boolean error handling flags with ErrorHandling enum
- Add determine_error_mode() helper function for centralized error mode selection
- Suppress error messages in JSON mode for clean programmatic output

Fixes #2476
Fixes #2493
