### PR TITLE
doc: Correct the history of modularity

### DIFF
--- a/doc/migrating_to_dnf5.7.rst
+++ b/doc/migrating_to_dnf5.7.rst
@@ -112,9 +112,10 @@ The change proposal: `MajorUpgradeOfMicrodnf
 Fedora Linux 39
 ---------------
 
-Discontinue modularity support in dnf5.  The Module Build Service was
+Discontinue modularity development in dnf5.  The Module Build Service was
 planned for shut down after Fedora Linux 38 reached EOL, so this
-release removed modularity support from the dnf5 stack.
+Fedora release removed a modular content from its repositories and
+the dnf5 team stopped developing modularity support in the dnf5 stack.
 
 The change proposal: `RetireModularity
 <https://fedoraproject.org/wiki/Changes/RetireModularity>`_


### PR DESCRIPTION
Fedora 39 stopped delivering modular content, but DNF5 continued to support modularity.