### PR TITLE
fix: do not prefilter when querying for SRPMs

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -842,16 +842,21 @@ void RepoqueryCommand::run() {
 
     if (srpm->get_value()) {
         libdnf5::rpm::PackageQuery srpms(ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
-        auto only_src_query = result_query;
+
+        libdnf5::rpm::PackageQuery only_src_query(ctx.get_base());
         only_src_query.filter_arch(std::vector<std::string>{"src", "nosrc"});
+
         for (const auto & pkg : result_query) {
-            if (!pkg.get_sourcerpm().empty()) {
-                auto tmp_q = only_src_query;
-                tmp_q.filter_name({pkg.get_source_name()});
-                tmp_q.filter_evr({pkg.get_evr()});
-                srpms |= tmp_q;
+            if (pkg.get_sourcerpm().empty()) {
+                continue;
             }
+
+            auto tmp_q = only_src_query;
+            tmp_q.filter_name({pkg.get_source_name()});
+            tmp_q.filter_evr({pkg.get_evr()});
+            srpms |= tmp_q;
         }
+
         result_query = srpms;
     }
 


### PR DESCRIPTION
When querying for the SRPMs, we iterate through the packages based on the arguments from the CLI, prefiltering the SRPMs based on the same criteria can lead to exclusion of some packages, e.g., common case is SRPM providing multiple RPM packages (e.g., `foo` provides both `foo` and `python3-foo`, but such prefiltering could result in not outputting the SRPM for `python3-foo`).

Fixes #2414
Merge with rpm-software-management/ci-dnf-stack#1781

### TODO

- [x] Where do I add tests for this?
  - https://github.com/rpm-software-management/ci-dnf-stack/pull/1781