### PR TITLE
Bindings: add iterator to libdnf5::OptionBinds

### DIFF
--- a/test/python3/libdnf5/conf/test_option.py
+++ b/test/python3/libdnf5/conf/test_option.py
@@ -88,3 +88,16 @@ class TestConfigurationOptions(base_test_case.BaseTestCase):
     def test_get_unknown_option_by_attribute(self):
         config = self.base.get_config()
         self.assertRaises(AttributeError, lambda: config.xyz)
+
+    def test_iterate_options(self):
+        config = self.base.get_config()
+
+        config.proxy = 'abcd'
+
+        proxy_option = None
+        for option in config.opt_binds():
+            if option.first == 'proxy':
+                proxy_option = (option.first, option.second.get_value_string())
+                break
+
+        self.assertEqual(proxy_option, ('proxy', 'abcd'))

--- a/test/python3/libdnf5/repo/test_repo.py
+++ b/test/python3/libdnf5/repo/test_repo.py
@@ -108,3 +108,17 @@ class TestRepo(base_test_case.BaseTestCase):
         self.assertEqual(dl_cbs.fastest_mirror_cnt, 0)
         self.assertEqual(dl_cbs.handle_mirror_failure_cnt, 0)
         self.assertEqual(cbs.repokey_import_cnt, 0)
+
+    def test_iterate_config_options(self):
+        repoid = "repomd-repo1"
+        repo = self.add_repo_repomd(repoid, load=False)
+        config = repo.get_config()
+
+        config.proxy = 'abcd'
+
+        proxy_option = None
+        for option in config.opt_binds():
+            if option.first == 'proxy':
+                proxy_option = (option.first, option.second.get_value_string())
+
+        self.assertEqual(proxy_option, ('proxy', 'abcd'))


### PR DESCRIPTION
This is another alternative to https://github.com/rpm-software-management/dnf5/pull/2384, based on a suggestion from https://github.com/rpm-software-management/dnf5/pull/2384#discussion_r2523972442 by @jrohel.

It also adds a couple of tests from the original PR created by @pkratoch.