### PR TITLE
Add '--noplugins' tsflag config value

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -594,6 +594,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     ``nocaps``        ``RPMTRANS_FLAG_NOCAPS``
     ``nocrypto``      ``RPMTRANS_FLAG_NOFILEDIGEST``
     ``deploops``      ``RPMTRANS_FLAG_DEPLOOPS``
+    ``noplugins``     ``RPMTRANS_FLAG_NOPLUGINS``
     ================  ===============================
 
     The ``nocrypto`` option will also set the ``_RPMVSF_NOSIGNATURES`` and
@@ -603,8 +604,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     It includes downloading of packages, OpenPGP keys check (including permanent import of
     additional keys if necessary), and rpm check to prevent file conflicts.
 
-    The ``nocaps`` is supported with rpm-4.14 or later. When ``nocaps`` is used but rpm
-    doesn't support it, DNF5 only reports it as an invalid tsflag.
+    The ``noplugins`` option disables use of rpm plugins.
 
     Default: empty.
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -76,6 +76,7 @@ constexpr std::pair<const char *, rpmtransFlags_e> string_tsflag_map[]{
     {"nocaps", RPMTRANS_FLAG_NOCAPS},
     {"nocrypto", RPMTRANS_FLAG_NOFILEDIGEST},
     {"deploops", RPMTRANS_FLAG_DEPLOOPS},
+    {"noplugins", RPMTRANS_FLAG_NOPLUGINS},
 };
 
 const std::map<base::Transaction::TransactionRunResult, BgettextMessage> TRANSACTION_RUN_RESULT_DICT = {
@@ -947,15 +948,7 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
         return TransactionRunResult::ERROR_LOCK;
     }
 
-    // fill and check the rpm transaction
     libdnf5::rpm::Transaction rpm_transaction(base);
-    rpm_transaction.fill(*transaction);
-    if (!rpm_transaction.check()) {
-        for (auto it : rpm_transaction.get_problems()) {
-            transaction_problems.emplace_back(it.to_string());
-        }
-        return TransactionRunResult::ERROR_CHECK;
-    }
 
     rpmtransFlags rpm_transaction_flags{RPMTRANS_FLAG_NONE};
     for (const auto & tsflag : config.get_tsflags_option().get_value()) {
@@ -976,6 +969,18 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
             rpm_transaction.set_signature_verify_flags(
                 rpm_transaction.get_signature_verify_flags() | RPMVSF_MASK_NOSIGNATURES | RPMVSF_MASK_NODIGESTS);
         }
+    }
+
+    // Set flags to ensure "noplugins" option is set before transactions are started
+    rpm_transaction.set_flags(rpm_transaction_flags);
+
+    // fill and check the rpm transaction
+    rpm_transaction.fill(*transaction);
+    if (!rpm_transaction.check()) {
+        for (auto it : rpm_transaction.get_problems()) {
+            transaction_problems.emplace_back(it.to_string());
+        }
+        return TransactionRunResult::ERROR_CHECK;
     }
 
     // Run rpm transaction test


### PR DESCRIPTION
Hi - I pushed a change to dnf recently as https://github.com/rpm-software-management/dnf/pull/2299 and @pkratoch suggested the same option should be available in dnf5, so this is basically that. Again, I don't know how much this is useful, but for dnf it allowed me to install some packages in a docker container where there isn't sufficient permission to run the unshare RPM plugin.

Similar to the dnf change, this will allow running `dnf5 --setopt=tsflags=noplugins` to disable all RPM plugins when installing/reinstalling/removing packages.

I thought it would be a fairly trivial change, but unfortunately had to do a bit of digging to find out why the flags weren't being applied, which is due to the `rpmtsAdd*` functions in turn calling `rpmtsSetupTransactionPlugins`. The latter needs to know about this flag before the transaction is set up, otherwise the plugins will be initialised and cannot be unloaded.

Also - and correct me if I'm wrong - since this will be compiled against librpm, then the more recently added flags `RPMTRANS_FLAG_NOPLUGINS` and `RPMTRANS_FLAG_NOCAPS` must be available at compile time and there is no such support for just reporting flags as invalid (indeed, an exception will be thrown and the transaction aborted if an invalid flag is given). I've therefore updated the documentation to remove those references.