### PR TITLE
doc: Name manual pages for versioned vendorpolicies

### DIFF
--- a/doc/dnf5.conf-vendorpolicy.5.rst
+++ b/doc/dnf5.conf-vendorpolicy.5.rst
@@ -60,6 +60,6 @@ by creating a file with the same name in the ``/etc/dnf/vendors.d/`` directory.
 See Also
 ========
 
-* :ref:`DNF5 Vendor Change Policy File Reference - v1.1 <dnf5_vendor_change_policy_v1_1-label>`
-* :ref:`DNF5 Vendor Change Policy File Reference - v1.0 <dnf5_vendor_change_policy_v1_0-label>`
+* :manpage:`dnf5.conf-vendorpolicy-v1_1(5)`, :ref:`DNF5 Vendor Change Policy File Reference - v1.1 <dnf5_vendor_change_policy_v1_1-label>`
+* :manpage:`dnf5.conf-vendorpolicy-v1_0(5)`, :ref:`DNF5 Vendor Change Policy File Reference - v1.0 <dnf5_vendor_change_policy_v1_0-label>`
 * :manpage:`dnf5.conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`


### PR DESCRIPTION
dnf5.conf-vendorpolicy(5) manual page does not document the policy configuration format. Instead it refers to separate documents whose manual page names are missing from the rendered groff page:

    SEE ALSO
	 • DNF5 Vendor Change Policy File Reference - v1.1 <#dnf5-vendor-change-policy-v1-1-label>

	 • DNF5 Vendor Change Policy File Reference - v1.0 <#dnf5-vendor-change-policy-v1-0-label>

	 • dnf5.conf(5), DNF5 Configuration Reference <#dnf5-conf-label>

It's difficult for readers to discover that the manual page names are dnf5.conf-vendorpolicy-v1_1(5) and dnf5.conf-vendorpolicy-v1_0(5).

This patch fixes it by explicitly naming the two pages in the SEE ALSO section.