### PR TITLE
libdnf5: fix inappropriate backslash consumption in config files

### DIFF
--- a/libdnf5/conf/vars.cpp
+++ b/libdnf5/conf/vars.cpp
@@ -173,14 +173,17 @@ std::pair<std::string, size_t> Vars::substitute_expression(std::string_view text
         }
 
         if (res[pos] == '\\') {
-            // Escape the next character (if there is one)
+            // Escape the next character only if it is special ($ or } in subexpressions)
             if (pos + 1 >= res.length()) {
                 break;
             }
-            res.erase(pos, 1);
-            total_scanned += 2;
-            pos += 1;
-            continue;
+            char next = res[pos + 1];
+            if (next == '$' || (next == '}' && depth > 0)) {
+                res.erase(pos, 1);
+                total_scanned += 2;
+                pos += 1;
+                continue;
+            }
         }
         if (res[pos] == '$') {
             // variable expression starts after the $ and includes the braces

--- a/test/libdnf5/conf/data/main.conf
+++ b/test/libdnf5/conf/data/main.conf
@@ -6,3 +6,7 @@ plugins=False
 
 [repo-1]
 baseurl=http://example.com/$var1,http://example.com/$var2
+
+[repo-backslash]
+name=M\y ug\\ly name
+baseurl=http://example.com/repo

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -58,6 +58,16 @@ void ConfTest::test_config_repo() {
     CPPUNIT_ASSERT_EQUAL(baseurl, config_repo.get_baseurl_option().get_value());
 }
 
+void ConfTest::test_config_repo_backslash() {
+    repo::ConfigRepo config_repo(config, "repo-backslash");
+    ConfigParser parser;
+    parser.read(PROJECT_SOURCE_DIR "/test/libdnf5/conf/data/main.conf");
+    base->setup();
+    config_repo.load_from_parser(parser, "repo-backslash", *base->get_vars(), logger);
+
+    CPPUNIT_ASSERT_EQUAL(std::string("M\\y ug\\\\ly name"), config_repo.get_name_option().get_value());
+}
+
 void ConfTest::test_config_pkg_gpgcheck() {
     // Ensure both pkg_gpgcheck and gpgcheck point to the same underlying OptionBool object
 

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -32,6 +32,7 @@ class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(ConfTest);
     CPPUNIT_TEST(test_config_main);
     CPPUNIT_TEST(test_config_repo);
+    CPPUNIT_TEST(test_config_repo_backslash);
     CPPUNIT_TEST(test_config_pkg_gpgcheck);
     CPPUNIT_TEST(test_config_load_from_config);
     CPPUNIT_TEST(test_gpgcheck_policy_legacy);
@@ -47,6 +48,7 @@ public:
 
     void test_config_main();
     void test_config_repo();
+    void test_config_repo_backslash();
     void test_config_pkg_gpgcheck();
     void test_config_load_from_config();
     void test_gpgcheck_policy_legacy();

--- a/test/libdnf5/conf/test_vars.cpp
+++ b/test/libdnf5/conf/test_vars.cpp
@@ -47,6 +47,21 @@ void VarsTest::test_vars() {
     CPPUNIT_ASSERT_EQUAL("456"s, base->get_vars()->substitute("${unset:-${var1:+${var2:+$var2}}}"));
 }
 
+void VarsTest::test_vars_backslash() {
+    base->setup();
+    auto vars = base->get_vars();
+    vars->set("var1", "value1", libdnf5::Vars::Priority::PLUGIN);
+
+    // Backslashes should be preserved unless escaping special characters ($ or } in subexpressions)
+    CPPUNIT_ASSERT_EQUAL("M\\y ug\\\\ly name"s, vars->substitute("M\\y ug\\\\ly name"));
+    CPPUNIT_ASSERT_EQUAL("My ug\\ly name"s, vars->substitute("My ug\\ly name"));
+    CPPUNIT_ASSERT_EQUAL("$var1"s, vars->substitute("\\$var1"));
+    // With only $ escaping, \\$var1 becomes \$var1
+    CPPUNIT_ASSERT_EQUAL("\\$var1"s, vars->substitute("\\\\$var1"));
+    // To test escaped brace, we need another one to actually close the expression
+    CPPUNIT_ASSERT_EQUAL("default}ext"s, vars->substitute("${unset:-default\\}ext}"));
+}
+
 
 void VarsTest::test_vars_multiple_dirs() {
     base->get_config().get_varsdir_option().set(std::vector<std::string>{

--- a/test/libdnf5/conf/test_vars.hpp
+++ b/test/libdnf5/conf/test_vars.hpp
@@ -30,6 +30,7 @@
 class VarsTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(VarsTest);
     CPPUNIT_TEST(test_vars);
+    CPPUNIT_TEST(test_vars_backslash);
     CPPUNIT_TEST(test_vars_multiple_dirs);
     CPPUNIT_TEST(test_vars_env);
     CPPUNIT_TEST(test_vars_api);
@@ -42,6 +43,7 @@ public:
     void setUp() override;
 
     void test_vars();
+    void test_vars_backslash();
     void test_vars_multiple_dirs();
     void test_vars_env();
     void test_vars_api();


### PR DESCRIPTION
The variable substitution engine in libdnf5 was overly aggressive, unconditionally removing backslashes even when they preceded normal characters (e.g., 'M\y' became 'My').

This change restricts backslash de-escaping to only special characters:
- '$' (to allow literal dollar signs)
- '}' (to allow literal braces within subexpressions)

This ensures that backslashes in repository names and paths are preserved literally, matching the behavior of --setopt and restoring compatibility with user expectations from DNF4.

Added unit tests to verify the fix and prevent regressions.

Fixes: #2503
