### PR TITLE
Add distro-sync support to dnf-automatic

### DIFF
--- a/dnf5-plugins/automatic_plugin/CMakeLists.txt
+++ b/dnf5-plugins/automatic_plugin/CMakeLists.txt
@@ -2,14 +2,18 @@
 set(GETTEXT_DOMAIN dnf5-plugin-automatic)
 add_definitions(-DGETTEXT_DOMAIN=\"${GETTEXT_DOMAIN}\")
 
+include(sdbus_cpp)
+
 file(GLOB_RECURSE AUTOMATIC_SOURCES *.cpp)
 add_library(automatic_cmd_plugin MODULE ${AUTOMATIC_SOURCES})
 
 # disable the 'lib' prefix in order to create automatic_cmd_plugin.so
 set_target_properties(automatic_cmd_plugin PROPERTIES PREFIX "")
 
+target_include_directories(automatic_cmd_plugin PRIVATE ${SDBUS_CPP_INCLUDE_DIRS})
 target_link_libraries(automatic_cmd_plugin PRIVATE libdnf5 libdnf5-cli)
 target_link_libraries(automatic_cmd_plugin PRIVATE dnf5)
+target_link_libraries(automatic_cmd_plugin PRIVATE ${SDBUS_CPP_LIBRARIES})
 
 install(TARGETS automatic_cmd_plugin LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dnf5/plugins/)
 install(DIRECTORY "config/usr/share" DESTINATION "${CMAKE_INSTALL_PREFIX}")

--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -471,6 +471,8 @@ void AutomaticCommand::run() {
                 emitter = std::make_unique<EmitterCommandEmail>(config_automatic, transaction, output_stream, success);
             } else if (emitter_name == "email") {
                 emitter = std::make_unique<EmitterEmail>(config_automatic, transaction, output_stream, success);
+            } else if (emitter_name == "dbus") {
+                emitter = std::make_unique<EmitterDBus>(config_automatic, transaction, output_stream, success);
             } else {
                 auto & logger = *base.get_logger();
                 logger.warning(_("Unknown report emitter for dnf5 automatic: \"{}\"."), emitter_name);

--- a/dnf5-plugins/automatic_plugin/automatic.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic.cpp
@@ -365,15 +365,20 @@ void AutomaticCommand::run() {
     // setup upgrade transaction goal
     auto settings = libdnf5::GoalJobSettings();
 
+    libdnf5::Goal goal(base);
+    const auto upgrade_type = config_automatic.config_commands.upgrade_type.get_value();
     // TODO(mblaha): Use advisory_query_from_cli_input from dnf5/commands/advisory_shared.hpp?
-    if (config_automatic.config_commands.upgrade_type.get_value() == "security") {
+    if (upgrade_type == "security") {
         auto advisories = libdnf5::advisory::AdvisoryQuery(base);
         advisories.filter_type("security");
         settings.set_advisory_filter(advisories);
         // TODO(mblaha): set also minimal=true?
+        goal.add_rpm_upgrade(settings);
+    } else if (upgrade_type == "distro-sync") {
+        goal.add_rpm_distro_sync(settings);
+    } else {
+        goal.add_rpm_upgrade(settings);
     }
-    libdnf5::Goal goal(base);
-    goal.add_rpm_upgrade(settings);
 
     auto transaction = goal.resolve();
 

--- a/dnf5-plugins/automatic_plugin/config/usr/share/dbus-1/interfaces/org.rpm.dnf.v0.Automatic.xml
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dbus-1/interfaces/org.rpm.dnf.v0.Automatic.xml
@@ -1,0 +1,49 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+Copyright Contributors to the DNF5 project.
+Copyright (C) 2022 Red Hat, Inc.
+SPDX-License-Identifier: LGPL-2.0-or-later
+
+This file is part of libdnf: https://github.com/rpm-software-management/dnf5/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<node>
+<!-- org.rpm.dnf.v0.Automatic:
+   @short_description: Interface for dnf5 automatic update notifications
+-->
+<interface name="org.rpm.dnf.v0.Automatic">
+
+    <!--
+        UpdateResult:
+        @result: a{sv}, dictionary of result attributes
+
+        Emitted on the system bus after each dnf5-automatic run to report
+        the outcome of the operation. The signal is published on the
+        well-known name org.rpm.dnf.v0.Automatic at the object path
+        /org/rpm/dnf/v0/Automatic.
+
+        The following keys are currently defined in @result:
+            - "success": boolean, true if the run completed successfully
+    -->
+    <signal name="UpdateResult">
+        <arg name="result" type="a{sv}" />
+    </signal>
+
+</interface>
+
+</node>

--- a/dnf5-plugins/automatic_plugin/config/usr/share/dbus-1/system.d/org.rpm.dnf.v0.Automatic.conf
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dbus-1/system.d/org.rpm.dnf.v0.Automatic.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="org.rpm.dnf.v0.Automatic"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="org.rpm.dnf.v0.Automatic"/>
+  </policy>
+</busconfig>

--- a/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
+++ b/dnf5-plugins/automatic_plugin/config/usr/share/dnf5/dnf5-plugins/automatic.conf
@@ -24,6 +24,7 @@ random_sleep = 0
 # What kind of upgrade to perform:
 # default                            = all available upgrades
 # security                           = only the security upgrades
+# distro-sync                        = sync packages to the latest available versions in enabled repos
 upgrade_type = default
 
 # When the system should reboot following upgrades:

--- a/dnf5-plugins/automatic_plugin/config_automatic.hpp
+++ b/dnf5-plugins/automatic_plugin/config_automatic.hpp
@@ -39,7 +39,7 @@ public:
     ConfigAutomaticCommands();
     ~ConfigAutomaticCommands() = default;
 
-    libdnf5::OptionEnum upgrade_type{"default", {"default", "security"}};
+    libdnf5::OptionEnum upgrade_type{"default", {"default", "security", "distro-sync"}};
     libdnf5::OptionNumber<std::uint32_t> random_sleep{0};
     libdnf5::OptionNumber<std::int32_t> network_online_timeout{60};
     libdnf5::OptionBool download_updates{true};

--- a/dnf5-plugins/automatic_plugin/emitters.cpp
+++ b/dnf5-plugins/automatic_plugin/emitters.cpp
@@ -25,11 +25,13 @@
 #include <libdnf5/base/transaction_package.hpp>
 #include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/format.hpp>
+#include <sdbus-c++/sdbus-c++.h>
 
 #include <cstdio>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <map>
 
 namespace dnf5 {
 
@@ -218,6 +220,17 @@ void EmitterEmail::notify() {
             curl_slist_free_all(recipients);
             curl_easy_cleanup(curl);
         }
+    }
+}
+
+void EmitterDBus::notify() {
+    try {
+        auto conn = sdbus::createSystemBusConnection(sdbus::ServiceName{"org.rpm.dnf.v0.Automatic"});
+        auto obj = sdbus::createObject(*conn, sdbus::ObjectPath{"/org/rpm/dnf/v0/Automatic"});
+        std::map<std::string, sdbus::Variant> result{{"success", sdbus::Variant{success}}};
+        obj->emitSignal("UpdateResult").onInterface("org.rpm.dnf.v0.Automatic").withArguments(result);
+    } catch (const sdbus::Error & e) {
+        std::cerr << "dnf5-automatic: D-Bus error: " << e.what() << std::endl;
     }
 }
 

--- a/dnf5-plugins/automatic_plugin/emitters.hpp
+++ b/dnf5-plugins/automatic_plugin/emitters.hpp
@@ -109,6 +109,15 @@ public:
     void notify() override;
 };
 
+/// Send the results as a D-Bus signal on the system bus
+class EmitterDBus : public Emitter {
+public:
+    using Emitter::Emitter;
+    EmitterDBus() = delete;
+
+    void notify() override;
+};
+
 }  // namespace dnf5
 
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -960,6 +960,7 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %ghost %attr(0644, root, root) %{_sysconfdir}/motd.d/dnf5-automatic
 %{_libdir}/dnf5/plugins/automatic_cmd_plugin.so
 %{_datadir}/dnf5/dnf5-plugins/automatic.conf
+%{_datadir}/dbus-1/system.d/org.rpm.dnf.v0.Automatic.conf
 %ghost %attr(0644, root, root) %config(noreplace) %{_sysconfdir}/dnf/automatic.conf
 %ghost %attr(0644, root, root) %config(noreplace) %{_sysconfdir}/dnf/dnf5-plugins/automatic.conf
 %if %{with man}

--- a/doc/dnf5_plugins/automatic.8.rst
+++ b/doc/dnf5_plugins/automatic.8.rst
@@ -109,9 +109,9 @@ Setting the mode of operation of the program.
 .. _upgrade_type_automatic-label:
 
 ``upgrade_type``
-    either one of ``default``, ``security``, default: ``default``
+    either one of ``default``, ``security``, ``distro-sync``, default: ``default``
 
-    What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory.
+    What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory, ``distro-sync`` synchronizes packages to the latest available versions in the enabled repositories (similar to ``dnf5 distro-sync``).
 
 ``reboot``
     either one of ``never``, ``when-changed``, ``when-needed``, default: ``never``


### PR DESCRIPTION
Adds distro-sync capability to the automatic plugin, and a D-bus emitter for desktop notifications, this is in preparation for the addition of a transactional style system in Fedora that's being worked on (similar to MicroOS)