### PR TITLE
Port bootc functionality from DNF4

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -127,6 +127,7 @@ void BuildDepCommand::set_argument_parser() {
     create_from_vendor_option(*this, from_vendors, true);
 
     create_store_option(*this);
+    create_transient_option(*this);
     create_offline_option(*this);
 
     auto spec_arg = parser.add_new_named_arg("spec");

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -473,6 +473,7 @@ Package management library.
 %config(noreplace) %{_sysconfdir}/dnf/dnf.conf
 %dir %{_sysconfdir}/dnf/vars
 %dir %{_sysconfdir}/dnf/protected.d
+%dir %{_sysconfdir}/dnf/usr-drift-protected-paths.d
 %else
 %exclude %{_sysconfdir}/dnf/dnf.conf
 %endif

--- a/dnf5/commands/autoremove/autoremove.cpp
+++ b/dnf5/commands/autoremove/autoremove.cpp
@@ -38,6 +38,7 @@ void AutoremoveCommand::set_argument_parser() {
         _("Remove all unneeded packages originally installed as dependencies."));
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void AutoremoveCommand::configure() {

--- a/dnf5/commands/debuginfo-install/debuginfo-install.cpp
+++ b/dnf5/commands/debuginfo-install/debuginfo-install.cpp
@@ -58,6 +58,7 @@ void DebuginfoInstallCommand::set_argument_parser() {
     cmd.register_positional_arg(patterns_arg);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void DebuginfoInstallCommand::configure() {

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -59,6 +59,7 @@ void DistroSyncCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void DistroSyncCommand::configure() {

--- a/dnf5/commands/do/do.cpp
+++ b/dnf5/commands/do/do.cpp
@@ -176,6 +176,7 @@ void DoCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void DoCommand::configure() {

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -62,6 +62,7 @@ void DowngradeCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void DowngradeCommand::configure() {

--- a/dnf5/commands/group/group_install.cpp
+++ b/dnf5/commands/group/group_install.cpp
@@ -45,6 +45,7 @@ void GroupInstallCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void GroupInstallCommand::configure() {

--- a/dnf5/commands/group/group_remove.cpp
+++ b/dnf5/commands/group/group_remove.cpp
@@ -36,6 +36,7 @@ void GroupRemoveCommand::set_argument_parser() {
     group_specs = std::make_unique<CompsSpecArguments>(*this, ArgumentParser::PositionalArg::AT_LEAST_ONE);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void GroupRemoveCommand::configure() {

--- a/dnf5/commands/group/group_upgrade.cpp
+++ b/dnf5/commands/group/group_upgrade.cpp
@@ -42,6 +42,7 @@ void GroupUpgradeCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void GroupUpgradeCommand::configure() {

--- a/dnf5/commands/history/history_redo.cpp
+++ b/dnf5/commands/history/history_redo.cpp
@@ -35,6 +35,7 @@ void HistoryRedoCommand::set_argument_parser() {
     transaction_specs->get_arg()->set_complete_hook_func(create_history_id_autocomplete(ctx));
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_store_option(*this);
+    create_transient_option(*this);
     create_offline_option(*this);
 }
 

--- a/dnf5/commands/history/history_rollback.cpp
+++ b/dnf5/commands/history/history_rollback.cpp
@@ -38,6 +38,7 @@ void HistoryRollbackCommand::set_argument_parser() {
     ignore_extras = std::make_unique<IgnoreExtrasOption>(*this);
     ignore_installed = std::make_unique<IgnoreInstalledOption>(*this);
     create_store_option(*this);
+    create_transient_option(*this);
     create_offline_option(*this);
 }
 

--- a/dnf5/commands/history/history_undo.cpp
+++ b/dnf5/commands/history/history_undo.cpp
@@ -38,6 +38,7 @@ void HistoryUndoCommand::set_argument_parser() {
     ignore_extras = std::make_unique<IgnoreExtrasOption>(*this);
     ignore_installed = std::make_unique<IgnoreInstalledOption>(*this);
     create_store_option(*this);
+    create_transient_option(*this);
     create_offline_option(*this);
 }
 

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -70,6 +70,7 @@ void InstallCommand::set_argument_parser() {
     advisory_enhancement = std::make_unique<EnhancementOption>(*this);
     advisory_newpackage = std::make_unique<NewpackageOption>(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void InstallCommand::configure() {

--- a/dnf5/commands/mark/mark.cpp
+++ b/dnf5/commands/mark/mark.cpp
@@ -39,6 +39,7 @@ void MarkCommand::set_argument_parser() {
     auto skip_unavailable = std::make_unique<SkipUnavailableOption>(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void MarkCommand::register_subcommands() {

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -62,6 +62,7 @@ void ReinstallCommand::set_argument_parser() {
     create_downloadonly_option(*this);
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void ReinstallCommand::configure() {

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -103,6 +103,7 @@ void RemoveCommand::set_argument_parser() {
 
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void RemoveCommand::configure() {

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -75,6 +75,7 @@ void SwapCommand::set_argument_parser() {
 
     create_offline_option(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void SwapCommand::configure() {

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -85,6 +85,7 @@ void UpgradeCommand::set_argument_parser() {
     advisory_enhancement = std::make_unique<EnhancementOption>(*this);
     advisory_newpackage = std::make_unique<NewpackageOption>(*this);
     create_store_option(*this);
+    create_transient_option(*this);
 }
 
 void UpgradeCommand::configure() {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -240,6 +240,12 @@ void Context::Impl::update_repo_metadata_from_advisory_options(
 }
 
 void Context::Impl::load_repos(bool load_system, bool load_available) {
+    if (persistence == libdnf5::base::TransactionPersistence::TRANSIENT &&
+        !base.get_config().get_usr_drift_protected_paths_option().get_value().empty()) {
+        base.get_config().get_optional_metadata_types_option().add_item(
+            libdnf5::Option::Priority::RUNTIME, libdnf5::METADATA_TYPE_FILELISTS);
+    }
+
     if (load_available) {
         libdnf5::repo::RepoQuery repos(base);
         repos.filter_enabled(true);

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -622,6 +622,11 @@ bool Context::Impl::cmd_requires_privileges() const {
         return false;
     }
 
+    // when storing a transaction, system should not be modified
+    if (!get_transaction_store_path().empty()) {
+        return false;
+    }
+
     // otherwise, transactional cmds with store option defined are expected to modify the system
     auto it_store = std::find_if(
         all_cmd_args.begin(), all_cmd_args.end(), [](auto arg) { return arg->get_long_name() == "store"; });

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -508,6 +508,8 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         transaction.set_comment(comment);
     }
 
+    transaction.set_persistence(persistence);
+
     auto result = transaction.run();
     if (result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
         print_error(libdnf5::utils::sformat(
@@ -662,6 +664,14 @@ const char * Context::get_comment() const noexcept {
 
 void Context::set_comment(const char * comment) noexcept {
     p_impl->set_comment(comment);
+}
+
+libdnf5::base::TransactionPersistence Context::get_persistence() const noexcept {
+    return p_impl->get_persistence();
+}
+
+void Context::set_persistence(libdnf5::base::TransactionPersistence persistence) noexcept {
+    p_impl->set_persistence(persistence);
 }
 
 std::string Context::get_cmdline() {

--- a/dnf5/context_impl.hpp
+++ b/dnf5/context_impl.hpp
@@ -39,6 +39,12 @@ public:
 
     void set_comment(const char * comment) noexcept { this->comment = comment; }
 
+    libdnf5::base::TransactionPersistence get_persistence() const noexcept { return persistence; }
+
+    void set_persistence(libdnf5::base::TransactionPersistence persistence) noexcept {
+        this->persistence = persistence;
+    }
+
     std::string get_cmdline() { return cmdline; }
 
     void set_cmdline(std::string & cmdline) { this->cmdline = cmdline; }
@@ -143,6 +149,8 @@ private:
 
     /// Points to user comment.
     const char * comment{nullptr};
+
+    libdnf5::base::TransactionPersistence persistence = libdnf5::base::TransactionPersistence::UNKNOWN;
 
     bool should_store_offline = false;
     bool json_output = false;

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -89,6 +89,12 @@ public:
     /// Stores pointer to user comment.
     void set_comment(const char * comment) noexcept;
 
+    /// Gets transaction persistence.
+    libdnf5::base::TransactionPersistence get_persistence() const noexcept;
+
+    /// Stores transaction persistence.
+    void set_persistence(libdnf5::base::TransactionPersistence persistence) noexcept;
+
     /// Get command line used to run the dnf5 command
     std::string get_cmdline();
 

--- a/dnf5/include/dnf5/shared_options.hpp
+++ b/dnf5/include/dnf5/shared_options.hpp
@@ -65,6 +65,10 @@ DNF_API void create_downloadonly_option(dnf5::Command & command);
 /// The value is stored in Context::transaction_store_path.
 DNF_API void create_store_option(dnf5::Command & command);
 
+/// Create the `--transient` option for a command provided as an argument.
+/// Sets the `persistence` configuration option to "transient".
+DNF_API void create_transient_option(dnf5::Command & command);
+
 /// Create the `--offline` option for a command provided as an argument.
 DNF_API void create_offline_option(dnf5::Command & command);
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -57,6 +57,7 @@
 #include "download_callbacks.hpp"
 #include "plugins.hpp"
 #include "signal_handlers.hpp"
+#include "utils/auth.hpp"
 
 #include <fcntl.h>
 #include <fmt/format.h>
@@ -1521,26 +1522,29 @@ int main(int argc, char * argv[]) try {
                 dump_repository_configuration(context, repo_id_list);
             }
 
+            std::optional<bool> is_bootc_system;
             if (context.p_impl->cmd_requires_privileges()) {
                 const auto & installroot = base.get_config().get_installroot_option().get_value();
 
-                if (installroot == "/" && !libdnf5::utils::bootc::is_writable()) {
-                    if (libdnf5::utils::bootc::is_bootc_system()) {
-                        throw libdnf5::cli::ReadOnlySystemError(
-                            M_("Error: this bootc system is configured to be read-only. For more information, run "
-                               "`bootc --help`."));
-                    }
-                    throw libdnf5::cli::ReadOnlySystemError(
-                        M_("Error: /usr is configured to be read-only. You may be running an image-based or immutable "
-                           "operating system. For more information, refer to your "
-                           "distribution's documentation."));
-                }
+                const auto & insufficient_privileges_error = libdnf5::cli::InsufficientPrivilegesError(
+                    M_("The requested operation requires superuser privileges. Please log in as a user with elevated "
+                       "rights, or use the \"--assumeno\" or \"--downloadonly\" options to run the command without "
+                       "modifying the system state."));
 
-                if (!user_has_privileges(context)) {
-                    throw libdnf5::cli::InsufficientPrivilegesError(M_(
-                        "The requested operation requires superuser privileges. Please log in as a user with elevated "
-                        "rights, or use the \"--assumeno\" or \"--downloadonly\" options to run the command without "
-                        "modifying the system state."));
+                if (installroot == "/" && !libdnf5::utils::bootc::is_writable()) {
+                    // is_bootc_system calls `bootc status` which errors unless run by UID 0.
+                    if (!libdnf5::utils::am_i_root()) {
+                        throw insufficient_privileges_error;
+                    }
+                    is_bootc_system = libdnf5::utils::bootc::is_bootc_system();
+                    if (!is_bootc_system) {
+                        throw libdnf5::cli::ReadOnlySystemError(
+                            M_("Error: /usr is configured to be read-only. You may be running an image-based or "
+                               "immutable operating system. For more information, refer to your "
+                               "distribution's documentation."));
+                    }
+                } else if (!user_has_privileges(context)) {
+                    throw insufficient_privileges_error;
                 }
             }
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1589,6 +1589,7 @@ int main(int argc, char * argv[]) try {
                                "the system reboots."));
                     }
                 }
+                context.set_persistence(libdnf5::base::TransactionPersistence::TRANSIENT);
 
             } else {
                 // Not a bootc transaction.
@@ -1596,6 +1597,7 @@ int main(int argc, char * argv[]) try {
                     throw libdnf5::cli::CommandExitError(
                         1, M_("Error: transient transactions are only supported on bootc systems."));
                 }
+                context.set_persistence(libdnf5::base::TransactionPersistence::PERSIST);
             }
 
             const auto load_available = context.get_load_available_repos() != dnf5::Context::LoadAvailableRepos::NONE;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -61,6 +61,7 @@
 
 #include <fcntl.h>
 #include <fmt/format.h>
+#include <fnmatch.h>
 #include <libdnf5-cli/argument_parser.hpp>
 #include <libdnf5-cli/exception.hpp>
 #include <libdnf5-cli/exit-codes.hpp>
@@ -93,6 +94,7 @@
 #include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <map>
 #include <utility>
 
 constexpr const char * DNF5_LOGGER_FILENAME = "dnf5.log";
@@ -1655,6 +1657,39 @@ int main(int argc, char * argv[]) try {
                                     cmd_line));
                             }
                         }
+                    }
+                }
+
+                // Check whether the transaction modifies usr_drift_protected_paths
+                const auto & usr_drift_protected_paths =
+                    base.get_config().get_usr_drift_protected_paths_option().get_value();
+                if (!usr_drift_protected_paths.empty()) {
+                    std::map<std::string, std::vector<std::string>> transaction_protected_paths;
+                    for (const auto & tspkg : context.get_transaction()->get_transaction_packages()) {
+                        const auto & pkg = tspkg.get_package();
+                        for (const auto & pkg_file_path : pkg.get_files()) {
+                            for (const auto & protected_pattern : usr_drift_protected_paths) {
+                                if (fnmatch(protected_pattern.c_str(), pkg_file_path.c_str(), 0) == 0) {
+                                    transaction_protected_paths[pkg.get_nevra()].push_back(pkg_file_path);
+                                }
+                            }
+                        }
+                    }
+                    if (!transaction_protected_paths.empty()) {
+                        context.print_error(
+                            _("This transaction would modify the following paths, possibly introducing "
+                              "inconsistencies when the transient overlay on /usr is discarded. See the "
+                              "usr_drift_protected_paths configuration option for more information."));
+                        for (const auto & [nevra, protected_paths] : transaction_protected_paths) {
+                            context.print_error(nevra);
+                            for (const auto & protected_path : protected_paths) {
+                                context.print_error(std::string("  ") + protected_path);
+                            }
+                        }
+                        throw libdnf5::cli::CommandExitError(
+                            1,
+                            M_("Operation aborted. Pass --setopt=usr_drift_protected_paths= to disable this "
+                               "check and proceed anyway."));
                     }
                 }
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1522,29 +1522,79 @@ int main(int argc, char * argv[]) try {
                 dump_repository_configuration(context, repo_id_list);
             }
 
+            // std::nullopt == Unknown whether system is bootc
             std::optional<bool> is_bootc_system;
-            if (context.p_impl->cmd_requires_privileges()) {
-                const auto & installroot = base.get_config().get_installroot_option().get_value();
 
+            const bool cmd_requires_privileges = context.p_impl->cmd_requires_privileges();
+            if (cmd_requires_privileges) {
                 const auto & insufficient_privileges_error = libdnf5::cli::InsufficientPrivilegesError(
                     M_("The requested operation requires superuser privileges. Please log in as a user with elevated "
                        "rights, or use the \"--assumeno\" or \"--downloadonly\" options to run the command without "
                        "modifying the system state."));
 
-                if (installroot == "/" && !libdnf5::utils::bootc::is_writable()) {
-                    // is_bootc_system calls `bootc status` which errors unless run by UID 0.
-                    if (!libdnf5::utils::am_i_root()) {
-                        throw insufficient_privileges_error;
+                // If the installroot is /, we care whether the system is bootc.
+                const auto & installroot = base.get_config().get_installroot_option().get_value();
+                if (installroot == "/") {
+                    if (libdnf5::utils::bootc::is_writable()) {
+                        // If the system is writable, we shouldn't error if
+                        // `bootc status` could not be determined.
+                        if (libdnf5::utils::am_i_root()) {
+                            try {
+                                is_bootc_system = libdnf5::utils::bootc::is_bootc_system();
+                            } catch (const libdnf5::RuntimeError & e) {
+                                context.print_info(libdnf5::utils::sformat(_("Warning: {}"), e.what()));
+                            }
+                        }
+                    } else {
+                        // /usr is not writable. We should try harder to
+                        // ascertain `bootc status` to avoid showing a bootc
+                        // user the generic error for read-only /usr.
+                        if (!libdnf5::utils::am_i_root()) {
+                            throw insufficient_privileges_error;
+                        }
+                        is_bootc_system = libdnf5::utils::bootc::is_bootc_system();
+                        if (!*is_bootc_system) {
+                            throw libdnf5::cli::ReadOnlySystemError(
+                                M_("Error: /usr is configured to be read-only. You may be running an image-based or "
+                                   "immutable operating system. For more information, refer to your "
+                                   "distribution's documentation."));
+                        }
                     }
-                    is_bootc_system = libdnf5::utils::bootc::is_bootc_system();
-                    if (!is_bootc_system) {
-                        throw libdnf5::cli::ReadOnlySystemError(
-                            M_("Error: /usr is configured to be read-only. You may be running an image-based or "
-                               "immutable operating system. For more information, refer to your "
-                               "distribution's documentation."));
-                    }
-                } else if (!user_has_privileges(context)) {
+                }
+
+                if (!user_has_privileges(context)) {
                     throw insufficient_privileges_error;
+                }
+            }
+
+            const bool is_bootc_transaction = cmd_requires_privileges && is_bootc_system.value_or(false);
+            bool bootc_system_needs_unlock = false;
+            const auto & persistence = base.get_config().get_persistence_option().get_value();
+            if (is_bootc_transaction) {
+                if (persistence == "persist") {
+                    throw libdnf5::cli::CommandExitError(
+                        1,
+                        M_("Error: persistent transactions aren't supported on bootc systems. Pass --transient to "
+                           "perform "
+                           "this operation in a transient overlay which will reset when the system reboots."));
+                }
+
+                if (!libdnf5::utils::bootc::is_writable()) {
+                    bootc_system_needs_unlock = true;
+                    if (persistence == "auto") {
+                        throw libdnf5::cli::CommandExitError(
+                            1,
+                            M_("Error: this bootc system is configured to be read-only. Pass --transient to "
+                               "perform this operation in a transient overlay which will reset when "
+                               "the system reboots."));
+                    }
+                }
+
+            } else {
+                // Not a bootc transaction.
+                if (persistence == "transient") {
+                    throw libdnf5::cli::CommandExitError(
+                        1, M_("Error: transient transactions are only supported on bootc systems."));
                 }
             }
 
@@ -1606,8 +1656,21 @@ int main(int argc, char * argv[]) try {
                     }
                 }
 
+                if (bootc_system_needs_unlock && !libdnf5::utils::bootc::has_read_only_usr_overlay()) {
+                    // Only tell the user about the transient overlay if
+                    // it's not already in place
+                    context.print_error(
+                        _("A transient overlay will be created on /usr that will be discarded on reboot. "
+                          "Keep in mind that changes to /etc and /var will still persist, and packages "
+                          "commonly modify these directories."));
+                }
+
                 if (!libdnf5::cli::utils::userconfirm::userconfirm(context.get_base().get_config())) {
                     throw libdnf5::cli::AbortedByUserError();
+                }
+
+                if (bootc_system_needs_unlock) {
+                    libdnf5::utils::bootc::make_usr_writable();
                 }
 
                 context.download_and_run(*context.get_transaction());

--- a/dnf5/shared_options.cpp
+++ b/dnf5/shared_options.cpp
@@ -138,6 +138,16 @@ void create_store_option(dnf5::Command & command) {
     });
 }
 
+void create_transient_option(dnf5::Command & command) {
+    auto & parser = command.get_context().get_argument_parser();
+    auto transient = parser.add_new_named_arg("transient");
+    transient->set_long_name("transient");
+    transient->set_description("Set up a transient overlay on /usr that will be discarded on reboot.");
+    transient->set_const_value("transient");
+    transient->link_value(&command.get_context().get_base().get_config().get_persistence_option());
+    command.get_argument_parser_command()->register_named_arg(transient);
+}
+
 void create_json_option(dnf5::Command & command) {
     auto & ctx = command.get_context();
     auto & parser = command.get_context().get_argument_parser();

--- a/doc/_shared/options/transaction.rst
+++ b/doc/_shared/options/transaction.rst
@@ -1,6 +1,11 @@
 ``--offline``
     | Store the transaction to be performed offline. See :ref:`offline command <offline_command_ref-label>`, :manpage:`dnf5-offline(8)`.
 
+.. _transient_option-label:
+
+``--transient``
+    Applicable only on bootc (bootable containers) systems. Perform transactions using a transient overlay which will be lost on the next reboot. See also the :ref:`persistence <persistence_options-label>` configuration option.
+
 ``--store=PATH``
     | Store the current transaction in a directory at the specified ``PATH`` instead of running it.
     | The stored transaction can be performed by the :ref:`replay command <replay_command_ref-label>`, :manpage:`dnf5-replay(8)`.

--- a/doc/commands/do.8.rst
+++ b/doc/commands/do.8.rst
@@ -95,6 +95,9 @@ Options
 ``--offline``
     | Store the transaction to be performed offline. See :manpage:`dnf5-offline(8)`, :ref:`Offline command <offline_command_ref-label>`.
 
+``--transient``
+    Applicable only on bootc (bootable containers) systems. Perform transactions using a transient overlay which will be lost on the next reboot. See also the :ref:`persistence <persistence_options-label>` configuration option.
+
 .. include:: ../_shared/options/advisories.rst
 
 .. include:: ../_shared/options/advisory-severities.rst

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -524,12 +524,12 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     They are protected via Obsoletes as well as user/plugin removals.
 
+    An entry prefixed with ``glob:``, such as ``glob:/path/to/dir/*.conf``,
+    expands to all matching files and reads one package per line from each.
+
     Default: ``dnf5,glob:/etc/dnf/protected.d/*.conf``.
 
     .. NOTE::
-       Any packages which should be protected can do so by including a file in ``/etc/dnf/protected.d``
-       with their  package name in it.
-
        DNF5 will protect also the package corresponding to the running version of the kernel. See also
        :ref:`protect_running_kernel <protect_running_kernel_options-label>` option.
 
@@ -680,9 +680,6 @@ repository configuration file should aside from repo ID consists of baseurl, met
     List of paths that are likely to cause problems when their contents drift
     with respect to ``/usr``, e.g. ``/etc/pam.d/*``. If a transient transaction
     would modify these paths, DNF5 aborts the operation and prints an error.
-    Supports globs. A list of paths can be protected by creating a ``.conf``
-    file in ``/etc/dnf/usr-drift-protected-paths.d/`` containing one path (or
-    glob pattern) per line.
 
     When using ``persistence=transient`` on bootc systems, a transient overlay
     is created on ``/usr``, and any changes DNF5 makes to ``/usr`` will be
@@ -695,6 +692,11 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     If any paths are protected by this option, DNF5 will download filelist
     metadata from repositories before resolving transient transactions.
+
+    An entry prefixed with ``glob:``, such as ``glob:/path/to/dir/*.conf``,
+    expands to all matching files and reads one path per line from each. Both
+    the glob pattern in the option list entry and the individual paths listed
+    within the files (e.g. ``/etc/pam.d/*``) may contain globs.
 
     Default: ``glob:/etc/dnf/usr-drift-protected-paths.d/*.conf``.
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -672,6 +672,32 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``False``.
 
+.. _usr_drift_protected_paths_options-label:
+
+``usr_drift_protected_paths``
+    :ref:`list <list-label>`
+
+    List of paths that are likely to cause problems when their contents drift
+    with respect to ``/usr``, e.g. ``/etc/pam.d/*``. If a transient transaction
+    would modify these paths, DNF5 aborts the operation and prints an error.
+    Supports globs. A list of paths can be protected by creating a ``.conf``
+    file in ``/etc/dnf/usr-drift-protected-paths.d/`` containing one path (or
+    glob pattern) per line.
+
+    When using ``persistence=transient`` on bootc systems, a transient overlay
+    is created on ``/usr``, and any changes DNF5 makes to ``/usr`` will be
+    discarded on reboot. However, other paths such as ``/etc`` and ``/var`` are
+    (often) not backed by a transient overlay, so changes to them will persist
+    across reboots. Usually, this "filesystem drift" is fine, but it can cause
+    problems in certain situations. For example, a configuration file in
+    ``/etc`` that's shared by multiple packages might reference a ``.so`` file
+    under ``/usr/lib64`` that no longer exists.
+
+    If any paths are protected by this option, DNF5 will download filelist
+    metadata from repositories before resolving transient transactions.
+
+    Default: ``glob:/etc/dnf/usr-drift-protected-paths.d/*.conf``.
+
 .. _varsdir_options-label:
 
 ``varsdir``

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -466,6 +466,24 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``/var/lib/dnf``.
 
+.. _persistence_options-label:
+
+``persistence``
+    :ref:`string <string-label>`
+
+    Whether changes should persist across system reboots.
+    Passing ``--transient`` (see :ref:`transient option <transient_option-label>`) will override this setting to ``transient``.
+    Valid values are:
+
+    * ``auto``: Changes will persist across reboots, unless the target is a running bootc system
+      and the system is already in an unlocked state (i.e. ``/usr`` is writable).
+    * ``transient``: Changes will be lost on the next reboot. Only applicable on bootc systems.
+      Beware that changes to ``/etc`` and ``/var`` will persist, depending on the configuration
+      of your bootc system. See also https://bootc.dev/bootc//man/bootc-usr-overlay.8.html.
+    * ``persist``: Changes will persist across reboots.
+
+    Default: ``auto``.
+
 .. _pluginconfpath_options-label:
 
 ``pluginconfpath``

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -28,6 +28,7 @@
 #include "libdnf5/base/goal_elements.hpp"
 #include "libdnf5/base/log_event.hpp"
 #include "libdnf5/base/solver_problems.hpp"
+#include "libdnf5/base/transaction_persistence.hpp"
 #include "libdnf5/common/proc.hpp"
 #include "libdnf5/defs.h"
 #include "libdnf5/rpm/transaction_callbacks.hpp"
@@ -150,6 +151,10 @@ public:
     /// @param comment Any string value.
     void set_comment(const std::string & comment);
 
+    /// @brief Setup the persistence of the transaction (persist or transient).
+    /// @param persistence TransactionPersistence value.
+    void set_persistence(libdnf5::base::TransactionPersistence persistence);
+
     /// Return string representation of the TransactionRunResult enum
     static std::string transaction_result_to_string(const TransactionRunResult result);
 
@@ -219,6 +224,7 @@ private:
     std::optional<uint32_t> user_id;
     std::string comment;
     std::string description;
+    libdnf5::base::TransactionPersistence persistence = libdnf5::base::TransactionPersistence::UNKNOWN;
 
     /// Clear the recorded last scriptlet output
     LIBDNF_LOCAL void clear_last_script_output();

--- a/include/libdnf5/base/transaction_persistence.hpp
+++ b/include/libdnf5/base/transaction_persistence.hpp
@@ -1,0 +1,14 @@
+// Copyright Contributors to the DNF5 project
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef LIBDNF5_BASE_TRANSACTION_PERSISTENCE_HPP
+#define LIBDNF5_BASE_TRANSACTION_PERSISTENCE_HPP
+
+namespace libdnf5::base {
+
+// @replaces libdnf:transaction/Types.hpp:enum:TransactionPersistence
+enum class TransactionPersistence : int { UNKNOWN = 0, PERSIST = 1, TRANSIENT = 2 };
+
+}  // namespace libdnf5::base
+
+#endif  // LIBDNF5_BASE_TRANSACTION_PERSISTENCE_HPP

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -230,6 +230,8 @@ public:
     const OptionBool & get_build_cache_option() const;
     OptionBool & get_skip_system_repo_lock_option();
     const OptionBool & get_skip_system_repo_lock_option() const;
+    OptionEnum & get_persistence_option();
+    const OptionEnum & get_persistence_option() const;
 
     // Repo main config
     /// @deprecated The option does nothing

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -232,6 +232,8 @@ public:
     const OptionBool & get_skip_system_repo_lock_option() const;
     OptionEnum & get_persistence_option();
     const OptionEnum & get_persistence_option() const;
+    OptionStringAppendList & get_usr_drift_protected_paths_option();
+    const OptionStringAppendList & get_usr_drift_protected_paths_option() const;
 
     // Repo main config
     /// @deprecated The option does nothing

--- a/include/libdnf5/transaction/transaction.hpp
+++ b/include/libdnf5/transaction/transaction.hpp
@@ -60,6 +60,7 @@ class TransactionHistory;
 enum class TransactionState : int { STARTED = 1, OK = 2, ERROR = 3 };
 
 LIBDNF_API std::string transaction_state_to_string(TransactionState state);
+LIBDNF_API std::string transaction_state_to_translated_string(TransactionState state);
 LIBDNF_API TransactionState transaction_state_from_string(const std::string & state);
 
 

--- a/include/libdnf5/transaction/transaction_item_action.hpp
+++ b/include/libdnf5/transaction/transaction_item_action.hpp
@@ -50,6 +50,7 @@ enum class TransactionItemAction : int {
 
 
 LIBDNF_API std::string transaction_item_action_to_string(TransactionItemAction action);
+LIBDNF_API std::string transaction_item_action_to_translated_string(TransactionItemAction action);
 LIBDNF_API TransactionItemAction transaction_item_action_from_string(const std::string & action);
 
 LIBDNF_API std::string transaction_item_action_to_letter(TransactionItemAction action);

--- a/include/libdnf5/transaction/transaction_item_reason.hpp
+++ b/include/libdnf5/transaction/transaction_item_reason.hpp
@@ -41,6 +41,7 @@ enum class TransactionItemReason : int {
 
 
 LIBDNF_API std::string transaction_item_reason_to_string(TransactionItemReason reason);
+LIBDNF_API std::string transaction_item_reason_to_translated_string(TransactionItemReason reason);
 LIBDNF_API TransactionItemReason transaction_item_reason_from_string(const std::string & reason);
 
 

--- a/include/libdnf5/utils/bootc.hpp
+++ b/include/libdnf5/utils/bootc.hpp
@@ -43,6 +43,28 @@ LIBDNF_API bool is_bootc_system();
 /// otherwise
 LIBDNF_API bool is_writable();
 
+/// @brief Check whether the bootc system has a read-only overlay on /usr
+///
+/// Calls `bootc status --json` and checks whether
+/// .status.usrOverlay.accessMode is "readOnly".
+///
+/// @throws libdnf5::SystemError if bootc command could not be executed
+/// @throws libdnf5::RuntimeError if bootc command exits with non-zero code
+LIBDNF_API bool has_read_only_usr_overlay();
+
+/// @brief Make /usr writable on bootc systems using a read-only overlay.
+///
+/// If /usr is already writable, this is a no-op. Otherwise, creates a
+/// read-only overlay over /usr (`bootc usr-overlay --read-only`) if none
+/// exists, and remounts /usr as read/write in a private mount namespace so
+/// this process can write to it.
+///
+/// @throws libdnf5::SystemError if unshare() fails, or if bootc command
+/// could not be executed
+/// @throws libdnf5::RuntimeError if the mount remount command fails, or if
+/// `bootc usr-overlay --read-only` fails
+LIBDNF_API void make_usr_writable();
+
 }  // namespace libdnf5::utils::bootc
 
 #endif  // LIBDNF5_BOOTC_HPP

--- a/include/libdnf5/utils/bootc.hpp
+++ b/include/libdnf5/utils/bootc.hpp
@@ -24,8 +24,23 @@
 
 namespace libdnf5::utils::bootc {
 
+/// @brief Call `bootc status` to check whether the system is deployed via
+/// bootc
+///
+/// Per bootc documentation, "bootc is not the only image based system; there
+/// are many. Detect bootc specifically via `bootc status`." Works on both
+/// OSTree and composefs-backed systems.
+///
+/// @throws libdnf5::RuntimeError if the bootc command is available but cannot
+/// be called, or it exits with non-zero code, or it outputs invalid JSON
+/// @returns true if the bootc command is available and `bootc status --json`
+/// has a .spec.image. Otherwise, returns false.
 LIBDNF_API bool is_bootc_system();
 
+/// @brief Check whether /usr is mounted read/write or read-only
+/// @throws libdnf5::SystemError if fails to stat /usr
+/// @returns false if the filesystem backing /usr is mounted read-only, true
+/// otherwise
 LIBDNF_API bool is_writable();
 
 }  // namespace libdnf5::utils::bootc

--- a/libdnf5-cli/output/transactioninfo.cpp
+++ b/libdnf5-cli/output/transactioninfo.cpp
@@ -27,6 +27,7 @@
 
 #include <fmt/format.h>
 #include <json-c/json.h>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <pwd.h>
 
 #include <sstream>
@@ -69,17 +70,20 @@ void print_transaction_item_table(std::vector<Item> items, const char * title) {
     scols_cell_set_data(scols_table_get_title(item_list.get()), title);
 
     // The two spaces indent the table the same way as child lines in KeyValueTable
-    scols_table_new_column(item_list.get(), "  Action", 0, 0);
-    scols_table_new_column(item_list.get(), "Package", 0, 0);
-    scols_table_new_column(item_list.get(), "Reason", 0, 0);
-    scols_table_new_column(item_list.get(), "Repository", 0, 0);
+    scols_table_new_column(item_list.get(), (std::string{"  "} + _("Action")).c_str(), 0, 0);
+    scols_table_new_column(item_list.get(), _("Package"), 0, 0);
+    scols_table_new_column(item_list.get(), _("Reason"), 0, 0);
+    scols_table_new_column(item_list.get(), _("Repository"), 0, 0);
 
     for (auto & pkg : items) {
         struct libscols_line * ln = scols_table_new_line(item_list.get(), NULL);
         scols_line_set_data(
-            ln, 0, ("  " + libdnf5::transaction::transaction_item_action_to_string(pkg.get_action())).c_str());
+            ln,
+            0,
+            ("  " + libdnf5::transaction::transaction_item_action_to_translated_string(pkg.get_action())).c_str());
         scols_line_set_data(ln, 1, pkg.to_string().c_str());
-        scols_line_set_data(ln, 2, libdnf5::transaction::transaction_item_reason_to_string(pkg.get_reason()).c_str());
+        scols_line_set_data(
+            ln, 2, libdnf5::transaction::transaction_item_reason_to_translated_string(pkg.get_reason()).c_str());
         scols_line_set_data(ln, 3, pkg.get_repoid().c_str());
     }
 
@@ -91,22 +95,22 @@ void print_transaction_item_table(std::vector<Item> items, const char * title) {
 
 void print_transaction_info(libdnf5::transaction::Transaction & transaction) {
     KeyValueTable info;
-    info.add_line("Transaction ID", transaction.get_id(), "bold");
-    info.add_line("Begin time", libdnf5::utils::string::format_epoch(transaction.get_dt_start()));
-    info.add_line("Begin rpmdb", transaction.get_rpmdb_version_begin());
-    info.add_line("End time", libdnf5::utils::string::format_epoch(transaction.get_dt_end()));
-    info.add_line("End rpmdb", transaction.get_rpmdb_version_end());
+    info.add_line(_("Transaction ID"), transaction.get_id(), "bold");
+    info.add_line(_("Begin time"), libdnf5::utils::string::format_epoch(transaction.get_dt_start()));
+    info.add_line(_("Begin rpmdb"), transaction.get_rpmdb_version_begin());
+    info.add_line(_("End time"), libdnf5::utils::string::format_epoch(transaction.get_dt_end()));
+    info.add_line(_("End rpmdb"), transaction.get_rpmdb_version_end());
 
-    info.add_line("User", generate_user_info_str(transaction.get_user_id()));
-    info.add_line("Status", libdnf5::transaction::transaction_state_to_string(transaction.get_state()));
-    info.add_line("Releasever", transaction.get_releasever());
-    info.add_line("Description", transaction.get_description());
-    info.add_line("Comment", transaction.get_comment());
+    info.add_line(_("User"), generate_user_info_str(transaction.get_user_id()));
+    info.add_line(_("Status"), libdnf5::transaction::transaction_state_to_translated_string(transaction.get_state()));
+    info.add_line(_("Releasever"), transaction.get_releasever());
+    info.add_line(_("Description"), transaction.get_description());
+    info.add_line(_("Comment"), transaction.get_comment());
 
     info.print();
-    print_transaction_item_table(transaction.get_packages(), "Packages altered:");
-    print_transaction_item_table(transaction.get_comps_groups(), "Groups altered:");
-    print_transaction_item_table(transaction.get_comps_environments(), "Environments altered:");
+    print_transaction_item_table(transaction.get_packages(), _("Packages altered:"));
+    print_transaction_item_table(transaction.get_comps_groups(), _("Groups altered:"));
+    print_transaction_item_table(transaction.get_comps_environments(), _("Environments altered:"));
 }
 
 // [NOTE] When editing JSON output format, do not forget to update the docs at doc/commands/history.8.rst

--- a/libdnf5-cli/output/transactionlist.cpp
+++ b/libdnf5-cli/output/transactionlist.cpp
@@ -27,6 +27,7 @@
 #include "libdnf5/transaction/transaction_history.hpp"
 
 #include <json-c/json.h>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libsmartcols/libsmartcols.h>
 
 
@@ -49,11 +50,11 @@ void print_transaction_list(std::vector<libdnf5::transaction::Transaction> & ts_
         scols_table_set_termforce(table.get(), SCOLS_TERMFORCE_ALWAYS);
     }
 
-    scols_table_new_column(table.get(), "ID", 0, SCOLS_FL_RIGHT);
-    scols_table_new_column(table.get(), "Command line", 0.7, SCOLS_FL_TRUNC);
-    scols_table_new_column(table.get(), "Date and time", 0, 0);
-    scols_table_new_column(table.get(), "Action(s)", 0, 0);
-    scols_table_new_column(table.get(), "Altered", 0, SCOLS_FL_RIGHT);
+    scols_table_new_column(table.get(), _("ID"), 0, SCOLS_FL_RIGHT);
+    scols_table_new_column(table.get(), _("Command line"), 0.7, SCOLS_FL_TRUNC);
+    scols_table_new_column(table.get(), _("Date and time"), 0, 0);
+    scols_table_new_column(table.get(), _("Action(s)"), 0, 0);
+    scols_table_new_column(table.get(), _("Altered"), 0, SCOLS_FL_RIGHT);
 
     if (libdnf5::cli::tty::is_coloring_enabled()) {
         scols_table_enable_colors(table.get(), 1);

--- a/libdnf5/base/base.cpp
+++ b/libdnf5/base/base.cpp
@@ -280,6 +280,13 @@ void Base::setup() {
         protected_option.set(protected_option.get_priority(), resolved_protected_packages);
     }
 
+    // Resolve usr_drift_protected_paths globs from installroot
+    {
+        auto & usr_drift_option = p_impl->config.get_usr_drift_protected_paths_option();
+        auto resolved_usr_drift = resolve_path_globs(usr_drift_option.get_value_string(), installroot_path);
+        usr_drift_option.set(usr_drift_option.get_priority(), resolved_usr_drift);
+    }
+
     load_plugins();
     p_impl->plugins.init();
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -470,6 +470,10 @@ void Transaction::set_comment(const std::string & comment) {
     this->comment = comment;
 }
 
+void Transaction::set_persistence(libdnf5::base::TransactionPersistence persistence) {
+    this->persistence = persistence;
+}
+
 bool Transaction::check_gpg_signatures() {
     return p_impl->check_gpg_signatures();
 }

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -236,6 +236,7 @@ class ConfigMain::Impl {
     OptionBool protect_running_kernel{true};
     OptionBool build_cache{true};
     OptionBool skip_system_repo_lock{false};
+    OptionEnum persistence{"auto", {"auto", "persist", "transient"}};
 
     // Repo main config
 
@@ -416,6 +417,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("protect_running_kernel", protect_running_kernel);
     owner.opt_binds().add("build_cache", build_cache);
     owner.opt_binds().add("skip_system_repo_lock", skip_system_repo_lock);
+    owner.opt_binds().add("persistence", persistence);
 
     // Repo main config
 
@@ -1075,6 +1077,13 @@ const OptionBool & ConfigMain::get_skip_system_repo_lock_option() const {
     return p_impl->skip_system_repo_lock;
 }
 
+OptionEnum & ConfigMain::get_persistence_option() {
+    return p_impl->persistence;
+}
+const OptionEnum & ConfigMain::get_persistence_option() const {
+    return p_impl->persistence;
+}
+
 // Repo main config
 OptionNumber<std::uint32_t> & ConfigMain::get_retries_option() {
     return p_impl->retries;
@@ -1509,6 +1518,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(protect_running_kernel, other.protect_running_kernel);
     load_option(build_cache, other.build_cache);
     load_option(skip_system_repo_lock, other.skip_system_repo_lock);
+    load_option(persistence, other.persistence);
 
     // Repo main config
     load_option(retries, other.retries);

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -238,6 +238,9 @@ class ConfigMain::Impl {
     OptionBool skip_system_repo_lock{false};
     OptionEnum persistence{"auto", {"auto", "persist", "transient"}};
 
+    OptionStringAppendList usr_drift_protected_paths{
+        std::vector<std::string>{"glob:/etc/dnf/usr-drift-protected-paths.d/*.conf"}};
+
     // Repo main config
 
     OptionNumber<std::uint32_t> retries{10};
@@ -418,6 +421,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("build_cache", build_cache);
     owner.opt_binds().add("skip_system_repo_lock", skip_system_repo_lock);
     owner.opt_binds().add("persistence", persistence);
+    owner.opt_binds().add("usr_drift_protected_paths", usr_drift_protected_paths);
 
     // Repo main config
 
@@ -1084,6 +1088,13 @@ const OptionEnum & ConfigMain::get_persistence_option() const {
     return p_impl->persistence;
 }
 
+OptionStringAppendList & ConfigMain::get_usr_drift_protected_paths_option() {
+    return p_impl->usr_drift_protected_paths;
+}
+const OptionStringAppendList & ConfigMain::get_usr_drift_protected_paths_option() const {
+    return p_impl->usr_drift_protected_paths;
+}
+
 // Repo main config
 OptionNumber<std::uint32_t> & ConfigMain::get_retries_option() {
     return p_impl->retries;
@@ -1519,6 +1530,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(build_cache, other.build_cache);
     load_option(skip_system_repo_lock, other.skip_system_repo_lock);
     load_option(persistence, other.persistence);
+    load_option(usr_drift_protected_paths, other.usr_drift_protected_paths);
 
     // Repo main config
     load_option(retries, other.retries);

--- a/libdnf5/transaction/transaction.cpp
+++ b/libdnf5/transaction/transaction.cpp
@@ -34,6 +34,8 @@
 #include "libdnf5/transaction/transaction_item.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 namespace libdnf5::transaction {
 
 class Transaction::Impl {
@@ -79,6 +81,17 @@ std::string transaction_state_to_string(TransactionState state) {
     return "";
 }
 
+std::string transaction_state_to_translated_string(TransactionState state) {
+    switch (state) {
+        case TransactionState::STARTED:
+            return _("Started");
+        case TransactionState::OK:
+            return _("Ok");
+        case TransactionState::ERROR:
+            return _("Error");
+    }
+    return "";
+}
 
 TransactionState transaction_state_from_string(const std::string & state) {
     if (state == "Started") {

--- a/libdnf5/transaction/transaction_item_action.cpp
+++ b/libdnf5/transaction/transaction_item_action.cpp
@@ -21,6 +21,8 @@
 
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 
 namespace libdnf5::transaction {
 
@@ -56,6 +58,33 @@ std::string transaction_item_action_to_string(TransactionItemAction action) {
     return "";
 }
 
+std::string transaction_item_action_to_translated_string(TransactionItemAction action) {
+    switch (action) {
+        case TransactionItemAction::INSTALL:
+            return _("Install");
+        case TransactionItemAction::UPGRADE:
+            return _("Upgrade");
+        case TransactionItemAction::DOWNGRADE:
+            return _("Downgrade");
+        case TransactionItemAction::REINSTALL:
+            return _("Reinstall");
+        case TransactionItemAction::REMOVE:
+            return _("Remove");
+        case TransactionItemAction::REPLACED:
+            return _("Replaced");
+        case TransactionItemAction::REASON_CHANGE:
+            return _("Reason Change");
+        case TransactionItemAction::ENABLE:
+            return _("Enable");
+        case TransactionItemAction::DISABLE:
+            return _("Disable");
+        case TransactionItemAction::RESET:
+            return _("Reset");
+        case TransactionItemAction::SWITCH:
+            return _("Switch");
+    }
+    return "";
+}
 
 TransactionItemAction transaction_item_action_from_string(const std::string & action) {
     if (action == "Install") {

--- a/libdnf5/transaction/transaction_item_reason.cpp
+++ b/libdnf5/transaction/transaction_item_reason.cpp
@@ -21,6 +21,8 @@
 
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
 
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
 
 namespace libdnf5::transaction {
 
@@ -48,6 +50,25 @@ std::string transaction_item_reason_to_string(TransactionItemReason reason) {
     return "";
 }
 
+std::string transaction_item_reason_to_translated_string(TransactionItemReason reason) {
+    switch (reason) {
+        case TransactionItemReason::NONE:
+            return _("None");
+        case TransactionItemReason::DEPENDENCY:
+            return _("Dependency");
+        case TransactionItemReason::USER:
+            return _("User");
+        case TransactionItemReason::CLEAN:
+            return _("Clean");
+        case TransactionItemReason::WEAK_DEPENDENCY:
+            return _("Weak Dependency");
+        case TransactionItemReason::GROUP:
+            return _("Group");
+        case TransactionItemReason::EXTERNAL_USER:
+            return _("External User");
+    }
+    return "";
+}
 
 TransactionItemReason transaction_item_reason_from_string(const std::string & reason) {
     if (reason == "None") {

--- a/libdnf5/utils/bootc.cpp
+++ b/libdnf5/utils/bootc.cpp
@@ -26,22 +26,46 @@
 
 #include <json.h>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
+#include <sched.h>
 #include <sys/statvfs.h>
 
 #include <cerrno>
-#include <iostream>
 #include <memory>
 #include <string>
 
 namespace libdnf5::utils::bootc {
 
-bool is_bootc_system() {
-    // Per https://raw.githubusercontent.com/bootc-dev/bootc/11cba840a4cc6dca9afc528f306ebe1406b647fa/docs/src/package-managers.md,
-    // check `bootc status --format=json` has non-null .spec.image to determine whether bootc is in use.
+std::unique_ptr<json_object, decltype(&json_object_put)> get_bootc_status() {
+    const auto & result = subprocess::run("bootc", {"bootc", "status", "--format=json"});
 
-    subprocess::CompletedProcess result;
+    // Check whether command failed (non-zero exit code)
+    if (result.returncode != 0) {
+        // Command ran but failed; show stderr to user
+        std::string stderr_content(reinterpret_cast<const char *>(result.stderr.data()), result.stderr.size());
+        if (!stderr_content.empty()) {
+            throw libdnf5::RuntimeError(M_("Error checking bootc status: {}"), stderr_content);
+        } else {
+            throw libdnf5::RuntimeError(
+                M_("Error checking bootc status: bootc command failed with exit code {}"), result.returncode);
+        }
+    }
+
+    std::string stdout_content(reinterpret_cast<const char *>(result.stdout.data()), result.stdout.size());
+    std::unique_ptr<json_object, decltype(&json_object_put)> root(
+        json_tokener_parse(stdout_content.c_str()), json_object_put);
+
+    if (!root) {
+        throw libdnf5::RuntimeError(M_("Error checking bootc status: Failed to parse JSON output"));
+    }
+
+    return root;
+}
+
+bool is_bootc_system() {
+    std::unique_ptr<json_object, decltype(&json_object_put)> bootc_status{nullptr, json_object_put};
+
     try {
-        result = subprocess::run("bootc", {"bootc", "status", "--format=json"});
+        bootc_status = get_bootc_status();
     } catch (const libdnf5::SystemError & ex) {
         if (ex.get_error_code() == ENOENT) {
             return false;
@@ -49,31 +73,8 @@ bool is_bootc_system() {
         throw libdnf5::RuntimeError(M_("Failed to query status of bootc system: {}"), std::string(ex.what()));
     }
 
-    // Check if command failed (non-zero exit code)
-    if (result.returncode != 0) {
-        // Command ran but failed - show stderr to user
-        std::string stderr_content(reinterpret_cast<const char *>(result.stderr.data()), result.stderr.size());
-        if (!stderr_content.empty()) {
-            throw libdnf5::RuntimeError(M_("Got the following error checking bootc status: {}"), stderr_content);
-        } else {
-            throw libdnf5::RuntimeError(
-                M_("Got the following error checking bootc status: bootc command failed with exit code {}"),
-                result.returncode);
-        }
-    }
-
-    // Parse JSON output to check if .spec.image is not null
-    std::string stdout_content(reinterpret_cast<const char *>(result.stdout.data()), result.stdout.size());
-    std::unique_ptr<json_object, decltype(&json_object_put)> root(
-        json_tokener_parse(stdout_content.c_str()), json_object_put);
-
-    if (!root) {
-        // Failed to parse JSON
-        throw libdnf5::RuntimeError(M_("Got the following error checking bootc status: Failed to parse JSON output"));
-    }
-
     json_object * spec_obj = nullptr;
-    if (!json_object_object_get_ex(root.get(), "spec", &spec_obj)) {
+    if (!json_object_object_get_ex(bootc_status.get(), "spec", &spec_obj)) {
         return false;
     }
     json_object * image_obj = nullptr;
@@ -89,6 +90,58 @@ bool is_writable() {
         throw libdnf5::SystemError(errno, M_("Failed to stat /usr filesystem"));
     }
     return (vfs.f_flag & ST_RDONLY) == 0;
+}
+
+bool has_read_only_usr_overlay() {
+    const auto & bootc_status = get_bootc_status();
+
+    json_object * status_obj = nullptr;
+    if (!json_object_object_get_ex(bootc_status.get(), "status", &status_obj)) {
+        return false;
+    }
+    json_object * usr_overlay_obj = nullptr;
+    if (!json_object_object_get_ex(status_obj, "usrOverlay", &usr_overlay_obj)) {
+        return false;
+    }
+    json_object * access_mode_obj = nullptr;
+    if (!json_object_object_get_ex(usr_overlay_obj, "accessMode", &access_mode_obj)) {
+        return false;
+    }
+    const char * access_mode = json_object_get_string(access_mode_obj);
+    return access_mode && std::string{access_mode} == "readOnly";
+}
+
+void make_usr_writable() {
+    if (is_writable()) {
+        return;
+    }
+
+    if (!has_read_only_usr_overlay()) {
+        // Set up transient overlay
+        const auto & result = subprocess::run("bootc", {"bootc", "usr-overlay", "--read-only"});
+        if (result.returncode != 0) {
+            std::string stderr_content(reinterpret_cast<const char *>(result.stderr.data()), result.stderr.size());
+            if (!stderr_content.empty()) {
+                throw libdnf5::RuntimeError(M_("Error running `bootc usr-overlay --read-only`: {}"), stderr_content);
+            } else {
+                throw libdnf5::RuntimeError(
+                    M_("Error running `bootc usr-overlay --read-only`: bootc command failed with exit code {}"),
+                    result.returncode);
+            }
+        }
+    }
+
+    // Set up mountns
+    if (unshare(CLONE_NEWNS) != 0) {
+        throw libdnf5::SystemError(errno, M_("Failed to unshare mount namespace"));
+    }
+
+    const auto & result = subprocess::run("mount", {"mount", "--options-source=disable", "-o", "remount,rw", "/usr"});
+
+    if (result.returncode != 0) {
+        std::string stderr_content(reinterpret_cast<const char *>(result.stderr.data()), result.stderr.size());
+        throw libdnf5::RuntimeError(M_("Failed to remount /usr as read-write: {}"), stderr_content);
+    }
 }
 
 }  // namespace libdnf5::utils::bootc


### PR DESCRIPTION
Adds the following bootc features from DNF4:

- `persistence` configuration option with values `transient`, `auto`, and `persist` (https://github.com/rpm-software-management/dnf/pull/2155)
- `--transient` flag to set `persistence=transient` (https://github.com/rpm-software-management/dnf/pull/2155)
- In transient mode, DNF calls `bootc usr-overlay --read-only` to mount a read-only overlayfs on /usr, and via `unshare` mounts this overlayfs as read/write in a private mount namespace. DNF can write to the overlay but it appears read-only to everything else on the system. (https://github.com/rpm-software-management/dnf/pull/2155)
- ~Whether a transaction is persistent or transient is stored in the history DB and listed by `history info` (https://github.com/rpm-software-management/dnf/pull/2240)~
- Check whether unsafe paths will be modified in transient transactions, as defined by the `usr_drift_protected_paths` option (https://github.com/rpm-software-management/dnf/pull/2244)

Additionally:

- ~history list --json` lists transaction persistence~
- ~Adds a migration mechanism to the transaction history DB. Using a database with a newer minor version than the latest version is allowed, but using a database with a new major version throws an error.~
- Changes `cmd_requires_privileges` to return `false` when storing a transaction via `--store`, which allows `--store` without root privileges or obtaining a write lock on the system repo, and allows it on bootc systems without unlocking `/usr`

~Marking as draft for now; I may try to move some functionality out of main.cpp and into libdnf5 or Context.~

Some commits were `Assisted-by Claude Opus 4.6`.