### PR TITLE
Introduce gpgcheck_policy to control gpgcheck

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -243,6 +243,31 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``[]``.
 
+.. _gpgcheck_policy_options-label:
+
+``gpgcheck_policy``
+    ``legacy``, ``full``, or ``all``
+
+    Controls how the ``gpgcheck`` option expands when set in a configuration section.
+
+    ``legacy``
+        ``gpgcheck=1`` sets only ``pkg_gpgcheck=1``.
+        This preserves the original DNF behavior.
+
+    ``full``
+        ``gpgcheck=1`` sets both ``pkg_gpgcheck=1`` and ``repo_gpgcheck=1``.
+
+    ``all``
+        ``gpgcheck=1`` sets ``pkg_gpgcheck=1``, ``repo_gpgcheck=1``, and ``localpkg_gpgcheck=1``.
+
+    Explicitly setting ``pkg_gpgcheck``, ``repo_gpgcheck``, or ``localpkg_gpgcheck`` in the
+    same configuration section overrides the policy for that specific option.
+
+    The policy is a global setting defined in ``[main]`` and affects all repository
+    sections that use ``gpgcheck``.
+
+    Default: ``full``.
+
 .. _group_package_types_options-label:
 
 ``group_package_types``
@@ -1004,7 +1029,9 @@ configuration.
     Doesn't apply for packages passed directly as arguments, as they are not in any repository,
     see :ref:`localpkg_gpgcheck <localpkg_gpgcheck_options-label>`.
 
-    Due to compatibility `gpgcheck` option is supported as well but `pkg_gpgcheck` is preferred.
+    Due to compatibility ``gpgcheck`` option is supported as well but ``pkg_gpgcheck`` is preferred.
+    The behavior of ``gpgcheck`` is controlled by the
+    :ref:`gpgcheck_policy <gpgcheck_policy_options-label>` option.
 
 .. _includepkgs_options-label:
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -243,6 +243,42 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``[]``.
 
+.. _gpgcheck_options-label:
+
+``gpgcheck``
+
+    Due to compatibility ``gpgcheck`` option is supported as well but ``pkg_gpgcheck`` is preferred.
+    The meaning of ``gpgcheck`` is controlled by the
+    :ref:`gpgcheck_policy <gpgcheck_policy_options-label>` option.
+
+    Default: ``pkg_gpgcheck`` value.
+.. :
+
+.. _gpgcheck_policy_options-label:
+
+``gpgcheck_policy``
+    ``legacy``, ``full``, or ``all``
+
+    Controls how the ``gpgcheck`` option expands when explicitly set in a configuration section.
+
+    ``legacy``
+        ``gpgcheck=1`` sets only ``pkg_gpgcheck=1``.
+        This preserves the original DNF behavior.
+
+    ``full``
+        ``gpgcheck=1`` sets both ``pkg_gpgcheck=1`` and ``repo_gpgcheck=1``.
+
+    ``all``
+        ``gpgcheck=1`` sets ``pkg_gpgcheck=1``, ``repo_gpgcheck=1``, and ``localpkg_gpgcheck=1``.
+
+    Explicitly setting ``pkg_gpgcheck``, ``repo_gpgcheck``, or ``localpkg_gpgcheck`` in the
+    same configuration section overrides the policy for that specific option.
+
+    The policy is a global setting defined in ``[main]`` and affects all repository
+    sections that use ``gpgcheck``.
+
+    Default: ``legacy``.
+
 .. _group_package_types_options-label:
 
 ``group_package_types``
@@ -1003,8 +1039,6 @@ configuration.
 
     Doesn't apply for packages passed directly as arguments, as they are not in any repository,
     see :ref:`localpkg_gpgcheck <localpkg_gpgcheck_options-label>`.
-
-    Due to compatibility `gpgcheck` option is supported as well but `pkg_gpgcheck` is preferred.
 
 .. _includepkgs_options-label:
 

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -276,6 +276,8 @@ public:
     const OptionBool & get_pkg_gpgcheck_option() const;
     OptionBool & get_repo_gpgcheck_option();
     const OptionBool & get_repo_gpgcheck_option() const;
+    OptionEnum & get_gpgcheck_policy_option();
+    const OptionEnum & get_gpgcheck_policy_option() const;
     /// @deprecated Use ConfigRepo::get_enabled_option()
     [[deprecated("Use ConfigRepo::get_enabled_option()")]]
     OptionBool & get_enabled_option();

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -114,6 +114,7 @@ class ConfigMain::Impl {
     Config & owner;
 
     void load_from_config(const Impl & other);
+    void apply_gpgcheck_policy(const ConfigParser & parser, const std::string & section, Option::Priority priority);
 
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
     OptionNumber<std::int32_t> errorlevel{3, 0, 10};
@@ -254,6 +255,8 @@ class ConfigMain::Impl {
     OptionStringAppendList protected_packages{std::vector<std::string>{"dnf5", "glob:/etc/dnf/protected.d/*.conf"}};
     OptionString username{""};
     OptionString password{""};
+    OptionBool gpgcheck{false};
+    OptionEnum gpgcheck_policy{"full", {"legacy", "full", "all"}};
     OptionBool pkg_gpgcheck{false};
     OptionBool repo_gpgcheck{false};
     OptionBool enabled{true};
@@ -447,9 +450,9 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("protected_packages", protected_packages);
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
+    owner.opt_binds().add("gpgcheck", gpgcheck);
+    owner.opt_binds().add("gpgcheck_policy", gpgcheck_policy);
     owner.opt_binds().add("pkg_gpgcheck", pkg_gpgcheck);
-    // Compatiblity alias for pkg_gpgcheck
-    owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
     owner.opt_binds().add("enabled", enabled);
     owner.opt_binds().add("enablegroups", enablegroups);
@@ -1189,11 +1192,11 @@ const OptionString & ConfigMain::get_password_option() const {
 
 OptionBool & ConfigMain::get_gpgcheck_option() {
     LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option()");
-    return p_impl->pkg_gpgcheck;
+    return p_impl->gpgcheck;
 }
 const OptionBool & ConfigMain::get_gpgcheck_option() const {
     LIBDNF5_DEPRECATED("Use get_pkg_gpgcheck_option() const");
-    return p_impl->pkg_gpgcheck;
+    return p_impl->gpgcheck;
 }
 
 OptionBool & ConfigMain::get_pkg_gpgcheck_option() {
@@ -1208,6 +1211,13 @@ OptionBool & ConfigMain::get_repo_gpgcheck_option() {
 }
 const OptionBool & ConfigMain::get_repo_gpgcheck_option() const {
     return p_impl->repo_gpgcheck;
+}
+
+OptionEnum & ConfigMain::get_gpgcheck_policy_option() {
+    return p_impl->gpgcheck_policy;
+}
+const OptionEnum & ConfigMain::get_gpgcheck_policy_option() const {
+    return p_impl->gpgcheck_policy;
 }
 
 OptionBool & ConfigMain::get_enabled_option() {
@@ -1363,6 +1373,47 @@ const OptionBool & ConfigMain::get_skip_if_unavailable_option() const {
     return p_impl->skip_if_unavailable;
 }
 
+void ConfigMain::Impl::apply_gpgcheck_policy(
+    const ConfigParser & parser, const std::string & section, Option::Priority priority) {
+    // Only apply if gpgcheck was explicitly set in this parsing round
+    if (gpgcheck.get_priority() < priority) {
+        return;
+    }
+
+    const auto gpgcheck_val = gpgcheck.get_value();
+    const auto & policy = gpgcheck_policy.get_value();
+
+    // Check which target options were explicitly set in the config section
+    bool pkg_gpgcheck_explicit = false;
+    bool repo_gpgcheck_explicit = false;
+    bool localpkg_gpgcheck_explicit = false;
+    auto section_iter = parser.get_data().find(section);
+    if (section_iter != parser.get_data().end()) {
+        pkg_gpgcheck_explicit = section_iter->second.find("pkg_gpgcheck") != section_iter->second.end();
+        repo_gpgcheck_explicit = section_iter->second.find("repo_gpgcheck") != section_iter->second.end();
+        localpkg_gpgcheck_explicit = section_iter->second.find("localpkg_gpgcheck") != section_iter->second.end();
+    }
+
+    // All policies: gpgcheck implies pkg_gpgcheck
+    if (!pkg_gpgcheck_explicit) {
+        pkg_gpgcheck.set(priority, gpgcheck_val);
+    }
+
+    // "full" or "all": also set repo_gpgcheck
+    if (policy == "full" || policy == "all") {
+        if (!repo_gpgcheck_explicit) {
+            repo_gpgcheck.set(priority, gpgcheck_val);
+        }
+    }
+
+    // "all": also set localpkg_gpgcheck
+    if (policy == "all") {
+        if (!localpkg_gpgcheck_explicit) {
+            localpkg_gpgcheck.set(priority, gpgcheck_val);
+        }
+    }
+}
+
 void ConfigMain::load_from_parser(
     const ConfigParser & parser,
     const std::string & section,
@@ -1370,6 +1421,8 @@ void ConfigMain::load_from_parser(
     Logger & logger,
     Option::Priority priority) {
     Config::load_from_parser(parser, section, vars, logger, priority);
+
+    p_impl->apply_gpgcheck_policy(parser, section, priority);
 
     if (geteuid() == 0) {
         p_impl->cachedir.set(Option::Priority::MAINCONFIG, p_impl->system_cachedir.get_value());
@@ -1487,6 +1540,8 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(protected_packages, other.protected_packages);
     load_option(username, other.username);
     load_option(password, other.password);
+    load_option(gpgcheck, other.gpgcheck);
+    load_option(gpgcheck_policy, other.gpgcheck_policy);
     load_option(pkg_gpgcheck, other.pkg_gpgcheck);
     load_option(repo_gpgcheck, other.repo_gpgcheck);
     load_option(enabled, other.enabled);

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -114,6 +114,7 @@ class ConfigMain::Impl {
     Config & owner;
 
     void load_from_config(const Impl & other);
+    void apply_gpgcheck_policy(const ConfigParser & parser, const std::string & section, Option::Priority priority);
 
     OptionNumber<std::int32_t> debuglevel{2, 0, 10};
     OptionNumber<std::int32_t> errorlevel{3, 0, 10};
@@ -254,6 +255,7 @@ class ConfigMain::Impl {
     OptionStringAppendList protected_packages{std::vector<std::string>{"dnf5", "glob:/etc/dnf/protected.d/*.conf"}};
     OptionString username{""};
     OptionString password{""};
+    OptionEnum gpgcheck_policy{"legacy", {"legacy", "full", "all"}};
     OptionBool pkg_gpgcheck{false};
     OptionBool repo_gpgcheck{false};
     OptionBool enabled{true};
@@ -450,6 +452,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("pkg_gpgcheck", pkg_gpgcheck);
     // Compatibility alias for pkg_gpgcheck
     owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
+    owner.opt_binds().add("gpgcheck_policy", gpgcheck_policy);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
     owner.opt_binds().add("enabled", enabled);
     owner.opt_binds().add("enablegroups", enablegroups);
@@ -1210,6 +1213,13 @@ const OptionBool & ConfigMain::get_repo_gpgcheck_option() const {
     return p_impl->repo_gpgcheck;
 }
 
+OptionEnum & ConfigMain::get_gpgcheck_policy_option() {
+    return p_impl->gpgcheck_policy;
+}
+const OptionEnum & ConfigMain::get_gpgcheck_policy_option() const {
+    return p_impl->gpgcheck_policy;
+}
+
 OptionBool & ConfigMain::get_enabled_option() {
     LIBDNF5_DEPRECATED("Use ConfigRepo::get_enabled_option()");
     return p_impl->enabled;
@@ -1363,6 +1373,34 @@ const OptionBool & ConfigMain::get_skip_if_unavailable_option() const {
     return p_impl->skip_if_unavailable;
 }
 
+void ConfigMain::Impl::apply_gpgcheck_policy(
+    const ConfigParser & parser, const std::string & section, Option::Priority priority) {
+    const auto & policy = gpgcheck_policy.get_value();
+    if (policy == "legacy") {
+        return;
+    }
+
+    // Only expand when the "gpgcheck" key is present in the section.
+    // "pkg_gpgcheck" should NOT trigger expansion — it controls only package checking.
+    auto section_iter = parser.get_data().find(section);
+    if (section_iter == parser.get_data().end() ||
+        section_iter->second.find("gpgcheck") == section_iter->second.end()) {
+        return;
+    }
+
+    const auto gpgcheck_val = pkg_gpgcheck.get_value();
+    bool repo_gpgcheck_explicit = section_iter->second.find("repo_gpgcheck") != section_iter->second.end();
+    bool localpkg_gpgcheck_explicit = section_iter->second.find("localpkg_gpgcheck") != section_iter->second.end();
+
+    if (!repo_gpgcheck_explicit) {
+        repo_gpgcheck.set(priority, gpgcheck_val);
+    }
+
+    if (policy == "all" && !localpkg_gpgcheck_explicit) {
+        localpkg_gpgcheck.set(priority, gpgcheck_val);
+    }
+}
+
 void ConfigMain::load_from_parser(
     const ConfigParser & parser,
     const std::string & section,
@@ -1370,6 +1408,8 @@ void ConfigMain::load_from_parser(
     Logger & logger,
     Option::Priority priority) {
     Config::load_from_parser(parser, section, vars, logger, priority);
+
+    p_impl->apply_gpgcheck_policy(parser, section, priority);
 
     if (geteuid() == 0) {
         p_impl->cachedir.set(Option::Priority::MAINCONFIG, p_impl->system_cachedir.get_value());
@@ -1487,6 +1527,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(protected_packages, other.protected_packages);
     load_option(username, other.username);
     load_option(password, other.password);
+    load_option(gpgcheck_policy, other.gpgcheck_policy);
     load_option(pkg_gpgcheck, other.pkg_gpgcheck);
     load_option(repo_gpgcheck, other.repo_gpgcheck);
     load_option(enabled, other.enabled);

--- a/libdnf5/conf/config_utils.cpp
+++ b/libdnf5/conf/config_utils.cpp
@@ -23,6 +23,8 @@
 
 #include <glob.h>
 
+#include <cstring>
+
 
 namespace libdnf5 {
 

--- a/libdnf5/conf/config_utils.hpp
+++ b/libdnf5/conf/config_utils.hpp
@@ -20,7 +20,8 @@
 #ifndef LIBDNF5_CONF_CONFIG_PRIVATE_HPP
 #define LIBDNF5_CONF_CONFIG_PRIVATE_HPP
 
-#include "libdnf5/conf/option.hpp"
+#include <filesystem>
+#include <string>
 
 
 namespace libdnf5 {

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -59,6 +59,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> username{main_config.get_username_option()};
     OptionChild<OptionString> password{main_config.get_password_option()};
     OptionChild<OptionStringAppendList> protected_packages{main_config.get_protected_packages_option()};
+    OptionBool gpgcheck{false};
     OptionChild<OptionBool> pkg_gpgcheck{main_config.get_pkg_gpgcheck_option()};
     OptionChild<OptionBool> repo_gpgcheck{main_config.get_repo_gpgcheck_option()};
     OptionChild<OptionBool> enablegroups{main_config.get_enablegroups_option()};
@@ -152,9 +153,8 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
     owner.opt_binds().add("username", username);
     owner.opt_binds().add("password", password);
     owner.opt_binds().add("protected_packages", protected_packages);
+    owner.opt_binds().add("gpgcheck", gpgcheck);
     owner.opt_binds().add("pkg_gpgcheck", pkg_gpgcheck);
-    // Compatibility alias for pkg_gpgcheck
-    owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
     owner.opt_binds().add("enablegroups", enablegroups);
     owner.opt_binds().add("retries", retries);
@@ -616,6 +616,33 @@ void ConfigRepo::load_from_parser(
     Logger & logger,
     Option::Priority priority) {
     Config::load_from_parser(parser, section, vars, logger, priority);
+
+    // Apply gpgcheck_policy: if gpgcheck was set in this repo section, expand it
+    if (p_impl->gpgcheck.get_priority() >= priority) {
+        const auto gpgcheck_val = p_impl->gpgcheck.get_value();
+        const auto & policy = p_impl->main_config.get_gpgcheck_policy_option().get_value();
+
+        // Check which target options were explicitly set in this section
+        bool pkg_gpgcheck_explicit = false;
+        bool repo_gpgcheck_explicit = false;
+        auto section_iter = parser.get_data().find(section);
+        if (section_iter != parser.get_data().end()) {
+            pkg_gpgcheck_explicit = section_iter->second.find("pkg_gpgcheck") != section_iter->second.end();
+            repo_gpgcheck_explicit = section_iter->second.find("repo_gpgcheck") != section_iter->second.end();
+        }
+
+        // All policies: gpgcheck implies pkg_gpgcheck
+        if (!pkg_gpgcheck_explicit) {
+            p_impl->pkg_gpgcheck.set(priority, gpgcheck_val);
+        }
+
+        // "full" or "all": also set repo_gpgcheck
+        if (policy == "full" || policy == "all") {
+            if (!repo_gpgcheck_explicit) {
+                p_impl->repo_gpgcheck.set(priority, gpgcheck_val);
+            }
+        }
+    }
 }
 
 }  // namespace libdnf5::repo

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -19,9 +19,9 @@
 
 #include "libdnf5/repo/config_repo.hpp"
 
-#include "conf/config_utils.hpp"
 #include "utils/deprecate.hpp"
 
+#include "libdnf5/conf/config_parser.hpp"
 #include "libdnf5/conf/const.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
@@ -616,6 +616,19 @@ void ConfigRepo::load_from_parser(
     Logger & logger,
     Option::Priority priority) {
     Config::load_from_parser(parser, section, vars, logger, priority);
+
+    // Only expand when the "gpgcheck" key is present — "pkg_gpgcheck" should not trigger expansion.
+    auto section_iter = parser.get_data().find(section);
+    if (section_iter != parser.get_data().end() &&
+        section_iter->second.find("gpgcheck") != section_iter->second.end()) {
+        const auto & policy = p_impl->main_config.get_gpgcheck_policy_option().get_value();
+        if (policy == "full" || policy == "all") {
+            bool repo_gpgcheck_explicit = section_iter->second.find("repo_gpgcheck") != section_iter->second.end();
+            if (!repo_gpgcheck_explicit) {
+                p_impl->repo_gpgcheck.set(priority, p_impl->pkg_gpgcheck.get_value());
+            }
+        }
+    }
 }
 
 }  // namespace libdnf5::repo

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -59,17 +59,94 @@ void ConfTest::test_config_repo() {
 }
 
 void ConfTest::test_config_pkg_gpgcheck() {
-    // Ensure both pkg_gpgcheck and gpgcheck point to the same underlying OptionBool object
-
+    // gpgcheck and pkg_gpgcheck are now separate options (gpgcheck is expanded via gpgcheck_policy)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    // For ConfigMain
-    CPPUNIT_ASSERT_EQUAL(&config.get_pkg_gpgcheck_option(), &config.get_gpgcheck_option());
-
-    // For ConfigRepo
-    repo::ConfigRepo config_repo(config, "test-repo");
-    CPPUNIT_ASSERT_EQUAL(&config_repo.get_pkg_gpgcheck_option(), &config_repo.get_gpgcheck_option());
+    // For ConfigMain: gpgcheck and pkg_gpgcheck are separate objects
+    CPPUNIT_ASSERT(&config.get_pkg_gpgcheck_option() != &config.get_gpgcheck_option());
 #pragma GCC diagnostic pop
+}
+
+void ConfTest::test_gpgcheck_policy_legacy() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "legacy");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_full() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "full");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_all() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "all");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_explicit_override() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "full");
+    parser.set_value("main", "gpgcheck", "1");
+    parser.set_value("main", "repo_gpgcheck", "0");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_repo() {
+    ConfigMain main_cfg;
+    {
+        ConfigParser parser;
+        parser.add_section("main");
+        parser.set_value("main", "gpgcheck_policy", "full");
+        main_cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+    }
+
+    repo::ConfigRepo repo_cfg(main_cfg, "test-repo");
+    ConfigParser repo_parser;
+    repo_parser.add_section("test-repo");
+    repo_parser.set_value("test-repo", "gpgcheck", "1");
+    repo_cfg.load_from_parser(repo_parser, "test-repo", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg.get_repo_gpgcheck_option().get_value());
+
+    repo::ConfigRepo repo_cfg2(main_cfg, "test-repo-2");
+    ConfigParser repo_parser2;
+    repo_parser2.add_section("test-repo-2");
+    repo_parser2.set_value("test-repo-2", "gpgcheck", "1");
+    repo_parser2.set_value("test-repo-2", "repo_gpgcheck", "0");
+    repo_cfg2.load_from_parser(repo_parser2, "test-repo-2", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg2.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, repo_cfg2.get_repo_gpgcheck_option().get_value());
 }
 
 void ConfTest::test_config_load_from_config() {

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -72,6 +72,112 @@ void ConfTest::test_config_pkg_gpgcheck() {
 #pragma GCC diagnostic pop
 }
 
+void ConfTest::test_gpgcheck_policy_legacy() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "legacy");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_full() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "full");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_all() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "all");
+    parser.set_value("main", "gpgcheck", "1");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_explicit_override() {
+    ConfigMain cfg;
+    ConfigParser parser;
+    parser.add_section("main");
+    parser.set_value("main", "gpgcheck_policy", "full");
+    parser.set_value("main", "gpgcheck", "1");
+    parser.set_value("main", "repo_gpgcheck", "0");
+    cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_repo_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, cfg.get_localpkg_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_repo() {
+    ConfigMain main_cfg;
+    {
+        ConfigParser parser;
+        parser.add_section("main");
+        parser.set_value("main", "gpgcheck_policy", "full");
+        main_cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+    }
+
+    repo::ConfigRepo repo_cfg(main_cfg, "test-repo");
+    ConfigParser repo_parser;
+    repo_parser.add_section("test-repo");
+    repo_parser.set_value("test-repo", "gpgcheck", "1");
+    repo_cfg.load_from_parser(repo_parser, "test-repo", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg.get_repo_gpgcheck_option().get_value());
+
+    repo::ConfigRepo repo_cfg2(main_cfg, "test-repo-2");
+    ConfigParser repo_parser2;
+    repo_parser2.add_section("test-repo-2");
+    repo_parser2.set_value("test-repo-2", "gpgcheck", "1");
+    repo_parser2.set_value("test-repo-2", "repo_gpgcheck", "0");
+    repo_cfg2.load_from_parser(repo_parser2, "test-repo-2", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg2.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, repo_cfg2.get_repo_gpgcheck_option().get_value());
+}
+
+void ConfTest::test_gpgcheck_policy_pkg_gpgcheck_no_expand() {
+    // pkg_gpgcheck=1 should NOT trigger policy expansion — only gpgcheck=1 should
+    ConfigMain main_cfg;
+    {
+        ConfigParser parser;
+        parser.add_section("main");
+        parser.set_value("main", "gpgcheck_policy", "full");
+        parser.set_value("main", "pkg_gpgcheck", "1");
+        main_cfg.load_from_parser(parser, "main", *base->get_vars(), logger);
+    }
+
+    CPPUNIT_ASSERT_EQUAL(true, main_cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, main_cfg.get_repo_gpgcheck_option().get_value());
+
+    repo::ConfigRepo repo_cfg(main_cfg, "test-repo");
+    ConfigParser repo_parser;
+    repo_parser.add_section("test-repo");
+    repo_parser.set_value("test-repo", "pkg_gpgcheck", "1");
+    repo_cfg.load_from_parser(repo_parser, "test-repo", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(true, repo_cfg.get_pkg_gpgcheck_option().get_value());
+    CPPUNIT_ASSERT_EQUAL(false, repo_cfg.get_repo_gpgcheck_option().get_value());
+}
+
 void ConfTest::test_config_load_from_config() {
     libdnf5::ConfigMain config;
 

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -34,6 +34,11 @@ class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST(test_config_repo);
     CPPUNIT_TEST(test_config_pkg_gpgcheck);
     CPPUNIT_TEST(test_config_load_from_config);
+    CPPUNIT_TEST(test_gpgcheck_policy_legacy);
+    CPPUNIT_TEST(test_gpgcheck_policy_full);
+    CPPUNIT_TEST(test_gpgcheck_policy_all);
+    CPPUNIT_TEST(test_gpgcheck_policy_explicit_override);
+    CPPUNIT_TEST(test_gpgcheck_policy_repo);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -43,6 +48,11 @@ public:
     void test_config_repo();
     void test_config_pkg_gpgcheck();
     void test_config_load_from_config();
+    void test_gpgcheck_policy_legacy();
+    void test_gpgcheck_policy_full();
+    void test_gpgcheck_policy_all();
+    void test_gpgcheck_policy_explicit_override();
+    void test_gpgcheck_policy_repo();
 
     std::unique_ptr<libdnf5::Base> base;
     libdnf5::LogRouter logger;

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -34,6 +34,12 @@ class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST(test_config_repo);
     CPPUNIT_TEST(test_config_pkg_gpgcheck);
     CPPUNIT_TEST(test_config_load_from_config);
+    CPPUNIT_TEST(test_gpgcheck_policy_legacy);
+    CPPUNIT_TEST(test_gpgcheck_policy_full);
+    CPPUNIT_TEST(test_gpgcheck_policy_all);
+    CPPUNIT_TEST(test_gpgcheck_policy_explicit_override);
+    CPPUNIT_TEST(test_gpgcheck_policy_repo);
+    CPPUNIT_TEST(test_gpgcheck_policy_pkg_gpgcheck_no_expand);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -43,6 +49,12 @@ public:
     void test_config_repo();
     void test_config_pkg_gpgcheck();
     void test_config_load_from_config();
+    void test_gpgcheck_policy_legacy();
+    void test_gpgcheck_policy_full();
+    void test_gpgcheck_policy_all();
+    void test_gpgcheck_policy_explicit_override();
+    void test_gpgcheck_policy_repo();
+    void test_gpgcheck_policy_pkg_gpgcheck_no_expand();
 
     std::unique_ptr<libdnf5::Base> base;
     libdnf5::LogRouter logger;


### PR DESCRIPTION
Introducing `gpgcheck_policy` option controlling what gpgcheck expands into: legacy (pkg only), full (pkg+repo, default), all (pkg+repo+localpkg).

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1859

Close: https://github.com/rpm-software-management/dnf5/issues/727