### PR TITLE
Change package state when the reason changes to GROUP

### DIFF
--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -1149,6 +1149,8 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
                 system_state.remove_package_nevra_state(pkg.get_nevra());
             } else if (tspkg.get_action() == TransactionPackage::Action::REASON_CHANGE) {
                 if (tspkg_reason == transaction::TransactionItemReason::GROUP) {
+                    // group packages are not stored in packages.toml but in groups.toml using its name
+                    system_state.set_package_reason(pkg.get_na(), transaction::TransactionItemReason::DEPENDENCY);
                     auto group_id = *tspkg.get_reason_change_group_id();
                     auto state = system_state.get_group_state(group_id);
                     auto pkg_name = pkg.get_name();


### PR DESCRIPTION
In case of REASON_CHANGE action, the reason must change even for the
GROUP reason, even though it is not used in the package states directly
(the DEPENDENCY in combination with the package name on the list of
packages belonging to a group is used instead).

Otherwise, the package can be still considered user-installed (if that
was the original reason).

Resolves: https://github.com/rpm-software-management/dnf5/issues/935

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1803