### PR TITLE
spec: remove libpkgmanifest-devel dep from dnf5-plugin-manifest

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -926,7 +926,6 @@ License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
-Requires:       pkgconfig(libpkgmanifest)
 Provides:       dnf5-command(manifest)
 
 %description plugin-manifest


### PR DESCRIPTION
`pkgconfig(libpkgmanifest)` is already declared as a `BuildRequires` earlier in the spec.  The plugin depends only on the runtime library, whose dependency is automatically generated, but not on the -devel package.