### PR TITLE
libdnf5-cli: Stop option parsing after "--"

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -1237,6 +1237,16 @@ std::vector<std::string> Context::match_specs(
         settings.set_with_provides(false);
         settings.set_with_filenames(false);
         settings.set_with_binaries(false);
+        // Patterns starting with '-' are not valid RPM package names.
+        // Without this, resolve_pkg_spec would parse '-' as a NEVRA
+        // name-version delimiter, causing '-v*' to match packages by
+        // version starting with 'v' instead of name. Safe to disable
+        // NEVRA because match_specs is only called from completion hooks
+        // the '-' prefixed arg only reaches here after "--" (the argument
+        // separator that stops named-arg/option parsing).
+        if (!pattern.empty() && pattern[0] == '-') {
+            settings.set_with_nevra(false);
+        }
         matched_pkgs_query.resolve_pkg_spec(pattern + '*', settings, true);
 
         for (const auto & package : matched_pkgs_query) {

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -353,6 +353,12 @@ Following options are applicable in the general context for any ``dnf5`` command
     | Exclude packages specified in ``PACKAGE-SPEC-N`` arguments from the transaction.
     | This is a list option.
 
+Special Arguments
+=================
+
+``--``
+    | Stop parsing command line options. All remaining arguments will be treated as positional arguments.
+
 
 Metadata Synchronization
 ========================

--- a/include/libdnf5-cli/argument_parser.hpp
+++ b/include/libdnf5-cli/argument_parser.hpp
@@ -224,7 +224,8 @@ public:
 
         /// Parses input.
         /// Returns number of consumed arguments from the input.
-        LIBDNF_CLI_LOCAL int parse(const char * option, int argc, const char * const argv[]);
+        LIBDNF_CLI_LOCAL int parse(
+            const char * option, int argc, const char * const argv[], bool stop_at_named_args = true);
 
         int nvals;  // Number of values required by this positional argument on the command line
         libdnf5::Option * init_value;
@@ -445,7 +446,10 @@ public:
         // Prints a completed argument `arg` or a table with suggestions and help to complete
         // if there is more than one solution.
         LIBDNF_CLI_LOCAL void print_complete(
-            const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments);
+            const char * arg,
+            std::vector<ArgumentParser::NamedArg *> named_args,
+            size_t used_positional_arguments,
+            bool stop_at_named_args = true);
 
         Command * parent{nullptr};
         std::string commands_help_header = "Commands:";

--- a/libdnf5-cli/argument_parser.cpp
+++ b/libdnf5-cli/argument_parser.cpp
@@ -349,14 +349,15 @@ ArgumentParser::PositionalArg::PositionalArg(
     libdnf_assert(!values || init_value, "\"init_value\" constructor parameter cannot be nullptr if \"value\" is set");
 }
 
-int ArgumentParser::PositionalArg::parse(const char * option, int argc, const char * const argv[]) {
+int ArgumentParser::PositionalArg::parse(
+    const char * option, int argc, const char * const argv[], bool stop_at_named_args) {
     if (const auto * arg = get_conflict_argument()) {
         auto [fmt_message, conflict_option] = get_conflict_arg_msg(arg);
         throw ArgumentParserConflictingArgumentsError(fmt_message, std::string(option), conflict_option);
     }
     if (owner.p_impl->complete_arg_ptr) {
         int usable_argc = 1;
-        while (usable_argc < argc && *argv[usable_argc] != '-') {
+        while (usable_argc < argc && (!stop_at_named_args || *argv[usable_argc] != '-')) {
             ++usable_argc;
         }
         auto count = static_cast<size_t>(nvals > 0 ? nvals : (nvals == OPTIONAL ? 1 : usable_argc));
@@ -382,14 +383,14 @@ int ArgumentParser::PositionalArg::parse(const char * option, int argc, const ch
         throw ArgumentParserPositionalArgFewValuesError(M_("Too few values for positional argument \"{}\""), this->id);
     }
     for (int i = 1; i < nvals; ++i) {
-        if (*argv[i] == '-') {
+        if (stop_at_named_args && *argv[i] == '-') {
             throw ArgumentParserPositionalArgFewValuesError(
                 M_("Too few values for positional argument \"{}\""), this->id);
         }
     }
     int usable_argc = 1;
     if (nvals <= 0) {
-        while (usable_argc < argc && *argv[usable_argc] != '-') {
+        while (usable_argc < argc && (!stop_at_named_args || *argv[usable_argc] != '-')) {
             ++usable_argc;
         }
     }
@@ -859,7 +860,10 @@ std::vector<std::string> ArgumentParser::Command::get_invocation() const noexcep
 ArgumentParser::Command::Command(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
 
 void ArgumentParser::Command::print_complete(
-    const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments) {
+    const char * arg,
+    std::vector<ArgumentParser::NamedArg *> named_args,
+    size_t used_positional_arguments,
+    bool stop_at_named_args) {
     const bool add_description = get_argument_parser().p_impl->complete_add_description;
 
     // Using the Help class to print the completion suggestions wits description, as it prints a table of two columns
@@ -870,6 +874,27 @@ void ArgumentParser::Command::print_complete(
     std::vector<std::string> suggestions;
 
     std::string last;
+
+    // After "--", do not suggest commands or named args, only positional arg completions.
+    if (!stop_at_named_args) {
+        if (used_positional_arguments < get_positional_args().size()) {
+            auto pos_arg = get_positional_args()[used_positional_arguments];
+            if (pos_arg->get_complete() && pos_arg->complete_hook) {
+                auto result = pos_arg->complete_hook(arg);
+                if (result.size() == 1) {
+                    if (result[0] == arg) {
+                        return;
+                    }
+                    std::cout << result[0] << std::endl;
+                    return;
+                }
+                for (const auto & line : result) {
+                    std::cout << line << std::endl;
+                }
+            }
+        }
+        return;
+    }
 
     // Search for matching commands.
     if (arg[0] == '\0' || arg[0] != '-') {
@@ -1078,7 +1103,15 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
     }
     size_t used_positional_arguments = 0;
     int short_option_idx = 0;
+    bool stop_at_named_args = true;
     for (int i = 1; i < argc;) {
+        if (stop_at_named_args && std::strcmp(argv[i], "--") == 0 &&
+            (!owner.p_impl->complete_arg_ptr || argv + i != owner.p_impl->complete_arg_ptr)) {
+            stop_at_named_args = false;
+            ++i;
+            short_option_idx = 0;
+            continue;
+        }
         char unused_short_option = 0;
         if (owner.p_impl->complete_arg_ptr) {
             if (argv + i > owner.p_impl->complete_arg_ptr) {
@@ -1087,13 +1120,14 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
                 print_complete(
                     argv[i],
                     inherit_named_args_from_parent ? extended_named_args : named_args,
-                    used_positional_arguments);
+                    used_positional_arguments,
+                    stop_at_named_args);
                 return;
             }
         }
         bool used = false;
         const auto * tmp = argv[i];
-        if (*tmp == '-') {
+        if (stop_at_named_args && *tmp == '-') {
             bool long_option = *++tmp == '-';
             if (long_option) {
                 ++tmp;
@@ -1127,7 +1161,7 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
                 unused_short_option = tmp[short_option_idx];
             }
         }
-        if (!used) {
+        if (!used && stop_at_named_args) {
             for (auto & cmd : cmds) {
                 if (cmd->id == argv[i]) {
                     if (const auto * arg = get_conflict_argument()) {
@@ -1148,9 +1182,9 @@ void ArgumentParser::CommandOrdinary::parse(const char * option, int argc, const
                 }
             }
         }
-        if (!used && *argv[i] != '-' && used_positional_arguments < pos_args.size()) {
+        if (!used && (!stop_at_named_args || *argv[i] != '-') && used_positional_arguments < pos_args.size()) {
             auto * pos_arg = pos_args[used_positional_arguments];
-            i += pos_arg->parse(argv[i], argc - i, &argv[i]);
+            i += pos_arg->parse(argv[i], argc - i, &argv[i], stop_at_named_args);
             auto nrepeats = pos_arg->get_nrepeats();
             if ((nrepeats > 0 && pos_arg->parse_count >= nrepeats) || nrepeats == PositionalArg::OPTIONAL) {
                 ++used_positional_arguments;
@@ -1300,7 +1334,15 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
     }
     size_t used_positional_arguments = 0;
     int short_option_idx = 0;
+    bool stop_at_named_args = true;
     for (int i = 1 + number_of_required_values; i < argc;) {
+        if (stop_at_named_args && std::strcmp(argv[i], "--") == 0 &&
+            (!owner.p_impl->complete_arg_ptr || argv + i != owner.p_impl->complete_arg_ptr)) {
+            stop_at_named_args = false;
+            ++i;
+            short_option_idx = 0;
+            continue;
+        }
         if (owner.p_impl->complete_arg_ptr) {
             if (argv + i > owner.p_impl->complete_arg_ptr) {
                 return;
@@ -1308,13 +1350,14 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
                 print_complete(
                     argv[i],
                     inherit_named_args_from_parent ? extended_named_args : named_args,
-                    used_positional_arguments);
+                    used_positional_arguments,
+                    stop_at_named_args);
                 return;
             }
         }
         bool used = false;
         const auto * tmp = argv[i];
-        if (*tmp == '-') {
+        if (stop_at_named_args && *tmp == '-') {
             bool long_option = *++tmp == '-';
             if (long_option) {
                 ++tmp;
@@ -1345,7 +1388,7 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
                 }
             }
         }
-        if (!used) {
+        if (!used && stop_at_named_args) {
             for (auto & cmd : cmds) {
                 if (cmd->id == argv[i]) {
                     if (const auto * arg = get_conflict_argument()) {
@@ -1366,9 +1409,9 @@ void ArgumentParser::CommandAlias::parse(const char * option, int argc, const ch
                 }
             }
         }
-        if (!used && *argv[i] != '-' && used_positional_arguments < pos_args.size()) {
+        if (!used && (!stop_at_named_args || *argv[i] != '-') && used_positional_arguments < pos_args.size()) {
             auto * pos_arg = pos_args[used_positional_arguments];
-            i += pos_arg->parse(argv[i], argc - i, &argv[i]);
+            i += pos_arg->parse(argv[i], argc - i, &argv[i], stop_at_named_args);
             auto nrepeats = pos_arg->get_nrepeats();
             if ((nrepeats > 0 && pos_arg->parse_count >= nrepeats) || nrepeats == PositionalArg::OPTIONAL) {
                 ++used_positional_arguments;

--- a/test/libdnf5-cli/test_argument_parser.cpp
+++ b/test/libdnf5-cli/test_argument_parser.cpp
@@ -205,6 +205,11 @@ void ArgumentParserTest::test_argument_parser() {
     CPPUNIT_ASSERT_EQUAL(keys_options, keys->get_linked_values());
     CPPUNIT_ASSERT_EQUAL(0, info->get_parse_count());
 
+    auto * repoquery_subcommand = arg_parser.add_new_command("subcommand");
+    repoquery->register_command(repoquery_subcommand);
+    auto * repoquery_alias = arg_parser.add_new_command_alias("rq", *repoquery);
+    test->register_command(repoquery_alias);
+
     {
         constexpr const char * argv[]{"test", "repoquery", "--installed", "--info"};
         arg_parser.parse(std::size(argv), argv);
@@ -234,6 +239,64 @@ void ArgumentParserTest::test_argument_parser() {
             std::string("abc"), dynamic_cast<const libdnf5::OptionString *>(options[0].get())->get_value());
         CPPUNIT_ASSERT_EQUAL(
             std::string("def"), dynamic_cast<const libdnf5::OptionString *>(options[1].get())->get_value());
+    }
+
+    {
+        // "--" terminates option parsing and all following values are treated as positional arguments.
+        keys->get_linked_values()->clear();
+        arg_parser.reset_parse_count();
+        constexpr const char * argv[]{"test", "repoquery", "--", "--info", "abc"};
+        arg_parser.parse(std::size(argv), argv);
+
+        const auto & options = *keys->get_linked_values();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(2), options.size());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("--info"), dynamic_cast<const libdnf5::OptionString *>(options[0].get())->get_value());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("abc"), dynamic_cast<const libdnf5::OptionString *>(options[1].get())->get_value());
+    }
+
+    {
+        // Multiple "--" after the first one are treated as positional arguments.
+        keys->get_linked_values()->clear();
+        arg_parser.reset_parse_count();
+        constexpr const char * argv[]{"test", "repoquery", "--", "--", "abc"};
+        arg_parser.parse(std::size(argv), argv);
+
+        const auto & options = *keys->get_linked_values();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(2), options.size());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("--"), dynamic_cast<const libdnf5::OptionString *>(options[0].get())->get_value());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("abc"), dynamic_cast<const libdnf5::OptionString *>(options[1].get())->get_value());
+    }
+
+    {
+        // A value matching a subcommand name after "--" is treated as a positional argument.
+        keys->get_linked_values()->clear();
+        arg_parser.reset_parse_count();
+        constexpr const char * argv[]{"test", "repoquery", "--", "subcommand"};
+        arg_parser.parse(std::size(argv), argv);
+
+        const auto & options = *keys->get_linked_values();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), options.size());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("subcommand"), dynamic_cast<const libdnf5::OptionString *>(options[0].get())->get_value());
+        CPPUNIT_ASSERT_EQUAL(repoquery, arg_parser.get_selected_command());
+    }
+
+    {
+        // Command aliases treat a matching subcommand name after "--" as positional too.
+        keys->get_linked_values()->clear();
+        arg_parser.reset_parse_count();
+        constexpr const char * argv[]{"test", "rq", "--", "subcommand"};
+        arg_parser.parse(std::size(argv), argv);
+
+        const auto & options = *keys->get_linked_values();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), options.size());
+        CPPUNIT_ASSERT_EQUAL(
+            std::string("subcommand"), dynamic_cast<const libdnf5::OptionString *>(options[0].get())->get_value());
+        CPPUNIT_ASSERT_EQUAL(static_cast<ArgParser::Command *>(repoquery_alias), arg_parser.get_selected_command());
     }
 
     {


### PR DESCRIPTION

Treat "--" as the positional argument separator. Once it is
encountered, all remaining command line arguments are handled as
positional values, even if they start with a hyphen or match a
subcommand name.

Update completion handling so option and subcommand suggestions are not
offered after the separator, and add parser tests for the new behavior.

Fixes: #700 
Relates to: #2700



