### PR TITLE
Display installation status in search command

### DIFF
--- a/dnf5/commands/search/search_processor.cpp
+++ b/dnf5/commands/search/search_processor.cpp
@@ -137,6 +137,8 @@ void SearchProcessor::update_priorities(const libdnf5::rpm::PackageSet & package
 
 SearchResults SearchProcessor::get_results() {
     libdnf5::rpm::PackageSet all_matches(base);
+    // libdnf5::rpm::PackageSet installed_matches(base);
+    SearchPackages installed_matches;
 
     for (auto it = patterns.begin(); it != patterns.end(); ++it) {
         libdnf5::rpm::PackageSet pattern_matches(base);
@@ -153,6 +155,15 @@ SearchResults SearchProcessor::get_results() {
                 pattern_matches |= get_description_matches(*it);
                 pattern_matches |= get_url_matches(*it);
             }
+        }
+
+        // Add any installed packages to the installed list.
+        // This is necessary mostly when we are not using the "--all"
+        // option and want to display installed status.
+        for(auto const & package : pattern_matches) {
+          if (package.is_installed()) {
+            installed_matches.packages.insert(package);
+          }
         }
 
         // For the first pattern we are always adding to the empty list.
@@ -181,6 +192,8 @@ SearchResults SearchProcessor::get_results() {
         results.group_results.push_back(
             {.matched_keys = get_matched_keys(priority), .matched_packages = std::move(packages)});
     }
+    results.installed_packages = std::move(installed_matches);
+
     results.options = {
         .search_all = search_all,
         .show_duplicates = showdupes,

--- a/dnf5/commands/search/search_processor.cpp
+++ b/dnf5/commands/search/search_processor.cpp
@@ -138,7 +138,6 @@ void SearchProcessor::update_priorities(const libdnf5::rpm::PackageSet & package
 SearchResults SearchProcessor::get_results() {
     libdnf5::rpm::PackageSet all_matches(base);
     // libdnf5::rpm::PackageSet installed_matches(base);
-    SearchPackages installed_matches;
 
     for (auto it = patterns.begin(); it != patterns.end(); ++it) {
         libdnf5::rpm::PackageSet pattern_matches(base);
@@ -157,15 +156,6 @@ SearchResults SearchProcessor::get_results() {
             }
         }
 
-        // Add any installed packages to the installed list.
-        // This is necessary mostly when we are not using the "--all"
-        // option and want to display installed status.
-        for(auto const & package : pattern_matches) {
-          if (package.is_installed()) {
-            installed_matches.packages.insert(package);
-          }
-        }
-
         // For the first pattern we are always adding to the empty list.
         // If we are using the "--all" option, we want any matches in the result.
         // Otherwise we use an intersection (AND) with all previous results.
@@ -173,6 +163,30 @@ SearchResults SearchProcessor::get_results() {
             all_matches.update(std::move(pattern_matches));
         } else {
             all_matches.intersection(std::move(pattern_matches));
+        }
+    }
+
+    // Find installed versions of all matched packages.
+    SearchPackages installed_matches;
+    if (search_all) {
+        // Just filter existing matches
+        for (auto const & package : all_matches) {
+            if(package.is_installed()) {
+                installed_matches.packages.insert(package);
+            }
+        }
+    } else {
+        // Find matching packages
+        for (auto const & package : all_matches) {
+          libdnf5::rpm::PackageQuery query(base);
+            query.filter_installed();
+            query.filter_name(package.get_name());
+            query.filter_arch(package.get_arch());
+            // This should only be one package, but insert all matches
+            // just in case.
+            for(auto const & package : query) {
+                installed_matches.packages.insert(std::move(package));
+            }
         }
     }
 

--- a/include/libdnf5-cli/output/search.hpp
+++ b/include/libdnf5-cli/output/search.hpp
@@ -66,6 +66,7 @@ struct SearchResults {
     SearchOptions options;                    ///< Search options that were used.
     std::vector<std::string> patterns;        ///< List of patterns to be matched, given by the user.
     std::vector<SearchResult> group_results;  ///< List of results groups.
+    SearchPackages installed_packages;        ///< List of matches that are also installed
 };
 
 /// @brief Write the search results to the standard output.

--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -112,6 +112,7 @@ void print_search_results(const SearchResults & results) {
             } else if (!results.options.show_duplicates) {
                 for (auto const & specific_package : results.installed_packages.packages) {
                     if (specific_package.get_name() == package.get_name()
+                        && specific_package.get_arch() == package.get_arch()
                         && specific_package.is_installed()) {
                         std::cout << " [outdated]";
                         break;

--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -110,10 +110,15 @@ void print_search_results(const SearchResults & results) {
             if (package.is_installed()){
                 std::cout << " [installed]";
             } else if (!results.options.show_duplicates) {
-                for (auto const & specific_package : results.installed_packages.packages) {
-                    if (specific_package.get_name() == package.get_name()
-                        && specific_package.get_arch() == package.get_arch()
-                        && specific_package.is_installed()) {
+                // Note that any deduplicated package will be the newest version,
+                // so any valid package must be below `upper_bound`.
+                auto const & installed = results.installed_packages.packages;
+                for(auto it = ++std::reverse_iterator(installed.upper_bound(package));
+                    // stop if we reach a package with a different name
+                    it != installed.rend() && (*it).get_name() == package.get_name();
+                    ++it) {
+                    // ensure we have the same arch package
+                    if ((*it).get_arch() == package.get_arch()) {
                         std::cout << " [outdated]";
                         break;
                     }

--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -107,6 +107,17 @@ void print_search_results(const SearchResults & results) {
             } else {
                 std::cout << highlight(package.get_name()) << "." << package.get_arch();
             }
+            if (package.is_installed()){
+                std::cout << " [installed]";
+            } else if (!results.options.show_duplicates) {
+                for (auto const & specific_package : results.installed_packages.packages) {
+                    if (specific_package.get_name() == package.get_name()
+                        && specific_package.is_installed()) {
+                        std::cout << " [outdated]";
+                        break;
+                    }
+                }
+            }
             std::cout << "\t" << highlight(package.get_summary()) << std::endl;
         }
     }


### PR DESCRIPTION
Fixes issue #2165.
Replaces PR #1114.

I chose to explicitly note when the installed package isn't up-to-date, since the displayed description could differ between installed and displayed packages.
I'm not very sure regarding the word "outdated" I chose for it.

Also, impact on performance was not tested.

~~Currently missing tests.~~
