### PR TITLE
Add --debuginfo option to download command

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -49,6 +49,7 @@ private:
     libdnf5::OptionBool * url_option{nullptr};
     libdnf5::OptionBool * allmirrors_option{nullptr};
     libdnf5::OptionBool * srpm_option{nullptr};
+    libdnf5::OptionBool * debuginfo_option{nullptr};
 
     std::vector<std::string> from_repos;
     std::vector<std::string> from_vendors;

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -62,6 +62,9 @@ Options
 ``--srpm``
     | Download the source rpm. Enables source repositories of all enabled binary repositories.
 
+``--debuginfo``
+    | Download the debuginfo rpm. Enables debuginfo repositories of all enabled binary repositories.
+
 ``--url``
     | Prints the list of URLs where the rpms can be downloaded instead of downloading.
 
@@ -95,6 +98,9 @@ Examples
 
 ``dnf5 download dnf5 --srpm``
     | Download the ``dnf5`` source rpm.
+
+``dnf5 download kernel --debuginfo``
+    | Download the ``kernel`` debuginfo rpm.
 
 See Also
 ========


### PR DESCRIPTION
Add a new `--debuginfo` flag to the download command that enables downloading debuginfo packages instead of regular packages.

ci test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1800

Fixes: #494 and  #948