### PR TITLE
dnfdaemon: Add install_time package attribute

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -42,7 +42,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         Following options and filters are supported:
 
             - package_attrs: list of strings
-                list of package attributes that are returned. Supported attributes are name, epoch, version, release, arch, repo_id, from_repo_id, is_installed, install_size, download_size, buildtime, sourcerpm, summary, url, license, description, files, changelogs, provides, requires, requires_pre, conflicts, obsoletes, recommends, suggests, enhances, supplements, evr, nevra, full_nevra, reason, vendor, group.
+                list of package attributes that are returned. Supported attributes are name, epoch, version, release, arch, repo_id, from_repo_id, is_installed, install_size, download_size, buildtime, install_time, sourcerpm, summary, url, license, description, files, changelogs, provides, requires, requires_pre, conflicts, obsoletes, recommends, suggests, enhances, supplements, evr, nevra, full_nevra, reason, vendor, group.
             - with_nevra: bool (default true)
                 match patterns against available packages NEVRAs
             - with_provides: bool (default true)

--- a/dnf5daemon-server/package.cpp
+++ b/dnf5daemon-server/package.cpp
@@ -37,6 +37,7 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"install_size", PackageAttribute::install_size},
     {"download_size", PackageAttribute::download_size},
     {"buildtime", PackageAttribute::buildtime},
+    {"install_time", PackageAttribute::install_time},
     {"sourcerpm", PackageAttribute::sourcerpm},
     {"summary", PackageAttribute::summary},
     {"url", PackageAttribute::url},
@@ -122,6 +123,9 @@ dnfdaemon::KeyValueMap package_to_map(
                 break;
             case PackageAttribute::buildtime:
                 dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_build_time()));
+                break;
+            case PackageAttribute::install_time:
+                dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_install_time()));
                 break;
             case PackageAttribute::sourcerpm:
                 dbus_package.emplace(attr, libdnf_package.get_sourcerpm());
@@ -261,6 +265,10 @@ std::string package_to_json(const libdnf5::rpm::Package & libdnf_package, const 
             case PackageAttribute::buildtime:
                 json_object_object_add(
                     json_pkg, cattr, json_object_new_int64(static_cast<int64_t>(libdnf_package.get_build_time())));
+                break;
+            case PackageAttribute::install_time:
+                json_object_object_add(
+                    json_pkg, cattr, json_object_new_int64(static_cast<int64_t>(libdnf_package.get_install_time())));
                 break;
             case PackageAttribute::sourcerpm:
                 json_object_object_add(json_pkg, cattr, json_object_new_string(libdnf_package.get_sourcerpm().c_str()));

--- a/dnf5daemon-server/package.hpp
+++ b/dnf5daemon-server/package.hpp
@@ -41,6 +41,7 @@ enum class PackageAttribute {
     install_size,
     download_size,
     buildtime,
+    install_time,
     sourcerpm,
     summary,
     url,


### PR DESCRIPTION
Expose the install_time attribute through the D-Bus package attribute system. This allows callers of the History.recent_changes() and Rpm.list() methods to query when a package was actually installed on the system, instead of having to use buildtime (when the RPM was built by the packager) as an inaccurate proxy.

The underlying libdnf5::rpm::Package::get_install_time() API already existed but was not wired into the daemon's attribute serialization.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2734