### PR TITLE
dnf-automatic: use /bin/sh

### DIFF
--- a/dnf5-plugins/automatic_plugin/bin/dnf-automatic
+++ b/dnf5-plugins/automatic_plugin/bin/dnf-automatic
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # Compatibility wrapper to handle old "/usr/bin/dnf-automatic" name from dnf4.
 
 dnf5 automatic "$@"


### PR DESCRIPTION
/bin/sh is guaranteed by POSIX but /usr/bin/sh is not.