### PR TITLE
Add e2k to ARCH_MAP

### DIFF
--- a/libdnf5/rpm/arch_private.hpp
+++ b/libdnf5/rpm/arch_private.hpp
@@ -65,6 +65,7 @@ static const struct {
     {"sparc", {"sparc", "sparc64", "sparc64v", "sparcv8", "sparcv9", "sparcv9v", nullptr}},
     {"x86_64", {"x86_64", "amd64", "ia32e", nullptr}},
     {"loongarch64", {"loongarch64", nullptr}},
+    {"e2k", {"e2k", "e2kv4", "e2kv5", "e2v6"}},
     {nullptr, {nullptr}}};
 
 }  // namespace libdnf5::rpm


### PR DESCRIPTION
This is a follow-up change to https://github.com/rpm-software-management/libdnf/pull/1720