### PR TITLE
spec: Do not build-require long unused libcomps-devel

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -175,10 +175,6 @@ BuildRequires:  pkgconfig(cppunit)
 BuildRequires:  rpm-build
 %endif
 
-%if %{with comps}
-BuildRequires:  pkgconfig(libcomps)
-%endif
-
 %if %{with modulemd}
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 %endif


### PR DESCRIPTION
Comps files are parsed by libsolv. Last use of libcomps was removed with commit 506f658d86162eb1d1300e4a5b945471603c8a2e ("comps: Initial support for loading groups").