### PR TITLE
MultiProgressBar: Optimize performance when registering many bars, exclude negative values from ticks and total_ticks sums

### DIFF
--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -195,7 +195,6 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
         // skip printing bars that haven't started yet
         if (bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::STARTED) {
-            bar->update();
             continue;
         }
 

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -218,22 +218,21 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     // then print the "total" progress bar
-    // completed bars can be unfinished
-    // add only processed ticks to both values
-    int64_t ticks = mbar.p_impl->done_ticks;
-    int64_t total_ticks = ticks;
-
-    for (auto & bar : mbar.p_impl->bars_todo) {
-        if (const auto bar_total_ticks = bar->get_total_ticks(); bar_total_ticks > 0) {
-            total_ticks += bar_total_ticks;
-        }
-        if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
-            ticks += bar_ticks;
-        }
-    }
-
     if ((mbar.p_impl->bars_all.size() >= mbar.p_impl->total_bar_visible_limit) &&
         (is_interactive || mbar.p_impl->bars_todo.empty())) {
+        // compute ticks and total_ticks for total progress bar
+        // done bars can be unfinished -> add only processed ticks to both values
+        int64_t ticks = mbar.p_impl->done_ticks;
+        int64_t total_ticks = ticks;
+        for (auto & bar : mbar.p_impl->bars_todo) {
+            if (const auto bar_total_ticks = bar->get_total_ticks(); bar_total_ticks > 0) {
+                total_ticks += bar_total_ticks;
+            }
+            if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
+                ticks += bar_ticks;
+            }
+        }
+
         if (mbar.p_impl->line_printed) {
             text_buffer << std::endl;
         }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -47,6 +47,9 @@ public:
     // Whether the last line was printed without a new line ending (such as an in progress bar)
     bool line_printed{false};
     std::size_t num_of_lines_to_clear{0};
+
+    // Reused across operator<< calls to retain allocated capacity between renders
+    std::ostringstream text_buffer;
 };
 
 
@@ -147,9 +150,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
     // We'll buffer the output text to a single string and print it all at once.
     // This is to avoid multiple writes to the terminal, which can cause flickering.
-    static std::ostringstream text_buffer;
-    text_buffer.str("");
-    text_buffer.clear();
+    std::ostringstream & text_buffer = mbar.p_impl->text_buffer;
 
     if (is_interactive && mbar.p_impl->num_of_lines_to_clear > 0) {
         if (mbar.p_impl->num_of_lines_to_clear > 1) {
@@ -263,6 +264,9 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     stream << text_buffer.str();  // Single syscall to output all commands
+
+    text_buffer.str("");
+    text_buffer.clear();
 
     return stream;
 }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -43,6 +43,7 @@ public:
     std::vector<ProgressBar *> bars_todo;
     std::vector<ProgressBar *> bars_done;
     DownloadProgressBar total;
+    int64_t done_ticks{0};
     // Whether the last line was printed without a new line ending (such as an in progress bar)
     bool line_printed{false};
     std::size_t num_of_lines_to_clear{0};
@@ -182,6 +183,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         bar->set_total(total_num_of_bars);
         text_buffer << *bar;
         text_buffer << std::endl;
+
+        if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
+            mbar.p_impl->done_ticks += bar_ticks;
+        }
         mbar.p_impl->bars_done.push_back(bar);
         it = mbar.p_impl->bars_todo.erase(it);
     }
@@ -213,17 +218,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     }
 
     // then print the "total" progress bar
-    int64_t ticks = 0;
-    int64_t total_ticks = 0;
-
-    for (auto & bar : mbar.p_impl->bars_done) {
-        if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
-            ticks += bar_ticks;
-        }
-    }
     // completed bars can be unfinished
     // add only processed ticks to both values
-    total_ticks = ticks;
+    int64_t ticks = mbar.p_impl->done_ticks;
+    int64_t total_ticks = ticks;
 
     for (auto & bar : mbar.p_impl->bars_todo) {
         if (const auto bar_total_ticks = bar->get_total_ticks(); bar_total_ticks > 0) {

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -217,15 +217,21 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     int64_t total_ticks = 0;
 
     for (auto & bar : mbar.p_impl->bars_done) {
-        // completed bars can be unfinished
-        // add only processed ticks to both values
-        total_ticks += bar->get_ticks();
-        ticks += bar->get_ticks();
+        if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
+            ticks += bar_ticks;
+        }
     }
+    // completed bars can be unfinished
+    // add only processed ticks to both values
+    total_ticks = ticks;
 
     for (auto & bar : mbar.p_impl->bars_todo) {
-        total_ticks += bar->get_total_ticks();
-        ticks += bar->get_ticks();
+        if (const auto bar_total_ticks = bar->get_total_ticks(); bar_total_ticks > 0) {
+            total_ticks += bar_total_ticks;
+        }
+        if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
+            ticks += bar_ticks;
+        }
     }
 
     if ((mbar.p_impl->bars_all.size() >= mbar.p_impl->total_bar_visible_limit) &&

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -41,7 +41,7 @@ public:
     std::size_t total_bar_visible_limit{0};
     std::vector<std::unique_ptr<ProgressBar>> bars_all;
     std::vector<ProgressBar *> bars_todo;
-    std::vector<ProgressBar *> bars_done;
+    std::size_t bars_done_count{0};
     DownloadProgressBar total;
     int64_t done_ticks{0};
     // Whether the last line was printed without a new line ending (such as an in progress bar)
@@ -164,10 +164,10 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     mbar.p_impl->num_of_lines_to_clear = 0;
     mbar.p_impl->line_printed = false;
 
-    // initialize bar number counter to bars_done.size(), clamp to bounds on overflow
-    auto number = cast_to_bar_number(mbar.p_impl->bars_done.size());
+    // initialize bar number counter to bars_done_count, clamp to bounds on overflow
+    auto number = cast_to_bar_number(mbar.p_impl->bars_done_count);
 
-    // print completed bars first and move them from bars_todo to bars_done
+    // print completed bars first and remove them from bars_todo
     for (auto it = mbar.p_impl->bars_todo.begin(); it != mbar.p_impl->bars_todo.end();) {
         auto * const bar = *it;
 
@@ -187,7 +187,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         if (const auto bar_ticks = bar->get_ticks(); bar_ticks > 0) {
             mbar.p_impl->done_ticks += bar_ticks;
         }
-        mbar.p_impl->bars_done.push_back(bar);
+        ++mbar.p_impl->bars_done_count;
         it = mbar.p_impl->bars_todo.erase(it);
     }
 
@@ -243,7 +243,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
         // print Total progress bar
         auto & mbar_total = mbar.get_total_bar();
-        mbar_total.set_number(cast_to_bar_number(mbar.p_impl->bars_done.size()));
+        mbar_total.set_number(cast_to_bar_number(mbar.p_impl->bars_done_count));
 
         mbar_total.set_total_ticks(total_ticks);
         mbar_total.set_ticks(ticks);

--- a/libdnf5-cli/progressbar/progress_bar.cpp
+++ b/libdnf5-cli/progressbar/progress_bar.cpp
@@ -67,7 +67,6 @@ public:
     bool auto_finish = true;
 
     std::chrono::time_point<std::chrono::system_clock> begin = std::chrono::system_clock::from_time_t(0);
-    std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::from_time_t(0);
 
     // current (average) speed over the last second
     std::chrono::time_point<std::chrono::system_clock> current_speed_window_start = std::chrono::system_clock::now();
@@ -253,7 +252,6 @@ void ProgressBar::reset() {
     p_impl->average_speed = 0;
     p_impl->auto_finish = true;
     p_impl->begin = std::chrono::system_clock::from_time_t(0);
-    p_impl->end = std::chrono::system_clock::from_time_t(0);
     p_impl->current_speed_window_start = std::chrono::system_clock::now();
     p_impl->current_speed = 0;
     p_impl->current_speed_window_ticks = 0;
@@ -352,7 +350,6 @@ void ProgressBar::update() {
             // avoid calling set_state() because it triggers update() and ends up in an endless recursion
             p_impl->state = ProgressBarState::SUCCESS;
         }
-        p_impl->end = now;
         p_impl->percent_done = 100;
         p_impl->remaining_seconds = 0;
     }

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -667,7 +667,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_already_downloade
         "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
         ">>> Already Downloaded\n"
         "----------------------------------------------------------------------\n"
-        "\\[1/3\\] Total                   ???% | ????? ??B\\/s |  -2.0   B | ???????";
+        "\\[1/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
 
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
@@ -685,7 +685,7 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_already_downloade
         "\\[2/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
         ">>> Already Downloaded\n"
         "----------------------------------------------------------------------\n"
-        "\\[2/3\\] Total                   ???% | ????? ??B\\/s |  -1.0   B | ???????";
+        "\\[2/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 
     // In progress download


### PR DESCRIPTION
Follow-up to the previous MultiProgressBar optimization https://github.com/rpm-software-management/dnf5/pull/2817, continuing optimization and bug fixes in MultiProgressBar rendering. Further performance improvements will likely require changes outside the rendering itself - in particular, adjusting when and how often `operator<<` is called.

Related to: https://github.com/rpm-software-management/dnf5/issues/2790

## Dead code removal
  
- **ProgressBar**: Remove `end` timestamp field set in `update()` but never read.

## Bug fix

- **MultiProgressBar**: Exclude negative tick values (e.g. -1 after creation) from `ticks` and `total_ticks` sums. Previously, uninitialized bars contributed negative ticks to the total progress bar.

## Performance

- **MultiProgressBar**: Remove unnecessary `update()` call on bars that have not started yet; it served no purpose and wasted CPU on every render when many unstarted bars were registered.

- **MultiProgressBar**: Replace `bars_done` vector with a counter, eliminating the memory allocation and `push_back` overhead.

- **MultiProgressBar**: Maintain `done_ticks` as an incremental counter updated when a bar moves to bars_done, replacing an O(n) loop over all done bars on every render.

- **MultiProgressBar**: Move ticks computation inside the total bar visibility guard so it runs only when the total bar is rendered.

## Code quality

- **MultiProgressBar**: Move `text_buffer` from a static local to an `Impl` member, fixing a shared-state issue when multiple MultiProgressBar instances exist.
