### PR TITLE
fix: Goal::add_rpm_reinstall(Package) passes available solvable id to solver

### DIFF
--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -2194,12 +2194,12 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                 bool skip_broken = settings.resolve_skip_broken(cfg_main);
                 bool best = settings.resolve_best(cfg_main);
                 bool clean_requirements_on_remove = settings.resolve_clean_requirements_on_remove();
-                solv::IdQueue ids_nevra_installed;
+                solv::IdQueue ids_available;
                 for (auto id : ids) {
-                    rpm::PackageQuery query(installed);
-                    query.filter_nevra(pool.get_nevra(id));
-                    if (query.empty()) {
-                        // Report when package with the same NEVRA is not installed
+                    auto nevra = pool.get_nevra(id);
+                    rpm::PackageQuery query_installed(installed);
+                    query_installed.filter_nevra(nevra);
+                    if (query_installed.empty()) {
                         transaction.p_impl->add_resolve_log(
                             action,
                             GoalProblem::NOT_INSTALLED,
@@ -2208,12 +2208,31 @@ void Goal::Impl::add_rpms_to_goal(base::Transaction & transaction) {
                             get_user_spec(id),
                             {},
                             log_level);
-                    } else {
-                        // Only installed packages can be reinstalled
-                        ids_nevra_installed.push_back(id);
+                        continue;
+                    }
+                    if (!pool.is_installed(id)) {
+                        ids_available.push_back(id);
+                        continue;
+                    }
+                    rpm::PackageQuery query_available(base);
+                    query_available.filter_available();
+                    query_available.filter_nevra(nevra);
+                    if (query_available.empty()) {
+                        transaction.p_impl->add_resolve_log(
+                            action,
+                            GoalProblem::NOT_AVAILABLE,
+                            settings,
+                            libdnf5::transaction::TransactionItemType::PACKAGE,
+                            get_user_spec(id),
+                            {},
+                            log_level);
+                        continue;
+                    }
+                    for (auto available_id : *query_available.p_impl) {
+                        ids_available.push_back(available_id);
                     }
                 }
-                rpm_goal.add_install(ids_nevra_installed, skip_broken, best, clean_requirements_on_remove);
+                rpm_goal.add_install(ids_available, skip_broken, best, clean_requirements_on_remove);
             } break;
             case GoalAction::UPGRADE: {
                 bool best = settings.resolve_best(cfg_main);

--- a/test/libdnf5/base/test_goal.cpp
+++ b/test/libdnf5/base/test_goal.cpp
@@ -154,6 +154,31 @@ void BaseGoalTest::test_reinstall() {
     CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
+void BaseGoalTest::test_reinstall_installed_package() {
+    // Tests reinstallation when passing an installed Package object.
+    // The solver must receive the available solvable id, not the installed one.
+    add_repo_rpm("rpm-repo1");
+    auto installed_pkg = add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
+
+    libdnf5::Goal goal(base);
+    goal.add_rpm_reinstall(installed_pkg);
+
+    auto transaction = goal.resolve();
+
+    std::vector<libdnf5::base::TransactionPackage> expected = {
+        libdnf5::base::TransactionPackage(
+            get_pkg("one-0:1-1.noarch"),
+            TransactionItemAction::REINSTALL,
+            TransactionItemReason::DEPENDENCY,
+            TransactionItemState::STARTED),
+        libdnf5::base::TransactionPackage(
+            get_pkg("one-0:1-1.noarch", true),
+            TransactionItemAction::REPLACED,
+            TransactionItemReason::DEPENDENCY,
+            TransactionItemState::STARTED)};
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
+}
+
 void BaseGoalTest::test_reinstall_from_cmdline() {
     // Tests the reinstallation using a cmdline package when a package with the same NEVRA is in available repo
     add_repo_rpm("rpm-repo1");

--- a/test/libdnf5/base/test_goal.hpp
+++ b/test/libdnf5/base/test_goal.hpp
@@ -39,6 +39,7 @@ class BaseGoalTest : public LibdnfPrivateTestCase {
     CPPUNIT_TEST(test_install_from_cmdline);
     CPPUNIT_TEST(test_install_from_cmdline_multiple_resolves);
     CPPUNIT_TEST(test_reinstall);
+    CPPUNIT_TEST(test_reinstall_installed_package);
     CPPUNIT_TEST(test_reinstall_from_cmdline);
     CPPUNIT_TEST(test_reinstall_user);
     CPPUNIT_TEST(test_remove);
@@ -73,6 +74,7 @@ public:
     void test_install_from_cmdline();
     void test_install_from_cmdline_multiple_resolves();
     void test_reinstall();
+    void test_reinstall_installed_package();
     void test_reinstall_from_cmdline();
     void test_reinstall_user();
     void test_remove();


### PR DESCRIPTION
fix: `Goal::add_rpm_reinstall(Package)` passes available solvable id to solver

Resolves: https://github.com/rpm-software-management/dnf5/issues/2777