### PR TITLE
Use newer version of packit/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
   - id: rpmlint
   # Passes if packit not installed. Needed for validation locally
 - repo: https://github.com/packit/pre-commit-hooks
-  rev: v1.2.0
+  rev: v1.3.0
   hooks:
   - id: validate-config


### PR DESCRIPTION
Since packit 1.6.0 `validate-config` was changed to `config validate`, new version of packit/pre-commit-hooks supports both.

This started to happen now because since https://github.com/rpm-software-management/ci-dnf-stack/pull/1771 packit is installed in `dnf-ci-host`. Previously without packit the `pre-commit - Validate package config` check was a no-op.