### PR TITLE
Add --debugsource option to download command

### DIFF
--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -50,6 +50,7 @@ private:
     libdnf5::OptionBool * allmirrors_option{nullptr};
     libdnf5::OptionBool * srpm_option{nullptr};
     libdnf5::OptionBool * debuginfo_option{nullptr};
+    libdnf5::OptionBool * debugsource_option{nullptr};
 
     std::vector<std::string> from_repos;
     std::vector<std::string> from_vendors;

--- a/doc/commands/download.8.rst
+++ b/doc/commands/download.8.rst
@@ -65,6 +65,9 @@ Options
 ``--debuginfo``
     | Download the debuginfo rpm. Enables debuginfo repositories of all enabled binary repositories.
 
+``--debugsource``
+    | Download the debugsource rpm. Enables debugsource repositories of all enabled binary repositories.
+
 ``--url``
     | Prints the list of URLs where the rpms can be downloaded instead of downloading.
 


### PR DESCRIPTION
Add a new `--debugsource` flag to the download command that enables downloading debugsource packages instead of regular packages.

ci tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1799

Fixes: rpm-software-management#494 rpm-software-management#948