### PR TITLE
Fix segmentation fault in cmd_requires_privileges

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -464,9 +464,14 @@ void Context::Impl::print_error(std::string_view msg) const {
 }
 
 bool Context::Impl::cmd_requires_privileges() const {
-    // the main, dnf5 command, is allowed
     auto cmd = owner.get_selected_command();
+    // During bash completion the selected command in session is not set.
+    // Privileges are not required during completion.
+    if (!cmd) {
+        return false;
+    }
     auto arg_cmd = cmd->get_argument_parser_command();
+    // the main, dnf5 command, is allowed
     if (arg_cmd->get_parent() == nullptr) {
         return false;
     }


### PR DESCRIPTION
During completion, Session::selected_command is never set. Since privileges are not required in completion mode, we can return early before attempting to dereference cmd (which is nullptr).

Issue was introduced in commit 73f51c9e by calling cmd_requires_privileges() from load_repos().

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2443105