### PR TITLE
Remove modularity support from advisories if compiled without modulemd

### DIFF
--- a/dnf5daemon-client/wrappers/dbus_advisory_wrapper.cpp
+++ b/dnf5daemon-client/wrappers/dbus_advisory_wrapper.cpp
@@ -45,10 +45,12 @@ DbusAdvisoryCollectionWrapper::DbusAdvisoryCollectionWrapper(
     for (const auto & pkg : raw_packages) {
         packages.emplace_back(pkg, advisory);
     }
+#ifdef WITH_MODULEMD
     auto raw_modules = key_value_map_get<KeyValueMapList>(rawdata, "modules", {});
     for (const auto & mdl : raw_modules) {
         modules.emplace_back(mdl, advisory);
     }
+#endif
 }
 
 

--- a/dnf5daemon-server/advisory.cpp
+++ b/dnf5daemon-server/advisory.cpp
@@ -95,6 +95,7 @@ KeyValueMapList collections_to_list(
             packages.emplace_back(std::move(package));
         }
 
+#ifdef WITH_MODULEMD
         KeyValueMapList modules;
         auto libdnf_modules = col.get_modules();
         for (const auto & mdl : libdnf_modules) {
@@ -107,10 +108,13 @@ KeyValueMapList collections_to_list(
             col_module["nsvca"] = sdbus::Variant(mdl.get_nsvca());
             modules.emplace_back(std::move(col_module));
         }
+#endif
 
         KeyValueMap collection;
         collection["packages"] = sdbus::Variant(std::move(packages));
+#ifdef WITH_MODULEMD
         collection["modules"] = sdbus::Variant(std::move(modules));
+#endif
         collections.emplace_back(std::move(collection));
     }
     return collections;

--- a/doc/commands/advisory.8.rst
+++ b/doc/commands/advisory.8.rst
@@ -55,7 +55,7 @@ Subcommands
 
 ``info``
     | Print detailed information about advisories.
-    | For each matching advisory, displays: Name, Title, Severity, Type, Status, Vendor, Issued date, Description, Message, Rights, References (with Title, Id, Type, and URL), and affected packages/modules organized by collection.
+    | For each matching advisory, displays: Name, Title, Severity, Type, Status, Vendor, Issued date, Description, Message, Rights, References (with Title, Id, Type, and URL), and affected packages@IF WITH_MODULEMD@/modules @ENDIF@organized by collection.
 
 ``summary``
     | Print a summary count of advisories by type and severity.
@@ -180,10 +180,10 @@ Each advisory object contains the following fields:
   - ``Type`` (string) - Reference type (cve, bugzilla, etc.).
   - ``Url`` (string) - Reference URL.
 
-- ``collections`` (object) - Package and module collections affected by the advisory:
+- ``collections`` (object) - Package @IF WITH_MODULEMD@and module @ENDIF@collections affected by the advisory:
 
-  - ``packages`` (array) - List of affected package NEVRAs (only present if packages exist).
-  - ``modules`` (array) - List of affected module NSVCAs (only present if modules exist).
+  - ``packages`` (array) - List of affected package NEVRAs (only present if packages exist).@IF WITH_MODULEMD@
+  - ``modules`` (array) - List of affected module NSVCAs (only present if modules exist).@ENDIF@
 
 For empty results:
 

--- a/libdnf5-cli/output/advisoryinfo.cpp
+++ b/libdnf5-cli/output/advisoryinfo.cpp
@@ -70,6 +70,7 @@ void AdvisoryInfo::Impl::add_advisory(IAdvisory & advisory) {
     for (auto & collection : advisory.get_collections()) {
         auto group_collection = add_line("Collection", "");
 
+#ifdef WITH_MODULEMD
         // Modules
         auto modules = collection->get_modules();
         if (!modules.empty()) {
@@ -81,6 +82,7 @@ void AdvisoryInfo::Impl::add_advisory(IAdvisory & advisory) {
                 module_iter++;
             }
         }
+#endif
 
         // Packages
         auto packages = collection->get_packages();
@@ -126,6 +128,7 @@ void AdvisoryInfoJSON::Impl::add_advisory(IAdvisory & advisory) {
     // Collections
     json_object * json_collections = json_object_new_object();
     for (auto & collection : advisory.get_collections()) {
+#ifdef WITH_MODULEMD
         // Modules
         auto modules = collection->get_modules();
         if (!modules.empty()) {
@@ -135,6 +138,7 @@ void AdvisoryInfoJSON::Impl::add_advisory(IAdvisory & advisory) {
             }
             json_object_object_add(json_collections, "modules", json_modules);
         }
+#endif
 
         // Packages
         auto packages = collection->get_packages();

--- a/libdnf5/advisory/advisory_collection.cpp
+++ b/libdnf5/advisory/advisory_collection.cpp
@@ -19,6 +19,10 @@
 
 
 #include "libdnf5/advisory/advisory_collection.hpp"
+#ifndef WITH_MODULEMD
+#include "libdnf5/common/exception.hpp"
+#include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+#endif
 
 #include "advisory/advisory_module_private.hpp"
 #include "advisory/advisory_package_private.hpp"
@@ -84,7 +88,11 @@ std::vector<AdvisoryPackage> AdvisoryCollection::get_packages() {
 
 std::vector<AdvisoryModule> AdvisoryCollection::get_modules() {
     std::vector<AdvisoryModule> output;
+#ifdef WITH_MODULEMD
     p_impl->get_modules(output);
+#else
+    throw RuntimeError(M_("This libdnf5 does not support modularity"));
+#endif
     return output;
 }
 
@@ -131,6 +139,7 @@ void AdvisoryCollection::get_packages(std::vector<AdvisoryPackage> & output, boo
     dataiterator_free(&di);
 }
 
+#ifdef WITH_MODULEMD
 void AdvisoryCollection::Impl::get_modules(std::vector<AdvisoryModule> & output) {
     Dataiterator di;
     auto & pool = get_rpm_pool(base);
@@ -159,6 +168,7 @@ void AdvisoryCollection::Impl::get_modules(std::vector<AdvisoryModule> & output)
     }
     dataiterator_free(&di);
 }
+#endif
 
 AdvisoryId AdvisoryCollection::get_advisory_id() const {
     return p_impl->advisory;

--- a/test/libdnf5/advisory/test_advisory.cpp
+++ b/test/libdnf5/advisory/test_advisory.cpp
@@ -91,10 +91,12 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), pkgs[1].get_name());
 
+#if WITH_MODULEMD
     std::vector<libdnf5::advisory::AdvisoryModule> mods = c.get_modules();
     CPPUNIT_ASSERT_EQUAL((size_t)2, mods.size());
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), mods[1].get_name());
+#endif
 
     libdnf5::advisory::AdvisoryQuery adv_query(base);
     adv_query.filter_name("DNF-2020-1");
@@ -109,10 +111,12 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL(std::string("wget"), pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("yum"), pkgs[1].get_name());
 
+#if WITH_MODULEMD
     mods.clear();
     mods = c1.get_modules();
     CPPUNIT_ASSERT_EQUAL((size_t)1, mods.size());
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
+#endif
 
     libdnf5::advisory::AdvisoryCollection c2 = colls[1];
     pkgs.clear();
@@ -120,8 +124,10 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL((size_t)1, pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), pkgs[0].get_name());
 
+#if WITH_MODULEMD
     mods.clear();
     mods = c2.get_modules();
     CPPUNIT_ASSERT_EQUAL((size_t)1, mods.size());
     CPPUNIT_ASSERT_EQUAL(std::string("perl"), mods[0].get_name());
+#endif
 }

--- a/test/libdnf5/advisory/test_advisory_module.cpp
+++ b/test/libdnf5/advisory/test_advisory_module.cpp
@@ -37,9 +37,14 @@ void AdvisoryAdvisoryModuleTest::setUp() {
     advisories.filter_name("DNF-2019-1");
     libdnf5::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf5::advisory::AdvisoryCollection> collections = advisory.get_collections();
+#ifdef WITH_MODULEMD
     modules = collections[0].get_modules();
+#else
+    CPPUNIT_ASSERT_THROW(collections[0].get_modules(), libdnf5::RuntimeError);
+#endif
 }
 
+#ifdef WITH_MODULEMD
 void AdvisoryAdvisoryModuleTest::test_get_name() {
     // Tests get_name method
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), std::string(modules[0].get_name()));
@@ -84,3 +89,4 @@ void AdvisoryAdvisoryModuleTest::test_get_advisory_collection() {
     size_t target_size = 2;
     CPPUNIT_ASSERT_EQUAL(target_size, out_mods.size());
 }
+#endif

--- a/test/libdnf5/advisory/test_advisory_module.hpp
+++ b/test/libdnf5/advisory/test_advisory_module.hpp
@@ -31,6 +31,7 @@
 class AdvisoryAdvisoryModuleTest : public BaseTestCase {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryModuleTest);
 
+#ifdef WITH_MODULEMD
     CPPUNIT_TEST(test_get_name);
     CPPUNIT_TEST(test_get_stream);
     CPPUNIT_TEST(test_get_version);
@@ -40,12 +41,14 @@ class AdvisoryAdvisoryModuleTest : public BaseTestCase {
     CPPUNIT_TEST(test_get_advisory_id);
     CPPUNIT_TEST(test_get_advisory);
     CPPUNIT_TEST(test_get_advisory_collection);
+#endif
 
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void setUp() override;
 
+#ifdef WITH_MODULEMD
     void test_get_name();
     void test_get_stream();
     void test_get_version();
@@ -55,6 +58,7 @@ public:
     void test_get_advisory_id();
     void test_get_advisory();
     void test_get_advisory_collection();
+#endif
 
 private:
     std::vector<libdnf5::advisory::AdvisoryModule> modules;

--- a/test/python3/libdnf5/CMakeLists.txt
+++ b/test/python3/libdnf5/CMakeLists.txt
@@ -4,6 +4,7 @@ set_property(TEST test_python3_libdnf PROPERTY RUN_SERIAL TRUE)
 
 set_property(TEST test_python3_libdnf PROPERTY ENVIRONMENT
     "LC_ALL=C"
+    "WITH_MODULEMD=${WITH_MODULEMD}"
     "PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}"
     "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
     "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python3"

--- a/test/python3/libdnf5/advisory/test_advisory.py
+++ b/test/python3/libdnf5/advisory/test_advisory.py
@@ -128,20 +128,24 @@ class TestAdvisory(base_test_case.BaseTestCase):
 
     def test_advisory_modules(self):
         collection = self.advisory.get_collections()[0]
-        adv_modules = collection.get_modules()
-        self.assertEqual(len(adv_modules), 2)
-        adv_module = adv_modules[0]
+        if base_test_case.WITH_MODULEMD:
+            adv_modules = collection.get_modules()
+            self.assertEqual(len(adv_modules), 2)
+            adv_module = adv_modules[0]
 
-        self.assertEqual(adv_module.get_advisory_id(), self.advisory.get_id())
-        self.assertEqual(adv_module.get_advisory(), self.advisory)
-        # We can't compare the collections directly because adv_module constructs
-        # a new instance of the same collection
-        self.assertEqual(adv_module.get_advisory_collection(
-        ).get_advisory_id(), self.advisory.get_id())
+            self.assertEqual(adv_module.get_advisory_id(), self.advisory.get_id())
+            self.assertEqual(adv_module.get_advisory(), self.advisory)
+            # We can't compare the collections directly because adv_module constructs
+            # a new instance of the same collection
+            self.assertEqual(adv_module.get_advisory_collection(
+            ).get_advisory_id(), self.advisory.get_id())
 
-        self.assertEqual(adv_module.get_name(), "perl-DBI")
-        self.assertEqual(adv_module.get_stream(), "master")
-        self.assertEqual(adv_module.get_version(), "2")
-        self.assertEqual(adv_module.get_context(), "2a")
-        self.assertEqual(adv_module.get_arch(), "x86_64")
-        self.assertEqual(adv_module.get_nsvca(), "perl-DBI:master:2:2a:x86_64")
+            self.assertEqual(adv_module.get_name(), "perl-DBI")
+            self.assertEqual(adv_module.get_stream(), "master")
+            self.assertEqual(adv_module.get_version(), "2")
+            self.assertEqual(adv_module.get_context(), "2a")
+            self.assertEqual(adv_module.get_arch(), "x86_64")
+            self.assertEqual(adv_module.get_nsvca(), "perl-DBI:master:2:2a:x86_64")
+        else:
+            with self.assertRaises(libdnf5.exception.RuntimeError):
+                collection.get_modules()

--- a/test/python3/libdnf5/base_test_case.py
+++ b/test/python3/libdnf5/base_test_case.py
@@ -28,6 +28,7 @@ import libdnf5
 
 PROJECT_BINARY_DIR = os.environ["PROJECT_BINARY_DIR"]
 PROJECT_SOURCE_DIR = os.environ["PROJECT_SOURCE_DIR"]
+WITH_MODULEMD = os.environ["WITH_MODULEMD"] == "ON"
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
"dnf5 advisory info --json" used to print "modules" collections in the
JSON output even if DNF5 was built with -DWITH_MODULEMD=OFF.

This patch stops processing and reporting modular data from updateinfo
repository metadata if modularity is disabled at build time. This
involes all "dnf5 advisory" outputs, documentation, D-Bus API, and
libdnf5 API.

To preserve public ABI and API, all modularity classes and class
members were preserved. But AdvisoryCollection::get_modules() now
raises a libdnf5::RuntimeError exception to distinguish from an empty
list of modules.

For the very same reason the modularity code could not been removed
from the D-Bus daemon (it extends libdnf5 API using subclassed templates
and thus needs to implement get_modules() method).

This patch also adapts the tests to expect the exception if modularity
is disabled.

Requires: #2806