### PR TITLE
dnf5: Reuse cached packages for offline transactions

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -39,6 +39,7 @@
 #include <libdnf5/rpm/package_set.hpp>
 #include <libdnf5/rpm/rpm_signature.hpp>
 #include <libdnf5/transaction/offline.hpp>
+#include <libdnf5/transaction/transaction_item_action.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
@@ -337,6 +338,37 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     state.write();
 }
 
+/// Prepopulate the offline destdir with already-cached packages from the repo
+/// cache to avoid re-downloading them.  Must be called before setting destdir,
+/// so that get_package_path() / is_available_locally() still resolve to the
+/// repo cache.
+static void prepopulate_offline_cache(
+    libdnf5::base::Transaction & transaction, const std::filesystem::path & packages_dir) {
+    bool packages_dir_created = false;
+    for (auto & tspkg : transaction.get_transaction_packages()) {
+        if (!libdnf5::transaction::transaction_item_action_is_inbound(tspkg.get_action())) {
+            continue;
+        }
+        auto pkg = tspkg.get_package();
+        if (pkg.get_repo()->get_type() == libdnf5::repo::Repo::Type::COMMANDLINE) {
+            continue;
+        }
+        if (!pkg.is_available_locally()) {
+            continue;
+        }
+        if (!packages_dir_created) {
+            std::filesystem::create_directories(packages_dir);
+            packages_dir_created = true;
+        }
+        auto cached_path = std::filesystem::path(pkg.get_package_path());
+        auto dest_path = packages_dir / cached_path.filename();
+        std::error_code ec;
+        if (!std::filesystem::exists(dest_path, ec)) {
+            std::filesystem::copy_file(cached_path, dest_path, ec);
+        }
+    }
+}
+
 void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     if (!transaction_store_path.empty()) {
         auto & config = base.get_config();
@@ -356,9 +388,10 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
                 throw libdnf5::cli::AbortedByUserError();
             }
         }
+        std::filesystem::create_directories(transaction_store_path);
+        prepopulate_offline_cache(transaction, packages_location);
         auto & destdir_opt = config.get_destdir_option();
         destdir_opt.set(packages_location);
-        std::filesystem::create_directories(transaction_store_path);
         // Override keepcache option because stored transaction packages should be always kept.
         // Following transactions should never remove them.
         auto & keepcache_opt = config.get_keepcache_option();
@@ -389,7 +422,9 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
                 throw libdnf5::cli::AbortedByUserError();
             }
         }
-        base.get_config().get_destdir_option().set(offline_destdir / "packages");
+        const auto & packages_dir = offline_destdir / "packages";
+        prepopulate_offline_cache(transaction, packages_dir);
+        base.get_config().get_destdir_option().set(packages_dir);
         transaction.set_download_local_pkgs(true);
     }
 


### PR DESCRIPTION
Before downloading packages for an offline transaction, reuse packages already downloaded to the cache (e.g., by dnf-automatic).

I'm not sure this is the best solution, but it doesn't affect the library in any way and resolves my use case: I have dnf-automatic configured to download available updates. However, sometimes (e.g., when a kernel or desktop environment update is available) I prefer to apply the updates offline. This scenario caused all the upgrades to be redownloaded to the separate offline cache. With this patch, the already downloaded packages are reused.