### PR TITLE
daemon: Add schedule_for_next_boot method to Offline interface

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.Offline.xml
@@ -148,6 +148,31 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         <arg name="error_msg" type="s" direction="out" />
     </method>
 
+    <!--
+        schedule_for_next_boot:
+        @options: an array of key/value pairs to modify the call behavior
+        @success: boolean, true if the offline transaction was successfully scheduled for the next boot
+        @error_msg: string, contains error encountered while scheduling the transaction
+
+        Schedule the prepared offline transaction for the next boot. This creates the magic symlink
+        /system-update and sets the transaction status to "ready". The system will not be rebooted;
+        the caller is responsible for initiating the reboot when appropriate.
+
+        The call might fail if there is no offline transaction in the "download-complete" or "ready" state,
+        or the transaction was not prepared using libdnf5.
+
+        Following @options are supported:
+            - interactive: boolean, default true
+                Set to "true", when the operation is done by a user, thus user interaction like password prompts can be done.
+
+        Unknown options are ignored.
+    -->
+    <method name="schedule_for_next_boot">
+        <arg name="options" type="a{sv}" direction="in" />
+        <arg name="success" type="b" direction="out" />
+        <arg name="error_msg" type="s" direction="out" />
+    </method>
+
 </interface>
 
 </node>

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -30,6 +30,26 @@
 
 const char * const ERR_ANOTHER_TOOL = "Offline transaction was initiated by another tool.";
 
+std::optional<libdnf5::offline::OfflineTransactionState> Offline::read_transaction_state(std::string & error_msg) {
+    const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
+    std::error_code ec;
+    if (!std::filesystem::exists(state_path, ec)) {
+        error_msg = "No offline transaction is stored.";
+        return std::nullopt;
+    }
+    libdnf5::offline::OfflineTransactionState state{state_path};
+    const auto & read_exception = state.get_read_exception();
+    if (read_exception != nullptr) {
+        try {
+            std::rethrow_exception(read_exception);
+        } catch (const std::exception & ex) {
+            error_msg = ex.what();
+        }
+        return std::nullopt;
+    }
+    return state;
+}
+
 std::filesystem::path Offline::get_datadir() {
     auto base = session.get_base();
     const auto & installroot = base->get_config().get_installroot_option().get_value();
@@ -135,6 +155,17 @@ void Offline::dbus_register() {
                     session.get_threads_manager().handle_method(
                         *this, &Offline::set_finish_action, call, session.session_locale);
                 },
+                {}},
+            sdbus::MethodVTableItem{
+                sdbus::MethodName{"schedule_for_next_boot"},
+                sdbus::Signature{"a{sv}"},
+                {"options"},
+                sdbus::Signature{"bs"},
+                {"success", "error_msg"},
+                [this](sdbus::MethodCall call) -> void {
+                    session.get_threads_manager().handle_method(
+                        *this, &Offline::schedule_for_next_boot, call, session.session_locale);
+                },
                 {}})
         .forInterface(dnfdaemon::INTERFACE_OFFLINE);
 #else
@@ -211,6 +242,17 @@ void Offline::dbus_register() {
         [this](sdbus::MethodCall call) -> void {
             session.get_threads_manager().handle_method(
                 *this, &Offline::set_finish_action, call, session.session_locale);
+        });
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_OFFLINE,
+        "schedule_for_next_boot",
+        {"a{sv}"},
+        {"options"},
+        "bs",
+        {"success", "error_msg"},
+        [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(
+                *this, &Offline::schedule_for_next_boot, call, session.session_locale);
         });
 #endif
 }
@@ -399,4 +441,49 @@ sdbus::MethodReply Offline::set_finish_action(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMap options{};
     call >> action;
     return impl_set_finish_action(call, action, options);
+}
+
+sdbus::MethodReply Offline::schedule_for_next_boot(sdbus::MethodCall & call) {
+    dnfdaemon::KeyValueMap options;
+    call >> options;
+
+    bool interactive = dnfdaemon::key_value_map_get<bool>(options, "interactive", true);
+    if (!session.check_authorization(
+            dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION, call.getSender(), interactive)) {
+        throw std::runtime_error("Not authorized");
+    }
+    bool success{false};
+    std::string error_msg{};
+
+    auto state = read_transaction_state(error_msg);
+    if (state) {
+        const auto & status = state->get_data().get_status();
+        if (status != libdnf5::offline::STATUS_DOWNLOAD_COMPLETE && status != libdnf5::offline::STATUS_READY) {
+            error_msg =
+                fmt::format("Cannot schedule offline transaction for next boot. Transaction status is \"{}\".", status);
+        } else {
+            const auto scheduled = offline_transaction_scheduled();
+            if (scheduled == Scheduled::ANOTHER_TOOL) {
+                error_msg = ERR_ANOTHER_TOOL;
+            } else {
+                // Handle both NOT_SCHEDULED (create symlink) and
+                // SCHEDULED (symlink already exists)
+                std::error_code ec;
+                if (scheduled == Scheduled::NOT_SCHEDULED) {
+                    std::filesystem::create_symlink(get_datadir(), libdnf5::offline::MAGIC_SYMLINK, ec);
+                }
+                if (ec) {
+                    error_msg = ec.message();
+                } else {
+                    state->get_data().set_status(libdnf5::offline::STATUS_READY);
+                    state->write();
+                    success = true;
+                }
+            }
+        }
+    }
+    auto reply = call.createReply();
+    reply << success;
+    reply << error_msg;
+    return reply;
 }

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -260,11 +260,10 @@ void Offline::dbus_register() {
 sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMap transaction_state;
 
-    const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-    // try load the offline transaction state
-    libdnf5::offline::OfflineTransactionState state{state_path};
-    if (!state.get_read_exception()) {
-        const auto & state_data = state.get_data();
+    std::string state_error;
+    auto state = read_transaction_state(state_error);
+    if (state) {
+        const auto & state_data = state->get_data();
         transaction_state["status"] = sdbus::Variant(state_data.get_status());
         transaction_state["cachedir"] = sdbus::Variant(state_data.get_cachedir());
         transaction_state["target_releasever"] = sdbus::Variant(state_data.get_target_releasever());
@@ -298,14 +297,11 @@ sdbus::MethodReply Offline::impl_cancel(sdbus::MethodCall & call, const dnfdaemo
             } else {
                 // Reset the status back to download-complete since the transaction
                 // is no longer scheduled for the next boot.
-                const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-                if (std::filesystem::exists(state_path, ec)) {
-                    libdnf5::offline::OfflineTransactionState state{state_path};
-                    if (!state.get_read_exception() &&
-                        state.get_data().get_status() == libdnf5::offline::STATUS_READY) {
-                        state.get_data().set_status(libdnf5::offline::STATUS_DOWNLOAD_COMPLETE);
-                        state.write();
-                    }
+                std::string state_error;
+                auto state = read_transaction_state(state_error);
+                if (state && state->get_data().get_status() == libdnf5::offline::STATUS_READY) {
+                    state->get_data().set_status(libdnf5::offline::STATUS_DOWNLOAD_COMPLETE);
+                    state->write();
                 }
             }
         } break;
@@ -399,28 +395,13 @@ sdbus::MethodReply Offline::impl_set_finish_action(
         error_msg =
             fmt::format("Unsupported finish action \"{}\". Valid options are \"reboot\", or \"poweroff\".", action);
     } else {
-        const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-        std::error_code ec;
-        // check presence of transaction state file
-        if (!std::filesystem::exists(state_path, ec)) {
-            error_msg = "No offline transaction is configured. Cannot set the finish action.";
-        } else {
-            // try load the offline transaction state
-            libdnf5::offline::OfflineTransactionState state{state_path};
-            const auto & read_exception = state.get_read_exception();
-            if (read_exception == nullptr) {
-                // set the poweroff_after item accordingly
-                state.get_data().set_poweroff_after(action == "poweroff");
-                // write the new state
-                state.write();
-                success = true;
-            } else {
-                try {
-                    std::rethrow_exception(read_exception);
-                } catch (const std::exception & ex) {
-                    error_msg = ex.what();
-                }
-            }
+        auto state = read_transaction_state(error_msg);
+        if (state) {
+            // set the poweroff_after item accordingly
+            state->get_data().set_poweroff_after(action == "poweroff");
+            // write the new state
+            state->write();
+            success = true;
         }
     }
     auto reply = call.createReply();

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -253,6 +253,18 @@ sdbus::MethodReply Offline::impl_cancel(sdbus::MethodCall & call, const dnfdaemo
             if (!std::filesystem::remove(libdnf5::offline::MAGIC_SYMLINK, ec) && ec) {
                 success = false;
                 error_msg = ec.message();
+            } else {
+                // Reset the status back to download-complete since the transaction
+                // is no longer scheduled for the next boot.
+                const std::filesystem::path state_path{get_datadir() / libdnf5::offline::TRANSACTION_STATE_FILENAME};
+                if (std::filesystem::exists(state_path, ec)) {
+                    libdnf5::offline::OfflineTransactionState state{state_path};
+                    if (!state.get_read_exception() &&
+                        state.get_data().get_status() == libdnf5::offline::STATUS_READY) {
+                        state.get_data().set_status(libdnf5::offline::STATUS_DOWNLOAD_COMPLETE);
+                        state.write();
+                    }
+                }
             }
         } break;
         case Scheduled::ANOTHER_TOOL:

--- a/dnf5daemon-server/services/offline/offline.hpp
+++ b/dnf5daemon-server/services/offline/offline.hpp
@@ -22,9 +22,11 @@
 
 #include "session.hpp"
 
+#include <libdnf5/transaction/offline.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <filesystem>
+#include <optional>
 
 class Offline : public IDbusSessionService {
 public:
@@ -45,6 +47,9 @@ private:
         sdbus::MethodCall & call, const std::string & action, const dnfdaemon::KeyValueMap & options);
     sdbus::MethodReply set_finish_action_with_options(sdbus::MethodCall & call);
     sdbus::MethodReply set_finish_action(sdbus::MethodCall & call);
+    sdbus::MethodReply schedule_for_next_boot(sdbus::MethodCall & call);
+
+    std::optional<libdnf5::offline::OfflineTransactionState> read_transaction_state(std::string & error_msg);
 
     enum class Scheduled { NOT_SCHEDULED, ANOTHER_TOOL, SCHEDULED };
     Scheduled offline_transaction_scheduled();


### PR DESCRIPTION
Add a new D-Bus method to the org.rpm.dnf.v0.Offline interface that schedules a prepared offline transaction for the next boot without rebooting. This creates the /system-update magic symlink and sets the transaction status to "ready", equivalent to `dnf5 offline reboot` without the actual reboot.

This is needed by GUI applications (e.g. GNOME Software) that download offline updates via the daemon and handle the reboot themselves.

Also fixes transaction status inconsistency after cancelling the offline transaction - the status is reverted to "download-complete" in such situations.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2693