### PR TITLE
spec: Disable modularity on RHEL >= 11

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -95,7 +95,13 @@ Provides:       dnf5-command(versionlock)
 
 %bcond_without acl
 %bcond_without comps
+
+%if 0%{?rhel} >= 11
+%bcond_with modulemd
+%else
 %bcond_without modulemd
+%endif
+
 %bcond_without systemd
 
 %bcond_with    html


### PR DESCRIPTION
Requires changes in tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1903