### PR TITLE
Invalidate offline transaction after successful online transaction

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -255,6 +255,22 @@ void check_state(const libdnf5::offline::OfflineTransactionState & state) {
     }
 }
 
+void invalidate_if_not_valid(libdnf5::offline::OfflineTransactionState & state, libdnf5::Base & base) {
+    if (state.is_pending() && !state.check_rpmdb_cookie(base)) {
+        auto cmd_line = state.get_data().get_cmd_line();
+        state.invalidate();
+        if (cmd_line.empty()) {
+            throw libdnf5::cli::CommandExitError(
+                1, M_("The system has been modified since the offline transaction was prepared."));
+        }
+        throw libdnf5::cli::CommandExitError(
+            1,
+            M_("The system has been modified since the offline transaction was prepared. "
+               "To reschedule, run: {}"),
+            cmd_line);
+    }
+}
+
 void reboot(bool poweroff = false) {
     if (std::getenv("DNF_SYSTEM_UPGRADE_NO_REBOOT")) {
         if (poweroff) {
@@ -328,6 +344,7 @@ void OfflineRebootCommand::run() {
     }
 
     check_state(*state);
+    invalidate_if_not_valid(*state, ctx.get_base());
 
     auto & offline_data = state->get_data();
     if (offline_data.get_status() != libdnf5::offline::STATUS_DOWNLOAD_COMPLETE &&
@@ -465,6 +482,9 @@ void OfflineExecuteCommand::configure() {
 
 void OfflineExecuteCommand::run() {
     auto & ctx = get_context();
+
+    invalidate_if_not_valid(*state, ctx.get_base());
+
     auto & offline_data = state->get_data();
 
     const auto & system_releasever = offline_data.get_system_releasever();
@@ -723,8 +743,16 @@ void OfflineStatusCommand::run() {
     }
     check_state(*state);
 
+    const bool rpmdb_changed = state->is_pending() && !state->check_rpmdb_cookie(get_context().get_base());
+
     const auto & status = state->get_data().get_status();
-    if (status == libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE) {
+    if (rpmdb_changed) {
+        std::cout << _("The system has been modified since the offline transaction was prepared. "
+                       "The offline transaction initiated by the following command is no longer valid:")
+                  << std::endl
+                  << "  " << state->get_data().get_cmd_line() << std::endl
+                  << _("To reschedule, run the command above. To clean up, run `dnf5 offline clean`.") << std::endl;
+    } else if (status == libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE) {
         std::cout << no_transaction_message << std::endl;
     } else if (status == libdnf5::offline::STATUS_DOWNLOAD_COMPLETE || status == libdnf5::offline::STATUS_READY) {
         std::cout << _("An offline transaction was initiated by the following command:") << std::endl

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -347,8 +347,7 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     const auto & packages_location = offline_destdir / "packages";
     const auto & comps_location = offline_destdir / "comps";
 
-    const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-    libdnf5::offline::OfflineTransactionState state{state_path};
+    auto state = libdnf5::offline::OfflineTransactionState::from_base(base);
 
     auto & offline_data = state.get_data();
     offline_data.set_status(libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE);
@@ -459,8 +458,7 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         const auto & offline_destdir = installroot / libdnf5::offline::DEFAULT_DESTDIR.relative_path();
         std::filesystem::create_directories(offline_datadir);
         std::filesystem::create_directories(offline_destdir);
-        const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-        libdnf5::offline::OfflineTransactionState state{state_path};
+        auto state = libdnf5::offline::OfflineTransactionState::from_base(base);
 
         // Check whether there is another pending offline transaction present
         auto & offline_data = state.get_data();

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -384,6 +384,7 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
         offline_data.set_module_platform_id(base.get_config().get_module_platform_id_option().get_value());
     }
 
+    state.capture_rpmdb_cookie(base);
     state.write();
 }
 
@@ -461,10 +462,9 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
         auto state = libdnf5::offline::OfflineTransactionState::from_base(base);
 
         // Check whether there is another pending offline transaction present
-        auto & offline_data = state.get_data();
-        if (offline_data.get_status() != libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE) {
+        if (state.is_pending()) {
             print_error(_("There is already an offline transaction queued, initiated by the following command:"));
-            print_error(fmt::format("\t{}", offline_data.get_cmd_line()));
+            print_error(fmt::format("\t{}", state.get_data().get_cmd_line()));
             print_error(_("Continuing will cancel the old offline transaction and replace it with this one."));
             if (!libdnf5::cli::utils::userconfirm::userconfirm(base.get_config())) {
                 throw libdnf5::cli::AbortedByUserError();
@@ -532,6 +532,17 @@ void Context::Impl::download_and_run(libdnf5::base::Transaction & transaction) {
     for (auto const & entry : transaction.get_gpg_signature_problems()) {
         print_error(entry);
     }
+
+    auto state = libdnf5::offline::OfflineTransactionState::from_base(base);
+    if (state.is_pending()) {
+        auto cmd_line = state.get_data().get_cmd_line();
+        state.invalidate();
+        print_error(_("Warning: Pending offline transaction has been invalidated."));
+        if (!cmd_line.empty()) {
+            print_error(libdnf5::utils::sformat(_("To reschedule, run: {}"), cmd_line));
+        }
+    }
+
     // TODO(mblaha): print a summary of successful transaction
 }
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -79,6 +79,7 @@
 #include <libdnf5/repo/repo_cache.hpp>
 #include <libdnf5/rpm/arch.hpp>
 #include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/bootc.hpp>
 #include <libdnf5/utils/locker.hpp>
@@ -1583,6 +1584,20 @@ int main(int argc, char * argv[]) try {
                             context.print_error(_(
                                 "Test mode enabled: Only package downloads, OpenPGP key installations and transaction "
                                 "checks will be performed."));
+                        }
+                    }
+                    if (!context.get_should_store_offline()) {
+                        auto offline_state = libdnf5::offline::OfflineTransactionState::from_base(base);
+                        if (offline_state.is_pending()) {
+                            auto cmd_line = offline_state.get_data().get_cmd_line();
+                            if (cmd_line.empty()) {
+                                context.print_error(_("Warning: A pending offline transaction will be invalidated."));
+                            } else {
+                                context.print_error(libdnf5::utils::sformat(
+                                    _("Warning: A pending offline transaction initiated by the following command "
+                                      "will be invalidated: {}"),
+                                    cmd_line));
+                            }
                         }
                     }
                 }

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -28,6 +28,7 @@
 #include "utils.hpp"
 
 #include <fmt/format.h>
+#include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/transaction/transaction_item.hpp>
 #include <libdnf5/transaction/transaction_item_action.hpp>
 #include <sdbus-c++/sdbus-c++.h>
@@ -424,6 +425,14 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
                         static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
                             rpm_result)));
             }
+
+            auto * base = session.get_base();
+            auto state = libdnf5::offline::OfflineTransactionState::from_base(*base);
+            if (state.is_pending()) {
+                state.invalidate();
+                base->get_logger()->info("Pending offline transaction has been invalidated.");
+            }
+
             // TODO(mblaha): clean up downloaded packages after successful transaction
         }
     }

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -262,6 +262,14 @@ sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
 
     std::string state_error;
     auto state = read_transaction_state(state_error);
+    bool is_valid = false;
+    if (state && state->is_pending()) {
+        try {
+            is_valid = state->check_rpmdb_cookie(*session.get_base());
+        } catch (const std::exception & ex) {
+            session.get_base()->get_logger()->warning("Failed to check offline transaction validity: {}", ex.what());
+        }
+    }
     if (state) {
         const auto & state_data = state->get_data();
         transaction_state["status"] = sdbus::Variant(state_data.get_status());
@@ -275,7 +283,7 @@ sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
     }
 
     auto reply = call.createReply();
-    reply << (offline_transaction_scheduled() == Scheduled::SCHEDULED);
+    reply << (is_valid && offline_transaction_scheduled() == Scheduled::SCHEDULED);
     reply << transaction_state;
     return reply;
 }

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -358,8 +358,7 @@ void Session::store_transaction_offline(bool downloadonly) {
     const auto & offline_datadir = installroot / libdnf5::offline::DEFAULT_DATADIR.relative_path();
     const auto & offline_destdir = installroot / libdnf5::offline::DEFAULT_DESTDIR.relative_path();
     std::filesystem::create_directories(offline_datadir);
-    const std::filesystem::path state_path{offline_datadir / libdnf5::offline::TRANSACTION_STATE_FILENAME};
-    libdnf5::offline::OfflineTransactionState state{state_path};
+    auto state = libdnf5::offline::OfflineTransactionState::from_base(*base);
     auto & state_data = state.get_data();
     state_data.set_status(libdnf5::offline::STATUS_DOWNLOAD_INCOMPLETE);
     state.write();

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -419,6 +419,7 @@ void Session::store_transaction_offline(bool downloadonly) {
         }
         state_data.set_status(libdnf5::offline::STATUS_READY);
     }
+    state.capture_rpmdb_cookie(*base);
     state.write();
 }
 

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -26,6 +26,10 @@
 #include <filesystem>
 #include <memory>
 
+namespace libdnf5 {
+class Base;
+}
+
 namespace libdnf5::offline {
 
 // Unique identifiers used to mark and identify system-upgrade boots in
@@ -119,6 +123,12 @@ public:
     /// Constructs a new OfflineTransactionState instance based on the state file location.
     /// @param path Path to the state file (default location is /usr/lib/sysimage/libdnf5/offline/offline-transaction-state.toml).
     OfflineTransactionState(std::filesystem::path path);
+
+    /// Creates a new OfflineTransactionState deriving the state file path
+    /// from the Base installroot configuration.
+    /// @param base The Base instance to derive the state file path from.
+    /// @return A new OfflineTransactionState instance.
+    static OfflineTransactionState from_base(const libdnf5::Base & base);
 
     OfflineTransactionState(const OfflineTransactionState & src);
     OfflineTransactionState & operator=(const OfflineTransactionState & src);

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -144,6 +144,14 @@ public:
     /// Returns path to the state file.
     std::filesystem::path get_path() const;
 
+    /// Returns true if a pending offline transaction exists — the state file
+    /// was read successfully and the status is not download-incomplete.
+    bool is_pending() const;
+
+    /// Remove the /system-update magic symlink (if it points to the state
+    /// file's directory) to prevent booting into offline transaction mode.
+    void invalidate();
+
 private:
     class LIBDNF_LOCAL Impl;
     /// Read offline transaction state data from the file

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -108,6 +108,10 @@ public:
     void set_module_platform_id(const std::string & module_platform_id);
     const std::string & get_module_platform_id() const;
 
+    /// Set the rpmdb cookie captured at offline transaction preparation time.
+    void set_rpmdb_cookie(const std::string & rpmdb_cookie);
+    std::string get_rpmdb_cookie() const;
+
 private:
     class LIBDNF_LOCAL Impl;
     std::unique_ptr<Impl> p_impl;
@@ -151,6 +155,14 @@ public:
     /// Remove the /system-update magic symlink (if it points to the state
     /// file's directory) to prevent booting into offline transaction mode.
     void invalidate();
+
+    /// Capture the current rpmdb cookie and store it in the state data.
+    /// The cookie is persisted when write() is called.
+    void capture_rpmdb_cookie(libdnf5::Base & base);
+
+    /// Returns true if the stored rpmdb cookie matches the current rpmdb,
+    /// or if no cookie was stored (backward compatibility).
+    bool check_rpmdb_cookie(libdnf5::Base & base) const;
 
 private:
     class LIBDNF_LOCAL Impl;

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -147,7 +147,6 @@ const std::string & OfflineTransactionStateData::get_module_platform_id() const 
     return p_impl->data.module_platform_id;
 }
 
-
 class OfflineTransactionState::Impl {
     friend OfflineTransactionState;
     std::exception_ptr read_exception;
@@ -220,6 +219,29 @@ OfflineTransactionState OfflineTransactionState::from_base(const Base & base) {
     return OfflineTransactionState(
         base.get_config().get_installroot_option().get_value() / DEFAULT_DATADIR.relative_path() /
         TRANSACTION_STATE_FILENAME);
+}
+
+bool OfflineTransactionState::is_pending() const {
+    if (p_impl->read_exception) {
+        return false;
+    }
+    const auto & status = p_impl->data.get_status();
+    return status == STATUS_DOWNLOAD_COMPLETE || status == STATUS_READY;
+}
+
+void OfflineTransactionState::invalidate() {
+    const auto datadir = p_impl->path.parent_path();
+    std::error_code ec;
+    auto target = std::filesystem::read_symlink(MAGIC_SYMLINK, ec);
+    if (ec) {
+        return;
+    }
+    std::error_code ec_target, ec_datadir;
+    auto canonical_target = std::filesystem::weakly_canonical(target, ec_target);
+    auto canonical_datadir = std::filesystem::weakly_canonical(datadir, ec_datadir);
+    if (!ec_target && !ec_datadir && canonical_target == canonical_datadir) {
+        std::filesystem::remove(MAGIC_SYMLINK, ec);
+    }
 }
 
 }  // namespace libdnf5::offline

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "rpm/transaction.hpp"
+
 #include "libdnf5/common/exception.hpp"
 
 #include <libdnf5/base/base.hpp>
@@ -26,7 +28,7 @@
 #include <toml.hpp>
 
 
-const int STATE_VERSION = 1;
+const int STATE_VERSION = 2;
 const std::string STATE_HEADER{"offline-transaction-state"};
 
 
@@ -40,6 +42,7 @@ struct OfflineTransactionStateTomlData {
     std::string cmd_line;
     bool poweroff_after = false;
     std::string module_platform_id;
+    std::string rpmdb_cookie;
 };
 
 TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
@@ -52,7 +55,9 @@ TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
     verb,
     cmd_line,
     poweroff_after,
-    module_platform_id)
+    module_platform_id,
+    rpmdb_cookie)
+
 
 namespace libdnf5::offline {
 
@@ -146,6 +151,14 @@ void OfflineTransactionStateData::set_module_platform_id(const std::string & mod
 const std::string & OfflineTransactionStateData::get_module_platform_id() const {
     return p_impl->data.module_platform_id;
 }
+
+void OfflineTransactionStateData::set_rpmdb_cookie(const std::string & rpmdb_cookie) {
+    p_impl->data.rpmdb_cookie = rpmdb_cookie;
+}
+std::string OfflineTransactionStateData::get_rpmdb_cookie() const {
+    return p_impl->data.rpmdb_cookie;
+}
+
 
 class OfflineTransactionState::Impl {
     friend OfflineTransactionState;
@@ -242,6 +255,20 @@ void OfflineTransactionState::invalidate() {
     if (!ec_target && !ec_datadir && canonical_target == canonical_datadir) {
         std::filesystem::remove(MAGIC_SYMLINK, ec);
     }
+}
+
+void OfflineTransactionState::capture_rpmdb_cookie(Base & base) {
+    rpm::Transaction rpm_ts(base);
+    p_impl->data.set_rpmdb_cookie(rpm_ts.get_db_cookie());
+}
+
+bool OfflineTransactionState::check_rpmdb_cookie(Base & base) const {
+    const auto & stored_cookie = p_impl->data.get_rpmdb_cookie();
+    if (stored_cookie.empty()) {
+        return true;
+    }
+    rpm::Transaction rpm_ts(base);
+    return rpm_ts.get_db_cookie() == stored_cookie;
 }
 
 }  // namespace libdnf5::offline

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -19,6 +19,7 @@
 
 #include "libdnf5/common/exception.hpp"
 
+#include <libdnf5/base/base.hpp>
 #include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <libdnf5/utils/fs/file.hpp>
@@ -213,6 +214,12 @@ void OfflineTransactionState::write() {
     file.write(toml::format(toml::value{toml::table{{STATE_HEADER, p_impl->data.p_impl->data}}}));
 #endif
     file.close();
+}
+
+OfflineTransactionState OfflineTransactionState::from_base(const Base & base) {
+    return OfflineTransactionState(
+        base.get_config().get_installroot_option().get_value() / DEFAULT_DATADIR.relative_path() /
+        TRANSACTION_STATE_FILENAME);
 }
 
 }  // namespace libdnf5::offline

--- a/test/libdnf5/transaction/test_offline.cpp
+++ b/test/libdnf5/transaction/test_offline.cpp
@@ -1,0 +1,87 @@
+// Copyright Contributors to the DNF5 project.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "test_offline.hpp"
+
+#include <libdnf5/transaction/offline.hpp>
+#include <libdnf5/utils/fs/file.hpp>
+
+#include <filesystem>
+
+
+using namespace libdnf5::offline;
+
+CPPUNIT_TEST_SUITE_REGISTRATION(OfflineTransactionStateTest);
+
+
+void OfflineTransactionStateTest::test_from_base_factory() {
+    auto expected_path = base.get_config().get_installroot_option().get_value() / DEFAULT_DATADIR.relative_path() /
+                         TRANSACTION_STATE_FILENAME;
+    auto state = OfflineTransactionState::from_base(base);
+    CPPUNIT_ASSERT_EQUAL(expected_path, state.get_path());
+}
+
+
+void OfflineTransactionStateTest::test_is_pending_no_file() {
+    auto state = OfflineTransactionState::from_base(base);
+    CPPUNIT_ASSERT(!state.is_pending());
+    CPPUNIT_ASSERT(state.get_read_exception() != nullptr);
+}
+
+
+void OfflineTransactionStateTest::test_is_pending_download_incomplete() {
+    auto state = OfflineTransactionState::from_base(base);
+    auto & data = state.get_data();
+    data.set_status(STATUS_DOWNLOAD_INCOMPLETE);
+    auto dir = state.get_path().parent_path();
+    std::filesystem::create_directories(dir);
+    state.write();
+
+    OfflineTransactionState state2(state.get_path());
+    CPPUNIT_ASSERT(!state2.is_pending());
+    CPPUNIT_ASSERT(state2.get_read_exception() == nullptr);
+}
+
+
+void OfflineTransactionStateTest::test_is_pending_download_complete() {
+    auto state = OfflineTransactionState::from_base(base);
+    auto & data = state.get_data();
+    data.set_status(STATUS_DOWNLOAD_COMPLETE);
+    auto dir = state.get_path().parent_path();
+    std::filesystem::create_directories(dir);
+    state.write();
+
+    OfflineTransactionState state2(state.get_path());
+    CPPUNIT_ASSERT(state2.is_pending());
+    CPPUNIT_ASSERT(state2.get_read_exception() == nullptr);
+}
+
+
+void OfflineTransactionStateTest::test_invalidate() {
+    auto state = OfflineTransactionState::from_base(base);
+    auto & data = state.get_data();
+    data.set_status(STATUS_DOWNLOAD_COMPLETE);
+    auto dir = state.get_path().parent_path();
+    std::filesystem::create_directories(dir);
+    state.write();
+
+    auto transaction_json = dir / "transaction.json";
+    libdnf5::utils::fs::File(transaction_json, "w").close();
+
+    auto packages_dir = dir.parent_path() / "packages";
+    std::filesystem::create_directories(packages_dir);
+    libdnf5::utils::fs::File(packages_dir / "test.rpm", "w").close();
+
+    CPPUNIT_ASSERT(std::filesystem::exists(state.get_path()));
+    CPPUNIT_ASSERT(std::filesystem::exists(transaction_json));
+
+    state.invalidate();
+
+    CPPUNIT_ASSERT(std::filesystem::exists(state.get_path()));
+    CPPUNIT_ASSERT(std::filesystem::exists(transaction_json));
+    CPPUNIT_ASSERT(std::filesystem::exists(packages_dir / "test.rpm"));
+
+    OfflineTransactionState state2(state.get_path());
+    CPPUNIT_ASSERT_EQUAL(STATUS_DOWNLOAD_COMPLETE, state2.get_data().get_status());
+    CPPUNIT_ASSERT(state2.is_pending());
+}

--- a/test/libdnf5/transaction/test_offline.cpp
+++ b/test/libdnf5/transaction/test_offline.cpp
@@ -85,3 +85,41 @@ void OfflineTransactionStateTest::test_invalidate() {
     CPPUNIT_ASSERT_EQUAL(STATUS_DOWNLOAD_COMPLETE, state2.get_data().get_status());
     CPPUNIT_ASSERT(state2.is_pending());
 }
+
+
+void OfflineTransactionStateTest::test_rpmdb_cookie_roundtrip() {
+    auto state = OfflineTransactionState::from_base(base);
+    state.capture_rpmdb_cookie(base);
+
+    auto & data = state.get_data();
+    CPPUNIT_ASSERT(!data.get_rpmdb_cookie().empty());
+
+    data.set_status(STATUS_DOWNLOAD_COMPLETE);
+    auto dir = state.get_path().parent_path();
+    std::filesystem::create_directories(dir);
+    state.write();
+
+    OfflineTransactionState state2(state.get_path());
+    CPPUNIT_ASSERT_EQUAL(data.get_rpmdb_cookie(), state2.get_data().get_rpmdb_cookie());
+    CPPUNIT_ASSERT(state2.check_rpmdb_cookie(base));
+}
+
+
+void OfflineTransactionStateTest::test_check_rpmdb_cookie_empty() {
+    auto state = OfflineTransactionState::from_base(base);
+    CPPUNIT_ASSERT(state.check_rpmdb_cookie(base));
+}
+
+
+void OfflineTransactionStateTest::test_check_rpmdb_cookie_mismatch() {
+    auto state = OfflineTransactionState::from_base(base);
+    auto & data = state.get_data();
+    data.set_rpmdb_cookie("bogus_cookie_value");
+    data.set_status(STATUS_DOWNLOAD_COMPLETE);
+    auto dir = state.get_path().parent_path();
+    std::filesystem::create_directories(dir);
+    state.write();
+
+    OfflineTransactionState state2(state.get_path());
+    CPPUNIT_ASSERT(!state2.check_rpmdb_cookie(base));
+}

--- a/test/libdnf5/transaction/test_offline.hpp
+++ b/test/libdnf5/transaction/test_offline.hpp
@@ -17,6 +17,9 @@ class OfflineTransactionStateTest : public BaseTestCase {
     CPPUNIT_TEST(test_is_pending_download_incomplete);
     CPPUNIT_TEST(test_is_pending_download_complete);
     CPPUNIT_TEST(test_invalidate);
+    CPPUNIT_TEST(test_rpmdb_cookie_roundtrip);
+    CPPUNIT_TEST(test_check_rpmdb_cookie_empty);
+    CPPUNIT_TEST(test_check_rpmdb_cookie_mismatch);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -25,6 +28,9 @@ public:
     void test_is_pending_download_incomplete();
     void test_is_pending_download_complete();
     void test_invalidate();
+    void test_rpmdb_cookie_roundtrip();
+    void test_check_rpmdb_cookie_empty();
+    void test_check_rpmdb_cookie_mismatch();
 };
 
 #endif  // LIBDNF5_TEST_TRANSACTION_TEST_OFFLINE_HPP

--- a/test/libdnf5/transaction/test_offline.hpp
+++ b/test/libdnf5/transaction/test_offline.hpp
@@ -1,0 +1,30 @@
+// Copyright Contributors to the DNF5 project.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef LIBDNF5_TEST_TRANSACTION_TEST_OFFLINE_HPP
+#define LIBDNF5_TEST_TRANSACTION_TEST_OFFLINE_HPP
+
+#include "../shared/base_test_case.hpp"
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class OfflineTransactionStateTest : public BaseTestCase {
+    CPPUNIT_TEST_SUITE(OfflineTransactionStateTest);
+    CPPUNIT_TEST(test_from_base_factory);
+    CPPUNIT_TEST(test_is_pending_no_file);
+    CPPUNIT_TEST(test_is_pending_download_incomplete);
+    CPPUNIT_TEST(test_is_pending_download_complete);
+    CPPUNIT_TEST(test_invalidate);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_from_base_factory();
+    void test_is_pending_no_file();
+    void test_is_pending_download_incomplete();
+    void test_is_pending_download_complete();
+    void test_invalidate();
+};
+
+#endif  // LIBDNF5_TEST_TRANSACTION_TEST_OFFLINE_HPP


### PR DESCRIPTION
- Add `OfflineTransactionState(Base&)` constructor that derives the state file path from installroot. This is just convenience layer to deduplicate some code.
- After a successful online RPM transaction (both CLI and daemon), check for a pending offline transaction and invalidate it. Removes the state file, transaction.json, and the /system-update magic symlink while preserving downloaded packages for reuse

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2467655

