### PR TITLE
dnf5daemon: fix recent_changes upgrade reporting

### DIFF
--- a/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
+++ b/dnf5daemon-server/dbus/interfaces/org.rpm.dnf.v0.History.xml
@@ -32,8 +32,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         @options: an array of key/value pairs
         @changeset: a dictionary {"<type_of_change>":[<package>,<package>,...]}
 
-        Get a list of packages that have been recently changed. The
-        "type_of_change" key in the output dictionary can be one of the
+        Get a list of packages that have been recently changed. The result
+        represents the difference between the currently installed package set
+        and the set at a given point in time.
+
+        The "type_of_change" key in the output dictionary can be one of the
         following: "installed", "removed", "upgraded", or "downgraded". The
         packages in the output are represented as dictionaries containing the
         requested set of attributes for the changed packages.
@@ -41,8 +44,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
         For installed, upgraded, and downgraded packages, the currently
         installed version is returned.
 
-        For upgraded and downgraded packages, the "original_evr" attribute
-        is also included, containing the package EVR before the change.
+        For upgraded and downgraded packages, the "original_evr" and
+        "original_arch" attributes are also included, containing the
+        package EVR and architecture before the change.
 
         If requested, upgraded packages may also include an "advisories" list
         field, indicating the name of the updates that contain the upgraded

--- a/dnf5daemon-server/services/history/history.cpp
+++ b/dnf5daemon-server/services/history/history.cpp
@@ -171,18 +171,24 @@ sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
     };
 
     // first pass: find the latest transaction end time for each package
+    // and collect NAs of UPGRADE/DOWNGRADE entries (keyed by name) so that
+    // REPLACED entries can find their replacement when the arch changed
     std::unordered_map<std::string, uint64_t> latest_trans_time;
+    std::unordered_map<std::string, std::string> upgraded_na;
     for (auto & transaction : transactions) {
         if (transaction.get_state() != libdnf5::transaction::TransactionState::OK) {
             continue;
         }
         for (const auto & pkg : transaction.get_packages()) {
             const auto action = pkg.get_action();
-            if (action != Action::INSTALL && action != Action::REMOVE && action != Action::REPLACED) {
+            auto key = get_pkg_key(pkg);
+            if (action == Action::UPGRADE || action == Action::DOWNGRADE) {
+                upgraded_na[pkg.get_name()] = key;
+            } else if (action != Action::INSTALL && action != Action::REMOVE && action != Action::REPLACED) {
                 continue;
             }
             auto dt_end = transaction.get_dt_end();
-            latest_trans_time[get_pkg_key(pkg)] = dt_end >= 0 ? static_cast<uint64_t>(dt_end) : 0;
+            latest_trans_time[key] = dt_end >= 0 ? static_cast<uint64_t>(dt_end) : 0;
         }
     }
 
@@ -227,8 +233,19 @@ sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
             } else {
                 // package was REMOVEd or REPLACED
                 // check the current installed version of the package
+                if (installed_pkg == installed_na.end() && action == Action::REPLACED) {
+                    // NA lookup failed, try to find the replacement via
+                    // the paired UPGRADE/DOWNGRADE record
+                    auto upgrade_it = upgraded_na.find(pkg.get_name());
+                    if (upgrade_it != upgraded_na.end()) {
+                        installed_pkg = installed_na.find(upgrade_it->second);
+                        if (installed_pkg != installed_na.end()) {
+                            seen_pkg.insert(upgrade_it->second);
+                        }
+                    }
+                }
                 if (installed_pkg != installed_na.end()) {
-                    if (libdnf5::rpm::cmp_nevra(pkg, installed_na.at(pkg_key))) {
+                    if (libdnf5::rpm::cmp_nevra(pkg, installed_pkg->second)) {
                         if (upgraded_requested) {
                             upgrades_installed.add(installed_pkg->second);
                             upgrades.emplace_back(pkg, installed_pkg->second);
@@ -243,11 +260,12 @@ sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
                                 upgrades_original.emplace_back(std::move(nevra));
                             }
                         }
-                    } else if (libdnf5::rpm::cmp_nevra(installed_na.at(pkg_key), pkg)) {
+                    } else if (libdnf5::rpm::cmp_nevra(installed_pkg->second, pkg)) {
                         if (downgraded_requested) {
                             auto replace_pkg = package_to_map(installed_pkg->second, pkg_attrs);
                             replace_pkg.emplace("original_evr", get_evr(pkg));
-                            replace_pkg.emplace("transaction_time", latest_trans_time[pkg_key]);
+                            replace_pkg.emplace("original_arch", pkg.get_arch());
+                            replace_pkg.emplace("transaction_time", latest_trans_time[installed_pkg->first]);
                             out_downgraded.push_back(std::move(replace_pkg));
                         }
                     }
@@ -295,6 +313,7 @@ sdbus::MethodReply History::recent_changes(sdbus::MethodCall & call) {
         for (const auto & [old_pkg, new_pkg] : upgrades) {
             auto replace_pkg = package_to_map(new_pkg, pkg_attrs);
             replace_pkg.emplace("original_evr", get_evr(old_pkg));
+            replace_pkg.emplace("original_arch", old_pkg.get_arch());
             replace_pkg.emplace("transaction_time", latest_trans_time[new_pkg.get_na()]);
             if (include_advisory) {
                 auto advisories = advisories_by_name.find(new_pkg.get_name());


### PR DESCRIPTION
When a package changes architecture during upgrade (e.g. noarch to x86_64), the REPLACED entry's name.arch key didn't match any installed package, causing it to be reported as a removal instead of an upgrade.

Collect UPGRADE/DOWNGRADE records in the first pass to build a map from package name to the new name.arch. When a REPLACED entry's name.arch lookup fails, use this map to find the replacement package's name.arch directly.

Fixes: https://github.com/rpm-software-management/dnf5/issues/2595