### PR TITLE
dnfdaemon: Increase the number of concurrent sessions

### DIFF
--- a/dnf5daemon-server/session_manager.cpp
+++ b/dnf5daemon-server/session_manager.cpp
@@ -33,7 +33,7 @@
 #include <thread>
 
 // TODO(mblaha): Make this constant configurable
-const unsigned int MAX_SESSIONS = 3;
+const unsigned int MAX_SESSIONS = 10;
 
 SessionManager::SessionManager() {
     connection = sdbus::createSystemBusConnection(dnfdaemon::DBUS_NAME);


### PR DESCRIPTION
GNOME Software requires multiple parallel sessions to be open for its
operations.