### PR TITLE
spec: Fix build with plugin-local disabled

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -1055,6 +1055,12 @@ pushd %{buildroot}%{_unitdir}/system-update.target.wants/
 popd
 %endif
 
+%if %{without plugin_local}
+rm -fv %{buildroot}%{_libdir}/libdnf5/plugins/local.*
+rm -fv %{buildroot}%{_sysconfdir}/dnf/libdnf5-plugins/local.conf
+rm -fv %{buildroot}%{_mandir}/man8/libdnf5-local.8*
+%endif
+
 mkdir -p %{buildroot}%{_libdir}/libdnf5/plugins
 
 %find_lang dnf5


### PR DESCRIPTION
Nothing in the build stops the local plugin from being built, so the files must be removed, otherwise the build fails with installed but unpackaged files.

This is a follow-up to https://github.com/rpm-software-management/dnf5/pull/2548.

This fixes the failed ELN build of 5.4.0.0: https://koji.fedoraproject.org/koji/buildinfo?buildID=2944613

/cc @ppisar
