### PR TITLE
transaction: sort packages when SOURCE_DATE_EPOCH set

### DIFF
--- a/test/data/repos-rpm/rpm-repo3/three-1-1.spec
+++ b/test/data/repos-rpm/rpm-repo3/three-1-1.spec
@@ -1,0 +1,18 @@
+Name:           three
+Epoch:          0
+Version:        1
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A dummy package
+BuildArch:      noarch
+
+%description
+A dummy package.
+
+%files
+
+%changelog

--- a/test/libdnf5/rpm/test_transaction.hpp
+++ b/test/libdnf5/rpm/test_transaction.hpp
@@ -31,11 +31,13 @@ class RpmTransactionTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(RpmTransactionTest);
     CPPUNIT_TEST(test_transaction);
     CPPUNIT_TEST(test_transaction_temp_files_cleanup);
+    CPPUNIT_TEST(test_source_date_epoch_sorting);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void test_transaction();
     void test_transaction_temp_files_cleanup();
+    void test_source_date_epoch_sorting();
 };
 
 #endif


### PR DESCRIPTION
For reproducible builds that involve RPMs, the exact order in which packages are installed matters. This affects some files that are easy to normalize in postprocessing (e.g. `/etc/passwd` line order), but it also affects the rpmdb, where e.g. row order may change. See this comment and following:

https://github.com/rpm-software-management/rpm/issues/2219#issuecomment-3220396780

This was fixed for the rpm-ostree use case by sorting the packages before adding them to the transaction and calling rpmtsOrder():

https://github.com/coreos/rpm-ostree/pull/5469

This is the dnf equivalent.

We only do this if SOURCE_DATE_EPOCH is defined for two reasons:
1. It reduces risk by limiting it to the group of people who actually care about these details. (Though ironically, this change itself will cause a rebuild of reproducible artifacts.)
2. It mitigates the concern raised in the linked discussions regarding well-defined reordering possibly masking bugs in RPMs that unknowingly rely on a specific order.

Ideally, this functionality would live on the rpm side instead. For the same reasons as above, this would also likely have to be an opt-in flag. Once we have that though, the logic here could be simplified.

Assisted-by: Claude Code / Sonnet 4.5