### PR TITLE
doc: Annotate a fix for CVE-2026-3836

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - libdnf5-cli: fix clang-format
 - libdnf5-cli: handle C or POSIX locale gracefully in progressbar width calculation
 - libdnf5-cli: remove unused utils::utf8 module
-- dnf5daemon-server: Fix daemon crash for invalid locale
+- dnf5daemon-server: Fix daemon crash for invalid locale (CVE-2026-3836)
 - subprocess: Bind /dev/null to child stdin
 - test: Test libdnf5::utils::subprocess::run
 - bootc: Handle read-only /usr on non-bootc system


### PR DESCRIPTION
The fix was delivered in ef98e1cc9a7b084a1ee70723206b3a5f450c48ee commit.

https://github.com/rpm-software-management/dnf5/pull/2643
https://bugzilla.redhat.com/show_bug.cgi?id=2445771
https://bugzilla.redhat.com/show_bug.cgi?id=2445770