### PR TITLE
Require rpm>=4.19.0 for sysusers, {pre,post}untrans RPM tags

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -153,7 +153,7 @@ BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
 BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
-BuildRequires:  pkgconfig(rpm) >= 4.17.0
+BuildRequires:  pkgconfig(rpm) >= 4.19.0
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
 BuildRequires:  toml11-static
 BuildRequires:  zlib-devel

--- a/dnf5/CMakeLists.txt
+++ b/dnf5/CMakeLists.txt
@@ -42,7 +42,7 @@ set_target_properties(dnf5 PROPERTIES C_VISIBILITY_PRESET hidden CXX_VISIBILITY_
 target_link_libraries(dnf5 PRIVATE common_obj libdnf5 libdnf5-cli Threads::Threads)
 install(TARGETS dnf5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
+pkg_check_modules(RPM REQUIRED rpm>=4.19.0)
 
 if(WITH_SYSTEMD)
   include(sdbus_cpp)

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -96,7 +96,7 @@ list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE "${LIBSOLVEXT_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${LIBSOLVEXT_LIBRARIES})
 target_link_libraries(libdnf5_iface INTERFACE ${LIBSOLVEXT_LIBRARIES})
 
-pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
+pkg_check_modules(RPM REQUIRED rpm>=4.19.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${RPM_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${RPM_LIBRARIES})
 target_link_libraries(libdnf5_iface INTERFACE ${RPM_LIBRARIES})

--- a/test/dnf5-plugins/needs_restarting_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/needs_restarting_plugin/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${PROJECT_SOURCE_DIR}/dnf5/include)
 
 include(sdbus_cpp)
 
-pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
+pkg_check_modules(RPM REQUIRED rpm>=4.19.0)
 
 add_executable(run_tests_needs_restarting ${TEST_NEEDS_RESTARTING_SOURCES})
 target_link_libraries(run_tests_needs_restarting PRIVATE common_obj stdc++ libdnf5 libdnf5-cli test_shared ${SDBUS_CPP_LIBRARIES} ${RPM_LIBRARIES})


### PR DESCRIPTION
083570d3cc7c added support for sysusers and {pre,post}untrans scriptlets.

Relevant RPM tags were introduced in RPM 4.19.0 but since CMake is satisfied with RPM as old as 4.17.0, it leads to build failures:

	-- Checking for module 'rpm>=4.17.0'
	--   Found rpm, version 4.18.1
	-- Looking for rpmteSetVfyLevel in rpm
	-- Looking for rpmteSetVfyLevel in rpm - not found
	(...)
	-- Checking for module 'rpm'
	--   Found rpm, version 4.18.1
	(...)
	-- Checking for module 'rpm>=4.17.0'
	--   Found rpm, version 4.18.1
	(...)
	/home/rpm/rpmbuild/BUILD/libdnf5/rpm/transaction.cpp: In static member function 'static libdnf5::rpm::TransactionCallbacks::ScriptType libdnf5::rpm::Transaction::rpm_tag_to_script_type(rpmTag_e)':
	/home/rpm/rpmbuild/BUILD/libdnf5/rpm/transaction.cpp:489:14: error: 'RPMTAG_SYSUSERS' was not declared in this scope; did you mean 'RPMTAG_FSSIZES'?
	  489 |         case RPMTAG_SYSUSERS:
	      |              ^~~~~~~~~~~~~~~
	      |              RPMTAG_FSSIZES
	/home/rpm/rpmbuild/BUILD/libdnf5/rpm/transaction.cpp:491:14: error: 'RPMTAG_PREUNTRANS' was not declared in this scope; did you mean 'RPMTAG_PRETRANS'?
	  491 |         case RPMTAG_PREUNTRANS:
	      |              ^~~~~~~~~~~~~~~~~
	      |              RPMTAG_PRETRANS
	/home/rpm/rpmbuild/BUILD/libdnf5/rpm/transaction.cpp:493:14: error: 'RPMTAG_POSTUNTRANS' was not declared in this scope; did you mean 'RPMTAG_POSTTRANS'?
	  493 |         case RPMTAG_POSTUNTRANS:
	      |              ^~~~~~~~~~~~~~~~~~
	      |              RPMTAG_POSTTRANS

Fixes: #2169