### PR TITLE
Add translated_name and translated_description for comps groups in dnf5daemon

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.comps.Group.xml
@@ -50,6 +50,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
                 any group matching to any of patterns is returned
             - contains_pkgs: list of strings
                 include only groups containing given packages
+            - lang: string (default current locale)
+                language code for translated_name and translated_description attributes
 
         Unknown options are ignored.
     -->

--- a/dnf5daemon-server/group.cpp
+++ b/dnf5daemon-server/group.cpp
@@ -22,6 +22,7 @@
 #include <fmt/format.h>
 
 #include <map>
+#include <optional>
 
 
 // map string group attribute name to actual attribute
@@ -29,6 +30,8 @@ const std::map<std::string, GroupAttribute> group_attributes{
     {"groupid", GroupAttribute::groupid},
     {"name", GroupAttribute::name},
     {"description", GroupAttribute::description},
+    {"translated_name", GroupAttribute::translated_name},
+    {"translated_description", GroupAttribute::translated_description},
     {"order", GroupAttribute::order},
     {"order_int", GroupAttribute::order_int},
     {"langonly", GroupAttribute::langonly},
@@ -40,7 +43,10 @@ const std::map<std::string, GroupAttribute> group_attributes{
     {"repos", GroupAttribute::repos},
 };
 
-dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const std::vector<std::string> & attributes) {
+dnfdaemon::KeyValueMap group_to_map(
+    libdnf5::comps::Group & libdnf_group,
+    const std::vector<std::string> & attributes,
+    const std::optional<std::string> & lang) {
     dnfdaemon::KeyValueMap dbus_group;
     // add group id by default
     dbus_group.emplace(std::make_pair("groupid", libdnf_group.get_groupid()));
@@ -59,6 +65,20 @@ dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const 
                 break;
             case GroupAttribute::description:
                 dbus_group.emplace(attr, libdnf_group.get_description());
+                break;
+            case GroupAttribute::translated_name:
+                if (lang) {
+                    dbus_group.emplace(attr, libdnf_group.get_translated_name(lang->c_str()));
+                } else {
+                    dbus_group.emplace(attr, libdnf_group.get_translated_name());
+                }
+                break;
+            case GroupAttribute::translated_description:
+                if (lang) {
+                    dbus_group.emplace(attr, libdnf_group.get_translated_description(lang->c_str()));
+                } else {
+                    dbus_group.emplace(attr, libdnf_group.get_translated_description());
+                }
                 break;
             case GroupAttribute::order:
                 dbus_group.emplace(attr, libdnf_group.get_order());

--- a/dnf5daemon-server/group.hpp
+++ b/dnf5daemon-server/group.hpp
@@ -24,6 +24,7 @@
 
 #include <libdnf5/comps/group/group.hpp>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,8 @@ enum class GroupAttribute {
     groupid,
     name,
     description,
-    // TODO(mblaha): translated_name, translated_description, packages, reason
+    translated_name,
+    translated_description,
     order,
     order_int,
     langonly,
@@ -44,6 +46,9 @@ enum class GroupAttribute {
     repos,
 };
 
-dnfdaemon::KeyValueMap group_to_map(libdnf5::comps::Group & libdnf_group, const std::vector<std::string> & attributes);
+dnfdaemon::KeyValueMap group_to_map(
+    libdnf5::comps::Group & libdnf_group,
+    const std::vector<std::string> & attributes,
+    const std::optional<std::string> & lang = std::nullopt);
 
 #endif

--- a/dnf5daemon-server/services/comps/group.cpp
+++ b/dnf5daemon-server/services/comps/group.cpp
@@ -27,6 +27,7 @@
 #include <libdnf5/comps/group/query.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
+#include <optional>
 #include <string>
 
 
@@ -126,8 +127,14 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMapList out_groups;
     std::vector<std::string> attributes =
         dnfdaemon::key_value_map_get<std::vector<std::string>>(options, "attributes", std::vector<std::string>{});
+
+    // Get optional language for translations
+    std::optional<std::string> lang;
+    if (options.find("lang") != options.end()) {
+        lang = dnfdaemon::key_value_map_get<std::string>(options, "lang");
+    }
     for (auto grp : query.list()) {
-        out_groups.push_back(group_to_map(grp, attributes));
+        out_groups.push_back(group_to_map(grp, attributes, lang));
     }
 
     auto reply = call.createReply();


### PR DESCRIPTION
Expose translation support for group names and descriptions with optional language parameter. Uses current locale when lang is not specified.

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1819
Fixes: #1351