### PR TITLE
style(dnf5daemon-server): add missing `override`

### DIFF
--- a/dnf5daemon-server/services/advisory/advisory.hpp
+++ b/dnf5daemon-server/services/advisory/advisory.hpp
@@ -35,7 +35,7 @@ class Advisory : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Advisory() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/base/base.hpp
+++ b/dnf5daemon-server/services/base/base.hpp
@@ -31,7 +31,7 @@ class Base : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Base() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/comps/group.hpp
+++ b/dnf5daemon-server/services/comps/group.hpp
@@ -28,7 +28,7 @@ class Group : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Group() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/goal/goal.hpp
+++ b/dnf5daemon-server/services/goal/goal.hpp
@@ -28,7 +28,7 @@ class Goal : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Goal() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/history/history.hpp
+++ b/dnf5daemon-server/services/history/history.hpp
@@ -28,7 +28,7 @@ class History : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~History() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/offline/offline.hpp
+++ b/dnf5daemon-server/services/offline/offline.hpp
@@ -30,7 +30,7 @@ class Offline : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Offline() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/repo/repo.hpp
+++ b/dnf5daemon-server/services/repo/repo.hpp
@@ -31,7 +31,7 @@ class Repo : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Repo() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:

--- a/dnf5daemon-server/services/rpm/rpm.hpp
+++ b/dnf5daemon-server/services/rpm/rpm.hpp
@@ -30,7 +30,7 @@ class Rpm : public IDbusSessionService {
 public:
     using IDbusSessionService::IDbusSessionService;
     ~Rpm() = default;
-    void dbus_register();
+    void dbus_register() override;
     void dbus_deregister();
 
 private:


### PR DESCRIPTION
cf. [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final).

One could consider marking these functions as `final`.