### PR TITLE
Disable modular filtering if modularity support is disabled

### DIFF
--- a/dnf5-plugins/reposync_plugin/reposync.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync.cpp
@@ -231,7 +231,11 @@ ReposyncCommand::download_list_type ReposyncCommand::get_packages_list(const lib
     // a separator is enforced.
     safe_write_path /= "";
 
+#ifdef WITH_MODULEMD
     libdnf5::rpm::PackageQuery query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_MODULAR_EXCLUDES);
+#else
+    libdnf5::rpm::PackageQuery query(ctx.get_base());
+#endif
     query.filter_available();
     query.filter_repo_id(repo.get_id());
 

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -331,8 +331,10 @@ void RepoqueryCommand::set_argument_parser() {
         '\0',
         "After filtering is finished use packages' corresponding source RPMs for output (enables source repositories).",
         false);
+#ifdef WITH_MODULEMD
     disable_modular_filtering = std::make_unique<libdnf5::cli::session::BoolOption>(
         *this, "disable-modular-filtering", '\0', "Include packages of inactive module streams.", false);
+#endif
 
     // Allowed values for --providers-of options (these package attributes return ReldepLists)
     std::vector<std::string> pkg_attrs_options{
@@ -559,9 +561,13 @@ static libdnf5::rpm::PackageSet resolve_nevras_to_packges(
 void RepoqueryCommand::run() {
     auto & ctx = get_context();
 
+#if WITH_MODULEMD
     libdnf5::sack::ExcludeFlags flags = disable_modular_filtering->get_value()
                                             ? libdnf5::sack::ExcludeFlags::IGNORE_MODULAR_EXCLUDES
                                             : libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES;
+#else
+    libdnf5::sack::ExcludeFlags flags = libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES;
+#endif
     if (!upgrades->get_value()) {
         flags = flags | libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK;
     }

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -74,7 +74,9 @@ private:
     std::unique_ptr<libdnf5::cli::session::BoolOption> recent{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> installonly{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> srpm{nullptr};
+#ifdef WITH_MODULEMD
     std::unique_ptr<libdnf5::cli::session::BoolOption> disable_modular_filtering{nullptr};
+#endif
     std::unique_ptr<libdnf5::cli::session::BoolOption> changelogs{nullptr};
     std::unique_ptr<libdnf5::cli::session::BoolOption> recursive{nullptr};
 

--- a/doc/commands/repoquery.8.rst
+++ b/doc/commands/repoquery.8.rst
@@ -60,8 +60,10 @@ Options
 
 .. include:: ../_shared/options/cves.rst
 
+@IF WITH_MODULEMD@
 ``--disable-modular-filtering``
     | Include packages of inactive module streams.
+@ENDIF@
 
 ``--duplicates``
     | Limit to installed duplicate packages (i.e. more package versions for  the  same  name and architecture).

--- a/doc/libdnf5_plugins/actions.8.rst
+++ b/doc/libdnf5_plugins/actions.8.rst
@@ -492,7 +492,7 @@ The ``trans_packages`` domain can only be used in ``goal_resolved``, ``pre_trans
    * ``IN`` - packages coming to the system (downgrade, install, reinstall, upgrade)
    * ``OUT`` - packages going out of the system (upgraded, downgraded, reinstalled, removed, replaced/obsoleted)
 
-* ``<param_name>`` - one of ``IGNORE_EXCLUDES``, ``IGNORE_MODULAR_EXCLUDES``, ``IGNORE_REGULAR_EXCLUDES``, ``IGNORE_REGULAR_CONFIG_EXCLUDES``, ``IGNORE_REGULAR_USER_EXCLUDES``
+* ``<param_name>`` - one of ``IGNORE_EXCLUDES``@IF WITH_MODULEMD@, ``IGNORE_MODULAR_EXCLUDES``@ENDIF@, ``IGNORE_REGULAR_EXCLUDES``, ``IGNORE_REGULAR_CONFIG_EXCLUDES``, ``IGNORE_REGULAR_USER_EXCLUDES``
 * ``<filter_name>`` - name of package attribute to filter; the array can contain multiple attributes
 
   General attributes

--- a/libdnf5-plugins/actions/actions.cpp
+++ b/libdnf5-plugins/actions/actions.cpp
@@ -1405,7 +1405,11 @@ void Actions::process_json_command(const CommandToRun & command, struct json_obj
                         if (param_key == "IGNORE_EXCLUDES") {
                             query_flags = query_flags | libdnf5::sack::ExcludeFlags::IGNORE_EXCLUDES;
                         } else if (param_key == "IGNORE_MODULAR_EXCLUDES") {
+#ifdef WITH_MODULEMD
                             query_flags = query_flags | libdnf5::sack::ExcludeFlags::IGNORE_MODULAR_EXCLUDES;
+#else
+                            // accept but ignore this parameter to preserve compatibility
+#endif
                         } else if (param_key == "IGNORE_REGULAR_EXCLUDES") {
                             query_flags = query_flags | libdnf5::sack::ExcludeFlags::IGNORE_REGULAR_EXCLUDES;
                         } else if (param_key == "IGNORE_REGULAR_CONFIG_EXCLUDES") {

--- a/libdnf5/rpm/package_sack.cpp
+++ b/libdnf5/rpm/package_sack.cpp
@@ -327,6 +327,7 @@ void PackageSack::Impl::clear_user_includes() {
     considered_uptodate = false;
 }
 
+#ifdef WITH_MODULEMD
 const PackageSet PackageSack::Impl::get_module_excludes() {
     if (module_excludes) {
         return PackageSet(base, *module_excludes);
@@ -360,6 +361,7 @@ void PackageSack::Impl::clear_module_excludes() {
     module_excludes.reset();
     considered_uptodate = false;
 }
+#endif
 
 VersionlockConfig PackageSack::Impl::get_versionlock_config() const {
     const auto & config = base->get_config();
@@ -412,7 +414,9 @@ std::optional<libdnf5::solv::SolvMap> PackageSack::Impl::compute_considered_map(
         (static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::IGNORE_REGULAR_USER_EXCLUDES) ||
          (!user_excludes && !user_includes)) &&
         (static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::USE_DISABLED_REPOSITORIES) || !repo_excludes) &&
+#ifdef WITH_MODULEMD
         (static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::IGNORE_MODULAR_EXCLUDES) || !module_excludes) &&
+#endif
         (static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK) || !versionlock_excludes)) {
         return {};
     }
@@ -425,9 +429,11 @@ std::optional<libdnf5::solv::SolvMap> PackageSack::Impl::compute_considered_map(
     //              (config_includes + user_includes + all_from_repos_not_using_includes)
     considered.set_all();
 
+#ifdef WITH_MODULEMD
     if (!static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::IGNORE_MODULAR_EXCLUDES) && module_excludes) {
         considered -= *module_excludes;
     }
+#endif
 
     if (!static_cast<bool>(flags & libdnf5::sack::ExcludeFlags::USE_DISABLED_REPOSITORIES) && repo_excludes) {
         considered -= *repo_excludes;

--- a/libdnf5/rpm/package_sack_impl.hpp
+++ b/libdnf5/rpm/package_sack_impl.hpp
@@ -106,11 +106,13 @@ public:
     void set_user_includes(const PackageSet & includes);
     void clear_user_includes();
 
+#ifdef WITH_MODULEMD
     const PackageSet get_module_excludes();
     void add_module_excludes(const PackageSet & excludes);
     void remove_module_excludes(const PackageSet & excludes);
     void set_module_excludes(const PackageSet & excludes);
     void clear_module_excludes();
+#endif
 
     VersionlockConfig get_versionlock_config() const;
     const PackageSet get_versionlock_excludes();
@@ -145,7 +147,9 @@ private:
     // TODO(jrohel): Recompute when state of repository is changed enabled/disabled or added solvable to disabled repo
     std::unique_ptr<libdnf5::solv::SolvMap> repo_excludes;
 
+#ifdef WITH_MODULEMD
     std::unique_ptr<libdnf5::solv::SolvMap> module_excludes;  // packages excluded by modularity
+#endif
 
     // packages excluded by versionlock feature
     std::unique_ptr<libdnf5::solv::SolvMap> versionlock_excludes;  // packages excluded by versionlock


### PR DESCRIPTION
This patch disables modular filtering code, "dnf5 repoquery
--disable-modular-filtering" option, and modular filtering from
a documenation if DNF5 is built without modularity support.

A configuration parsers of the actions plugin is kept to ignore
IGNORE_MODULAR_EXCLUDES parameter in order not break old configuration
files.

Requires: #2806