### PR TITLE
add dup alias

### DIFF
--- a/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
+++ b/dnf5/config/usr/share/dnf5/aliases.d/compatibility.conf
@@ -110,6 +110,13 @@ descr = "Alias for 'distro-sync'"
 group_id = 'commands-compatibility-aliases'
 complete = false
 
+['dup']
+type = 'command'
+attached_command = 'distro-sync'
+descr = "Alias for 'distro-sync'"
+group_id = 'commands-compatibility-aliases'
+complete = false
+
 ['grp']
 type = 'command'
 attached_command = 'group'


### PR DESCRIPTION
Adds dup alias to distro-sync

openSUSE Tumbleweed and MicroOS users are used to this command alias, via zypper dup, and with the forthcoming availability of transactional updates via libdnf-plugin-txnupd making transactional systems available to fedora, and the use of the same plugin on openSUSE systems using dnf it provides a familiar command