### PR TITLE
tests: Set LC_ALL=C to prevent locale-dependent test failures

### DIFF
--- a/test/dnf5-plugins/automatic_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/automatic_plugin/CMakeLists.txt
@@ -14,4 +14,7 @@ add_executable(run_tests_automatic ${TEST_AUTOMATIC_SOURCES})
 target_link_libraries(run_tests_automatic PRIVATE stdc++ libdnf5 libdnf5-cli test_shared)
 
 add_test(NAME test_automatic COMMAND run_tests_automatic)
-set_tests_properties(test_automatic PROPERTIES RUN_SERIAL FALSE)
+set_tests_properties(test_automatic PROPERTIES
+    RUN_SERIAL FALSE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/dnf5-plugins/copr_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/copr_plugin/CMakeLists.txt
@@ -25,4 +25,7 @@ target_link_libraries(run_tests_copr PRIVATE ${JSONC_LIBRARIES})
 add_compile_definitions(TEST_DATADIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
 add_test(NAME test_copr COMMAND run_tests_copr)
-set_tests_properties(test_copr PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_copr PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/dnf5-plugins/needs_restarting_plugin/CMakeLists.txt
+++ b/test/dnf5-plugins/needs_restarting_plugin/CMakeLists.txt
@@ -24,4 +24,7 @@ add_executable(run_tests_needs_restarting ${TEST_NEEDS_RESTARTING_SOURCES})
 target_link_libraries(run_tests_needs_restarting PRIVATE common_obj stdc++ libdnf5 libdnf5-cli test_shared ${SDBUS_CPP_LIBRARIES} ${RPM_LIBRARIES})
 
 add_test(NAME test_needs_restarting COMMAND run_tests_needs_restarting)
-set_tests_properties(test_needs_restarting PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_needs_restarting PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/dnf5daemon-server/CMakeLists.txt
+++ b/test/dnf5daemon-server/CMakeLists.txt
@@ -13,6 +13,7 @@ add_test(
 set_property(TEST test_dnf5daemon_server PROPERTY RUN_SERIAL TRUE)
 
 set_property(TEST test_dnf5daemon_server PROPERTY ENVIRONMENT
+    "LC_ALL=C"
     "${ASAN_OPTIONS}"
     "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
 )

--- a/test/libdnf5-cli/CMakeLists.txt
+++ b/test/libdnf5-cli/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries(run_tests_cli PRIVATE stdc++ libdnf5 libdnf5-cli test_shar
 
 
 add_test(NAME test_libdnf_cli COMMAND run_tests_cli)
+set_tests_properties(test_libdnf_cli PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/libdnf5/CMakeLists.txt
+++ b/test/libdnf5/CMakeLists.txt
@@ -32,4 +32,7 @@ endif()
 
 
 add_test(NAME test_libdnf COMMAND run_tests)
-set_tests_properties(test_libdnf PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_libdnf PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/perl5/CMakeLists.txt
+++ b/test/perl5/CMakeLists.txt
@@ -27,6 +27,7 @@ macro(add_perl_test)
     set_property(TEST "${target}" PROPERTY RUN_SERIAL TRUE)
 
     set_property(TEST ${target} PROPERTY ENVIRONMENT
+        "LC_ALL=C"
         "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
         "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
         "${ASAN_OPTIONS}"

--- a/test/python3/libdnf5/CMakeLists.txt
+++ b/test/python3/libdnf5/CMakeLists.txt
@@ -3,6 +3,7 @@ add_test(NAME test_python3_libdnf COMMAND ${Python3_EXECUTABLE} -m unittest WORK
 set_property(TEST test_python3_libdnf PROPERTY RUN_SERIAL TRUE)
 
 set_property(TEST test_python3_libdnf PROPERTY ENVIRONMENT
+    "LC_ALL=C"
     "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
     "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
     "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python3"

--- a/test/python3/libdnf5_cli/CMakeLists.txt
+++ b/test/python3/libdnf5_cli/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 
 add_test(NAME test_python3_libdnf_cli COMMAND ${Python3_EXECUTABLE} -m unittest WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_property(TEST test_python3_libdnf_cli PROPERTY ENVIRONMENT
+    "LC_ALL=C"
     "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python3"
     "${ASAN_OPTIONS}"
 )

--- a/test/ruby/CMakeLists.txt
+++ b/test/ruby/CMakeLists.txt
@@ -20,6 +20,7 @@ macro(add_ruby_test)
     # should be fixed
     set(ASAN_OPTIONS "${ASAN_OPTIONS},detect_odr_violation=0")
     set_property(TEST ${target} PROPERTY ENVIRONMENT
+        "LC_ALL=C"
         "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
         "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
         "${ASAN_OPTIONS}"

--- a/test/tutorial-templates/CMakeLists.txt
+++ b/test/tutorial-templates/CMakeLists.txt
@@ -27,4 +27,7 @@ target_compile_definitions(run_tests_tutorial_templates PRIVATE
 add_dependencies(run_tests_tutorial_templates template_plugin template_dnf5_cmd_plugin dnf5)
 
 add_test(NAME test_tutorial_templates COMMAND run_tests_tutorial_templates)
-set_tests_properties(test_tutorial_templates PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_tutorial_templates PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -12,4 +12,7 @@ target_link_libraries(run_tests_tutorial PRIVATE stdc++ libdnf5 libdnf5-cli cppu
 
 
 add_test(NAME test_tutorial COMMAND run_tests_tutorial)
-set_tests_properties(test_tutorial PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_tutorial PROPERTIES
+    RUN_SERIAL TRUE
+    ENVIRONMENT "LC_ALL=C"
+)


### PR DESCRIPTION
Unit tests were failing in non-English locales because they check for English error messages but did not set locale environment variables. So current system locale was used.

Set "LC_ALL=C" for all test types (Perl, Python, Ruby, C++) to ensure non-localized error messages. This fixes test failures in locales like "cs_CZ.UTF-8" where error messages would be translated.

Closes: https://github.com/rpm-software-management/dnf5/issues/2624