### PR TITLE
MultiProgressBar: Optimize performance when registering many bars, add overflow checks

### DIFF
--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -143,11 +143,11 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     mbar.p_impl->num_of_lines_to_clear = 0;
     mbar.p_impl->line_printed = false;
 
-    // store numbers of bars in progress
-    std::vector<int32_t> numbers;
-    for (auto * bar : mbar.p_impl->bars_todo) {
-        numbers.insert(numbers.begin(), bar->get_number());
-    }
+    // initialize bar number counter to bars_done.size(), clamp to max on overflow
+    using NumberType = decltype(mbar.get_total_bar().get_number());
+    NumberType number = std::cmp_less(mbar.p_impl->bars_done.size(), std::numeric_limits<NumberType>::max())
+                            ? static_cast<NumberType>(mbar.p_impl->bars_done.size())
+                            : std::numeric_limits<NumberType>::max();
 
     // print completed bars first and remove them from the list
     for (std::size_t i = 0; i < mbar.p_impl->bars_todo.size(); i++) {
@@ -155,8 +155,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         if (!bar->is_finished()) {
             continue;
         }
-        bar->set_number(numbers.back());
-        numbers.pop_back();
+        if (number < std::numeric_limits<decltype(number)>::max()) {
+            ++number;
+        }
+        bar->set_number(number);
         bar->set_total(total_num_of_bars);
         text_buffer << *bar;
         text_buffer << std::endl;
@@ -168,8 +170,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
     // then print incomplete
     for (auto & bar : mbar.p_impl->bars_todo) {
-        bar->set_number(numbers.back());
-        numbers.pop_back();
+        if (number < std::numeric_limits<decltype(number)>::max()) {
+            ++number;
+        }
+        bar->set_number(number);
 
         // skip printing bars that haven't started yet
         if (bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::STARTED) {

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -199,12 +199,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     // then print the "total" progress bar
-    int32_t total_numbers = 0;
     int64_t ticks = 0;
     int64_t total_ticks = 0;
 
     for (auto & bar : mbar.p_impl->bars_done) {
-        total_numbers = std::max(total_numbers, bar->get_total());
         // completed bars can be unfinished
         // add only processed ticks to both values
         total_ticks += bar->get_ticks();
@@ -212,11 +210,9 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     for (auto & bar : mbar.p_impl->bars_todo) {
-        total_numbers = std::max(total_numbers, bar->get_total());
         total_ticks += bar->get_total_ticks();
         ticks += bar->get_ticks();
     }
-
 
     if ((mbar.p_impl->bars_all.size() >= mbar.p_impl->total_bar_visible_limit) &&
         (is_interactive || mbar.p_impl->bars_todo.empty())) {

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -149,12 +149,15 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
                             ? static_cast<NumberType>(mbar.p_impl->bars_done.size())
                             : std::numeric_limits<NumberType>::max();
 
-    // print completed bars first and remove them from the list
-    for (std::size_t i = 0; i < mbar.p_impl->bars_todo.size(); i++) {
-        auto * bar = mbar.p_impl->bars_todo[i];
+    // print completed bars first and move them from bars_todo to bars_done
+    for (auto it = mbar.p_impl->bars_todo.begin(); it != mbar.p_impl->bars_todo.end();) {
+        auto * const bar = *it;
+
         if (!bar->is_finished()) {
+            ++it;
             continue;
         }
+
         if (number < std::numeric_limits<decltype(number)>::max()) {
             ++number;
         }
@@ -163,9 +166,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         text_buffer << *bar;
         text_buffer << std::endl;
         mbar.p_impl->bars_done.push_back(bar);
-        // TODO(dmach): use iterator
-        mbar.p_impl->bars_todo.erase(mbar.p_impl->bars_todo.begin() + static_cast<int>(i));
-        i--;
+        it = mbar.p_impl->bars_todo.erase(it);
     }
 
     // then print incomplete

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -28,6 +28,8 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <limits>
+#include <utility>
 
 
 namespace libdnf5::cli::progressbar {
@@ -82,21 +84,19 @@ void MultiProgressBar::set_total_bar_number_widget_visible(bool value) noexcept 
 }
 
 void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
+    // set bar number, clamp to max on overflow
+    using NumberType = decltype(bar->get_number());
+    NumberType next_number = std::cmp_less(p_impl->bars_all.size() + 1, std::numeric_limits<NumberType>::max())
+                                 ? static_cast<NumberType>(p_impl->bars_all.size() + 1)
+                                 : std::numeric_limits<NumberType>::max();
+    bar->set_number(next_number);
+
+    // register bar to MultiProgressBar
     p_impl->bars_todo.push_back(bar.get());
-
-    // if the number is not set, automatically find and set the next available
-    if (bar->get_number() == 0) {
-        int number = 0;
-        for (auto i : p_impl->bars_todo) {
-            number = std::max(number, i->get_number());
-        }
-        bar->set_number(number + 1);
-    }
-
     p_impl->bars_all.push_back(std::move(bar));
 
     // update total (in [num/total]) in total progress bar
-    auto registered_bars_count = static_cast<int32_t>(p_impl->bars_all.size());
+    auto registered_bars_count = next_number;
     if (p_impl->total.get_total() < registered_bars_count) {
         p_impl->total.set_total(registered_bars_count);
     }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -100,11 +100,6 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
     if (p_impl->total.get_total() < registered_bars_count) {
         p_impl->total.set_total(registered_bars_count);
     }
-
-    // update total (in [num/total]) in all bars to do
-    for (auto & i : p_impl->bars_todo) {
-        i->set_total(p_impl->total.get_total());
-    }
 }
 
 
@@ -132,6 +127,7 @@ std::size_t MultiProgressBar::get_total_num_of_bars() const noexcept {
 std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     const bool is_interactive{tty::is_interactive()};
     auto terminal_width = static_cast<std::size_t>(tty::get_width());
+    auto total_num_of_bars = mbar.p_impl->total.get_total();
 
     // We'll buffer the output text to a single string and print it all at once.
     // This is to avoid multiple writes to the terminal, which can cause flickering.
@@ -166,6 +162,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         }
         bar->set_number(numbers.back());
         numbers.pop_back();
+        bar->set_total(total_num_of_bars);
         text_buffer << *bar;
         text_buffer << std::endl;
         mbar.p_impl->bars_done.push_back(bar);
@@ -192,6 +189,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         if (mbar.p_impl->line_printed) {
             text_buffer << std::endl;
         }
+        bar->set_total(total_num_of_bars);
         text_buffer << *bar;
         mbar.p_impl->line_printed = true;
         mbar.p_impl->num_of_lines_to_clear++;

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -110,11 +110,6 @@ void MultiProgressBar::set_total_num_of_bars(std::size_t value) noexcept {
     auto num_of_bars = static_cast<int>(value);
     if (num_of_bars != p_impl->total.get_total()) {
         p_impl->total.set_total(num_of_bars);
-
-        // update total (in [num/total]) in all bars to do
-        for (auto & i : p_impl->bars_todo) {
-            i->set_total(p_impl->total.get_total());
-        }
     }
 }
 

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -48,6 +48,29 @@ public:
     std::size_t num_of_lines_to_clear{0};
 };
 
+
+namespace {
+
+using BarNumberType = decltype(std::declval<ProgressBar>().get_number());
+
+/// Safely casts any numeric value to BarNumberType, clamping it within bounds.
+BarNumberType cast_to_bar_number(auto value) {
+    // Check if the input value exceeds the maximum limit of the target type
+    if (std::cmp_greater(value, std::numeric_limits<BarNumberType>::max())) {
+        return std::numeric_limits<BarNumberType>::max();
+    }
+
+    // Check if the input value is below the minimum limit of the target type
+    if (std::cmp_less(value, std::numeric_limits<BarNumberType>::min())) {
+        return std::numeric_limits<BarNumberType>::min();
+    }
+
+    return static_cast<BarNumberType>(value);
+}
+
+}  // namespace
+
+
 MultiProgressBar::Impl::Impl() : total(0, _("Total")) {
     total.set_auto_finish(false);
     total.start();
@@ -84,11 +107,8 @@ void MultiProgressBar::set_total_bar_number_widget_visible(bool value) noexcept 
 }
 
 void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
-    // set bar number, clamp to max on overflow
-    using NumberType = decltype(bar->get_number());
-    NumberType next_number = std::cmp_less(p_impl->bars_all.size() + 1, std::numeric_limits<NumberType>::max())
-                                 ? static_cast<NumberType>(p_impl->bars_all.size() + 1)
-                                 : std::numeric_limits<NumberType>::max();
+    // set bar number, clamp to bounds on overflow
+    auto next_number = cast_to_bar_number(p_impl->bars_all.size() + 1);
     bar->set_number(next_number);
 
     // register bar to MultiProgressBar
@@ -107,7 +127,7 @@ void MultiProgressBar::set_total_num_of_bars(std::size_t value) noexcept {
     if (value < p_impl->bars_all.size()) {
         value = p_impl->bars_all.size();
     }
-    auto num_of_bars = static_cast<int>(value);
+    auto num_of_bars = cast_to_bar_number(value);
     if (num_of_bars != p_impl->total.get_total()) {
         p_impl->total.set_total(num_of_bars);
     }
@@ -143,11 +163,8 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     mbar.p_impl->num_of_lines_to_clear = 0;
     mbar.p_impl->line_printed = false;
 
-    // initialize bar number counter to bars_done.size(), clamp to max on overflow
-    using NumberType = decltype(mbar.get_total_bar().get_number());
-    NumberType number = std::cmp_less(mbar.p_impl->bars_done.size(), std::numeric_limits<NumberType>::max())
-                            ? static_cast<NumberType>(mbar.p_impl->bars_done.size())
-                            : std::numeric_limits<NumberType>::max();
+    // initialize bar number counter to bars_done.size(), clamp to bounds on overflow
+    auto number = cast_to_bar_number(mbar.p_impl->bars_done.size());
 
     // print completed bars first and move them from bars_todo to bars_done
     for (auto it = mbar.p_impl->bars_todo.begin(); it != mbar.p_impl->bars_todo.end();) {
@@ -223,7 +240,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
         // print Total progress bar
         auto & mbar_total = mbar.get_total_bar();
-        mbar_total.set_number(static_cast<int>(mbar.p_impl->bars_done.size()));
+        mbar_total.set_number(cast_to_bar_number(mbar.p_impl->bars_done.size()));
 
         mbar_total.set_total_ticks(total_ticks);
         mbar_total.set_ticks(ticks);


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/2790

When thousands of progressbars were registered, several operations in `MultiProgressBar` ran in O(n*n) time, making both registration and rendering very slow. This PR fixes the root causes.

## Performance fixes

- **`add_bar`: O(n) progressbar number scan -> O(1)**: The original code searched for the next free progressbar `number` by iterating all registered progressbars. Since `operator<<` reassigns numbers by completion order anyway, a caller-set number has no meaningful effect. The number is now always assigned directly as `bars_all.size() + 1`.

- **`add_bar`: Remove O(n*n) set_total loop**: `add_bar()` updated the `total` field of every registered progressbar on each call. With n bars this is O(n*n) total. The loop is removed; `total` is set lazily in `operator<<` just before each progressbar is rendered.

- **`set_total_num_of_bars`: Remove O(n) set_total loop**: Same issue as above, now also fixed in `set_total_num_of_bars()`.

- **`operator<<`: O(n*n) number vector -> O(1) counter**: A vector of progressbar numbers was built by inserting at the front (O(n) per insert, O(n*n) total). Replaced with a simple counter initialized to `bars_done.size()`.

## Code quality

- Remove total_numbers variable accumulated in a loop across two iterations but never read in `operator<<`.

- Replace index-based loop with iterator-based erase pattern in `operator<<`, resolving an existing TODO comment.

- Add overflow checks that were completely missing throughout, and extract them into a `cast_to_bar_number()` helper to avoid duplication.
