### PR TITLE
spec: Disable building libdnf5-plugin-local on RHEL >= 10

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -85,7 +85,12 @@ Provides:       dnf5-command(versionlock)
 %bcond_without plugin_rhsm
 %bcond_without plugin_manifest
 %bcond_without python_plugins_loader
+
+%if 0%{?rhel} >= 10
+%bcond_with plugin_local
+%else
 %bcond_without plugin_local
+%endif
 
 %bcond_without acl
 %bcond_without comps


### PR DESCRIPTION
To follow what dnf-plugins-core does and because local plugin was always a source of problems.

From RHEL 10 because sombebody could rebase it in EPEL 10.

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1798