### PR TITLE
MultiProgressBar: Add and use PrintMode::ACTIVE_BARS_ONLY for faster rendering

### DIFF
--- a/dnf5-plugins/manifest_plugin/download_callbacks.cpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.cpp
@@ -35,7 +35,8 @@ void DownloadCallbacks::set_show_total_bar_limit(std::size_t limit) {
 void * DownloadCallbacks::add_new_download(
     [[maybe_unused]] void * user_data, const char * description, double total_to_download) {
     if (!multi_progress_bar) {
-        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+            libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY);
         multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
     }
     auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(
@@ -49,6 +50,10 @@ void * DownloadCallbacks::add_new_download(
 
 int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, double downloaded) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     auto total = static_cast<int64_t>(total_to_download);
     if (total > 0) {
         progress_bar->set_total_ticks(total);
@@ -57,6 +62,7 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
         progress_bar->start();
     }
     progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    multi_progress_bar->mark_bar_active(progress_bar);
     if (is_time_to_print()) {
         print();
     }
@@ -65,6 +71,10 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
 
 int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     switch (status) {
         case TransferStatus::SUCCESSFUL:
             // Correction of the total data size for the download.
@@ -86,17 +96,23 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
+    multi_progress_bar->mark_bar_active(progress_bar);
     print();
     return ReturnCode::OK;
 }
 
 int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     std::string message = std::string(msg) + " - " + url;
     if (metadata) {
         message = message + " - " + metadata;
     }
     progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->mark_bar_active(progress_bar);
     print();
     return ReturnCode::OK;
 }

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -35,7 +35,8 @@ void DownloadCallbacks::set_show_total_bar_limit(std::size_t limit) {
 void * DownloadCallbacks::add_new_download(
     [[maybe_unused]] void * user_data, const char * description, double total_to_download) {
     if (!multi_progress_bar) {
-        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+            libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY);
         multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
     }
     auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(
@@ -49,6 +50,10 @@ void * DownloadCallbacks::add_new_download(
 
 int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, double downloaded) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     auto total = static_cast<int64_t>(total_to_download);
     if (total > 0) {
         progress_bar->set_total_ticks(total);
@@ -57,6 +62,7 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
         progress_bar->start();
     }
     progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    multi_progress_bar->mark_bar_active(progress_bar);
     if (is_time_to_print()) {
         print();
     }
@@ -65,6 +71,10 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
 
 int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     switch (status) {
         case TransferStatus::SUCCESSFUL:
             // Correction of the total data size for the download.
@@ -86,17 +96,23 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
+    multi_progress_bar->mark_bar_active(progress_bar);
     print();
     return ReturnCode::OK;
 }
 
 int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
     auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    // Also ensures mark_bar_active() is not called on a finished bar.
+    if (progress_bar->is_finished()) {
+        return ReturnCode::OK;
+    }
     std::string message = std::string(msg) + " - " + url;
     if (metadata) {
         message = message + " - " + metadata;
     }
     progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->mark_bar_active(progress_bar);
     print();
     return ReturnCode::OK;
 }

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -125,7 +125,8 @@ void DownloadCB::add_new_download(sdbus::Signal & signal) {
         signal >> description;
         signal >> total_to_download;
         if (!multi_progress_bar) {
-            multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+            multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+                libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY);
             multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
         }
         auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(
@@ -142,7 +143,8 @@ void DownloadCB::end(sdbus::Signal & signal) {
         std::string download_id;
         signal >> download_id;
         auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+        // Also ensures mark_bar_active() is not called on a finished bar.
+        if (progress_bar == nullptr || progress_bar->is_finished()) {
             return;
         }
 
@@ -169,6 +171,7 @@ void DownloadCB::end(sdbus::Signal & signal) {
                 progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
                 break;
         }
+        multi_progress_bar->mark_bar_active(progress_bar);
         print();
     }
 }
@@ -178,7 +181,8 @@ void DownloadCB::progress(sdbus::Signal & signal) {
         std::string download_id;
         signal >> download_id;
         auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+        // Also ensures mark_bar_active() is not called on a finished bar.
+        if (progress_bar == nullptr || progress_bar->is_finished()) {
             return;
         }
         int64_t total_to_download;
@@ -192,6 +196,7 @@ void DownloadCB::progress(sdbus::Signal & signal) {
             progress_bar->start();
         }
         progress_bar->set_ticks(downloaded);
+        multi_progress_bar->mark_bar_active(progress_bar);
         print();
     }
 }
@@ -201,7 +206,8 @@ void DownloadCB::mirror_failure(sdbus::Signal & signal) {
         std::string download_id;
         signal >> download_id;
         auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+        // Also ensures mark_bar_active() is not called on a finished bar.
+        if (progress_bar == nullptr || progress_bar->is_finished()) {
             return;
         }
         std::string msg;
@@ -216,6 +222,7 @@ void DownloadCB::mirror_failure(sdbus::Signal & signal) {
             message += " - " + metadata;
         }
         progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+        multi_progress_bar->mark_bar_active(progress_bar);
         print();
     }
 }

--- a/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
@@ -41,7 +41,18 @@ class LIBDNF_CLI_API MultiProgressBar {
 public:
     static constexpr std::size_t NEVER_VISIBLE_LIMIT = static_cast<std::size_t>(-1);
 
+    /// Controls which unfinished bars are rendered on each print.
+    enum class PrintMode {
+        ALL_BARS,         ///< All unfinished bars are rendered on every print.
+        ACTIVE_BARS_ONLY  ///< Only bars marked via mark_bar_active() are rendered.
+    };
+
+    /// Constructs a MultiProgressBar with the given print mode.
+    explicit MultiProgressBar(PrintMode print_mode);
+
+    /// Constructs a MultiProgressBar with PrintMode::ALL_BARS.
     explicit MultiProgressBar();
+
     ~MultiProgressBar();
 
     MultiProgressBar(const MultiProgressBar & src) = delete;
@@ -50,7 +61,17 @@ public:
     MultiProgressBar(MultiProgressBar && src) noexcept = delete;
     MultiProgressBar & operator=(MultiProgressBar && src) noexcept = delete;
 
+    PrintMode get_print_mode() const noexcept;
+
     void add_bar(std::unique_ptr<ProgressBar> && bar);
+
+    /// Marks a bar as active for rendering in the next print.
+    /// In modes other than PrintMode::ACTIVE_BARS_ONLY this is a no-op.
+    /// Can be called multiple times on the same bar without side effects.
+    /// Must not be called on a bar that has already been rendered in a finished
+    /// state; doing so would cause it to be counted again as a finished bar
+    /// in the next render.
+    void mark_bar_active(ProgressBar * bar);
 
     // In interactive mode MultiProgressBar doesn't print a newline after unfinished progressbars.
     // Finished progressbars always end with a newline.

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <limits>
+#include <set>
 #include <utility>
 
 
@@ -36,13 +37,17 @@ namespace libdnf5::cli::progressbar {
 
 class MultiProgressBar::Impl {
 public:
-    Impl();
+    Impl(PrintMode print_mode);
+
+    const PrintMode print_mode;
 
     std::size_t total_bar_visible_limit{0};
     std::vector<std::unique_ptr<ProgressBar>> bars_all;
     std::vector<ProgressBar *> bars_todo;
     std::size_t bars_done_count{0};
     DownloadProgressBar total;
+    std::set<ProgressBar *> bars_newly_active;
+
     int64_t done_ticks{0};
     // Whether the last line was printed without a new line ending (such as an in progress bar)
     bool line_printed{false};
@@ -75,23 +80,33 @@ BarNumberType cast_to_bar_number(auto value) {
 }  // namespace
 
 
-MultiProgressBar::Impl::Impl() : total(0, _("Total")) {
+MultiProgressBar::Impl::Impl(PrintMode print_mode) : print_mode(print_mode), total(0, _("Total")) {
     total.set_auto_finish(false);
     total.start();
 }
 
 
-MultiProgressBar::MultiProgressBar() : p_impl(new Impl()) {
+MultiProgressBar::MultiProgressBar(PrintMode print_mode) : p_impl(new Impl(print_mode)) {
     if (tty::is_interactive()) {
         std::cerr << tty::cursor_hide;
     }
 }
+
+
+MultiProgressBar::MultiProgressBar() : MultiProgressBar(PrintMode::ALL_BARS) {}
+
 
 MultiProgressBar::~MultiProgressBar() {
     if (tty::is_interactive()) {
         std::cerr << tty::cursor_show;
     }
 }
+
+
+MultiProgressBar::PrintMode MultiProgressBar::get_print_mode() const noexcept {
+    return p_impl->print_mode;
+}
+
 
 void MultiProgressBar::print() {
     std::cerr << *this;
@@ -116,7 +131,9 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
     bar->set_number(next_number);
 
     // register bar to MultiProgressBar
-    p_impl->bars_todo.push_back(bar.get());
+    if (p_impl->print_mode == PrintMode::ALL_BARS) {
+        p_impl->bars_todo.push_back(bar.get());
+    }
     p_impl->bars_all.push_back(std::move(bar));
 
     // update total (in [num/total]) in total progress bar
@@ -126,6 +143,11 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
     }
 }
 
+void MultiProgressBar::mark_bar_active(ProgressBar * bar) {
+    if (p_impl->print_mode == PrintMode::ACTIVE_BARS_ONLY) {
+        p_impl->bars_newly_active.insert(bar);
+    }
+}
 
 void MultiProgressBar::set_total_num_of_bars(std::size_t value) noexcept {
     if (value < p_impl->bars_all.size()) {
@@ -169,7 +191,15 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     auto number = cast_to_bar_number(mbar.p_impl->bars_done_count);
 
     // print completed bars first and remove them from bars_todo
-    for (auto it = mbar.p_impl->bars_todo.begin(); it != mbar.p_impl->bars_todo.end();) {
+    for (auto it = mbar.p_impl->bars_todo.begin();
+         it != mbar.p_impl->bars_todo.end() || !mbar.p_impl->bars_newly_active.empty();) {
+        if (it != mbar.p_impl->bars_todo.end()) {
+            mbar.p_impl->bars_newly_active.erase(*it);
+        } else {
+            auto newly_active_it = mbar.p_impl->bars_newly_active.begin();
+            it = mbar.p_impl->bars_todo.insert(it, *newly_active_it);
+            mbar.p_impl->bars_newly_active.erase(newly_active_it);
+        }
         auto * const bar = *it;
 
         if (!bar->is_finished()) {
@@ -220,7 +250,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
     // then print the "total" progress bar
     if ((mbar.p_impl->bars_all.size() >= mbar.p_impl->total_bar_visible_limit) &&
-        (is_interactive || mbar.p_impl->bars_todo.empty())) {
+        (is_interactive || mbar.p_impl->bars_all.size() == mbar.p_impl->bars_done_count)) {
         // compute ticks and total_ticks for total progress bar
         // done bars can be unfinished -> add only processed ticks to both values
         int64_t ticks = mbar.p_impl->done_ticks;
@@ -248,7 +278,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         mbar_total.set_total_ticks(total_ticks);
         mbar_total.set_ticks(ticks);
 
-        if (mbar.p_impl->bars_todo.empty()) {
+        if (mbar.p_impl->bars_all.size() == mbar.p_impl->bars_done_count) {
             // all bars have finished, set the "Total" bar as finished too according to their states
             mbar_total.set_state(ProgressBarState::SUCCESS);
         }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <limits>
-#include <set>
+#include <map>
 #include <utility>
 
 
@@ -46,7 +46,8 @@ public:
     std::vector<ProgressBar *> bars_todo;
     std::size_t bars_done_count{0};
     DownloadProgressBar total;
-    std::set<ProgressBar *> bars_newly_active;
+    std::map<ProgressBar *, std::size_t> bars_newly_active;
+    std::map<std::size_t, ProgressBar *> bars_newly_active_by_index;
 
     int64_t done_ticks{0};
     // Whether the last line was printed without a new line ending (such as an in progress bar)
@@ -145,7 +146,11 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
 
 void MultiProgressBar::mark_bar_active(ProgressBar * bar) {
     if (p_impl->print_mode == PrintMode::ACTIVE_BARS_ONLY) {
-        p_impl->bars_newly_active.insert(bar);
+        const auto newly_active_bars_count = p_impl->bars_newly_active.size();
+        auto [it, inserted] = p_impl->bars_newly_active.emplace(bar, newly_active_bars_count);
+        if (inserted) {
+            p_impl->bars_newly_active_by_index.emplace(newly_active_bars_count, bar);
+        }
     }
 }
 
@@ -194,11 +199,18 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
     for (auto it = mbar.p_impl->bars_todo.begin();
          it != mbar.p_impl->bars_todo.end() || !mbar.p_impl->bars_newly_active.empty();) {
         if (it != mbar.p_impl->bars_todo.end()) {
-            mbar.p_impl->bars_newly_active.erase(*it);
+            if (auto newly_active_it = mbar.p_impl->bars_newly_active.find(*it);
+                newly_active_it != mbar.p_impl->bars_newly_active.end()) {
+                mbar.p_impl->bars_newly_active_by_index.erase(newly_active_it->second);
+                mbar.p_impl->bars_newly_active.erase(newly_active_it);
+            }
         } else {
-            auto newly_active_it = mbar.p_impl->bars_newly_active.begin();
-            it = mbar.p_impl->bars_todo.insert(it, *newly_active_it);
-            mbar.p_impl->bars_newly_active.erase(newly_active_it);
+            // std::map is ordered by key, so begin() returns the bar with the lowest index,
+            // preserving the order of bars activation.
+            auto newly_active_by_index_it = mbar.p_impl->bars_newly_active_by_index.begin();
+            it = mbar.p_impl->bars_todo.insert(it, newly_active_by_index_it->second);
+            mbar.p_impl->bars_newly_active.erase(newly_active_by_index_it->second);
+            mbar.p_impl->bars_newly_active_by_index.erase(newly_active_by_index_it);
         }
         auto * const bar = *it;
 

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -105,6 +105,41 @@ void ProgressbarTest::test_multi_progress_bar() {
     ASSERT_MATCHES(expected, oss.str());
 }
 
+void ProgressbarTest::test_multi_progress_bar_print_active_only() {
+    // In non interactive mode finished multiline progressbar ends with a new line.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const download_progress_bar1_raw = download_progress_bar1.get();
+    download_progress_bar1->set_ticks(10);
+    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const download_progress_bar2_raw = download_progress_bar2.get();
+    download_progress_bar2->set_ticks(10);
+    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+
+    // Mark progressbars as active
+    // Can be called multiple times on the same bar without side effects
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+}
+
 void ProgressbarTest::test_multi_progress_bar_unfinished() {
     // In non-interacitve mode:
     // - unfinished progressbars are not printed
@@ -138,6 +173,58 @@ void ProgressbarTest::test_multi_progress_bar_unfinished() {
 
     // Next iteration
     download_progress_bar2_raw->set_ticks(10);
+    download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+}
+
+void ProgressbarTest::test_multi_progress_bar_unfinished_print_active_only() {
+    // In non-interacitve mode:
+    // - unfinished progressbars are not printed
+    // - total is not printed until all progressbars are finished
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const download_progress_bar1_raw = download_progress_bar1.get();
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const download_progress_bar2_raw = download_progress_bar2.get();
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY};
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+
+    download_progress_bar1_raw->set_ticks(10);
+    download_progress_bar1_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+
+    download_progress_bar2_raw->set_ticks(4);
+    download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected = "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+
+    // More iterations
+    download_progress_bar2_raw->set_ticks(5);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
+    oss << multi_progress_bar;
+    download_progress_bar2_raw->set_ticks(6);
+    //multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
+    oss << multi_progress_bar;
+    expected = "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+
+    // Next iteration
+    download_progress_bar2_raw->set_ticks(10);
+    //multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
     download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     oss << multi_progress_bar;
     expected =

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -30,7 +30,9 @@ class ProgressbarTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_progress_bar_multi_byte_character);
     CPPUNIT_TEST(test_download_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar);
+    CPPUNIT_TEST(test_multi_progress_bar_print_active_only);
     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
+    CPPUNIT_TEST(test_multi_progress_bar_unfinished_print_active_only);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -41,7 +43,9 @@ public:
     void test_progress_bar_multi_byte_character();
     void test_download_progress_bar();
     void test_multi_progress_bar();
+    void test_multi_progress_bar_print_active_only();
     void test_multi_progress_bar_unfinished();
+    void test_multi_progress_bar_unfinished_print_active_only();
 };
 
 

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -347,6 +347,42 @@ void ProgressbarInteractiveTest::test_multi_progress_bar_with_total_finished() {
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 }
 
+void ProgressbarInteractiveTest::test_multi_progress_bar_with_total_finished_print_active_only() {
+    // In interactive mode finished multi progressbar ends with a new line.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const download_progress_bar1_raw = download_progress_bar1.get();
+    download_progress_bar1->set_ticks(10);
+    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const download_progress_bar2_raw = download_progress_bar2.get();
+    download_progress_bar2->set_ticks(10);
+    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+
+    // Mark progressbars as active
+    // Can be called multiple times on the same bar without side effects
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B |  ??????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B |  ??????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B |  ??????\n";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
 void ProgressbarInteractiveTest::test_multi_progress_bar_with_messages_with_total() {
     // In interactive mode not finished progressbar with messages doesn't end with a new line.
     // However finished progressbar does end with a new line.
@@ -472,6 +508,74 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages_with_tot
     download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
     oss << multi_progress_bar;
     download_progress_bar2_raw->pop_message();
+    oss << multi_progress_bar;
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
+void ProgressbarInteractiveTest::test_multi_progress_bars_with_messages_with_total_print_active_only() {
+    // ACTIVE_BARS_ONLY variant of test_multi_progress_bars_with_messages_with_total
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    download_progress_bar1->set_ticks(10);
+    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    download_progress_bar2->set_auto_finish(false);
+    download_progress_bar2->start();
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY};
+    auto * const download_progress_bar1_raw = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    auto * const download_progress_bar2_raw = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+
+    download_progress_bar2_raw->set_ticks(4);
+    download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
+
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        ">>> test message1\n"
+        ">>> test message2\n"
+        ">>> test もで 諤奯ゞ\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    download_progress_bar2_raw->pop_message();
+    download_progress_bar2_raw->pop_message();
+    download_progress_bar2_raw->pop_message();
+
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
+
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????\n"
+        "\n"
+        "\n";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // new iteration
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    // multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
+    oss << multi_progress_bar;
+
+    download_progress_bar2_raw->pop_message();
+    // multi_progress_bar.mark_bar_active(download_progress_bar2_raw);  // No need to call bar is already active
     oss << multi_progress_bar;
 
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
@@ -691,6 +795,73 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_already_downloade
     // In progress download
     download_progress_bar3_raw->set_ticks(4);
     download_progress_bar3_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
+
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[2/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[3/3\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/3\\] Total                    40% | ????? ??B\\/s |   4.0   B | ???????";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
+void ProgressbarInteractiveTest::test_multi_progress_bars_with_already_downloaded_print_active_only() {
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto download_progress_bar3 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto * const download_progress_bar1_raw = download_progress_bar1.get();
+    auto * const download_progress_bar2_raw = download_progress_bar2.get();
+    auto * const download_progress_bar3_raw = download_progress_bar3.get();
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::PrintMode::ACTIVE_BARS_ONLY};
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.add_bar(std::move(download_progress_bar3));
+
+    // First download progress bar represents already downloaded package
+    download_progress_bar1_raw->set_ticks(0);
+    download_progress_bar1_raw->set_total_ticks(0);
+    download_progress_bar1_raw->add_message(libdnf5::cli::progressbar::MessageType::SUCCESS, "Already Downloaded");
+    download_progress_bar1_raw->start();
+    download_progress_bar1_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.mark_bar_active(download_progress_bar1_raw);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // Add another already downloaded package
+    download_progress_bar2_raw->set_ticks(0);
+    download_progress_bar2_raw->set_total_ticks(0);
+    download_progress_bar2_raw->add_message(libdnf5::cli::progressbar::MessageType::SUCCESS, "Already Downloaded");
+    download_progress_bar2_raw->start();
+    download_progress_bar2_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    multi_progress_bar.mark_bar_active(download_progress_bar2_raw);
+
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[2/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // In progress download
+    download_progress_bar3_raw->set_ticks(4);
+    download_progress_bar3_raw->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
+    multi_progress_bar.mark_bar_active(download_progress_bar3_raw);
 
     oss << multi_progress_bar;
     expected =

--- a/test/libdnf5-cli/test_progressbar_interactive.hpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.hpp
@@ -32,12 +32,15 @@ class ProgressbarInteractiveTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_download_progress_bar_with_messages);
     CPPUNIT_TEST(test_download_progress_bar_with_long_messages);
     CPPUNIT_TEST(test_multi_progress_bar_with_total_finished);
+    CPPUNIT_TEST(test_multi_progress_bar_with_total_finished_print_active_only);
     CPPUNIT_TEST(test_multi_progress_bar_with_messages_with_total);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages_with_total);
+    CPPUNIT_TEST(test_multi_progress_bars_with_messages_with_total_print_active_only);
     CPPUNIT_TEST(test_multi_progress_bar_with_messages);
     CPPUNIT_TEST(test_multi_progress_bar_with_short_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_already_downloaded);
+    CPPUNIT_TEST(test_multi_progress_bars_with_already_downloaded_print_active_only);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -50,12 +53,15 @@ public:
     void test_download_progress_bar_with_messages();
     void test_download_progress_bar_with_long_messages();
     void test_multi_progress_bar_with_total_finished();
+    void test_multi_progress_bar_with_total_finished_print_active_only();
     void test_multi_progress_bar_with_messages_with_total();
     void test_multi_progress_bars_with_messages_with_total();
+    void test_multi_progress_bars_with_messages_with_total_print_active_only();
     void test_multi_progress_bar_with_messages();
     void test_multi_progress_bar_with_short_messages();
     void test_multi_progress_bars_with_messages();
     void test_multi_progress_bars_with_already_downloaded();
+    void test_multi_progress_bars_with_already_downloaded_print_active_only();
 };
 
 


### PR DESCRIPTION
Follows up on https://github.com/rpm-software-management/dnf5/pull/2817 and https://github.com/rpm-software-management/dnf5/pull/2822. Introduces `PrintMode::ACTIVE_BARS_ONLY` for `MultiProgressBar`, which provides a dramatic speedup when many bars are registered but only one to a few are active at a time - the typical case in practise.

Unlike the previous optimizations, this mode requires cooperation from the caller: the `MultiProgressBar` must be constructed with `PrintMode::ACTIVE_BARS_ONLY` and active bars must be marked explicitly via the new `mark_bar_active(ProgressBar *)` method before print.

Unit tests are included.

dnf5::DownloadCallbacks, manifest_plugin::DownloadCallbacks and dnf5daemon-client::DownloadCB were switched to ACTIVE_BARS_ONLY mode.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2790