### PR TITLE
Verify RPM signatures per package in dnf download

### DIFF
--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -27,8 +27,10 @@
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/rpm/package_set.hpp>
+#include <libdnf5/rpm/rpm_signature.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
+#include <filesystem>
 #include <algorithm>
 #include <iostream>
 #include <map>
@@ -170,7 +172,6 @@ void DownloadCommand::set_argument_parser() {
             arch_option.emplace(value);
             return true;
         });
-
 
     cmd.register_named_arg(arch);
     cmd.register_named_arg(resolve);
@@ -415,6 +416,36 @@ void DownloadCommand::run() {
         std::cout << "Downloading Packages:" << std::endl;
     }
     downloader.download();
+
+    // gpg verification
+    bool all_ok = true;
+    std::error_code ec;
+    libdnf5::rpm::RpmSignature rpm_signature(ctx.get_base());
+
+    for (const auto & [nevra, pkg] : packages_to_download) {
+        if (!pkg.is_pkg_gpgcheck_enabled()) {
+            continue;
+        }
+
+        auto pkg_path = pkg.get_package_path();
+        if (std::filesystem::exists(pkg_path, ec)) {
+            auto check_result = rpm_signature.check_package_signature(pkg_path);
+            if (check_result != libdnf5::rpm::RpmSignature::CheckResult::OK) {
+                std::cerr << libdnf5::utils::sformat(
+                    _("OpenPGP verification FAILED for '{}': {}"),
+                    std::filesystem::path(pkg_path).filename().c_str(),
+                    rpm_signature.check_result_to_string(check_result))
+                          << std::endl;
+                std::filesystem::remove(pkg_path, ec);
+                all_ok = false;
+            }
+        }
+    }
+
+    if (!all_ok) {
+        throw libdnf5::cli::CommandExitError(
+            1, M_("OpenPGP signature verification failed for some packages."));
+    }
 }
 
 


### PR DESCRIPTION
With all due respect, I'm asking to implement this warning, because as an user, I had no idea that `dnf download` downloads RPMs without any GPG verification whatsoever. Then when you end up using those packages in your personal projects, there's supply chain risk, as well as when you install a RPM with `sudo dnf install` – no verification in that case as well, because:
```
keepassxc              x86_64 2.7.5-1.mga9             @commandline    31.1 MiB
Warning: skipped OpenPGP checks for 1 package from repository: @commandline
```
Now consider this: one downloads with `dnf download`, then does `sudo dnf install [whatever RPM]`, all security checks get bypassed because `@commandline` "repository", which is a major self-reinforcing security oversight. APT, on other hand, screams loudly and proudly that the repository has no public key, therefore downloads don't even succeed. I understand that there are fundamental philosophical differences between APT and DNF, however, we can take a glance:
```
The following signatures couldn't be verified because the public key is not available
W: GPG error: https://ports.ubuntu.com/ubuntu-ports xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 40976EAF437D05B5 NO_PUBKEY 3B4FE6ACC0B21F32
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
```
Those are **_three warnings_**, that happen during `apt update`, and the user needs to provide extra flags/repo configuration for the download to succeed. `apt-get download` blocks DEBs from unsigned repos and reports them as:
```
E: Version '[version]' for '[package]' was not found
```
I strongly believe we can do better than whatever we have now. It doesn't help that the overwhelming majority share of DNF5 comes from Fedora, which only reinforces the cognitive bias that "Fedora has us covered by default", when in this instance, this is not the case.

I'm thankful to the DNF community for the work that was made over the years, but this issue needs to be solved.

PS. This warning does not change any existing behavior or break any workflows, it simply informs users of a security property they currently have no way of knowing.