### PR TITLE
Warn when upgrades are silently skipped due to vendor change restriction

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1080,6 +1080,22 @@ static bool has_named_arg(libdnf5::cli::ArgumentParser::Command * command, std::
     return false;
 }
 
+static void print_vendor_change_skipped(dnf5::Context & context) {
+    if (context.get_transaction() == nullptr) {
+        return;
+    }
+    const auto & skipped = context.get_transaction()->get_vendor_change_skipped_packages();
+    if (skipped.empty()) {
+        return;
+    }
+    std::vector<std::pair<std::string, std::string>> pairs;
+    pairs.reserve(skipped.size());
+    for (const auto & [pkg, installed_vendor] : skipped) {
+        pairs.emplace_back(installed_vendor, pkg.get_vendor());
+    }
+    libdnf5::cli::output::print_vendor_change_skipped(pairs);
+}
+
 static void print_resolve_hints(dnf5::Context & context) {
     auto & conf = context.get_base().get_config();
     std::vector<std::string> hints;
@@ -1123,11 +1139,15 @@ static void print_resolve_hints(dnf5::Context & context) {
         }
     }
 
+    // vendor_change is set from RULE_UPDATE solver errors (e.g. a reinstall whose only
+    // available copy is from a different vendor). Hoisted here so it can be combined
+    // with has_vendor_change_skipped below, which fires even without a SOLVER_ERROR.
+    bool vendor_change = false;
+
     if ((transaction_problems & libdnf5::GoalProblem::SOLVER_ERROR) == libdnf5::GoalProblem::SOLVER_ERROR) {
         bool conflict = false;
         bool broken_file_dep = false;
         bool best = false;
-        bool vendor_change = false;
         // walk through all solver problem to detect a conflict, missing file dependency and best
         for (const auto & resolve_log : context.get_transaction()->get_resolve_logs()) {
             if (resolve_log.get_problem() == libdnf5::GoalProblem::SOLVER_ERROR) {
@@ -1175,11 +1195,6 @@ static void print_resolve_hints(dnf5::Context & context) {
             }
         }
 
-        if (!conf.get_allow_vendor_change_option().get_value() && vendor_change) {
-            const std::string_view arg{"--allow-vendor-change"};
-            hints.emplace_back(libdnf5::utils::sformat(_("{} to allow changing package vendors"), arg));
-        }
-
         if (broken_file_dep) {
             const std::string_view arg{"--setopt=optional_metadata_types=filelists"};
             auto optional_metadata = conf.get_optional_metadata_types_option().get_value();
@@ -1195,6 +1210,19 @@ static void print_resolve_hints(dnf5::Context & context) {
                 hints.emplace_back(libdnf5::utils::sformat(_("{} to skip uninstallable packages"), arg));
             }
         }
+    }
+
+    // Two sources trigger this hint:
+    // - vendor_change: a RULE_UPDATE solver error (e.g. reinstall where only a different-vendor
+    //   copy is available). Requires SOLVER_ERROR, set above.
+    // - has_vendor_change_skipped: upgrades/downgrades silently dropped by the solver because
+    //   the only candidate would require a vendor change. The solver succeeds without them so
+    //   there is no SOLVER_ERROR; checking only inside that block would miss this case.
+    bool has_vendor_change_skipped =
+        context.get_transaction() && !context.get_transaction()->get_vendor_change_skipped_packages().empty();
+    if (!conf.get_allow_vendor_change_option().get_value() && (vendor_change || has_vendor_change_skipped)) {
+        const std::string_view arg{"--allow-vendor-change"};
+        hints.emplace_back(libdnf5::utils::sformat(_("{} to allow changing package vendors"), arg));
     }
 
     if (hints.size() > 0) {
@@ -1635,8 +1663,13 @@ int main(int argc, char * argv[]) try {
                 download_callbacks->set_show_total_bar_limit(0);
 
                 libdnf5::cli::output::TransactionAdapter cli_output_transaction(*context.get_transaction());
-                if (!libdnf5::cli::output::print_transaction_table(
-                        static_cast<libdnf5::cli::output::ITransaction &>(cli_output_transaction))) {
+                auto transaction_table_printed = libdnf5::cli::output::print_transaction_table(
+                    static_cast<libdnf5::cli::output::ITransaction &>(cli_output_transaction));
+
+                print_vendor_change_skipped(context);
+                print_resolve_hints(context);
+
+                if (!transaction_table_printed) {
                     return static_cast<int>(libdnf5::cli::ExitCode::SUCCESS);
                 }
 
@@ -1737,6 +1770,7 @@ int main(int argc, char * argv[]) try {
                          "of the host system, pass --use-host-config.")
                     << std::endl;
             } else {
+                print_vendor_change_skipped(context);
                 if (context.get_transaction() != nullptr) {
                     // download command can throw GoalResolveError without context.transaction being set
                     print_resolve_hints(context);

--- a/dnf5daemon-client/commands/command.cpp
+++ b/dnf5daemon-client/commands/command.cpp
@@ -69,7 +69,19 @@ void TransactionCommand::run_transaction(bool offline) {
 
     // print the transaction to the user and ask for confirmation
     libdnf5::cli::output::TransactionAdapter cli_output_transaction(dbus_goal_wrapper);
-    if (!libdnf5::cli::output::print_transaction_table(cli_output_transaction)) {
+    const bool table_printed = libdnf5::cli::output::print_transaction_table(cli_output_transaction);
+
+    const auto & skipped = dbus_goal_wrapper.get_vendor_change_skipped_packages();
+    if (!skipped.empty()) {
+        std::vector<std::pair<std::string, std::string>> pairs;
+        pairs.reserve(skipped.size());
+        for (const auto & [pkg, installed_vendor] : skipped) {
+            pairs.emplace_back(installed_vendor, pkg.get_vendor());
+        }
+        libdnf5::cli::output::print_vendor_change_skipped(pairs);
+    }
+
+    if (!table_printed) {
         return;
     }
 

--- a/dnf5daemon-client/wrappers/dbus_goal_wrapper.cpp
+++ b/dnf5daemon-client/wrappers/dbus_goal_wrapper.cpp
@@ -44,8 +44,12 @@ DbusGoalWrapper::DbusGoalWrapper(const std::vector<dnfdaemon::DbusTransactionIte
             transaction_modules.push_back(DbusTransactionModuleWrapper(ti));
         } else if (object_type == "Skipped") {
             auto trans_item_attrs = std::get<3>(ti);
-            if (key_value_map_get<std::string>(trans_item_attrs, "reason_skipped", "conflict") == "conflict") {
+            auto reason = key_value_map_get<std::string>(trans_item_attrs, "reason_skipped", "conflict");
+            if (reason == "conflict") {
                 conflicting_packages.emplace_back(std::get<4>(ti));
+            } else if (reason == "vendor_change") {
+                auto installed_vendor = key_value_map_get<std::string>(trans_item_attrs, "installed_vendor", "");
+                vendor_change_skipped_packages.emplace_back(std::get<4>(ti), std::move(installed_vendor));
             } else {
                 broken_dependency_packages.emplace_back(std::get<4>(ti));
             }

--- a/dnf5daemon-client/wrappers/dbus_goal_wrapper.hpp
+++ b/dnf5daemon-client/wrappers/dbus_goal_wrapper.hpp
@@ -49,6 +49,9 @@ public:
 
     std::vector<DbusPackageWrapper> get_conflicting_packages() const { return conflicting_packages; }
     std::vector<DbusPackageWrapper> get_broken_dependency_packages() const { return broken_dependency_packages; }
+    const std::vector<std::pair<DbusPackageWrapper, std::string>> & get_vendor_change_skipped_packages() const {
+        return vendor_change_skipped_packages;
+    }
 
 private:
     std::vector<DbusTransactionPackageWrapper> transaction_packages;
@@ -57,6 +60,7 @@ private:
     std::vector<DbusTransactionModuleWrapper> transaction_modules;
     std::vector<DbusPackageWrapper> conflicting_packages;
     std::vector<DbusPackageWrapper> broken_dependency_packages;
+    std::vector<std::pair<DbusPackageWrapper, std::string>> vendor_change_skipped_packages;
     std::vector<std::string> resolve_logs;
 };
 

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -292,6 +292,19 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
                 trans_item_attrs,
                 package_to_map(pkg, pkg_attrs));
         }
+        std::vector<std::string> vendor_pkg_attrs = pkg_attrs;
+        vendor_pkg_attrs.emplace_back("vendor");
+        for (const auto & [pkg, installed_vendor] : transaction.get_vendor_change_skipped_packages()) {
+            dnfdaemon::KeyValueMap trans_item_attrs{};
+            trans_item_attrs.emplace("reason_skipped", "vendor_change");
+            trans_item_attrs.emplace("installed_vendor", installed_vendor);
+            dbus_transaction.emplace_back(
+                dbus_transaction_item_type_to_string(dnfdaemon::DbusTransactionItemType::SKIPPED),
+                "",
+                "",
+                trans_item_attrs,
+                package_to_map(pkg, vendor_pkg_attrs));
+        }
     }
 
     auto reply = call.createReply();

--- a/include/libdnf5-cli/output/transaction_table.hpp
+++ b/include/libdnf5-cli/output/transaction_table.hpp
@@ -59,6 +59,13 @@ LIBDNF_CLI_API void print_resolve_logs(const ITransaction & transaction, std::os
 
 LIBDNF_CLI_API bool print_transaction_table(ITransaction & transaction);
 
+/// Print the "Skipping N package(s) due to vendor change restriction" section.
+/// @param vendor_pairs  Each entry is {installed_vendor, candidate_vendor} for
+///                      one skipped package; the function groups by transition.
+/// @param stream        Output stream; defaults to stdout.
+LIBDNF_CLI_API void print_vendor_change_skipped(
+    const std::vector<std::pair<std::string, std::string>> & vendor_pairs, std::FILE * stream = stdout);
+
 }  // namespace libdnf5::cli::output
 
 #endif  // LIBDNF5_CLI_OUTPUT_TRANSACTION_TABLE_HPP

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -100,6 +100,9 @@ public:
     /// @return list of packages skipped due to conflicts
     std::vector<libdnf5::rpm::Package> get_conflicting_packages() const;
 
+    /// @return list of packages skipped due to vendor change restriction, paired with installed vendor string
+    const std::vector<std::pair<libdnf5::rpm::Package, std::string>> & get_vendor_change_skipped_packages() const;
+
     /// @return `true` if the transaction is empty.
     bool empty() const;
 

--- a/libdnf5-cli/output/transaction_table.cpp
+++ b/libdnf5-cli/output/transaction_table.cpp
@@ -35,6 +35,7 @@
 #include <libsmartcols/libsmartcols.h>
 
 #include <algorithm>
+#include <map>
 #include <optional>
 #include <unordered_set>
 
@@ -758,6 +759,32 @@ void print_resolve_logs(const ITransaction & transaction, std::ostream & stream)
     }
 }
 
+
+void print_vendor_change_skipped(
+    const std::vector<std::pair<std::string, std::string>> & vendor_pairs, std::FILE * stream) {
+    if (vendor_pairs.empty()) {
+        return;
+    }
+    auto is_empty_vendor = [](const std::string & v) { return v.empty() || v == "<NULL>"; };
+    std::map<std::string, unsigned int> summaries;
+    for (const auto & [installed_vendor, candidate_vendor] : vendor_pairs) {
+        auto from = is_empty_vendor(installed_vendor) ? std::string(_("(none)")) : installed_vendor;
+        auto to = is_empty_vendor(candidate_vendor) ? std::string(_("(none)")) : candidate_vendor;
+        ++summaries[libdnf5::utils::sformat("\"{}\" -> \"{}\"", from, to)];
+    }
+    for (const auto & [transition, count] : summaries) {
+        std::fputs(
+            libdnf5::utils::sformat(
+                P_("Skipping {0} package due to vendor change restriction: {1}.",
+                   "Skipping {0} packages due to vendor change restriction: {1}.",
+                   count),
+                count,
+                transition)
+                .c_str(),
+            stream);
+        std::fputc('\n', stream);
+    }
+}
 
 bool print_transaction_table(ITransaction & transaction) {
     // even correctly resolved transaction can contain some warnings / hints / infos

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -3600,6 +3600,7 @@ base::Transaction Goal::resolve() {
 
     auto & pool = get_rpm_pool(p_impl->base);
     pool.get_incoming_vendor_bypassed_solvables() = p_impl->incoming_vendor_bypassed_solvables;
+    pool.clear_blocked_vendor_changes();
 
     ret |= p_impl->rpm_goal.resolve();
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -60,7 +60,7 @@
 
 #include <filesystem>
 #include <iostream>
-#include <ranges>
+#include <set>
 #include <sstream>
 #include <string_view>
 #include <thread>
@@ -221,7 +221,10 @@ Transaction::Impl::Impl(Transaction & transaction, const Impl & src)
 #endif
       resolve_logs(src.resolve_logs),
       transaction_problems(src.transaction_problems),
-      signature_problems(src.signature_problems) {
+      signature_problems(src.signature_problems),
+      broken_dependency_packages(src.broken_dependency_packages),
+      conflicting_packages(src.conflicting_packages),
+      vendor_change_skipped_packages(src.vendor_change_skipped_packages) {
 }
 
 Transaction::Impl & Transaction::Impl::operator=(const Impl & other) {
@@ -239,6 +242,9 @@ Transaction::Impl & Transaction::Impl::operator=(const Impl & other) {
     resolve_logs = other.resolve_logs;
     transaction_problems = other.transaction_problems;
     signature_problems = other.signature_problems;
+    broken_dependency_packages = other.broken_dependency_packages;
+    conflicting_packages = other.conflicting_packages;
+    vendor_change_skipped_packages = other.vendor_change_skipped_packages;
     return *this;
 }
 
@@ -416,6 +422,11 @@ std::vector<libdnf5::rpm::Package> Transaction::get_broken_dependency_packages()
 
 std::vector<libdnf5::rpm::Package> Transaction::get_conflicting_packages() const {
     return p_impl->conflicting_packages;
+}
+
+const std::vector<std::pair<libdnf5::rpm::Package, std::string>> & Transaction::get_vendor_change_skipped_packages()
+    const {
+    return p_impl->vendor_change_skipped_packages;
 }
 
 std::string Transaction::transaction_result_to_string(const TransactionRunResult result) {
@@ -694,6 +705,11 @@ void Transaction::Impl::set_transaction(
 #endif
     GoalProblem problems) {
     process_solver_problems(solved_goal);
+
+    // Snapshot blocked_vendor_changes from the first solve before the strict-mode
+    // re-solve below can add entries from its own vendor-change denials.
+    const auto blocked_vendor_changes = get_rpm_pool(base).get_blocked_vendor_changes();
+
     if (!solver_problems.empty()) {
         add_resolve_log(GoalProblem::SOLVER_ERROR, solver_problems);
     } else {
@@ -707,6 +723,60 @@ void Transaction::Impl::set_transaction(
             add_resolve_log(GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT, solver_problems);
         }
     }
+
+    // Third solve: detect packages skipped due to vendor change restriction.
+    // Only run when vendor change is disallowed and the solver actually
+    // rejected at least one vendor change during the first solve.
+    if (!base->get_config().get_allow_vendor_change_option().get_value() && !blocked_vendor_changes.empty()) {
+        rpm::solv::GoalPrivate vendor_goal(solved_goal);
+        vendor_goal.set_allow_vendor_change(true);
+        const auto vendor_problems = vendor_goal.resolve();
+        if ((vendor_problems & GoalProblem::SOLVER_ERROR) != GoalProblem::SOLVER_ERROR &&
+            vendor_goal.get_transaction()) {
+            auto & pool = get_rpm_pool(base);
+            std::set<std::string> original_nevras;
+            if (solved_goal.get_transaction()) {
+                for (auto id : solved_goal.list_upgrades()) {
+                    original_nevras.emplace(pool.get_nevra(id));
+                }
+                for (auto id : solved_goal.list_downgrades()) {
+                    original_nevras.emplace(pool.get_nevra(id));
+                }
+                for (auto id : solved_goal.list_reinstalls()) {
+                    original_nevras.emplace(pool.get_nevra(id));
+                }
+                for (auto id : solved_goal.list_installs()) {
+                    original_nevras.emplace(pool.get_nevra(id));
+                }
+            }
+
+            // A candidate was skipped due to vendor change restriction when:
+            //   1. vendor_goal (vendor change allowed) would include it, and
+            //   2. the first solve excluded it, and
+            //   3. the first solve's vendor-change callback denied the transition.
+            // blocked_vendor_changes maps incoming solvable IDs to the installed
+            // vendor string for every transition the callback denied, covering all
+            // categories — upgrades, downgrades, reinstalls, installs-via-obsolete,
+            // and installonly packages.
+            auto check = [&](libdnf5::solv::IdQueue && ids) {
+                for (auto id : ids) {
+                    if (original_nevras.contains(pool.get_nevra(id))) {
+                        continue;
+                    }
+                    auto it = blocked_vendor_changes.find(id);
+                    if (it != blocked_vendor_changes.end()) {
+                        vendor_change_skipped_packages.emplace_back(rpm::Package(base, rpm::PackageId(id)), it->second);
+                    }
+                }
+            };
+
+            check(vendor_goal.list_upgrades());
+            check(vendor_goal.list_downgrades());
+            check(vendor_goal.list_reinstalls());
+            check(vendor_goal.list_installs());
+        }
+    }
+
     this->problems = problems;
 
     if ((problems & GoalProblem::MODULE_SOLVER_ERROR) != GoalProblem::NO_PROBLEM ||

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -133,6 +133,7 @@ private:
     std::vector<std::vector<std::pair<libdnf5::ProblemRules, std::vector<std::string>>>> solver_problems{};
     std::vector<libdnf5::rpm::Package> broken_dependency_packages;
     std::vector<libdnf5::rpm::Package> conflicting_packages;
+    std::vector<std::pair<libdnf5::rpm::Package, std::string>> vendor_change_skipped_packages;
 
     // history db transaction id
     int64_t history_db_id = 0;

--- a/libdnf5/solv/pool.cpp
+++ b/libdnf5/solv/pool.cpp
@@ -35,8 +35,14 @@ namespace libdnf5::solv {
 // Check if an illegal vendor change occurs when an installed solvable is replaced by a new solvable.
 // Returns 1 if the vendor change is illegal, otherwise returns 0.
 int RpmPool::callback_policy_illegal_vendorchange(::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv) {
-    auto & vendor_change_manager = reinterpret_cast<RpmPool *>(libsolv_pool->appdata)->vendor_change_manager;
-    return vendor_change_manager.is_vendor_change_allowed(*installed, *new_solv) ? 0 : 1;
+    auto & rpmpool = *reinterpret_cast<RpmPool *>(libsolv_pool->appdata);
+    if (rpmpool.vendor_change_manager.is_vendor_change_allowed(*installed, *new_solv)) {
+        return 0;
+    }
+    Id outgoing_vendor = installed->vendor ? installed->vendor : ID_EMPTY;
+    rpmpool.blocked_vendor_changes.insert_or_assign(
+        pool_solvable2id(libsolv_pool, new_solv), std::string(pool_id2str(libsolv_pool, outgoing_vendor)));
+    return 1;
 }
 
 

--- a/libdnf5/solv/pool.cpp
+++ b/libdnf5/solv/pool.cpp
@@ -34,14 +34,22 @@ namespace libdnf5::solv {
 
 // Check if an illegal vendor change occurs when an installed solvable is replaced by a new solvable.
 // Returns 1 if the vendor change is illegal, otherwise returns 0.
-int RpmPool::callback_policy_illegal_vendorchange(::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv) {
+// noexcept: this is a C callback registered with libsolv; exceptions must not propagate into C code.
+// is_vendor_change_allowed() is intentionally outside the catch: a bug there should terminate via
+// noexcept rather than be silently swallowed. Recording the denial is best-effort only.
+int RpmPool::callback_policy_illegal_vendorchange(
+    ::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv) noexcept {
     auto & rpmpool = *reinterpret_cast<RpmPool *>(libsolv_pool->appdata);
     if (rpmpool.vendor_change_manager.is_vendor_change_allowed(*installed, *new_solv)) {
         return 0;
     }
-    Id outgoing_vendor = installed->vendor ? installed->vendor : ID_EMPTY;
-    rpmpool.blocked_vendor_changes.insert_or_assign(
-        pool_solvable2id(libsolv_pool, new_solv), std::string(pool_id2str(libsolv_pool, outgoing_vendor)));
+    try {
+        Id outgoing_vendor = installed->vendor ? installed->vendor : ID_EMPTY;
+        rpmpool.blocked_vendor_changes.insert_or_assign(
+            pool_solvable2id(libsolv_pool, new_solv), std::string(pool_id2str(libsolv_pool, outgoing_vendor)));
+    } catch (...) {
+        // Recording is best-effort; allocation failures must not escape into C code.
+    }
     return 1;
 }
 

--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -28,6 +28,8 @@
 
 #include <climits>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 extern "C" {
 #include <solv/dataiterator.h>
@@ -281,12 +283,22 @@ public:
         return vendor_change_manager.get_incoming_vendor_bypassed_solvables();
     }
 
+    /// Clear the denied-vendor-change record before each solver run.
+    void clear_blocked_vendor_changes() { blocked_vendor_changes.clear(); }
+
+    /// Return the map of incoming solvable IDs that were denied a vendor change
+    /// during the last solve, paired with the installed (outgoing) vendor string.
+    [[nodiscard]] const std::unordered_map<Id, std::string> & get_blocked_vendor_changes() const noexcept {
+        return blocked_vendor_changes;
+    }
+
 private:
     friend class VendorChangeManager;
 
     static int callback_policy_illegal_vendorchange(::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv);
 
     VendorChangeManager vendor_change_manager;
+    std::unordered_map<Id, std::string> blocked_vendor_changes;
 };
 
 

--- a/libdnf5/solv/pool.hpp
+++ b/libdnf5/solv/pool.hpp
@@ -295,7 +295,8 @@ public:
 private:
     friend class VendorChangeManager;
 
-    static int callback_policy_illegal_vendorchange(::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv);
+    static int callback_policy_illegal_vendorchange(
+        ::Pool * libsolv_pool, Solvable * installed, Solvable * new_solv) noexcept;
 
     VendorChangeManager vendor_change_manager;
     std::unordered_map<Id, std::string> blocked_vendor_changes;


### PR DESCRIPTION
When allow_vendor_change=false (planned Fedora 45 default), the solver silently drops upgrade/downgrade candidates that would change a package's vendor. The only user-visible output is "Nothing to do." with no indication of what was skipped or why.

Run another goal resolve with `allow_vendor_change=true` and diff the results to identify which packages were blocked by vendor policy. Print a `Skipping N package(s) due to vendor change restriction: 'Vendor A' -> 'Vendor B'.` messages for each vendor transition, followed by a hint pointing to `--setopt=allow_vendor_change=true`.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2818