### PR TITLE
local plugin: propagate spec local plugin build option to cmake

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -970,6 +970,7 @@ DNF5 plugin for working with RPM package manifest files.
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
     -DWITH_PLUGIN_APPSTREAM=%{?with_plugin_appstream:ON}%{!?with_plugin_appstream:OFF} \
     -DWITH_PLUGIN_EXPIRED_PGP_KEYS=%{?with_plugin_expired_pgp_keys:ON}%{!?with_plugin_expired_pgp_keys:OFF} \
+    -DWITH_PLUGIN_LOCAL=%{?with_plugin_local:ON}%{!?with_plugin_local:OFF} \
     -DWITH_PLUGIN_RHSM=%{?with_plugin_rhsm:ON}%{!?with_plugin_rhsm:OFF} \
     -DWITH_PLUGIN_MANIFEST=%{?with_plugin_manifest:ON}%{!?with_plugin_manifest:OFF} \
     -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \


### PR DESCRIPTION
Without this turning off `local plugin` in spec is not enough, it still builds and fails the rpm build due to unexpected `local plugin` files.

This is an alternative to https://github.com/rpm-software-management/dnf5/pull/2618