### PR TITLE
Disuse modular configuration options if built without modularity

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -474,10 +474,12 @@ void OfflineExecuteCommand::configure() {
     ctx.get_base().get_config().get_system_cachedir_option().set(cachedir);
     ctx.get_base().get_config().get_cachedir_option().set(cachedir);
 
+#ifdef WITH_MODULEMD
     auto module_platform_id = state->get_data().get_module_platform_id();
     if (!module_platform_id.empty()) {
         ctx.get_base().get_config().get_module_platform_id_option().set(module_platform_id);
     }
+#endif
 }
 
 void OfflineExecuteCommand::run() {

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -387,9 +387,11 @@ void Context::Impl::store_offline(libdnf5::base::Transaction & transaction) {
     }
     offline_data.set_target_releasever(base.get_vars()->get_value("releasever"));
 
+#ifdef WITH_MODULEMD
     if (!base.get_config().get_module_platform_id_option().empty()) {
         offline_data.set_module_platform_id(base.get_config().get_module_platform_id_option().get_value());
     }
+#endif
 
     state.capture_rpmdb_cookie(base);
     state.write();

--- a/dnf5daemon-server/services/offline/offline.cpp
+++ b/dnf5daemon-server/services/offline/offline.cpp
@@ -279,7 +279,9 @@ sdbus::MethodReply Offline::get_status(sdbus::MethodCall & call) {
         transaction_state["verb"] = sdbus::Variant(state_data.get_verb());
         transaction_state["cmd_line"] = sdbus::Variant(state_data.get_cmd_line());
         transaction_state["poweroff_after"] = sdbus::Variant(state_data.get_poweroff_after());
+#ifdef WITH_MODULEMD
         transaction_state["module_platform_id"] = sdbus::Variant(state_data.get_module_platform_id());
+#endif
     }
 
     auto reply = call.createReply();

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -61,7 +61,9 @@ static const std::unordered_set<std::string> ALLOWED_MAIN_CONF_OVERRIDES = {
     "installonlypkgs",
     "install_weak_deps",
     "keepcache",
+#ifdef WITH_MODULEMD
     "module_obsoletes",
+#endif
     "module_platform_id",
     "module_stream_switch",
     "multilib_policy",

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -64,8 +64,8 @@ static const std::unordered_set<std::string> ALLOWED_MAIN_CONF_OVERRIDES = {
 #ifdef WITH_MODULEMD
     "module_obsoletes",
     "module_platform_id",
-#endif
     "module_stream_switch",
+#endif
     "multilib_policy",
     "obsoletes",
     "optional_metadata_types",

--- a/dnf5daemon-server/session.cpp
+++ b/dnf5daemon-server/session.cpp
@@ -63,8 +63,8 @@ static const std::unordered_set<std::string> ALLOWED_MAIN_CONF_OVERRIDES = {
     "keepcache",
 #ifdef WITH_MODULEMD
     "module_obsoletes",
-#endif
     "module_platform_id",
+#endif
     "module_stream_switch",
     "multilib_policy",
     "obsoletes",
@@ -407,10 +407,12 @@ void Session::store_transaction_offline(bool downloadonly) {
     }
     state_data.set_target_releasever(base->get_vars()->get_value("releasever"));
 
+#ifdef WITH_MODULEMD
     const auto module_platform_id = base->get_config().get_module_platform_id_option();
     if (!module_platform_id.empty()) {
         state_data.set_module_platform_id(module_platform_id.get_value());
     }
+#endif
 
     // create the magic symlink /system-update -> datadir
     if (downloadonly) {

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -397,6 +397,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``1M``.
 
+@IF WITH_MODULEMD@
 .. _module_platform_id_options-label:
 
 ``module_platform_id``
@@ -406,6 +407,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     It is necessary to perform a system upgrade and switch to a new platform.
 
     Default: empty.
+@ENDIF@
 
 .. _module_stream_switch_options-label:
 

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -407,7 +407,6 @@ repository configuration file should aside from repo ID consists of baseurl, met
     It is necessary to perform a system upgrade and switch to a new platform.
 
     Default: empty.
-@ENDIF@
 
 .. _module_stream_switch_options-label:
 
@@ -417,6 +416,7 @@ repository configuration file should aside from repo ID consists of baseurl, met
     If enabled, allows switching enabled streams of a module.
 
     Default: ``False``.
+@ENDIF@
 
 .. _multilib_policy_options-label:
 

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -218,7 +218,9 @@ public:
     OptionString & get_module_platform_id_option();
     // Unused if built without modularity support
     const OptionString & get_module_platform_id_option() const;
+    // Unused if built without modularity support
     OptionBool & get_module_stream_switch_option();
+    // Unused if built without modularity support
     const OptionBool & get_module_stream_switch_option() const;
     // Unused if built without modularity support
     OptionBool & get_module_obsoletes_option();

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -218,7 +218,9 @@ public:
     const OptionString & get_module_platform_id_option() const;
     OptionBool & get_module_stream_switch_option();
     const OptionBool & get_module_stream_switch_option() const;
+    // Unused if built without modularity support
     OptionBool & get_module_obsoletes_option();
+    // Unused if built without modularity support
     const OptionBool & get_module_obsoletes_option() const;
     OptionString & get_user_agent_option();
     const OptionString & get_user_agent_option() const;

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -214,7 +214,9 @@ public:
     OptionBool & get_ignorearch_option();
     const OptionBool & get_ignorearch_option() const;
 
+    // Unused if built without modularity support
     OptionString & get_module_platform_id_option();
+    // Unused if built without modularity support
     const OptionString & get_module_platform_id_option() const;
     OptionBool & get_module_stream_switch_option();
     const OptionBool & get_module_stream_switch_option() const;

--- a/include/libdnf5/transaction/offline.hpp
+++ b/include/libdnf5/transaction/offline.hpp
@@ -105,6 +105,7 @@ public:
     bool get_poweroff_after() const;
 
     /// Set module_platform_id for the offline transaction.
+    /// Unused if built without modularity support.
     void set_module_platform_id(const std::string & module_platform_id);
     const std::string & get_module_platform_id() const;
 

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -228,7 +228,7 @@ class ConfigMain::Impl {
     OptionBool downloadonly{false};  // runtime only option
     OptionBool ignorearch{false};
     OptionString module_platform_id{nullptr, ".+:.+", false};  // unused if modularity support is disabled
-    OptionBool module_stream_switch{false};
+    OptionBool module_stream_switch{false};                    // unused if modularity support is disabled
     OptionBool module_obsoletes{false};                        // unused if modularity support is disabled
 
     OptionString user_agent{get_user_agent()};
@@ -414,9 +414,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("ignorearch", ignorearch);
 #ifdef WITH_MODULEMD
     owner.opt_binds().add("module_platform_id", module_platform_id);
-#endif
     owner.opt_binds().add("module_stream_switch", module_stream_switch);
-#ifdef WITH_MODULEMD
     owner.opt_binds().add("module_obsoletes", module_obsoletes);
 #endif
     owner.opt_binds().add("user_agent", user_agent);
@@ -1527,9 +1525,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(ignorearch, other.ignorearch);
 #ifdef WITH_MODULEMD
     load_option(module_platform_id, other.module_platform_id);
-#endif
     load_option(module_stream_switch, other.module_stream_switch);
-#ifdef WITH_MODULEMD
     load_option(module_obsoletes, other.module_obsoletes);
 #endif
     load_option(user_agent, other.user_agent);

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -229,7 +229,7 @@ class ConfigMain::Impl {
     OptionBool ignorearch{false};
     OptionString module_platform_id{nullptr, ".+:.+", false};
     OptionBool module_stream_switch{false};
-    OptionBool module_obsoletes{false};
+    OptionBool module_obsoletes{false};                        // unused if modularity support is disabled
 
     OptionString user_agent{get_user_agent()};
     OptionBool countme{false};
@@ -414,7 +414,9 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("ignorearch", ignorearch);
     owner.opt_binds().add("module_platform_id", module_platform_id);
     owner.opt_binds().add("module_stream_switch", module_stream_switch);
+#ifdef WITH_MODULEMD
     owner.opt_binds().add("module_obsoletes", module_obsoletes);
+#endif
     owner.opt_binds().add("user_agent", user_agent);
     owner.opt_binds().add("countme", countme);
     owner.opt_binds().add("protect_running_kernel", protect_running_kernel);
@@ -1523,7 +1525,9 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(ignorearch, other.ignorearch);
     load_option(module_platform_id, other.module_platform_id);
     load_option(module_stream_switch, other.module_stream_switch);
+#ifdef WITH_MODULEMD
     load_option(module_obsoletes, other.module_obsoletes);
+#endif
     load_option(user_agent, other.user_agent);
     load_option(countme, other.countme);
     load_option(protect_running_kernel, other.protect_running_kernel);

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -227,7 +227,7 @@ class ConfigMain::Impl {
     OptionString comment{nullptr};
     OptionBool downloadonly{false};  // runtime only option
     OptionBool ignorearch{false};
-    OptionString module_platform_id{nullptr, ".+:.+", false};
+    OptionString module_platform_id{nullptr, ".+:.+", false};  // unused if modularity support is disabled
     OptionBool module_stream_switch{false};
     OptionBool module_obsoletes{false};                        // unused if modularity support is disabled
 
@@ -412,7 +412,9 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("destdir", destdir);
     owner.opt_binds().add("comment", comment);
     owner.opt_binds().add("ignorearch", ignorearch);
+#ifdef WITH_MODULEMD
     owner.opt_binds().add("module_platform_id", module_platform_id);
+#endif
     owner.opt_binds().add("module_stream_switch", module_stream_switch);
 #ifdef WITH_MODULEMD
     owner.opt_binds().add("module_obsoletes", module_obsoletes);
@@ -1523,7 +1525,9 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(comment, other.comment);
     load_option(downloadonly, other.downloadonly);
     load_option(ignorearch, other.ignorearch);
+#ifdef WITH_MODULEMD
     load_option(module_platform_id, other.module_platform_id);
+#endif
     load_option(module_stream_switch, other.module_stream_switch);
 #ifdef WITH_MODULEMD
     load_option(module_obsoletes, other.module_obsoletes);

--- a/libdnf5/transaction/offline.cpp
+++ b/libdnf5/transaction/offline.cpp
@@ -55,7 +55,9 @@ TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(
     verb,
     cmd_line,
     poweroff_after,
+#ifdef WITH_MODULEMD
     module_platform_id,
+#endif
     rpmdb_cookie)
 
 
@@ -145,8 +147,10 @@ bool OfflineTransactionStateData::get_poweroff_after() const {
     return p_impl->data.poweroff_after;
 }
 
-void OfflineTransactionStateData::set_module_platform_id(const std::string & module_platform_id) {
+void OfflineTransactionStateData::set_module_platform_id([[maybe_unused]] const std::string & module_platform_id) {
+#ifdef WITH_MODULEMD
     p_impl->data.module_platform_id = module_platform_id;
+#endif
 }
 const std::string & OfflineTransactionStateData::get_module_platform_id() const {
     return p_impl->data.module_platform_id;


### PR DESCRIPTION
This patch set hides and stops processing these configuration options:

module_obsoletes
module_platform_id
module_stream_switch

if DNF5 is built without modularity support. Documentation and D-Bus interface is also adapted.

However, accessors to these options are retained in API to preserve compatibility.

Requires: #2806
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1921