### PR TITLE
fix: fixed misalignment in transaction progress list in zh_CN locale

### DIFF
--- a/dnf5/po/zh_CN.po
+++ b/dnf5/po/zh_CN.po
@@ -1161,7 +1161,7 @@ msgstr "软件包事务中出现意外操作: {}"
 
 #: context.cpp:845
 msgid "Installing {}"
-msgstr "安装{}"
+msgstr "安装 {}"
 
 #: context.cpp:866
 msgid "Prepare transaction"


### PR DESCRIPTION
Previously, the output of msgid `Installing {}` is `安装{}` in zh_CN locale, which cause a misalignment on console output.

<img width="1920" height="1080" alt="a8ccb6995fe36a0d3646fc3d57222729" src="https://github.com/user-attachments/assets/df6823f2-613a-4db0-a91e-99e129530404" />

I added a space behind `安装`, making it align with other message such as `升级`
