### PR TITLE
Call post_transaction plugin hooks in reverse order

### DIFF
--- a/libdnf5/plugin/plugins.cpp
+++ b/libdnf5/plugin/plugins.cpp
@@ -279,9 +279,9 @@ void Plugins::pre_transaction(const libdnf5::base::Transaction & transaction) {
 }
 
 void Plugins::post_transaction(const libdnf5::base::Transaction & transaction) {
-    for (auto & plugin : plugins) {
-        if (plugin->get_enabled()) {
-            plugin->post_transaction(transaction);
+    for (auto plugin = plugins.rbegin(), stop = plugins.rend(); plugin != stop; ++plugin) {
+        if ((*plugin)->get_enabled()) {
+            (*plugin)->post_transaction(transaction);
         }
     }
 }

--- a/libdnf5/plugin/plugins.hpp
+++ b/libdnf5/plugin/plugins.hpp
@@ -111,6 +111,7 @@ public:
 
     void pre_transaction(const libdnf5::base::Transaction & transaction);
 
+    /// Call post_transaction of all allowed plugins in reverse order.
     void post_transaction(const libdnf5::base::Transaction & transaction);
 
     /// Call finish of all allowed plugins in reverse order.


### PR DESCRIPTION
Plugins are loaded and called in alphabetical order by their config filename. By reversing post_transaction iteration, pre_transaction and post_transaction form symmetric brackets: a plugin that acts first in pre_transaction acts last in post_transaction.