### PR TITLE
build: Work around detecting Ruby vendorarch directory

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -9,6 +9,18 @@ message("Building bindings for ruby")
 find_package(Ruby REQUIRED)
 include_directories(${Ruby_INCLUDE_DIRS})
 
+# Upstream CMake cannot detect Ruby_VENDORARCH_DIR
+# <http://public.kitware.com/Bug/view.php?id=12965>,
+# <https://gitlab.kitware.com/cmake/cmake/-/work_items/27888>.
+# Some distributors patch CMake for it
+# <https://bugzilla.redhat.com/show_bug.cgi?id=822796>.
+if ("${Ruby_VENDORARCH_DIR}" STREQUAL "")
+    execute_process(
+        COMMAND "${Ruby_EXECUTABLE}" -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']"
+        OUTPUT_VARIABLE Ruby_VENDORARCH_DIR)
+endif()
+message(STATUS "Ruby files will be installed to ${Ruby_VENDORARCH_DIR}")
+
 # The clang build is failing due to a deprecation warning, reported to swig:
 # https://github.com/swig/swig/issues/3170
 # Temporarily disable the warning to have a working clang build.


### PR DESCRIPTION
If DNF5 is configured to build Ruby bindings, they are installed into a path set in Ruby_VENDORARCH_DIR CMake variable. That variable was supposed to be set by CMake's Ruby module, but the module was broken and the variable was set to an empty string
<https://gitlab.kitware.com/cmake/cmake/-/work_items/27888>. As a result the DNF5 build script installed the file into a wrong path (/libdnf5 and /libdnf5_cli).

This went unnoticed because many distributors patch CMake to fix this issue <https://bugzilla.redhat.com/show_bug.cgi?id=822796>.

Also relying on the variable is doubtful because it is not documented <https://cmake.org/cmake/help/v4.3/module/FindRuby.html#result-variables>.

To alleviate both issue, this patch detects the vendorarch directory manually, if CMake module fails to do it.

Resolves: #2782