### PR TITLE
POC: Show packages skipped due to vendor change restriction

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1610,6 +1610,12 @@ int main(int argc, char * argv[]) try {
             }
         } catch (libdnf5::cli::GoalResolveError & ex) {
             std::cerr << ex.what() << std::endl;
+            if (context.get_transaction() != nullptr) {
+                libdnf5::cli::output::TransactionAdapter cli_output_transaction(*context.get_transaction());
+                libdnf5::cli::output::TransactionTable table(
+                    static_cast<libdnf5::cli::output::ITransaction &>(cli_output_transaction));
+                table.print_table();
+            }
             if (!any_repos_from_system_configuration && base.get_config().get_installroot_option().get_value() != "/" &&
                 !base.get_config().get_use_host_config_option().get_value()) {
                 std::cerr

--- a/dnf5daemon-client/wrappers/dbus_goal_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_goal_wrapper.hpp
@@ -49,6 +49,7 @@ public:
 
     std::vector<DbusPackageWrapper> get_conflicting_packages() const { return conflicting_packages; }
     std::vector<DbusPackageWrapper> get_broken_dependency_packages() const { return broken_dependency_packages; }
+    std::vector<std::pair<DbusPackageWrapper, std::string>> get_vendor_change_skipped_packages() const { return {}; }
 
 private:
     std::vector<DbusTransactionPackageWrapper> transaction_packages;

--- a/include/libdnf5-cli/output/adapters/transaction_tmpl.hpp
+++ b/include/libdnf5-cli/output/adapters/transaction_tmpl.hpp
@@ -161,6 +161,16 @@ public:
         return ret;
     }
 
+    std::vector<std::pair<std::unique_ptr<IPackage>, std::string>> get_vendor_change_skipped_packages() const override {
+        std::vector<std::pair<std::unique_ptr<IPackage>, std::string>> ret;
+        const auto & skipped = transaction->get_vendor_change_skipped_packages();
+        ret.reserve(skipped.size());
+        for (const auto & [pkg, installed_vendor] : skipped) {
+            ret.emplace_back(std::unique_ptr<IPackage>(new PackageAdapter(pkg)), installed_vendor);
+        }
+        return ret;
+    }
+
     std::vector<std::unique_ptr<ITransactionGroup>> get_transaction_groups() const override {
         std::vector<std::unique_ptr<ITransactionGroup>> ret;
         const auto & trans_groups = transaction->get_transaction_groups();

--- a/include/libdnf5-cli/output/interfaces/transaction.hpp
+++ b/include/libdnf5-cli/output/interfaces/transaction.hpp
@@ -85,6 +85,8 @@ public:
     virtual std::vector<std::unique_ptr<ITransactionPackage>> get_transaction_packages() const = 0;
     virtual std::vector<std::unique_ptr<IPackage>> get_conflicting_packages() const = 0;
     virtual std::vector<std::unique_ptr<IPackage>> get_broken_dependency_packages() const = 0;
+    virtual std::vector<std::pair<std::unique_ptr<IPackage>, std::string>> get_vendor_change_skipped_packages()
+        const = 0;
     virtual std::vector<std::unique_ptr<ITransactionGroup>> get_transaction_groups() const = 0;
     virtual std::vector<std::unique_ptr<ITransactionModule>> get_transaction_modules() const = 0;
     virtual std::vector<std::unique_ptr<ITransactionEnvironment>> get_transaction_environments() const = 0;

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -99,6 +99,9 @@ public:
     /// @return list of packages skipped due to conflicts
     std::vector<libdnf5::rpm::Package> get_conflicting_packages() const;
 
+    /// @return list of packages skipped due to vendor change restriction, paired with installed vendor string
+    std::vector<std::pair<libdnf5::rpm::Package, std::string>> get_vendor_change_skipped_packages() const;
+
     /// @return `true` if the transaction is empty.
     bool empty() const;
 

--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -265,6 +265,7 @@ private:
     std::optional<libdnf5::transaction::TransactionItemAction> current_action;
     std::optional<libdnf5::transaction::TransactionItemReason> current_reason;
     bool table_empty{true};
+    std::vector<std::pair<std::string, unsigned int>> vendor_change_summaries;
 };
 
 TransactionTable::Impl::Impl(ITransaction & transaction) {
@@ -496,8 +497,6 @@ TransactionTable::Impl::Impl(ITransaction & transaction) {
     for (const auto & [skipped_packages, header] : skipped) {
         std::optional<std::reference_wrapper<TransactionTableSection>> section;
         for (const auto & pkg : skipped_packages) {
-            // Packages for which another package with the same NEVRA is already part
-            // of the transaction are skipped.
             if (tspkgs_nevra.contains(pkg->get_full_nevra())) {
                 continue;
             }
@@ -519,10 +518,33 @@ TransactionTable::Impl::Impl(ITransaction & transaction) {
             section.value().get().set_last_line(ln);
         }
     }
+
+    {
+        auto vendor_change = transaction.get_vendor_change_skipped_packages();
+        for (const auto & [pkg, installed_vendor] : vendor_change) {
+            if (tspkgs_nevra.contains(pkg->get_full_nevra())) {
+                continue;
+            }
+            auto is_empty_vendor = [](const std::string & v) { return v.empty() || v == "<NULL>"; };
+            auto from_vendor = is_empty_vendor(installed_vendor) ? std::string(_("None")) : installed_vendor;
+            auto candidate_vendor = pkg->get_vendor();
+            auto to_vendor = is_empty_vendor(candidate_vendor) ? std::string(_("None")) : candidate_vendor;
+            std::string key = libdnf5::utils::sformat("\"{}\" -> \"{}\"", from_vendor, to_vendor);
+            auto it =
+                std::find_if(vendor_change_summaries.begin(), vendor_change_summaries.end(), [&](const auto & entry) {
+                    return entry.first == key;
+                });
+            if (it != vendor_change_summaries.end()) {
+                it->second++;
+            } else {
+                vendor_change_summaries.emplace_back(std::move(key), 1);
+            }
+        }
+    }
 }
 
 void TransactionTable::Impl::print_table() {
-    if (table_empty) {
+    if (table_empty && vendor_change_summaries.empty()) {
         return;
     }
     auto fd = scols_table_get_stream(*tb);
@@ -534,6 +556,25 @@ void TransactionTable::Impl::print_table() {
             std::fputc('\n', fd);
         }
         scols_table_print_range(*tb, section.get_first_line(), section.get_last_line());
+    }
+    if (!vendor_change_summaries.empty()) {
+        if (!table_empty) {
+            std::fputc('\n', fd);
+        }
+        for (const auto & [vendor_transition, count] : vendor_change_summaries) {
+            std::fputs(
+                libdnf5::utils::sformat(
+                    P_("Skipping {0} package due to vendor change restriction: {1}.",
+                       "Skipping {0} packages due to vendor change restriction: {1}.",
+                       count),
+                    count,
+                    vendor_transition)
+                    .c_str(),
+                fd);
+            std::fputc('\n', fd);
+        }
+        std::fputs(_("Use '--setopt=allow_vendor_change=true' to include vendor-changed packages."), fd);
+        std::fputc('\n', fd);
     }
     std::fputc('\n', fd);
     // add empty line after the transaction table

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -58,6 +58,7 @@
 #include <filesystem>
 #include <iostream>
 #include <ranges>
+#include <set>
 #include <sstream>
 #include <string_view>
 #include <thread>
@@ -415,6 +416,10 @@ std::vector<libdnf5::rpm::Package> Transaction::get_conflicting_packages() const
     return p_impl->conflicting_packages;
 }
 
+std::vector<std::pair<libdnf5::rpm::Package, std::string>> Transaction::get_vendor_change_skipped_packages() const {
+    return p_impl->vendor_change_skipped_packages;
+}
+
 std::string Transaction::transaction_result_to_string(const TransactionRunResult result) {
     switch (result) {
         case TransactionRunResult::SUCCESS:
@@ -700,6 +705,60 @@ void Transaction::Impl::set_transaction(
             add_resolve_log(GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT, solver_problems);
         }
     }
+
+    // Third solve: detect packages skipped due to vendor change restriction.
+    // Only run when vendor change is disallowed and the solver actually
+    // rejected at least one vendor change during the first solve.
+    if (!solved_goal.get_allow_vendor_change() && get_rpm_pool(base).get_vendor_changes_blocked()) {
+        rpm::solv::GoalPrivate vendor_goal(solved_goal);
+        vendor_goal.set_allow_vendor_change(true);
+        if (vendor_goal.resolve() != GoalProblem::SOLVER_ERROR && vendor_goal.get_transaction()) {
+            std::set<Id> original_ids;
+            if (solved_goal.get_transaction()) {
+                for (auto id : solved_goal.list_upgrades()) {
+                    original_ids.insert(id);
+                }
+                for (auto id : solved_goal.list_downgrades()) {
+                    original_ids.insert(id);
+                }
+                for (auto id : solved_goal.list_reinstalls()) {
+                    original_ids.insert(id);
+                }
+                for (auto id : solved_goal.list_installs()) {
+                    original_ids.insert(id);
+                }
+            }
+
+            rpm::PackageQuery installed_query(base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
+            installed_query.filter_installed();
+
+            auto check_vendor_diff = [&](libdnf5::solv::IdQueue && ids) {
+                for (auto id : ids) {
+                    if (original_ids.contains(id)) {
+                        continue;
+                    }
+                    rpm::Package candidate(base, rpm::PackageId(id));
+                    rpm::PackageQuery installed_na(installed_query);
+                    installed_na.filter_name({candidate.get_name()});
+                    installed_na.filter_arch({candidate.get_arch()});
+                    for (const auto & installed_pkg : installed_na) {
+                        if (installed_pkg.get_vendor() != candidate.get_vendor()) {
+                            auto installed_vendor = installed_pkg.get_vendor();
+                            vendor_change_skipped_packages.emplace_back(
+                                std::move(candidate), std::move(installed_vendor));
+                            break;
+                        }
+                    }
+                }
+            };
+
+            check_vendor_diff(vendor_goal.list_upgrades());
+            check_vendor_diff(vendor_goal.list_downgrades());
+            check_vendor_diff(vendor_goal.list_reinstalls());
+            check_vendor_diff(vendor_goal.list_installs());
+        }
+    }
+
     this->problems = problems;
 
     if ((problems & GoalProblem::MODULE_SOLVER_ERROR) != GoalProblem::NO_PROBLEM ||

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -131,6 +131,7 @@ private:
     std::vector<std::vector<std::pair<libdnf5::ProblemRules, std::vector<std::string>>>> solver_problems{};
     std::vector<libdnf5::rpm::Package> broken_dependency_packages;
     std::vector<libdnf5::rpm::Package> conflicting_packages;
+    std::vector<std::pair<libdnf5::rpm::Package, std::string>> vendor_change_skipped_packages;
 
     // history db transaction id
     int64_t history_db_id = 0;

--- a/libdnf5/rpm/solv/goal_private.cpp
+++ b/libdnf5/rpm/solv/goal_private.cpp
@@ -424,6 +424,10 @@ libdnf5::GoalProblem GoalPrivate::resolve() {
     libsolv_solver.set_flag(SOLVER_FLAG_ALLOW_VENDORCHANGE, vendor_change);
     libsolv_solver.set_flag(SOLVER_FLAG_DUP_ALLOW_VENDORCHANGE, vendor_change);
 
+    if (!allow_vendor_change) {
+        pool.reset_vendor_changes_blocked();
+    }
+
 #if defined(LIBSOLV_FLAG_FOCUSNEW)
     // Ensure the solver tries to install the latest versions of dependencies, even if it results in a bigger transaction
     // Available since libsolv-0.7.30

--- a/libdnf5/rpm/solv/goal_private.hpp
+++ b/libdnf5/rpm/solv/goal_private.hpp
@@ -151,6 +151,7 @@ public:
     void set_allow_downgrade(bool value) { allow_downgrade = value; }
     void set_allow_erasing(bool value) { allow_erasing = value; }
     void set_allow_vendor_change(bool value) { allow_vendor_change = value; }
+    bool get_allow_vendor_change() const { return allow_vendor_change; }
     void set_install_weak_deps(bool value) { install_weak_deps = value; }
     /// Remove SOLVER_WEAK and add SOLVER_BEST to all jobs to allow report skipped packages and best candidates
     /// with broken dependencies

--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -281,6 +281,9 @@ public:
         return vendor_change_manager.get_incoming_vendor_bypassed_solvables();
     }
 
+    void reset_vendor_changes_blocked() { vendor_change_manager.reset_vendor_changes_blocked(); }
+    bool get_vendor_changes_blocked() const { return vendor_change_manager.get_vendor_changes_blocked(); }
+
 private:
     friend class VendorChangeManager;
 

--- a/libdnf5/solv/vendor_change_manager.cpp
+++ b/libdnf5/solv/vendor_change_manager.cpp
@@ -139,6 +139,7 @@ bool VendorChangeManager::is_vendor_change_allowed(Solvable & outgoing, Solvable
     if (outgoing_vendor_mask.empty()) {
         // The outgoing vendor is not involved in any valid policy change.
         // Therefore, any change is illegal.
+        vendor_changes_blocked = true;
         return false;
     }
 
@@ -171,6 +172,7 @@ bool VendorChangeManager::is_vendor_change_allowed(Solvable & outgoing, Solvable
         }
     }
 
+    vendor_changes_blocked = true;
     return false;  // Illegal vendor change
 }
 

--- a/libdnf5/solv/vendor_change_manager.hpp
+++ b/libdnf5/solv/vendor_change_manager.hpp
@@ -65,6 +65,9 @@ public:
     /// @return true if the transition is permitted by the policies
     [[nodiscard]] bool is_vendor_change_allowed(Solvable & outgoing, Solvable & incoming);
 
+    void reset_vendor_changes_blocked() { vendor_changes_blocked = false; }
+    bool get_vendor_changes_blocked() const { return vendor_changes_blocked; }
+
     /// Check if a solvable is in the list of incoming solvables that bypass vendor check.
     /// @param solvable_id The solvable ID to check
     /// @return true if the solvable bypasses vendor check, false otherwise
@@ -96,6 +99,7 @@ private:
     std::vector<VendorChangePolicy> vendor_policies_def;
     std::vector<VendorChangeMasks> vendor_masks;
     SolvMap incoming_vendor_bypassed_solvables{0};
+    bool vendor_changes_blocked{false};
 
     /// Retrieve or cache masks for a specific vendor
     /// @param vendor The vendor ID


### PR DESCRIPTION
This is purely vibe-coded PoC how the reporting of packages skipped due to sticky vendors might look like. I did not even review the code, only run several test commands on my system. It definitely needs discussion, review, and thorough testing.

## Summary
  
When `allow_vendor_change=false` (planned as Fedora 45 default via DisableVendorChangeByDefault), the solver silently skips packages whose upgrade or downgrade would require a vendor change. Users get no feedback — just "Nothing to do" or a cryptic "no solution possible" with no indication that vendor policy is the cause.

This PR adds a third solver run that re-solves with vendor change allowed and diffs the results to identify what was blocked. Skipped packages are displayed in the transaction table with vendor transition details and an actionable hint.

Scenario: I have dnf5 nightly copr repo enabled and installed dnf5 from there. Now I want to distro-sync to the versions in Fedora repos:

Before the patch:
```
❯ sudo dnf distro-sync --repo=fedora,updates dnf5
Updating and loading repositories:
Repositories loaded.
Nothing to do.
```

With the patch:
```
❯ sudo ./build/dnf5/dnf5 distro-sync --repo=fedora,updates dnf5
Updating and loading repositories:
Repositories loaded.
Package                                                       Arch   Version                             Repository       Size
Skipping packages due to vendor change restriction:
 dnf5                                                         x86_64 5.2.18.0-4.fc43                     updates       2.8 MiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5                                                      x86_64 5.2.18.0-4.fc43                     updates       3.8 MiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5-cli                                                  x86_64 5.2.18.0-4.fc43                     updates     924.8 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 dnf5-plugins                                                 x86_64 5.2.18.0-4.fc43                     updates       1.3 MiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 dnf5-plugin-automatic                                        x86_64 5.2.18.0-4.fc43                     updates     179.1 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 python3-libdnf5-python-plugins-loader                        x86_64 5.2.18.0-4.fc43                     updates      52.3 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 python3-libdnf5                                              x86_64 5.2.18.0-4.fc43                     updates       9.2 MiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5-plugin-expired-pgp-keys                              x86_64 5.2.18.0-4.fc43                     updates      82.4 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5-plugin-actions                                       x86_64 5.2.18.0-4.fc43                     updates     270.2 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5-devel                                                x86_64 5.2.18.0-4.fc43                     updates     686.9 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 dnf5daemon-server                                            x86_64 5.2.18.0-4.fc43                     updates     742.5 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 dnf5daemon-client                                            x86_64 5.2.18.0-4.fc43                     updates     593.5 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 libdnf5-cli-devel                                            x86_64 5.2.18.0-4.fc43                     updates     188.9 KiB
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
 dnf5daemon-server-polkit                                     noarch 5.2.18.0-4.fc43                     updates     326.0   B
   Fedora Copr - user rpmsoftwaremanagement -> Fedora Project                                                                 
Use '--setopt=allow_vendor_change=true' to include vendor-changed packages.

Nothing to do.
```

## Design

- Uses a separate (third) solver run rather than piggy-backing on the existing strict-mode second solve, to get a clean single-variable diff with no interaction between FORCEBEST/SOLVER_WEAK and vendor change flags.
- Diffs upgrades, downgrades, reinstalls, and installs to cover both `upgrade` (silent skip) and `distro-sync` (downgrade) scenarios.
- Filters results to only report packages where the vendor actually changed, excluding transitive dependency shifts from the re-solve.
- Gracefully handles the case where the vendor-allowed solve itself fails.

## Open items

- [ ] The sub-line showing vendor transition uses only the Package column; libsmartcols has no column-spanning support so remaining columns render as empty space
- [ ] `distro-sync` without a specific package produces verbose solver errors ("does not belong to a distupgrade repository") that could be improved separately
- [ ] Consider a first-class `--allow-vendor-change` CLI flag instead of `--setopt=allow_vendor_change=true`
- [ ] Performance: the third solve is an extra `solver_solve()` call; could be skipped when no cross-vendor candidates exist