### PR TITLE
manifest install, module subcommands: require privileges

### DIFF
--- a/dnf5-plugins/manifest_plugin/manifest_install.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_install.cpp
@@ -1,6 +1,7 @@
 // Copyright Contributors to the DNF5 project.
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include "dnf5/shared_options.hpp"
 #include "manifest.hpp"
 
 #include <libdnf5/rpm/package_query.hpp>
@@ -21,6 +22,8 @@ void ManifestInstallCommand::set_argument_parser() {
 
     auto & cmd = *get_argument_parser_command();
     cmd.set_description(_("Install all packages specified in the manifest file"));
+
+    create_store_option(*this);
 }
 
 void ManifestInstallCommand::pre_configure() {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -578,10 +578,19 @@ bool Context::Impl::cmd_requires_privileges() const {
         return false;
     }
 
-    // first a hard-coded list of commands that always need to be run with elevated privileges
+    // first handle hard-coded commands that always need to be run with elevated privileges
     auto main_arg_cmd = cmd->get_parent_command() != owner.get_root_command() ? arg_cmd->get_parent() : arg_cmd;
-    std::vector<std::string> privileged_cmds = {"automatic", "offline", "system-upgrade", "replay"};
-    if (std::find(privileged_cmds.begin(), privileged_cmds.end(), main_arg_cmd->get_id()) != privileged_cmds.end()) {
+    if (main_arg_cmd->get_id() == "module") {
+        static constexpr std::array<const char *, 3> privileged_module_cmds = {"enable", "disable", "reset"};
+        if (std::find(privileged_module_cmds.begin(), privileged_module_cmds.end(), arg_cmd->get_id()) !=
+            privileged_module_cmds.end()) {
+            return true;
+        }
+    }
+    static constexpr std::array<const char *, 4> privileged_main_cmds = {
+        "automatic", "offline", "system-upgrade", "replay"};
+    if (std::find(privileged_main_cmds.begin(), privileged_main_cmds.end(), main_arg_cmd->get_id()) !=
+        privileged_main_cmds.end()) {
         return true;
     }
 


### PR DESCRIPTION
This is needed for https://github.com/rpm-software-management/dnf5/pull/2785