### PR TITLE
Add remove --duplicates option to remove older duplicate packages

### DIFF
--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -65,6 +65,17 @@ void RemoveCommand::set_argument_parser() {
     oldinstallonly_opt->link_value(oldinstallonly);
     cmd.register_named_arg(oldinstallonly_opt);
 
+    duplicates = dynamic_cast<libdnf5::OptionBool *>(
+        parser.add_init_value(std::unique_ptr<libdnf5::OptionBool>(new libdnf5::OptionBool(false))));
+    auto duplicates_opt = parser.add_new_named_arg("duplicates");
+    duplicates_opt->set_long_name("duplicates");
+    duplicates_opt->set_description("Remove older versions of duplicate packages and reinstall the newest version");
+    duplicates_opt->set_const_value("true");
+    duplicates_opt->link_value(duplicates);
+    cmd.register_named_arg(duplicates_opt);
+
+    oldinstallonly_opt->add_conflict_argument(*duplicates_opt);
+
     oldinstallonly_limit = dynamic_cast<libdnf5::OptionNumber<std::int32_t> *>(parser.add_init_value(
         std::unique_ptr<libdnf5::OptionNumber<std::int32_t>>(new libdnf5::OptionNumber<std::int32_t>(0))));
     auto limit_opt = parser.add_new_named_arg("limit");
@@ -75,6 +86,8 @@ void RemoveCommand::set_argument_parser() {
         "Limit the number of installonly package versions to keep (must be >=1, used with --oldinstallonly)");
     limit_opt->link_value(oldinstallonly_limit);
     cmd.register_named_arg(limit_opt);
+
+    limit_opt->add_conflict_argument(*duplicates_opt);
 
     auto keys = parser.add_new_positional_arg("specs", ArgumentParser::PositionalArg::UNLIMITED, nullptr, nullptr);
     keys->set_description("List of <package-spec-NF>|@<group-spec>|@<environment-spec> to remove");
@@ -95,7 +108,8 @@ void RemoveCommand::set_argument_parser() {
 void RemoveCommand::configure() {
     auto & context = get_context();
     context.set_load_system_repo(true);
-    context.set_load_available_repos(Context::LoadAvailableRepos::NONE);
+    context.set_load_available_repos(
+        duplicates->get_value() ? Context::LoadAvailableRepos::ENABLED : Context::LoadAvailableRepos::NONE);
 }
 
 void RemoveCommand::run() {
@@ -173,6 +187,46 @@ void RemoveCommand::run() {
                     }
                     goal->add_rpm_remove(packages[i]);
                 }
+            }
+        }
+    } else if (duplicates->get_value()) {
+        auto & base = ctx.get_base();
+
+        libdnf5::rpm::PackageQuery duplicate_query(base);
+        duplicate_query.filter_installed();
+
+        libdnf5::rpm::PackageQuery installonly_query(base);
+        installonly_query.filter_installonly();
+        duplicate_query -= installonly_query;
+
+        if (!pkg_specs.empty()) {
+            libdnf5::rpm::PackageQuery filtered(base, libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
+            for (const auto & spec : pkg_specs) {
+                libdnf5::rpm::PackageQuery spec_query(duplicate_query);
+                spec_query.filter_name({spec}, libdnf5::sack::QueryCmp::GLOB);
+                filtered |= spec_query;
+            }
+            duplicate_query = filtered;
+        }
+
+        duplicate_query.filter_duplicates();
+
+        std::map<std::string, std::vector<libdnf5::rpm::Package>> packages_by_na;
+        for (const auto & pkg : duplicate_query) {
+            packages_by_na[pkg.get_na()].push_back(pkg);
+        }
+
+        for (auto & [na, packages] : packages_by_na) {
+            std::sort(packages.begin(), packages.end(), [](const auto & a, const auto & b) {
+                return libdnf5::rpm::cmp_nevra(b, a);
+            });
+
+            libdnf5::GoalJobSettings settings;
+            settings.set_skip_unavailable(libdnf5::GoalSetting::SET_TRUE);
+            goal->add_rpm_reinstall(packages[0].get_full_nevra(), settings);
+
+            for (size_t i = 1; i < packages.size(); ++i) {
+                goal->add_rpm_remove(packages[i]);
             }
         }
     } else {

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -42,6 +42,7 @@ private:
     std::vector<std::string> installed_from_repos;
     libdnf5::OptionBool * oldinstallonly{nullptr};
     libdnf5::OptionNumber<std::int32_t> * oldinstallonly_limit{nullptr};
+    libdnf5::OptionBool * duplicates{nullptr};
     bool running_kernel_skipped{false};
     std::string running_kernel_nevra;
 };

--- a/doc/commands/remove.8.rst
+++ b/doc/commands/remove.8.rst
@@ -31,6 +31,8 @@ Synopsis
 
 ``dnf5 remove --oldinstallonly [--limit=<LIMIT>] [<package-spec-NF>...]``
 
+``dnf5 remove --duplicates [<package-spec-NF>...]``
+
 
 Description
 ===========
@@ -45,6 +47,13 @@ When the ``--oldinstallonly`` option is used, the command removes old installonl
 (e.g. kernels) that exceed the configured ``installonly_limit``. The currently running kernel
 is never removed. If package specs are provided, only matching installonly packages are
 considered for removal.
+
+When the ``--duplicates`` option is used, the command removes older versions of duplicate
+packages. Duplicate packages are packages with the same name and architecture but different
+version installed on the system. Installonly packages (such as kernels) are excluded since
+they are expected to have multiple versions installed. To ensure the integrity of the system,
+the newest version of each duplicate is reinstalled. If package specs are provided, only
+matching packages are considered.
 
 
 Options
@@ -64,6 +73,11 @@ Options
     | Override the ``installonly_limit`` configuration value. Must be greater than or equal to 1
       to keep at least the newest installed version. Can only be used with ``--oldinstallonly``.
 
+``--duplicates``
+    | Remove older versions of duplicate packages and reinstall the newest version.
+    | Installonly packages are automatically excluded.
+    | Cannot be used together with ``--oldinstallonly``.
+
 .. include:: ../_shared/options/transaction.rst
 
 
@@ -81,6 +95,12 @@ Examples
 
 ``dnf5 remove --oldinstallonly --limit=2``
     | Remove old installonly packages, keeping only the 2 newest versions of each.
+
+``dnf5 remove --duplicates``
+    | Remove all older duplicate packages and reinstall the newest versions.
+
+``dnf5 remove --duplicates glibc``
+    | Remove older duplicate versions of ``glibc`` and reinstall the newest.
 
 
 See Also


### PR DESCRIPTION
Removes older versions of duplicate packages (same name and arch, different version) and reinstalls the newest version to ensure system integrity. Installonly packages are excluded. Available repos are loaded when needed for the reinstall step.

Resolves: https://github.com/rpm-software-management/dnf5/issues/760

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1895