### PR TITLE
Add --oldinstallonly option to remove command

### DIFF
--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -20,6 +20,14 @@
 #include "remove.hpp"
 
 #include <dnf5/shared_options.hpp>
+#include <libdnf5-cli/argument_parser_errors.hpp>
+#include <libdnf5/conf/option_number.hpp>
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/rpm/package_sack.hpp>
+#include <libdnf5/utils/bgettext/bgettext-mark.h>
+#include <libdnf5/utils/format.hpp>
+
+#include <map>
 
 namespace dnf5 {
 
@@ -48,7 +56,27 @@ void RemoveCommand::set_argument_parser() {
     noautoremove->link_value(&ctx.get_base().get_config().get_clean_requirements_on_remove_option());
     cmd.register_named_arg(noautoremove);
 
-    auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
+    oldinstallonly = dynamic_cast<libdnf5::OptionBool *>(
+        parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));
+    auto oldinstallonly_opt = parser.add_new_named_arg("oldinstallonly");
+    oldinstallonly_opt->set_long_name("oldinstallonly");
+    oldinstallonly_opt->set_description("Remove old installonly packages");
+    oldinstallonly_opt->set_const_value("true");
+    oldinstallonly_opt->link_value(oldinstallonly);
+    cmd.register_named_arg(oldinstallonly_opt);
+
+    oldinstallonly_limit = dynamic_cast<libdnf5::OptionNumber<std::int32_t> *>(parser.add_init_value(
+        std::unique_ptr<libdnf5::OptionNumber<std::int32_t>>(new libdnf5::OptionNumber<std::int32_t>(0))));
+    auto limit_opt = parser.add_new_named_arg("limit");
+    limit_opt->set_long_name("limit");
+    limit_opt->set_has_value(true);
+    limit_opt->set_arg_value_help("LIMIT");
+    limit_opt->set_description(
+        "Limit the number of installonly package versions to keep (must be >=1, used with --oldinstallonly)");
+    limit_opt->link_value(oldinstallonly_limit);
+    cmd.register_named_arg(limit_opt);
+
+    auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::UNLIMITED, nullptr, nullptr);
     keys->set_description("List of <package-spec-NF>|@<group-spec>|@<environment-spec> to remove");
     keys->set_parse_hook_func(
         [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
@@ -71,21 +99,122 @@ void RemoveCommand::configure() {
 }
 
 void RemoveCommand::run() {
-    auto goal = get_context().get_goal();
+    auto & ctx = get_context();
+    auto goal = ctx.get_goal();
 
-    // Limit remove spec capabity to prevent multiple matches. Remove command should not match anything after performing
-    // a remove action with the same spec. NEVRA and filenames are the only types that have no overlaps.
-    libdnf5::GoalJobSettings settings;
-    settings.set_from_repo_ids(installed_from_repos);
-    settings.set_with_nevra(true);
-    settings.set_with_provides(false);
-    settings.set_with_filenames(true);
-    settings.set_with_binaries(false);
-    for (const auto & spec : pkg_specs) {
-        goal->add_remove(spec, settings);
+    if (oldinstallonly->get_value()) {
+        auto & base = ctx.get_base();
+        auto & cfg_main = base.get_config();
+        std::int32_t installonly_limit;
+
+        if (oldinstallonly_limit->get_priority() >= libdnf5::Option::Priority::COMMANDLINE) {
+            installonly_limit = oldinstallonly_limit->get_value();
+            if (installonly_limit < 1) {
+                throw libdnf5::cli::ArgumentParserInvalidValueError(
+                    M_("Option '--limit' must be equal or greater than 1 (to keep at least the newest installed "
+                       "package)."));
+            }
+        } else {
+            installonly_limit = static_cast<std::int32_t>(cfg_main.get_installonly_limit_option().get_value());
+        }
+
+        libdnf5::rpm::PackageQuery installed_installonly(base);
+        installed_installonly.filter_installed();
+        installed_installonly.filter_installonly();
+
+        // If package specs provided, filter to only those packages
+        if (!pkg_specs.empty()) {
+            libdnf5::rpm::PackageQuery filtered_query(base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
+            for (const auto & spec : pkg_specs) {
+                libdnf5::rpm::PackageQuery spec_query(installed_installonly);
+                spec_query.filter_name({spec}, libdnf5::sack::QueryCmp::GLOB);
+                filtered_query |= spec_query;
+            }
+            installed_installonly = filtered_query;
+        }
+
+        // Detect the running kernel so we can skip it instead of causing an error.
+        auto running_kernel = base.get_rpm_package_sack()->get_running_kernel();
+        auto running_kernel_id = running_kernel.get_id();
+        std::string running_kernel_epoch;
+        std::string running_kernel_version;
+        std::string running_kernel_release;
+        std::string running_kernel_arch;
+        if (running_kernel_id.id > 0) {
+            running_kernel_epoch = running_kernel.get_epoch();
+            running_kernel_version = running_kernel.get_version();
+            running_kernel_release = running_kernel.get_release();
+            running_kernel_arch = running_kernel.get_arch();
+            running_kernel_nevra = running_kernel_version + "-" + running_kernel_release + "." + running_kernel_arch;
+        }
+
+        std::map<std::string, std::vector<libdnf5::rpm::Package>> packages_by_name;
+        for (const auto & pkg : installed_installonly) {
+            packages_by_name[pkg.get_name()].push_back(pkg);
+        }
+
+        for (auto & [name, packages] : packages_by_name) {
+            if (installonly_limit > 0 && packages.size() > static_cast<size_t>(installonly_limit)) {
+                // Sort packages newest first by inverting the comparator
+                // cmp_nevra(a, b) returns true if a < b (ascending/oldest first)
+                // So we swap arguments to get descending/newest first
+                std::sort(packages.begin(), packages.end(), [](const auto & a, const auto & b) {
+                    return libdnf5::rpm::cmp_nevra(b, a);
+                });
+
+                // Keep the first installonly_limit packages (newest), remove the rest (oldest)
+                for (size_t i = static_cast<size_t>(installonly_limit); i < packages.size(); ++i) {
+                    if (!running_kernel_version.empty() && packages[i].get_epoch() == running_kernel_epoch &&
+                        packages[i].get_version() == running_kernel_version &&
+                        packages[i].get_release() == running_kernel_release &&
+                        packages[i].get_arch() == running_kernel_arch) {
+                        running_kernel_skipped = true;
+                        continue;
+                    }
+                    goal->add_rpm_remove(packages[i]);
+                }
+            }
+        }
+    } else {
+        // Validate that --limit requires --oldinstallonly
+        if (oldinstallonly_limit->get_value() > 0) {
+            throw libdnf5::cli::ArgumentParserMissingDependentArgumentError(
+                M_("Option '--limit' can only be used with '--oldinstallonly'."));
+        }
+
+        if (pkg_specs.empty()) {
+            throw libdnf5::cli::ArgumentParserMissingCommandError(
+                M_("Missing positional arguments for \"remove\" command. "
+                   "Add \"--help\" for more information about the arguments."));
+        }
+
+        // Limit remove spec capabity to prevent multiple matches. Remove command should not match anything after performing
+        // a remove action with the same spec. NEVRA and filenames are the only types that have no overlaps.
+        libdnf5::GoalJobSettings settings;
+        settings.set_from_repo_ids(installed_from_repos);
+        settings.set_with_nevra(true);
+        settings.set_with_provides(false);
+        settings.set_with_filenames(true);
+        settings.set_with_binaries(false);
+        for (const auto & spec : pkg_specs) {
+            goal->add_remove(spec, settings);
+        }
     }
+
     // To enable removal of dependency packages it requires to use allow_erasing
     goal->set_allow_erasing(true);
+}
+
+void RemoveCommand::goal_resolved() {
+    Command::goal_resolved();
+
+    if (running_kernel_skipped) {
+        auto & ctx = get_context();
+        ctx.print_info(libdnf5::utils::sformat(
+            _("Warning: The currently running kernel '{}' is not the latest installed version and was not removed. "
+              "Please reboot into the latest kernel and run this command again to complete the cleanup."),
+            running_kernel_nevra));
+    }
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -35,10 +35,15 @@ public:
     void set_argument_parser() override;
     void configure() override;
     void run() override;
+    void goal_resolved() override;
 
 private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> installed_from_repos;
+    libdnf5::OptionBool * oldinstallonly{nullptr};
+    libdnf5::OptionNumber<std::int32_t> * oldinstallonly_limit{nullptr};
+    bool running_kernel_skipped{false};
+    std::string running_kernel_nevra;
 };
 
 }  // namespace dnf5

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -29,6 +29,8 @@ Synopsis
 
 ``dnf5 remove [options] <package-spec-NF>|@<group-spec>|@<environment-spec>...``
 
+``dnf5 remove --oldinstallonly [--limit=<LIMIT>] [<package-spec-NF>...]``
+
 
 Description
 ===========
@@ -39,6 +41,11 @@ environments from the system.
 If you want to keep the dependencies that were installed together with the given package,
 set the ``clean_requirements_on_remove`` configuration option to ``False``.
 
+When the ``--oldinstallonly`` option is used, the command removes old installonly packages
+(e.g. kernels) that exceed the configured ``installonly_limit``. The currently running kernel
+is never removed. If package specs are provided, only matching installonly packages are
+considered for removal.
+
 
 Options
 =======
@@ -48,6 +55,15 @@ Options
 ``--no-autoremove``
     | Disable removal of dependencies that are no longer used.
 
+``--oldinstallonly``
+    | Remove old installonly packages that exceed the ``installonly_limit`` configuration value.
+    | When used without package specs, all installonly package types are considered.
+    | The currently running kernel is automatically skipped.
+
+``--limit=<LIMIT>``
+    | Override the ``installonly_limit`` configuration value. Must be greater than or equal to 1
+      to keep at least the newest installed version. Can only be used with ``--oldinstallonly``.
+
 .. include:: ../_shared/options/transaction.rst
 
 
@@ -56,6 +72,15 @@ Examples
 
 ``dnf5 remove tito``
     | Remove the ``tito`` package.
+
+``dnf5 remove --oldinstallonly``
+    | Remove all old installonly packages exceeding the configured ``installonly_limit``.
+
+``dnf5 remove --oldinstallonly kernel``
+    | Remove old kernel packages exceeding the configured ``installonly_limit``.
+
+``dnf5 remove --oldinstallonly --limit=2``
+    | Remove old installonly packages, keeping only the 2 newest versions of each.
 
 
 See Also


### PR DESCRIPTION
Adds `--oldinstallonly` flag to remove old installonly packages (e.g., kernels) that exceed the configured installonly_limit. 

Optional `--limit` parameter allows overriding the config value (must be >1 to keep newest installed version).

Usage:
```
  dnf5 remove --oldinstallonly              # Remove all old installonly pkgs
  dnf5 remove --oldinstallonly kernel       # Remove old kernels only
  dnf5 remove --oldinstallonly --limit=2    # Keep only 2 newest versions
```

ci-tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1782

Closes: #762