### PR TITLE
tests: Disable plugins in tutorial tests to prevent host dependency

### DIFF
--- a/doc/tutorial/api-changes/session.rst
+++ b/doc/tutorial/api-changes/session.rst
@@ -27,14 +27,14 @@ DNF5 Python:
 .. literalinclude:: ../tests/bindings/python3/api_changes_from_dnf4/create_base.py
     :language: py
     :linenos:
-    :lines: -5,12-
+    :lines: -5,14-
 
 DNF5 C++:
 
 .. literalinclude:: ../tests/api_changes_from_dnf4/create_base.cpp
     :language: c++
     :linenos:
-    :lines: 2,4-7,14-
+    :lines: 2,4-7,16-
 
 Setting of configuration and variables should be done before calling the ``libdnf5::Base::setup`` in DNF5.
 

--- a/doc/tutorial/bindings/python3/session.rst
+++ b/doc/tutorial/bindings/python3/session.rst
@@ -21,3 +21,4 @@ option is available. Here's how you can achieve the same effect using the Python
 .. literalinclude:: ../../tests/bindings/python3/session/force_arch.py
     :language: python
     :linenos:
+    :lines: -8,13-

--- a/doc/tutorial/session.rst
+++ b/doc/tutorial/session.rst
@@ -23,4 +23,4 @@ option is available. Here's how you can achieve the same effect using the API:
 .. literalinclude:: tests/session/force_arch.cpp
     :language: c++
     :linenos:
-    :lines: 2,4-
+    :lines: 2,4-10,15-

--- a/test/python3/libdnf5/tutorial/api_changes_from_dnf4/create_base.py
+++ b/test/python3/libdnf5/tutorial/api_changes_from_dnf4/create_base.py
@@ -7,6 +7,8 @@ base = libdnf5.base.Base()
 base_config = base.get_config()
 base_config.cachedir = cachedir
 base_config.installroot = installroot
+# For unit tests only - Prevent loading plugins from the host system.
+# In production code, plugins are typically left enabled (default behavior).
 base_config.plugins = False
 
 # Optionally, load configuration from the file defined in the current

--- a/test/python3/libdnf5/tutorial/session/force_arch.py
+++ b/test/python3/libdnf5/tutorial/session/force_arch.py
@@ -6,6 +6,10 @@ base = libdnf5.base.Base()
 # Optionally load configuration from the config files.
 base.load_config()
 
+# For unit tests only - Prevent loading plugins from the host system.
+# In production code, plugins are typically left enabled (default behavior).
+base.get_config().get_plugins_option().set(False)
+
 # Override the detected system architecture, similar to how the
 # `--forcearch=aarch64` switch works in the dnf5 command line tool.
 vars = base.get_vars().get()

--- a/test/tutorial/api_changes_from_dnf4/create_base.cpp
+++ b/test/tutorial/api_changes_from_dnf4/create_base.cpp
@@ -9,6 +9,8 @@ libdnf5::Base base;
 auto & base_config = base.get_config();
 base_config.get_cachedir_option().set(cachedir);
 base_config.get_installroot_option().set(installroot);
+// For unit tests only - Prevent loading plugins from the host system.
+// In production code, plugins are typically left enabled (default behavior).
 base_config.get_plugins_option().set(false);
 
 // Optionally, load configuration from the file defined in the current

--- a/test/tutorial/session/force_arch.cpp
+++ b/test/tutorial/session/force_arch.cpp
@@ -8,6 +8,10 @@ libdnf5::Base base;
 // Optionally load configuration from the config files.
 base.load_config();
 
+// For unit tests only - Prevent loading plugins from the host system.
+// In production code, plugins are typically left enabled (default behavior).
+base.get_config().get_plugins_option().set(false);
+
 // Override the detected system architecture, similar to how the
 // `--forcearch=aarch64` switch works in the dnf5 command line tool.
 base.get_vars()->set("arch", "aarch64");


### PR DESCRIPTION
Tutorial tests failed when host had libdnf5 plugins enabled because base.setup() loaded plugins from /etc/dnf/libdnf5-plugins/.

Changes:
- Added plugin disabling to force_arch.cpp and force_arch.py tutorial files
- Updated comments in all tutorial files to clarify that plugin disabling is for unit test isolation, not typical production usage

Closes: https://github.com/rpm-software-management/dnf5/issues/2629