### PR TITLE
More copy->reflink replacements across the code base

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -26,6 +26,7 @@
 #include "utils/url.hpp"
 
 #include "libdnf5/utils/fs/file.hpp"
+#include "libdnf5/utils/fs/utils.hpp"
 
 #include <fmt/format.h>
 #include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
@@ -414,7 +415,7 @@ static void prepopulate_offline_cache(
         auto dest_path = packages_dir / cached_path.filename();
         std::error_code ec;
         if (!std::filesystem::exists(dest_path, ec)) {
-            std::filesystem::copy_file(cached_path, dest_path, ec);
+            libdnf5::utils::fs::reflink_or_copy(cached_path, dest_path, ec);
         }
     }
 }

--- a/include/libdnf5/utils/fs/utils.hpp
+++ b/include/libdnf5/utils/fs/utils.hpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 
@@ -23,6 +24,13 @@ namespace libdnf5::utils::fs {
 /// @return A vector of alphabetically sorted, unique filesystem paths to regular files or links to regular files.
 [[nodiscard]] std::vector<std::filesystem::path> LIBDNF_API
 create_sorted_file_list(const std::vector<std::filesystem::path> & directories, std::string_view file_extension);
+
+/// Like std::filesystem::copy(src, dest, copy_options::overwrite_existing), but
+/// performs a reflink (copy-on-write clone via the FICLONE ioctl) when the
+/// filesystem supports it, falling back to a plain byte copy otherwise. Sets `ec`
+/// on error and clears it otherwise. Never throws.
+void LIBDNF_API
+reflink_or_copy(const std::filesystem::path & src, const std::filesystem::path & dest, std::error_code & ec) noexcept;
 
 }  // namespace libdnf5::utils::fs
 

--- a/libdnf5-plugins/local/local.cpp
+++ b/libdnf5-plugins/local/local.cpp
@@ -11,6 +11,7 @@
 #include <libdnf5/plugin/iplugin.hpp>
 #include <libdnf5/repo/repo.hpp>
 #include <libdnf5/repo/repo_query.hpp>
+#include <libdnf5/utils/fs/utils.hpp>
 #include <sys/wait.h>
 
 
@@ -104,20 +105,32 @@ public:
                 if (pkg.get_repo_id() == LOCAL_REPO_NAME_GPGCHECK || pkg.get_repo_id() == LOCAL_REPO_NAME_NOGPGCHECK) {
                     continue;
                 }
+                auto src = std::filesystem::path(pkg.get_package_path());
+                std::error_code ec;
                 if (pkg.is_pkg_gpgcheck_enabled()) {
                     if (!need_rebuild_gpgcheck) {
-                        std::filesystem::create_directories(repodir);
+                        std::filesystem::create_directories(repodir, ec);
                     }
-                    std::filesystem::copy(
-                        pkg.get_package_path(), repodir, std::filesystem::copy_options::overwrite_existing);
-                    need_rebuild_gpgcheck = true;
+                    if (!ec) {
+                        libdnf5::utils::fs::reflink_or_copy(src, repodir / src.filename(), ec);
+                    }
+                    if (!ec) {
+                        need_rebuild_gpgcheck = true;
+                    }
                 } else {
                     if (!need_rebuild_nogpgcheck) {
-                        std::filesystem::create_directories(repodir_nogpgcheck);
+                        std::filesystem::create_directories(repodir_nogpgcheck, ec);
                     }
-                    std::filesystem::copy(
-                        pkg.get_package_path(), repodir_nogpgcheck, std::filesystem::copy_options::overwrite_existing);
-                    need_rebuild_nogpgcheck = true;
+                    if (!ec) {
+                        libdnf5::utils::fs::reflink_or_copy(src, repodir_nogpgcheck / src.filename(), ec);
+                    }
+                    if (!ec) {
+                        need_rebuild_nogpgcheck = true;
+                    }
+                }
+                if (ec) {
+                    auto & logger = *get_base().get_logger();
+                    logger.warning("local plugin: failed to copy {}: {}", src.string(), ec.message());
                 }
             }
         }

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -30,6 +30,7 @@ constexpr const char * REPOID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmno
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/conf/const.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+#include "libdnf5/utils/fs/utils.hpp"
 
 extern "C" {
 #include <solv/repo_rpmdb.h>
@@ -544,6 +545,27 @@ void Repo::internalize() {
 }
 
 
+namespace {
+
+// Reflink-or-copy every entry from a flat cache directory into `dest_dir`.
+// Regular files are reflinked when possible; other entry types fall back to std::filesystem::copy.
+void reflink_or_copy_cache(
+    const std::filesystem::path & src_dir, const std::filesystem::path & dest_dir, std::error_code & ec) {
+    for (const auto & entry : std::filesystem::directory_iterator(src_dir, ec)) {
+        auto dest = dest_dir / entry.path().filename();
+        if (entry.is_regular_file()) {
+            utils::fs::reflink_or_copy(entry.path(), dest, ec);
+        } else {
+            std::filesystem::copy(entry.path(), dest, ec);
+        }
+        if (ec) {
+            return;
+        }
+    }
+}
+
+}  // namespace
+
 bool Repo::clone_root_metadata() {
     auto & logger = *p_impl->base->get_logger();
 
@@ -585,38 +607,40 @@ bool Repo::clone_root_metadata() {
     auto repodata_cachedir = std::filesystem::path(repo_cachedir) / CACHE_METADATA_DIR;
     auto root_repodata_metalink = std::filesystem::path(root_repo_cachedir) / CACHE_METALINK_FILE;
     auto root_repodata_mirrorlist = std::filesystem::path(root_repo_cachedir) / CACHE_MIRRORLIST_FILE;
-    try {
-        std::filesystem::create_directories(repodata_cachedir);
-        std::filesystem::copy(root_repodata_cachedir, repodata_cachedir);
-        if (std::filesystem::exists(root_repodata_metalink)) {
-            std::filesystem::copy(root_repodata_metalink, repo_cachedir);
-        }
-        if (std::filesystem::exists(root_repodata_mirrorlist)) {
-            std::filesystem::copy(root_repodata_mirrorlist, repo_cachedir);
-        }
-    } catch (const std::filesystem::filesystem_error & e) {
+    std::filesystem::create_directories(repodata_cachedir, ec);
+    if (!ec) {
+        reflink_or_copy_cache(root_repodata_cachedir, repodata_cachedir, ec);
+    }
+    if (!ec && std::filesystem::exists(root_repodata_metalink, ec)) {
+        utils::fs::reflink_or_copy(root_repodata_metalink, repo_cachedir / root_repodata_metalink.filename(), ec);
+    }
+    if (!ec && std::filesystem::exists(root_repodata_mirrorlist, ec)) {
+        utils::fs::reflink_or_copy(root_repodata_mirrorlist, repo_cachedir / root_repodata_mirrorlist.filename(), ec);
+    }
+    if (ec) {
         logger.debug(
             "Error when cloning root repodata from \"{}\" to \"{}\" : \"{}\"",
             root_repodata_cachedir.c_str(),
             repodata_cachedir.c_str(),
-            e.what());
+            ec.message());
         repo_cache.remove_metadata();
         return false;
     }
 
     auto root_solv_cachedir = std::filesystem::path(root_repo_cachedir) / CACHE_SOLV_FILES_DIR;
     auto solv_cachedir = std::filesystem::path(repo_cachedir) / CACHE_SOLV_FILES_DIR;
-    try {
-        if (std::filesystem::exists(root_solv_cachedir)) {
-            std::filesystem::create_directories(solv_cachedir);
-            std::filesystem::copy(root_solv_cachedir, solv_cachedir);
+    if (std::filesystem::exists(root_solv_cachedir, ec)) {
+        std::filesystem::create_directories(solv_cachedir, ec);
+        if (!ec) {
+            reflink_or_copy_cache(root_solv_cachedir, solv_cachedir, ec);
         }
-    } catch (const std::filesystem::filesystem_error & e) {
+    }
+    if (ec) {
         logger.debug(
             "Error when cloning root solv data from \"{}\" to \"{}\" : \"{}\"",
             root_solv_cachedir.c_str(),
             solv_cachedir.c_str(),
-            e.what());
+            ec.message());
         repo_cache.remove_solv_files();
     }
 

--- a/libdnf5/utils/fs/utils.hpp
+++ b/libdnf5/utils/fs/utils.hpp
@@ -34,13 +34,6 @@ namespace libdnf5::utils::fs {
 /// Implements copy and remove fallback.
 void move_recursive(const std::filesystem::path & src, const std::filesystem::path & dest);
 
-/// Like std::filesystem::copy(src, dest, copy_options::overwrite_existing), but
-/// performs a reflink (copy-on-write clone via the FICLONE ioctl) when the
-/// filesystem supports it, falling back to a plain byte copy otherwise. Sets `ec`
-/// on error and clears it otherwise. Never throws.
-void reflink_or_copy(
-    const std::filesystem::path & src, const std::filesystem::path & dest, std::error_code & ec) noexcept;
-
 }  // namespace libdnf5::utils::fs
 
 #endif


### PR DESCRIPTION
This is a follow-up to https://github.com/rpm-software-management/dnf5/pull/2804

The code now leverages `reflink_or_copy` in several additional places:

- prepopulating the cache for offline and stored transactions
- the local plugin
- cloning the user cache from the root one