### PR TITLE
Fix typos and non-standard variable names found by codespell

### DIFF
--- a/dnf5-plugins/repomanage_plugin/repomanage.cpp
+++ b/dnf5-plugins/repomanage_plugin/repomanage.cpp
@@ -79,7 +79,7 @@ void RepomanageCommand::set_argument_parser() {
 }
 
 void RepomanageCommand::pre_configure() {
-    // We are not intereseted in any configured repositories.
+    // We are not interested in any configured repositories.
     // Don't create them and don't load them.
     get_context().set_create_repos(false);
 }

--- a/dnf5-plugins/reposync_plugin/reposync.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync.cpp
@@ -367,7 +367,7 @@ void ReposyncCommand::run() {
                 for (const auto & base_url : repo->get_config().get_baseurl_option().get_value()) {
                     remote_locations.emplace_back(base_url);
                 }
-                // find first available mirror prefering file and https schemes
+                // find first available mirror preferring file and https schemes
                 std::string repo_location{};
                 for (const auto & scheme : schemes) {
                     for (const auto & mirror : remote_locations) {

--- a/dnf5daemon-server/services/history/history.cpp
+++ b/dnf5daemon-server/services/history/history.cpp
@@ -171,7 +171,7 @@ sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
             }
             auto added = seen_pkg.insert(pkg_key);
             if (!added.second) {
-                // only interested in the first occurence of given key
+                // only interested in the first occurrence of given key
                 continue;
             }
 

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -119,7 +119,7 @@ void Session::setup_base() {
         libdnf5::ConfigParser parser;
         parser.read(dnfdaemon_conf_file_path);
         // Load options from the dnf5daemon-server.conf with greater priority than
-        // Priority::MAINCONFIG to by-pass cachedir option being automatically overriden
+        // Priority::MAINCONFIG to by-pass cachedir option being automatically overridden
         // from system_cachedir. With different cachedir and system_cachedir, quick
         // clone_root_metadata() method is available.
         base->get_config().load_from_parser(

--- a/libdnf5/conf/config_parser.cpp
+++ b/libdnf5/conf/config_parser.cpp
@@ -31,15 +31,15 @@
 namespace libdnf5 {
 
 static void read(ConfigParser & cfg_parser, IniParser & parser) {
-    IniParser::ItemType readed_type;
-    while ((readed_type = parser.next()) != IniParser::ItemType::END_OF_INPUT) {
+    IniParser::ItemType item_type;
+    while ((item_type = parser.next()) != IniParser::ItemType::END_OF_INPUT) {
         auto section = parser.get_section();
-        if (readed_type == IniParser::ItemType::SECTION) {
+        if (item_type == IniParser::ItemType::SECTION) {
             cfg_parser.add_section(std::move(section), std::move(parser.get_raw_item()));
-        } else if (readed_type == IniParser::ItemType::KEY_VAL) {
+        } else if (item_type == IniParser::ItemType::KEY_VAL) {
             cfg_parser.set_value(
                 section, std::move(parser.get_key()), std::move(parser.get_value()), std::move(parser.get_raw_item()));
-        } else if (readed_type == IniParser::ItemType::COMMENT_LINE || readed_type == IniParser::ItemType::EMPTY_LINE) {
+        } else if (item_type == IniParser::ItemType::COMMENT_LINE || item_type == IniParser::ItemType::EMPTY_LINE) {
             if (section.empty()) {
                 cfg_parser.get_header() += parser.get_raw_item();
             } else {

--- a/libdnf5/logger/rotating_file_logger.cpp
+++ b/libdnf5/logger/rotating_file_logger.cpp
@@ -205,7 +205,7 @@ void RotatingFileLogger::Impl::write(const char * line) noexcept {
                     }
 
                     // and proceed with writing regardless the rotation
-                    // succeded, or not.
+                    // succeeded, or not.
                 }
             }
 

--- a/libdnf5/module/module_sack_impl.hpp
+++ b/libdnf5/module/module_sack_impl.hpp
@@ -129,7 +129,7 @@ public:
     /// Enable module stream.
     /// @param module_spec module to be enabled.
     /// @param count if `true`, count the change towards the limit of module status modifications.
-    /// @return `true` if requested change realy triggers a change in the ModuleDB, `false` otherwise,
+    /// @return `true` if requested change really triggers a change in the ModuleDB, `false` otherwise,
     ///         and a set of module:stream strings for modules with multiple streams and no enabled or default one.
     /// @throw NoModuleError if the module doesn't exist.
     /// @since 5.0.14

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -399,10 +399,10 @@ bool RepoDownloader::is_metalink_in_sync(Repo & repo, LrMetalink * metalink) try
 
     std::ifstream repomd(download_data.repomd_filename, std::ifstream::binary);
     char buf[4096];
-    int readed;
-    while ((readed = static_cast<int>(repomd.readsome(buf, sizeof(buf)))) > 0) {
+    int n_read;
+    while ((n_read = static_cast<int>(repomd.readsome(buf, sizeof(buf)))) > 0) {
         for (auto & hash : hashes)
-            solv_chksum_add(hash.chksum.get(), buf, readed);
+            solv_chksum_add(hash.chksum.get(), buf, n_read);
     }
 
     for (auto & hash : hashes) {

--- a/libdnf5/solv/vendor_change_manager.cpp
+++ b/libdnf5/solv/vendor_change_manager.cpp
@@ -126,7 +126,7 @@ bool VendorChangeManager::is_vendor_change_allowed(Solvable & outgoing, Solvable
     auto incoming_vendor = incoming.vendor ? incoming.vendor : ID_EMPTY;
 
     if (incoming_vendor == outgoing_vendor) {
-        return true;  // OK, no vendor change occured
+        return true;  // OK, no vendor change occurred
     }
 
     // Check if the incoming solvable bypasses vendor check.

--- a/libdnf5/transaction/transaction_sr.cpp
+++ b/libdnf5/transaction/transaction_sr.cpp
@@ -346,7 +346,7 @@ TransactionReplay to_replay(libdnf5::transaction::Transaction & trans) {
     for (const auto & pkg : trans.get_packages()) {
         PackageReplay package_replay;
 
-        // Use to_nevra_string in order to have nevra wihtout epoch if it is 0
+        // Use to_nevra_string in order to have nevra without epoch if it is 0
         package_replay.nevra = rpm::to_nevra_string(pkg);
         package_replay.action = pkg.get_action();
         package_replay.reason = pkg.get_reason();

--- a/libdnf5/utils/fs/utils.cpp
+++ b/libdnf5/utils/fs/utils.cpp
@@ -55,15 +55,15 @@ namespace stdfs = std::filesystem;
         lseek(fd2, 0, SEEK_SET);
         char buf1[block_size];
         char buf2[block_size];
-        ssize_t readed;
+        ssize_t n_read;
         do {
-            readed = read(fd1, &buf1, block_size);
-            auto readed2 = read(fd2, &buf2, block_size);
-            if (readed2 != readed || std::memcmp(&buf1, &buf2, static_cast<size_t>(readed)) != 0) {
+            n_read = read(fd1, &buf1, block_size);
+            auto n_read2 = read(fd2, &buf2, block_size);
+            if (n_read2 != n_read || std::memcmp(&buf1, &buf2, static_cast<size_t>(n_read)) != 0) {
                 ret = false;
                 break;
             }
-        } while (readed == block_size);
+        } while (n_read == block_size);
     } while (false);
 
     if (fd1 != -1) {


### PR DESCRIPTION
Fix spelling mistakes in comments and rename non-standard variable names
found by [codespell](https://github.com/codespell-project/codespell):

**Typos in comments:**
- `intereseted` → `interested` (repomanage_plugin/repomanage.cpp)
- `prefering` → `preferring` (reposync_plugin/reposync.cpp)
- `occured` → `occurred` (libdnf5/solv/vendor_change_manager.cpp)
- `wihtout` → `without` (libdnf5/transaction/transaction_sr.cpp)
- `succeded` → `succeeded` (libdnf5/logger/rotating_file_logger.cpp)
- `occurence` → `occurrence` (dnf5daemon-server/services/history/history.cpp)
- `overriden` → `overridden` (dnf5daemon-server/session.cpp)
- `realy` → `really` (libdnf5/module/module_sack_impl.hpp)

**Non-standard variable names (past tense of "read" is "read", not "readed"):**
- `readed` → `n_read` (libdnf5/utils/fs/utils.cpp)
- `readed` → `n_read` (libdnf5/repo/repo_downloader.cpp)
- `readed_type` → `item_type` (libdnf5/conf/config_parser.cpp)