### PR TITLE
Add --[no-]allow-vendor-change option

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -335,6 +335,22 @@ void RootCommand::set_argument_parser() {
 
     no_best->add_conflict_argument(*best);
 
+    auto allow_vendor_change = parser.add_new_named_arg("allow-vendor-change");
+    allow_vendor_change->set_long_name("allow-vendor-change");
+    allow_vendor_change->set_description(_("allow automatic package replacements from different vendors"));
+    allow_vendor_change->set_const_value("true");
+    allow_vendor_change->link_value(&config.get_allow_vendor_change_option());
+    global_options_group->register_argument(allow_vendor_change);
+
+    auto no_allow_vendor_change = parser.add_new_named_arg("no-allow-vendor-change");
+    no_allow_vendor_change->set_long_name("no-allow-vendor-change");
+    no_allow_vendor_change->set_description(_("do not allow automatic package replacements from different vendors"));
+    no_allow_vendor_change->set_const_value("false");
+    no_allow_vendor_change->link_value(&config.get_allow_vendor_change_option());
+    global_options_group->register_argument(no_allow_vendor_change);
+
+    no_allow_vendor_change->add_conflict_argument(*allow_vendor_change);
+
     {
         auto no_docs = parser.add_new_named_arg("no-docs");
         no_docs->set_long_name("no-docs");
@@ -1160,7 +1176,7 @@ static void print_resolve_hints(dnf5::Context & context) {
         }
 
         if (!conf.get_allow_vendor_change_option().get_value() && vendor_change) {
-            const std::string_view arg{"--setopt=allow_vendor_change=true"};
+            const std::string_view arg{"--allow-vendor-change"};
             hints.emplace_back(libdnf5::utils::sformat(_("{} to allow changing package vendors"), arg));
         }
 

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -183,6 +183,11 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--assumeno``
     | Automatically answer no for all questions.
 
+.. _allow_vendor_change_option_ref-label:
+
+``--allow-vendor-change``
+    | Allow automatic package replacements from different vendors for RPM upgrades or downgrades.
+
 .. _best_option_ref-label:
 
 ``--best``
@@ -259,6 +264,13 @@ Following options are applicable in the general context for any ``dnf5`` command
     | Setup installroot path.
     | Absolute path is required.
     | :ref:`See <installroot_misc_ref-label>` :manpage:`dnf5-installroot(7)` for more info.
+
+.. _no_allow_vendor_change_option_ref-label:
+
+``--no-allow-vendor-change``
+    | Do not allow automatic package replacements from different vendors for RPM upgrades or downgrades.
+    | The behavior of this option can be fine-tuned with vendor change policy configuration.
+    | :ref:`See <vendorpolicy_conf-label>` :manpage:`dnf5.conf-vendorpolicy(5)` for more info.
 
 .. _no_best_option_ref-label:
 
@@ -511,6 +523,7 @@ Library Plugins:
 
 Configuration:
     | :manpage:`dnf5.conf(5)`, :ref:`DNF5 Configuration Reference <dnf5_conf-label>`
+    | :manpage:`dnf5.conf-vendorpolicy(5)`, :ref:`DNF5 Vendor Change Policy File Reference <vendorpolicy_conf-label>`
 
 Miscellaneous:
     | :manpage:`dnf5-aliases(7)`, :ref:`Aliases for command line arguments <aliases_misc_ref-label>`


### PR DESCRIPTION
Since allowing vendor changes is now suggested by DNF in certain scenarios where it is disabled by default, this makes it a bit more ergonomic to control.

@jrohel 
Updated/extended CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1917