### PR TITLE
Add tmpfiles config to create system repo lockfile 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_policy(VERSION ${CMAKE_VERSION})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(SYSTEMD_DIR "/usr/lib/systemd/system")
+set(TMPFILES_DIR "/usr/lib/tmpfiles.d")
 
 message("Building ${PROJECT_NAME} version ${PROJECT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project(dnf5 LANGUAGES CXX C VERSION ${VERSION_PRIME}.${VERSION_MAJOR}.${VERSION
 cmake_policy(VERSION ${CMAKE_VERSION})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set(SYSTEMD_DIR "/usr/lib/systemd/system")
-set(TMPFILES_DIR "/usr/lib/tmpfiles.d")
+set(SYSTEMD_DIR "/usr/lib/systemd/system" CACHE PATH "Directory for systemd unit files")
+set(TMPFILES_DIR "/usr/lib/tmpfiles.d" CACHE PATH "Directory for systemd tmpfiles.d files")
 
 message("Building ${PROJECT_NAME} version ${PROJECT_VERSION}")
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -490,6 +490,7 @@ Package management library.
 %verify(not md5 size mtime) %attr(0644, root, root) %ghost %{_prefix}/lib/sysimage/libdnf5/transaction_history.sqlite{,-shm,-wal}
 %license lgpl-2.1.txt
 %ghost %attr(0755, root, root) %dir %{_var}/cache/libdnf5
+%{_tmpfilesdir}/libdnf5.conf
 %attr(0755, root, root) %dir %{_sharedstatedir}/dnf
 %verify(not md5 size mtime) %attr(0644, root, root) %{_sharedstatedir}/dnf/system-repo.lock
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -1031,6 +1031,8 @@ DNF5 plugin for working with RPM package manifest files.
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \
     -DWITH_MODULEMD=%{?with_modulemd:ON}%{!?with_modulemd:OFF} \
     -DWITH_SYSTEMD=%{?with_systemd:ON}%{!?with_systemd:OFF} \
+    -DSYSTEMD_DIR=%{_unitdir} \
+    -DTMPFILES_DIR=%{_tmpfilesdir} \
     \
     -DWITH_HTML=%{?with_html:ON}%{!?with_html:OFF} \
     -DWITH_MAN=%{?with_man:ON}%{!?with_man:OFF} \

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,3 +1,4 @@
 if (WITH_SYSTEMD)
   add_subdirectory("systemd")
+  add_subdirectory("tmpfiles.d")
 endif()

--- a/etc/tmpfiles.d/CMakeLists.txt
+++ b/etc/tmpfiles.d/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES libdnf5.conf DESTINATION "${TMPFILES_DIR}")

--- a/etc/tmpfiles.d/libdnf5.conf
+++ b/etc/tmpfiles.d/libdnf5.conf
@@ -1,0 +1,3 @@
+# Create the libdnf5 system repo lock file
+d /var/lib/dnf 0755 root root -
+f /var/lib/dnf/system-repo.lock 0644 root root -


### PR DESCRIPTION
Packaged files in /var are not deployed on Fedora Atomic systems, so if we don't have something create the file initially, non-privileged users won't be able to obtain the lock until a privileged user runs DNF and creates the lockfile.

Resolves https://github.com/rpm-software-management/dnf5/issues/2761.