### PR TITLE
GH workflow: Fix permission syntax in "Upload *.pot files to dnf5-l10n repository

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           app-id: ${{ vars.RSM_CI_APP_ID }}
           private-key: ${{ secrets.RSM_CI_APP_PRIVATE_KEY }}
-          permissions: |
-            contents: "write"
+          permission-contents: "write"
           repositories: "rpm-software-management/dnf5-l10n"
 
       - name: Clone source repository


### PR DESCRIPTION
Uploading POT files to dnf4-l10n repository failed <https://github.com/rpm-software-management/dnf5/actions/runs/24274751559/job/70886519048> with:

    Run actions/create-github-app-token@v1

    Warning: Unexpected input(s) 'permissions', valid inputs are ['app-id', 'app_id', 'private-key', 'private_key', 'owner', 'repositories', 'skip-token-revoke', 'skip_token_revoke', 'github-api-url', 'permission-actions', 'permission-administration', 'permission-checks', 'permission-codespaces', 'permission-contents', 'permission-dependabot-secrets', 'permission-deployments', 'permission-email-addresses', 'permission-environments', 'permission-followers', 'permission-git-ssh-keys', 'permission-gpg-keys', 'permission-interaction-limits', 'permission-issues', 'permission-members', 'permission-metadata', 'permission-organization-administration', 'permission-organization-announcement-banners', 'permission-organization-copilot-seat-management', 'permission-organization-custom-org-roles', 'permission-organization-custom-properties', 'permission-organization-custom-roles', 'permission-organization-events', 'permission-organization-hooks', 'permission-organization-packages', 'permission-organization-personal-access-token-requests', 'permission-organization-personal-access-tokens', 'permission-organization-plan', 'permission-organization-projects', 'permission-organization-secrets', 'permission-organization-self-hosted-runners', 'permission-organization-user-blocking', 'permission-packages', 'permission-pages', 'permission-profile', 'permission-pull-requests', 'permission-repository-custom-properties', 'permission-repository-hooks', 'permission-repository-projects', 'permission-secret-scanning-alerts', 'permission-secrets', 'permission-security-events', 'permission-single-file', 'permission-starring', 'permission-statuses', 'permission-team-discussions', 'permission-vulnerability-alerts', 'permission-workflows']

It seems the syntax we used was invalid. Per
<https://github.com/actions/create-github-app-token/tree/v1?tab=readme-ov-file#permission-permission-name>, <https://github.com/actions/create-github-app-token/tree/v3?tab=readme-ov-file#permission-permission-name>, and
<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions> it should be spelled as "permission-contents: write".