### PR TITLE
spec: Escape macros in spec comments

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -989,9 +989,9 @@ DNF5 plugin for working with RPM package manifest files.
 %if %{with man}
 %{_mandir}/man8/dnf*-manifest.8.*
 %endif
-%endif  # %{with plugin_manifest}
+%endif  # %%{with plugin_manifest}
 
-%endif  # %{with dnf5_plugins}
+%endif  # %%{with dnf5_plugins}
 
 
 # ========== unpack, build, check & install ==========


### PR DESCRIPTION
rpmlint correctly complained:

    dnf5.spec:992: W: macro-in-comment %{with
    dnf5.spec:994: W: macro-in-comment %{with

A hash sign is a shell comment, not a spec comment. Hence macros after the hash sign are still expanded. This flaw was introduced with commit 55187ad0e56617144be719a39a7943b472936d85 (spec: add `%bcond_without plugin_manifest`).

This patch fixes it.