### PR TITLE
copr: ignore case-sensitivity in the distrubution name

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_config.cpp
+++ b/dnf5-plugins/copr_plugin/copr_config.cpp
@@ -98,6 +98,7 @@ void CoprConfig::load_all_configuration() {
 
     // Set the "name_version" for the later convenience
     std::string name_version = this->get_value("main", "distribution");
+    name_version = libdnf5::utils::string::tolower(name_version);
     name_version += "-" + this->get_value("main", "releasever");
     this->set_value("main", "name_version", name_version);
 

--- a/dnf5-plugins/copr_plugin/copr_config.hpp
+++ b/dnf5-plugins/copr_plugin/copr_config.hpp
@@ -22,6 +22,7 @@
 
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/conf/config_parser.hpp>
+#include "utils/string.hpp"
 
 namespace dnf5 {
 


### PR DESCRIPTION
Fix https://github.com/fedora-copr/copr/issues/3539