### PR TITLE
Fix subprocess issues found with dash shell

### DIFF
--- a/libdnf5/utils/subprocess.cpp
+++ b/libdnf5/utils/subprocess.cpp
@@ -231,7 +231,7 @@ CompletedProcess run(const std::string & command, const std::vector<std::string>
                 throw SystemError(errno, M_("poll failed during subprocess I/O"));
             }
 
-            if (fds[STDOUT_FD].revents & POLLIN) {
+            if (fds[STDOUT_FD].revents & (POLLIN | POLLHUP)) {
                 const ssize_t bytes_read = read(fds[STDOUT_FD].fd, buffer, sizeof(buffer));
                 if (bytes_read > 0) {
                     stdout_bytes.insert(
@@ -245,7 +245,7 @@ CompletedProcess run(const std::string & command, const std::vector<std::string>
                 }
             }
 
-            if (fds[STDERR_FD].revents & POLLIN) {
+            if (fds[STDERR_FD].revents & (POLLIN | POLLHUP)) {
                 const ssize_t bytes_read = read(fds[STDERR_FD].fd, buffer, sizeof(buffer));
                 if (bytes_read > 0) {
                     stderr_bytes.insert(
@@ -259,11 +259,10 @@ CompletedProcess run(const std::string & command, const std::vector<std::string>
                 }
             }
 
-            // Check for errors or hangup on any descriptor
-            if (fds[STDOUT_FD].revents & (POLLERR | POLLHUP)) {
+            if (fds[STDOUT_FD].revents & POLLERR) {
                 fds[STDOUT_FD].fd = -1;
             }
-            if (fds[STDERR_FD].revents & (POLLERR | POLLHUP)) {
+            if (fds[STDERR_FD].revents & POLLERR) {
                 fds[STDERR_FD].fd = -1;
             }
         }

--- a/test/libdnf5/utils/test_subprocess.cpp
+++ b/test/libdnf5/utils/test_subprocess.cpp
@@ -92,7 +92,7 @@ void UtilsSubprocessTest::test_binary_data() {
     // Test that binary data (non-text) is captured correctly
     // Use printf to output bytes including null bytes and non-printable characters
     const auto result = libdnf5::utils::subprocess::run(
-        "/usr/bin/env", {"/usr/bin/env", "sh", "-c", "printf '\\x00\\x01\\x02\\xff\\xfe'; printf '\\x03\\x04' >&2"});
+        "/usr/bin/env", {"/usr/bin/env", "sh", "-c", "printf '\\000\\001\\002\\377\\376'; printf '\\003\\004' >&2"});
 
     CPPUNIT_ASSERT_EQUAL(0, result.returncode);
 


### PR DESCRIPTION
The \xNN hex escapes in printf are not supported by POSIX shells like dash. Replace with \NNN octal escapes so the test works regardless of which shell is used.

Also a race condition in child process output polling was discovered while running the tests with dash shell.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2704