### PR TITLE
Preserve original filepath in resolve log messages

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -147,7 +147,11 @@ public:
     Impl(const BaseWeakPtr & base);
     ~Impl();
 
-    void add_rpm_ids(GoalAction action, const rpm::Package & rpm_package, const GoalJobSettings & settings);
+    void add_rpm_ids(
+        GoalAction action,
+        const rpm::Package & rpm_package,
+        const GoalJobSettings & settings,
+        const std::string & user_spec = {});
     void add_rpm_ids(GoalAction action, const rpm::PackageSet & package_set, const GoalJobSettings & settings);
 
     GoalProblem add_specs_to_goal(base::Transaction & transaction);
@@ -245,8 +249,8 @@ private:
         std::optional<std::string>,
         GoalJobSettings>>
         rpm_reason_change_specs;
-    /// <libdnf5::GoalAction, rpm Ids, libdnf5::GoalJobSettings settings>
-    std::vector<std::tuple<GoalAction, libdnf5::solv::IdQueue, GoalJobSettings>> rpm_ids;
+    /// <libdnf5::GoalAction, rpm Ids, libdnf5::GoalJobSettings settings, user-facing spec>
+    std::vector<std::tuple<GoalAction, libdnf5::solv::IdQueue, GoalJobSettings, std::string>> rpm_ids;
     /// <libdnf5::GoalAction, std::string filepath, libdnf5::GoalJobSettings settings>
     std::vector<std::tuple<GoalAction, std::string, GoalJobSettings>> rpm_filepaths;
 
@@ -493,12 +497,16 @@ void Goal::Impl::add_spec(GoalAction action, const std::string & spec, const Goa
     }
 }
 
-void Goal::Impl::add_rpm_ids(GoalAction action, const rpm::Package & rpm_package, const GoalJobSettings & settings) {
+void Goal::Impl::add_rpm_ids(
+    GoalAction action,
+    const rpm::Package & rpm_package,
+    const GoalJobSettings & settings,
+    const std::string & user_spec) {
     libdnf_assert_same_base(base, rpm_package.get_base());
 
     libdnf5::solv::IdQueue ids;
     ids.push_back(rpm_package.get_id().id);
-    rpm_ids.push_back(std::make_tuple(action, std::move(ids), settings));
+    rpm_ids.push_back(std::make_tuple(action, std::move(ids), settings, user_spec));
 }
 
 void Goal::Impl::add_rpm_ids(GoalAction action, const rpm::PackageSet & package_set, const GoalJobSettings & settings) {
@@ -508,7 +516,7 @@ void Goal::Impl::add_rpm_ids(GoalAction action, const rpm::PackageSet & package_
     for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id);
     }
-    rpm_ids.push_back(std::make_tuple(action, std::move(ids), settings));
+    rpm_ids.push_back(std::make_tuple(action, std::move(ids), settings, std::string{}));
 }
 
 // @replaces part of libdnf/sack/query.cpp:method:filterAdvisory called with HY_EQG and HY_UPGRADE
@@ -2134,7 +2142,10 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
 
     rpm::PackageQuery installed(base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
     installed.filter_installed();
-    for (auto [action, ids, settings] : rpm_ids) {
+    for (auto [action, ids, settings, user_spec] : rpm_ids) {
+        auto get_user_spec = [&user_spec, &pool](int id) -> std::string {
+            return user_spec.empty() ? pool.get_nevra(id) : user_spec;
+        };
         switch (action) {
             case GoalAction::INSTALL: {
                 bool skip_broken = settings.resolve_skip_broken(cfg_main);
@@ -2194,7 +2205,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::NOT_INSTALLED,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {},
                             log_level);
                     } else {
@@ -2226,7 +2237,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::NOT_INSTALLED,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {},
                             libdnf5::Logger::Level::WARNING);
                         continue;
@@ -2242,7 +2253,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                                 GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
                                 settings,
                                 libdnf5::transaction::TransactionItemType::PACKAGE,
-                                {pool.get_nevra(id)},
+                                get_user_spec(id),
                                 {},
                                 libdnf5::Logger::Level::WARNING);
                             continue;
@@ -2256,7 +2267,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::ALREADY_INSTALLED,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {pool.get_name(id) + ("." + arch)},
                             libdnf5::Logger::Level::WARNING);
                         // include installed packages with higher or equal version into transaction to prevent downgrade
@@ -2284,7 +2295,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::NOT_INSTALLED,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {},
                             log_level);
                         continue;
@@ -2297,7 +2308,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {},
                             log_level);
                         continue;
@@ -2313,7 +2324,7 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             GoalProblem::INSTALLED_LOWEST_VERSION,
                             settings,
                             libdnf5::transaction::TransactionItemType::PACKAGE,
-                            {pool.get_nevra(id)},
+                            get_user_spec(id),
                             {name_arch},
                             log_level);
                         continue;
@@ -3324,7 +3335,7 @@ void Goal::Impl::add_paths_to_goal() {
                     continue;
                 }
             }
-            add_rpm_ids(action, pkg->second, settings);
+            add_rpm_ids(action, pkg->second, settings, path);
         }
     }
 

--- a/test/libdnf5/base/test_goal.cpp
+++ b/test/libdnf5/base/test_goal.cpp
@@ -324,6 +324,27 @@ void BaseGoalTest::test_upgrade_not_downgrade_from_cmdline() {
     CPPUNIT_ASSERT_EQUAL(libdnf5::GoalUsedSetting::UNUSED, first_event.get_job_settings()->get_used_skip_unavailable());
 }
 
+void BaseGoalTest::test_upgrade_not_installed_from_cmdline() {
+    // Tests the upgrade using a local RPM file path when the package is not installed.
+    // The resolve log should contain the original file path, not the resolved NEVRA.
+    // (https://bugzilla.redhat.com/show_bug.cgi?id=2362262)
+    std::string rpm_path = PROJECT_BINARY_DIR "/test/data/repos-rpm/rpm-repo1/one-2-1.noarch.rpm";
+
+    libdnf5::Goal goal(base);
+    goal.add_upgrade(rpm_path);
+
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
+
+    auto & log = transaction.get_resolve_logs();
+    CPPUNIT_ASSERT_EQUAL((size_t)1, log.size());
+    auto & first_event = *log.begin();
+    CPPUNIT_ASSERT_EQUAL(libdnf5::GoalAction::UPGRADE, first_event.get_action());
+    CPPUNIT_ASSERT_EQUAL(libdnf5::GoalProblem::NOT_INSTALLED, first_event.get_problem());
+    CPPUNIT_ASSERT_EQUAL(rpm_path, *first_event.get_spec());
+}
+
 void BaseGoalTest::test_upgrade_not_available() {
     base.get_config().get_best_option().set(true);
     base.get_config().get_clean_requirements_on_remove_option().set(true);

--- a/test/libdnf5/base/test_goal.hpp
+++ b/test/libdnf5/base/test_goal.hpp
@@ -45,6 +45,7 @@ class BaseGoalTest : public LibdnfPrivateTestCase {
     CPPUNIT_TEST(test_upgrade);
     CPPUNIT_TEST(test_upgrade_from_cmdline);
     CPPUNIT_TEST(test_upgrade_not_downgrade_from_cmdline);
+    CPPUNIT_TEST(test_upgrade_not_installed_from_cmdline);
     CPPUNIT_TEST(test_upgrade_not_available);
     CPPUNIT_TEST(test_upgrade_all);
     CPPUNIT_TEST(test_upgrade_user);
@@ -77,6 +78,7 @@ public:
     void test_upgrade();
     void test_upgrade_from_cmdline();
     void test_upgrade_not_downgrade_from_cmdline();
+    void test_upgrade_not_installed_from_cmdline();
     void test_upgrade_not_available();
     void test_upgrade_all();
     void test_upgrade_user();


### PR DESCRIPTION
When a user passes a local RPM file (e.g., ./foo-1.0.rpm) to upgrade, downgrade, or reinstall, the error messages reported the package NEVRA from the RPM header instead of the original user-provided filepath.
This was confusing because the message did not match the argument the user typed.

Add an optional user_spec parameter to add_rpm_ids() and extend the rpm_ids tuple to carry it. In add_paths_to_goal(), pass the original filepath through. In add_rpms_to_goal(), use the user_spec when available, falling back to the NEVRA for non-cmdline packages.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2362262