### PR TITLE
Move system-repo.lock to /var/lib/dnf/system-repo.lock

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -488,10 +488,10 @@ Package management library.
 %verify(not md5 size mtime) %attr(0644, root, root) %ghost %{_prefix}/lib/sysimage/libdnf5/packages.toml
 %verify(not md5 size mtime) %attr(0644, root, root) %ghost %{_prefix}/lib/sysimage/libdnf5/system.toml
 %verify(not md5 size mtime) %attr(0644, root, root) %ghost %{_prefix}/lib/sysimage/libdnf5/transaction_history.sqlite{,-shm,-wal}
-%verify(not md5 size mtime) %attr(0664, root, root) %ghost %{_prefix}/lib/sysimage/libdnf5/system-repo.lock
 %license lgpl-2.1.txt
 %ghost %attr(0755, root, root) %dir %{_var}/cache/libdnf5
-%ghost %attr(0755, root, root) %dir %{_sharedstatedir}/dnf
+%attr(0755, root, root) %dir %{_sharedstatedir}/dnf
+%verify(not md5 size mtime) %attr(0644, root, root) %{_sharedstatedir}/dnf/system-repo.lock
 
 # ========== libdnf5-cli ==========
 
@@ -1087,14 +1087,15 @@ for file in \
     environments.toml groups.toml modules.toml nevras.toml packages.toml \
     system.toml \
     transaction_history.sqlite transaction_history.sqlite-shm \
-    transaction_history.sqlite-wal \
-    system-repo.lock
+    transaction_history.sqlite-wal
 do
     touch %{buildroot}%{_prefix}/lib/sysimage/libdnf5/$file
 done
 mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/comps_groups
 mkdir -p %{buildroot}%{_prefix}/lib/sysimage/libdnf5/offline
 touch %{buildroot}%{_sysconfdir}/dnf/versionlock.toml
+mkdir -p %{buildroot}%{_sharedstatedir}/dnf
+touch %{buildroot}%{_sharedstatedir}/dnf/system-repo.lock
 
 %if 0%{?fedora} || 0%{?rhel} > 10
 ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/microdnf

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1226,9 +1226,9 @@ static bool user_has_privileges(dnf5::Context & context) {
     const auto & transaction_lock_path =
         installroot / std::filesystem::path{libdnf5::TRANSACTION_LOCK_FILEPATH}.relative_path();
 
-    const auto & system_state_dir = context.get_base().get_config().get_system_state_dir_option().get_value();
+    const auto & persistdir = context.get_base().get_config().get_persistdir_option().get_value();
     const auto & system_repo_lock_path =
-        installroot / std::filesystem::path{system_state_dir}.relative_path() / libdnf5::SYSTEM_REPO_LOCK_FILENAME;
+        installroot / std::filesystem::path{persistdir}.relative_path() / libdnf5::SYSTEM_REPO_LOCK_FILENAME;
 
     try {
         std::filesystem::create_directories(transaction_lock_path.parent_path());

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -446,10 +446,10 @@ bool Base::Impl::lock_system_repo(libdnf5::utils::LockAccess access, libdnf5::ut
     if (!system_repo_lock.has_value()) {
         auto & installroot_option = config.get_installroot_option();
         installroot_option.lock("Locked by Base::Impl::lock_system_repo()");
-        const auto & system_state_dir = config.get_system_state_dir_option().get_value();
+        const auto & persistdir = config.get_persistdir_option().get_value();
 
         const auto & relative_path =
-            std::filesystem::path{system_state_dir}.relative_path() / std::filesystem::path{SYSTEM_REPO_LOCK_FILENAME};
+            std::filesystem::path{persistdir}.relative_path() / std::filesystem::path{SYSTEM_REPO_LOCK_FILENAME};
         const auto & lock_file_path = installroot_option.get_value() / relative_path;
 
         std::filesystem::create_directories(lock_file_path.parent_path());


### PR DESCRIPTION
The lockfile should not be `%ghost` since DNF5 expects it to always exist.

/var is a better place for the lockfile, in part since on bootc systems, we can open it for writing before unlocking /usr.

Resolves https://github.com/rpm-software-management/dnf5/issues/2709.