### PR TITLE
spec: Remove unused dependency on "check" pkg-config file

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -147,7 +147,6 @@ BuildRequires:  bash-completion
 BuildRequires:  cmake >= 3.21
 BuildRequires:  doxygen
 BuildRequires:  gettext
-BuildRequires:  pkgconfig(check)
 BuildRequires:  pkgconfig(fmt)
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(libcrypto)


### PR DESCRIPTION
The Check library is not used anywhere now. It seems the build-time dependency was copied from libdnf project, without actually being used at that time either.