### PR TITLE
only install systemd service files if WITH_SYSTEMD is set

### DIFF
--- a/dnf5-plugins/automatic_plugin/CMakeLists.txt
+++ b/dnf5-plugins/automatic_plugin/CMakeLists.txt
@@ -12,7 +12,10 @@ target_link_libraries(automatic_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(automatic_cmd_plugin PRIVATE dnf5)
 
 install(TARGETS automatic_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)
-install(DIRECTORY "config/usr/" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(DIRECTORY "config/usr/share" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+if (WITH_SYSTEMD)
+  install(DIRECTORY "config/usr/lib" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+endif()
 
 install(PROGRAMS bin/dnf-automatic TYPE BIN)
 

--- a/dnf5daemon-server/dbus/CMakeLists.txt
+++ b/dnf5daemon-server/dbus/CMakeLists.txt
@@ -2,15 +2,17 @@ set(SYSTEMD_UNIT_DIR /usr/lib/systemd/system)
 set(DBUS_SHARE_DIR /usr/share/dbus-1)
 set(DBUS_CONFIG_DIR ${DBUS_SHARE_DIR}/system.d)
 
-install (
-    FILES "dnf5daemon-server.service"
-    DESTINATION ${SYSTEMD_UNIT_DIR}
-)
+if (WITH_SYSTEMD)
+  install (
+      FILES "dnf5daemon-server.service"
+      DESTINATION ${SYSTEMD_UNIT_DIR}
+  )
 
-install (
-    FILES "org.rpm.dnf.v0.service"
-    DESTINATION ${DBUS_SHARE_DIR}/system-services
-)
+  install (
+      FILES "org.rpm.dnf.v0.service"
+      DESTINATION ${DBUS_SHARE_DIR}/system-services
+  )
+endif()
 
 install (
     FILES "org.rpm.dnf.v0.conf"

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory("systemd")
+if (WITH_SYSTEMD)
+  add_subdirectory("systemd")
+endif()


### PR DESCRIPTION
 No need to install systemd service files if a user configures dnf with -DWITH_SYSTEMD=OFF
