### PR TITLE
Fix GoalPrivate::operator= not resetting resolve-time members

### DIFF
--- a/libdnf5/rpm/solv/goal_private.hpp
+++ b/libdnf5/rpm/solv/goal_private.hpp
@@ -263,10 +263,20 @@ inline GoalPrivate::~GoalPrivate() {
 
 inline GoalPrivate & GoalPrivate::operator=(const GoalPrivate & src) {
     if (this != &src) {
+        // Copy inputs
         base = src.base;
         staging = src.staging;
         installonly = src.installonly;
         installonly_limit = src.installonly_limit;
+
+        // Reset resolve-time artifacts
+        transaction_group_reason.reset();
+        transaction_user_installed.reset();
+
+        // Copy inputs (pointers)
+        exclude_from_weak.reset(src.exclude_from_weak ? new libdnf5::solv::SolvMap(*src.exclude_from_weak) : nullptr);
+
+        // Reset solver state
         if (libsolv_solver.is_initialized()) {
             libsolv_solver.reset();
         }
@@ -274,15 +284,27 @@ inline GoalPrivate & GoalPrivate::operator=(const GoalPrivate & src) {
             transaction_free(libsolv_transaction);
             libsolv_transaction = nullptr;
         }
+
+        // Copy inputs (pointers)
         protected_packages.reset(
             src.protected_packages ? new libdnf5::solv::SolvMap(*src.protected_packages) : nullptr);
         removal_of_protected.reset();
         protected_running_kernel = src.protected_running_kernel;
+        user_installed_packages.reset(
+            src.user_installed_packages ? new libdnf5::solv::IdQueue(*src.user_installed_packages) : nullptr);
+
+        // Copy inputs (flags)
         allow_downgrade = src.allow_downgrade;
         allow_erasing = src.allow_erasing;
         allow_vendor_change = src.allow_vendor_change;
         install_weak_deps = src.install_weak_deps;
         run_in_strict_mode = src.run_in_strict_mode;
+
+        // Reset resolve-time state
+        clean_deps_present = false;
+        groups.clear();
+        environments.clear();
+        reason_changes.clear();
     }
     return *this;
 }

--- a/test/dnf5daemon-server/test_install.py
+++ b/test/dnf5daemon-server/test_install.py
@@ -161,3 +161,18 @@ class InstallTest(support.InstallrootCase):
         )
 
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))
+
+    def test_install_file_multiple_resolves(self):
+        '''
+        Test that resolving a file install multiple times in the same session
+        does not crash with "Id is out of bitmap range".
+        '''
+        rpm_path = self.path_to_repo_rpm("rpm-repo1", "one-1-1.noarch.rpm")
+
+        for i in range(16):
+            self.iface_goal.reset(dbus.Dictionary({}, signature='sv'))
+            self.iface_rpm.install([rpm_path], dbus.Dictionary({}, signature='sv'))
+            resolved, result = self.iface_goal.resolve(
+                dbus.Dictionary({}, signature='sv'))
+            self.assertEqual(result, 0,
+                             f"Resolve failed on iteration {i}")

--- a/test/libdnf5/base/test_goal.cpp
+++ b/test/libdnf5/base/test_goal.cpp
@@ -93,6 +93,21 @@ void BaseGoalTest::test_install_from_cmdline() {
     CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
+void BaseGoalTest::test_install_from_cmdline_multiple_resolves() {
+    // Tests that resolving a cmdline package install multiple times does not
+    // crash with "Id is out of bitmap range" due to stale bitmap in operator=.
+    add_repo_rpm("rpm-repo1");
+
+    libdnf5::Goal goal(base);
+
+    for (int i = 0; i < 16; ++i) {
+        auto cmdline_pkg = add_cmdline_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+        goal.add_rpm_install(cmdline_pkg);
+        CPPUNIT_ASSERT_NO_THROW_MESSAGE("Resolve failed on iteration " + std::to_string(i), goal.resolve());
+        goal.reset();
+    }
+}
+
 void BaseGoalTest::test_install_multilib_all() {
     add_repo_solv("solv-multilib");
     base.get_config().get_multilib_policy_option().set("all");

--- a/test/libdnf5/base/test_goal.hpp
+++ b/test/libdnf5/base/test_goal.hpp
@@ -37,6 +37,7 @@ class BaseGoalTest : public LibdnfPrivateTestCase {
     CPPUNIT_TEST(test_install_installed_pkg);
     CPPUNIT_TEST(test_install_or_reinstall);
     CPPUNIT_TEST(test_install_from_cmdline);
+    CPPUNIT_TEST(test_install_from_cmdline_multiple_resolves);
     CPPUNIT_TEST(test_reinstall);
     CPPUNIT_TEST(test_reinstall_from_cmdline);
     CPPUNIT_TEST(test_reinstall_user);
@@ -70,6 +71,7 @@ public:
     void test_install_installed_pkg();
     void test_install_or_reinstall();
     void test_install_from_cmdline();
+    void test_install_from_cmdline_multiple_resolves();
     void test_reinstall();
     void test_reinstall_from_cmdline();
     void test_reinstall_user();


### PR DESCRIPTION
GoalPrivate::operator= was missing resets for several members that were
added after the original implementation. Most critically,
transaction_user_installed and transaction_group_reason bitmaps were
never reset, causing 'Id is out of bitmap range' crashes when
Goal::resolve() was called multiple times in the same session (e.g. via
dnf5daemon-server when gnome-software installs multiple local RPMs).

The fix aligns operator= with the copy constructor:
- Reset resolve-time artifacts (transaction_group_reason,
  transaction_user_installed)
- Copy input pointers (exclude_from_weak, user_installed_packages)
- Reset resolve-time state (clean_deps_present, groups, environments,
  reason_changes)

Fixes: https://github.com/rpm-software-management/dnf5/issues/2756
Assisted-by: GitHub Copilot
