### PR TITLE
CI: Build and test on ELN

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,6 +64,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+      - fedora-eln
     packages: [dnf5]
     additional_repos:
       - "copr://rpmsoftwaremanagement/dnf-nightly"
@@ -89,6 +90,7 @@ jobs:
     identifier: "dnf5-tests"
     targets:
       - fedora-all
+      - fedora-eln
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: &CI_DNF_STACK_REF main
     tmt_plan: "^/plans/integration/behave-dnf5$"
@@ -104,6 +106,7 @@ jobs:
     identifier: "createrepo_c-tests"
     targets:
       - fedora-all
+      - fedora-eln
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: *CI_DNF_STACK_REF
     tmt_plan: "^/plans/integration/behave-createrepo_c$"
@@ -135,6 +138,7 @@ jobs:
     identifier: "dnf5daemon-tests"
     targets:
       - fedora-all
+      - fedora-eln
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: *CI_DNF_STACK_REF
     tmt_plan: "^/plans/integration/behave-dnf5daemon$"


### PR DESCRIPTION
Because ELN is configured as RHEL, i.e. differently from Fedora.

I left out building en explicit non-modular configuration on ELN because ELN will disable modularity implicitly in near future. There is no need to build the same thing twice.

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1898
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1901