### PR TITLE
reposync: exit non-zero when a package fails to download

### DIFF
--- a/dnf5-plugins/reposync_plugin/reposync.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync.cpp
@@ -279,10 +279,14 @@ void ReposyncCommand::download_packages(const ReposyncCommand::download_list_typ
         downloader.add(pkg, pth.parent_path());
     }
     downloader.download();
-    // TODO(mblaha): Return exit code 1 if any of packages was not downloaded.
-    // In case of fail_fast set to false, the download() method does
-    // not throw an exception if particular package could not be downloaded.
-    // See https://github.com/rpm-software-management/dnf5/issues/1926 for details
+    const auto failed_packages = downloader.get_failed_packages();
+    if (!failed_packages.empty()) {
+        for (const auto & pkg : failed_packages) {
+            std::cerr << libdnf5::utils::sformat(_("Failed to download package: {}"), pkg.get_full_nevra())
+                      << std::endl;
+        }
+        throw libdnf5::cli::CommandExitError(1, M_("Failed to download one or more packages"));
+    }
 }
 
 void ReposyncCommand::delete_old_local_packages(

--- a/include/libdnf5/repo/package_downloader.hpp
+++ b/include/libdnf5/repo/package_downloader.hpp
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace libdnf5::repo {
 
@@ -50,6 +51,10 @@ public:
 
     /// Download the previously added packages.
     void download();
+
+    /// Packages that failed to download in the last download() call (e.g. checksum/size mismatch).
+    /// Meaningful when fail_fast is false; empty if all succeeded.
+    std::vector<libdnf5::rpm::Package> get_failed_packages() const;
 
     /// Configure whether to fail the whole download on a first error or keep downloading.
     /// @param value If true, download will fail on the first error, otherwise it continues.

--- a/libdnf5/repo/package_downloader.cpp
+++ b/libdnf5/repo/package_downloader.cpp
@@ -70,6 +70,7 @@ public:
     void * user_data;
     void * user_cb_data{nullptr};
     bool need_call_end_callback{false};
+    bool transfer_failed{false};
 };
 
 static int end_callback(void * data, LrTransferStatus status, const char * msg) {
@@ -77,6 +78,9 @@ static int end_callback(void * data, LrTransferStatus status, const char * msg) 
 
     auto * package_target = static_cast<PackageTarget *>(data);
     auto cb_status = static_cast<DownloadCallbacks::TransferStatus>(status);
+    if (cb_status == DownloadCallbacks::TransferStatus::ERROR) {
+        package_target->transfer_failed = true;
+    }
     if (auto * download_callbacks = package_target->package.get_base()->get_download_callbacks()) {
         libdnf_assert(package_target->need_call_end_callback == true, "unexpected end_callback call");
         package_target->need_call_end_callback = false;
@@ -138,6 +142,11 @@ void PackageDownloader::add(const libdnf5::rpm::Package & package, const std::st
 
 
 void PackageDownloader::download() try {
+    // Reset failure state from any previous download() call so retries
+    // (repeated download() calls) report fresh per-package results.
+    for (auto & target : p_impl->targets) {
+        target.transfer_failed = false;
+    }
     if (p_impl->targets.empty()) {
         return;
     }
@@ -229,6 +238,9 @@ void PackageDownloader::download() try {
         if (!same_file) {
             std::filesystem::copy(source, destination, std::filesystem::copy_options::overwrite_existing, ec);
         }
+        if (ec) {
+            local_pkg_target->transfer_failed = true;
+        }
         if (auto * download_callbacks = local_pkg_target->package.get_base()->get_download_callbacks()) {
             std::string msg;
             DownloadCallbacks::TransferStatus status;
@@ -287,6 +299,16 @@ void PackageDownloader::download() try {
     throw;
 } catch (const std::runtime_error & e) {
     libdnf5::throw_with_nested(PackageDownloadError(M_("Failed to download packages")));
+}
+
+std::vector<libdnf5::rpm::Package> PackageDownloader::get_failed_packages() const {
+    std::vector<libdnf5::rpm::Package> failed;
+    for (const auto & target : p_impl->targets) {
+        if (target.transfer_failed) {
+            failed.push_back(target.package);
+        }
+    }
+    return failed;
 }
 
 void PackageDownloader::set_fail_fast(bool value) {


### PR DESCRIPTION
reposync runs PackageDownloader with fail_fast=false and never checks per-package results, so it exits 0 even when a package fails its size/checksum verification and is dropped, silently producing an incomplete mirror.

Expose per-package download failures from libdnf5 PackageDownloader via a new get_failed_packages() method, and make reposync print the failed packages and exit 1 when any package failed (download as much as possible, then fail).

Resolves #1926