### PR TITLE
Move libdnf5/conf/config.h creation after feature detection

### DIFF
--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -7,9 +7,6 @@ if (NOT WITH_MODULEMD)
     list(REMOVE_ITEM LIBDNF5_SOURCES ${LIBDNF5_SOURCES_MODULES})
 endif()
 
-# create config header file
-configure_file("config.h.in" ${CMAKE_CURRENT_SOURCE_DIR}/conf/config.h)
-
 # gather all pkg-config requires and write them to a .pc file later
 list(APPEND LIBDNF5_PC_REQUIRES)
 list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE)
@@ -137,6 +134,8 @@ list(JOIN LIBDNF5_PC_REQUIRES ", " LIBDNF5_PC_REQUIRES_STRING)
 list(SORT LIBDNF5_PC_REQUIRES_PRIVATE)
 list(JOIN LIBDNF5_PC_REQUIRES_PRIVATE ", " LIBDNF5_PC_REQUIRES_PRIVATE_STRING)
 
+# create config header file after feature detection is complete
+configure_file("config.h.in" ${CMAKE_CURRENT_SOURCE_DIR}/conf/config.h)
 
 # create a .pc file
 configure_file("libdnf5.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libdnf5.pc @ONLY)


### PR DESCRIPTION
Features need to be detected before they can be written down, doh. In particular this is needed for the rpmteSetVfyLevel() symbol detection from 4db642138c76474553213b0f9005a78f32fbf932, which previously only worked by chance in some incremental build cases.

Move the config header creation after all the detection is complete, next to the other configure_file() which is down there for similar reasons...

Fixes: #2479