### PR TITLE
zsh-completion: Escape colons in completion candidates

### DIFF
--- a/dnf5/zsh-completion/_dnf5
+++ b/dnf5/zsh-completion/_dnf5
@@ -8,6 +8,7 @@ _dnf5() {
         [[ -z "$line" ]] && continue
         word="${line%%[[:space:]]*}"
         [[ -z "$word" ]] && continue
+        word="${word//:/\\:}"
         if [[ "$line" =~ '\((.+)\)$' ]]; then
             entry="${word}:${match[1]}"
         else


### PR DESCRIPTION
prevent full nevra package lines from having a description, which would cause them to rank above package name only lines and have a -EPOCH appended to the package name when selected