### PR TITLE
closed

### DIFF
--- a/dnf5/signal_handlers.cpp
+++ b/dnf5/signal_handlers.cpp
@@ -28,6 +28,8 @@ namespace {
 
 // reset formatting and show the cursor
 constexpr std::string_view reset_formatting = "\033[0m\033[?25h";
+// "resume" formatting and hide the cursor
+constexpr std::string_view resume_formatting = "\033[?25l";
 
 void signal_handler([[maybe_unused]] int signum) {
     // only write the reset code to interactive terminals
@@ -39,6 +41,32 @@ void signal_handler([[maybe_unused]] int signum) {
     _exit(1);
 }
 
+void sigtstp_handler([[maybe_unused]] int signum) {
+    // only write the reset code to interactive terminals
+    if (libdnf5::cli::tty::is_interactive()) {
+        // store the unused result to avoid "ignoring return value" warning
+        [[maybe_unused]] auto result = write(STDOUT_FILENO, reset_formatting.data(), reset_formatting.size());
+    }
+
+    // discard the previous signal, otherwise the kernel will hold the next raise(SIGTSTP) indefinitely
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTSTP);
+    sigprocmask(SIG_UNBLOCK, &mask, NULL);
+
+    // set the handler to the default one to handle the actual logic, this (sigtstp_handler) handler only shows and re-hides the cursor
+    std::signal(SIGTSTP, SIG_DFL);
+    raise(SIGTSTP);
+
+
+    std::signal(SIGTSTP, sigtstp_handler);
+    // received sigcont, hide the cursor agian
+    if (libdnf5::cli::tty::is_interactive()) {
+        // store the unused result to avoid "ignoring return value" warning
+        [[maybe_unused]] auto result = write(STDOUT_FILENO, resume_formatting.data(), resume_formatting.size());
+    }
+}
+
 }  // anonymous namespace
 
 namespace dnf5 {
@@ -46,6 +74,7 @@ namespace dnf5 {
 void install_signal_handlers() {
     std::signal(SIGINT, signal_handler);
     std::signal(SIGTERM, signal_handler);
+    std::signal(SIGTSTP, sigtstp_handler);
 }
 
 }  // namespace dnf5


### PR DESCRIPTION
A couple of days ago I noticed that ^Z (SIGTSTP) doesn't make the cursor re-appear (set \e[?25 to high), I've implemented a handler that sets the cursor to high when SIGTSTP is caught, and then sets it back to low on resume (fg, SIGCONT)