### PR TITLE
do-release workflow: use correct base branch

### DIFF
--- a/.github/workflows/do-release.yaml
+++ b/.github/workflows/do-release.yaml
@@ -17,14 +17,22 @@ jobs:
         with:
           app-id: ${{ vars.RSM_CI_APP_ID }}
           private-key: ${{ secrets.RSM_CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Create GitHub release
         run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)
           # Take the lines between the first two headers from CHANGELOG.md,
           # and use it as a description for the new release.
           CHANGELOG=$(awk 'BEGIN { first = 0 } /^# / { if (first == 0) { first = 1 } else { exit } } /^[^#]/ { print $0 }' CHANGELOG.md)
-          # Use the changelog re-calculated to create a new release
-          gh release create ${VERSION} --draft --title ${VERSION} -n "${CHANGELOG}"
+
+          gh release create ${VERSION} \
+            --target ${{ github.event.pull_request.base.ref }} \
+            --draft \
+            --title ${VERSION} \
+            -n "${CHANGELOG}"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The tag and GitHub release should be created from the base branch of the "release" PR that was just merged, not the main branch of the repository. Necessary for releasing from stable branches, e.g. release-5.2.x.x.

I suppose we'll have to wait until the next release on an old stable branch to test this, or test it on a fork. If this change works for us, I'll propose changing https://github.com/packit/packit/blob/main/.github/workflows/do_release.yml, which this file is based on.