### PR TITLE
MultiProgressBar: Add and use TrackingMode::ON_CHANGE for faster rendering

### DIFF
--- a/dnf5-plugins/manifest_plugin/download_callbacks.cpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.cpp
@@ -48,15 +48,15 @@ void * DownloadCallbacks::add_new_download(
 }
 
 int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, double downloaded) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     auto total = static_cast<int64_t>(total_to_download);
     if (total > 0) {
-        progress_bar->set_total_ticks(total);
+        multi_progress_bar->bar_set_total_ticks(progress_bar, total);
     }
-    if (progress_bar->get_state() == libdnf5::cli::progressbar::ProgressBarState::READY) {
-        progress_bar->start();
+    if (multi_progress_bar->bar_get_state(progress_bar) == libdnf5::cli::progressbar::ProgressBarState::READY) {
+        multi_progress_bar->bar_start(progress_bar);
     }
-    progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    multi_progress_bar->bar_set_ticks(progress_bar, static_cast<int64_t>(downloaded));
     if (is_time_to_print()) {
         print();
     }
@@ -64,26 +64,26 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
 }
 
 int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     switch (status) {
         case TransferStatus::SUCCESSFUL:
             // Correction of the total data size for the download.
             // Sometimes Librepo returns a larger data size for download than the actual file size.
-            progress_bar->set_total_ticks(progress_bar->get_ticks());
+            multi_progress_bar->bar_set_total_ticks(progress_bar, multi_progress_bar->bar_get_ticks(progress_bar));
 
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
             break;
         case TransferStatus::ALREADYEXISTS:
             // skipping the download -> downloading 0 bytes
-            progress_bar->set_ticks(0);
-            progress_bar->set_total_ticks(0);
-            progress_bar->add_message(libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
-            progress_bar->start();
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+            multi_progress_bar->bar_set_ticks(progress_bar, 0);
+            multi_progress_bar->bar_set_total_ticks(progress_bar, 0);
+            multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
+            multi_progress_bar->bar_start(progress_bar);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
             break;
         case TransferStatus::ERROR:
-            progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, msg);
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+            multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, msg);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
     print();
@@ -91,12 +91,12 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
 }
 
 int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     std::string message = std::string(msg) + " - " + url;
     if (metadata) {
         message = message + " - " + metadata;
     }
-    progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, message);
     print();
     return ReturnCode::OK;
 }

--- a/dnf5-plugins/manifest_plugin/download_callbacks.cpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.cpp
@@ -35,7 +35,8 @@ void DownloadCallbacks::set_show_total_bar_limit(std::size_t limit) {
 void * DownloadCallbacks::add_new_download(
     [[maybe_unused]] void * user_data, const char * description, double total_to_download) {
     if (!multi_progress_bar) {
-        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+            libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE);
         multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
     }
     auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -868,7 +868,9 @@ void Command::goal_resolved() {
 }
 
 
-RpmTransCB::RpmTransCB(Context & context) : context(context) {
+RpmTransCB::RpmTransCB(Context & context)
+    : multi_progress_bar(libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE),
+      context(context) {
     multi_progress_bar.set_total_bar_visible_limit(libdnf5::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
 }
 

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -873,8 +873,9 @@ RpmTransCB::RpmTransCB(Context & context) : context(context) {
 }
 
 RpmTransCB::~RpmTransCB() {
-    if (active_progress_bar && active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    if (active_progress_bar &&
+        multi_progress_bar.bar_get_state(*active_progress_bar) != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+        multi_progress_bar.bar_set_state(*active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     }
     if (active_progress_bar) {
         multi_progress_bar.print();
@@ -889,7 +890,8 @@ int RpmTransCB::rpm_messages_to_progress(const libdnf5::cli::progressbar::Messag
     auto transaction = context.get_transaction();
     int retval = 0;
     for (const auto & msg : transaction->get_rpm_messages()) {
-        active_progress_bar->add_message(message_type, libdnf5::utils::sformat("[RPM] {}", msg));
+        multi_progress_bar.bar_add_message(
+            *active_progress_bar, message_type, libdnf5::utils::sformat("[RPM] {}", msg));
         ++retval;
     }
     return retval;
@@ -897,7 +899,7 @@ int RpmTransCB::rpm_messages_to_progress(const libdnf5::cli::progressbar::Messag
 
 void RpmTransCB::install_progress(
     [[maybe_unused]] const libdnf5::base::TransactionPackage & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
@@ -946,7 +948,7 @@ void RpmTransCB::install_stop(
 }
 
 void RpmTransCB::transaction_progress(uint64_t amount, [[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
@@ -957,13 +959,13 @@ void RpmTransCB::transaction_start(uint64_t total) {
 }
 
 void RpmTransCB::transaction_stop([[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(total));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(total));
     multi_progress_bar.print();
 }
 
 void RpmTransCB::uninstall_progress(
     [[maybe_unused]] const libdnf5::base::TransactionPackage & item, uint64_t amount, [[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
@@ -992,18 +994,20 @@ void RpmTransCB::uninstall_stop(
 
 void RpmTransCB::unpack_error(const libdnf5::base::TransactionPackage & item) {
     rpm_messages_to_progress(libdnf5::cli::progressbar::MessageType::ERROR);
-    active_progress_bar->add_message(
+    multi_progress_bar.bar_add_message(
+        *active_progress_bar,
         libdnf5::cli::progressbar::MessageType::ERROR,
         libdnf5::utils::sformat(_("Unpack error: {}"), item.get_package().get_full_nevra()));
-    active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+    multi_progress_bar.bar_set_state(*active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
     multi_progress_bar.print();
 }
 
 void RpmTransCB::cpio_error(const libdnf5::base::TransactionPackage & item) {
-    active_progress_bar->add_message(
+    multi_progress_bar.bar_add_message(
+        *active_progress_bar,
         libdnf5::cli::progressbar::MessageType::ERROR,
         libdnf5::utils::sformat(_("Cpio error: {}"), item.get_package().get_full_nevra()));
-    active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+    multi_progress_bar.bar_set_state(*active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
     multi_progress_bar.print();
 }
 
@@ -1012,9 +1016,9 @@ int RpmTransCB::script_output_to_progress(const libdnf5::cli::progressbar::Messa
     auto output = transaction->get_last_script_output();
     int retval = 0;
     if (!output.empty()) {
-        active_progress_bar->add_message(message_type, _("Scriptlet output:"));
+        multi_progress_bar.bar_add_message(*active_progress_bar, message_type, _("Scriptlet output:"));
         for (auto & line : libdnf5::utils::string::split(output, "\n")) {
-            active_progress_bar->add_message(message_type, line);
+            multi_progress_bar.bar_add_message(*active_progress_bar, message_type, line);
             ++retval;
         }
     }
@@ -1037,7 +1041,8 @@ void RpmTransCB::script_start(
         multi_progress_bar.set_total_num_of_bars(multi_progress_bar.get_total_num_of_bars() + 1);
         new_progress_bar(static_cast<int64_t>(-1), _("Running scriptlets"));
     }
-    active_progress_bar->add_message(
+    multi_progress_bar.bar_add_message(
+        *active_progress_bar,
         libdnf5::cli::progressbar::MessageType::INFO,
         libdnf5::utils::sformat(
             _("Running {} scriptlet: {}"), script_type_to_string(type), to_full_nevra_string(nevra)));
@@ -1052,13 +1057,15 @@ void RpmTransCB::script_stop(
     libdnf5::cli::progressbar::MessageType message_type = libdnf5::cli::progressbar::MessageType::WARNING;
     switch (return_code) {
         case RPMRC_OK:
-            active_progress_bar->add_message(
+            multi_progress_bar.bar_add_message(
+                *active_progress_bar,
                 libdnf5::cli::progressbar::MessageType::INFO,
                 libdnf5::utils::sformat(
                     _("Finished {} scriptlet: {}"), script_type_to_string(type), to_full_nevra_string(nevra)));
             break;
         case RPMRC_NOTFOUND:
-            active_progress_bar->add_message(
+            multi_progress_bar.bar_add_message(
+                *active_progress_bar,
                 libdnf5::cli::progressbar::MessageType::WARNING,
                 libdnf5::utils::sformat(
                     _("Non-critical error in {} scriptlet: {}"),
@@ -1067,7 +1074,8 @@ void RpmTransCB::script_stop(
             break;
         default:
             message_type = libdnf5::cli::progressbar::MessageType::ERROR;
-            active_progress_bar->add_message(
+            multi_progress_bar.bar_add_message(
+                *active_progress_bar,
                 libdnf5::cli::progressbar::MessageType::ERROR,
                 libdnf5::utils::sformat(
                     _("Error in {} scriptlet: {}"), script_type_to_string(type), to_full_nevra_string(nevra)));
@@ -1079,8 +1087,8 @@ void RpmTransCB::script_stop(
         // remove the script start/stop messages in case the script
         // finished successfully and no rpm log message or scriptlet
         // output was printed.
-        active_progress_bar->pop_message();
-        active_progress_bar->pop_message();
+        multi_progress_bar.bar_pop_message(*active_progress_bar);
+        multi_progress_bar.bar_pop_message(*active_progress_bar);
     }
     multi_progress_bar.print();
 }
@@ -1093,7 +1101,7 @@ void RpmTransCB::elem_progress(
 }
 
 void RpmTransCB::verify_progress(uint64_t amount, [[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
     if (is_time_to_print()) {
         multi_progress_bar.print();
     }
@@ -1109,20 +1117,21 @@ void RpmTransCB::verify_start([[maybe_unused]] uint64_t total) {
 }
 
 void RpmTransCB::verify_stop([[maybe_unused]] uint64_t total) {
-    active_progress_bar->set_ticks(static_cast<int64_t>(total));
+    multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(total));
     multi_progress_bar.print();
 }
 
 void RpmTransCB::new_progress_bar(int64_t total, const std::string & descr) {
-    if (active_progress_bar && active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    if (active_progress_bar &&
+        multi_progress_bar.bar_get_state(*active_progress_bar) != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+        multi_progress_bar.bar_set_state(*active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     }
     auto progress_bar =
         std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), descr);
-    progress_bar->set_auto_finish(false);
-    progress_bar->start();
     active_progress_bar = progress_bar.get();
     multi_progress_bar.add_bar(std::move(progress_bar));
+    multi_progress_bar.bar_set_auto_finish(*active_progress_bar, false);
+    multi_progress_bar.bar_start(*active_progress_bar);
 }
 
 bool RpmTransCB::is_time_to_print() {

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -48,15 +48,15 @@ void * DownloadCallbacks::add_new_download(
 }
 
 int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, double downloaded) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     auto total = static_cast<int64_t>(total_to_download);
     if (total > 0) {
-        progress_bar->set_total_ticks(total);
+        multi_progress_bar->bar_set_total_ticks(progress_bar, total);
     }
-    if (progress_bar->get_state() == libdnf5::cli::progressbar::ProgressBarState::READY) {
-        progress_bar->start();
+    if (multi_progress_bar->bar_get_state(progress_bar) == libdnf5::cli::progressbar::ProgressBarState::READY) {
+        multi_progress_bar->bar_start(progress_bar);
     }
-    progress_bar->set_ticks(static_cast<int64_t>(downloaded));
+    multi_progress_bar->bar_set_ticks(progress_bar, static_cast<int64_t>(downloaded));
     if (is_time_to_print()) {
         print();
     }
@@ -64,26 +64,26 @@ int DownloadCallbacks::progress(void * user_cb_data, double total_to_download, d
 }
 
 int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const char * msg) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     switch (status) {
         case TransferStatus::SUCCESSFUL:
             // Correction of the total data size for the download.
             // Sometimes Librepo returns a larger data size for download than the actual file size.
-            progress_bar->set_total_ticks(progress_bar->get_ticks());
+            multi_progress_bar->bar_set_total_ticks(progress_bar, multi_progress_bar->bar_get_ticks(progress_bar));
 
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
             break;
         case TransferStatus::ALREADYEXISTS:
             // skipping the download -> downloading 0 bytes
-            progress_bar->set_ticks(0);
-            progress_bar->set_total_ticks(0);
-            progress_bar->add_message(libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
-            progress_bar->start();
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+            multi_progress_bar->bar_set_ticks(progress_bar, 0);
+            multi_progress_bar->bar_set_total_ticks(progress_bar, 0);
+            multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
+            multi_progress_bar->bar_start(progress_bar);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
             break;
         case TransferStatus::ERROR:
-            progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, msg);
-            progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+            multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, msg);
+            multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
     print();
@@ -91,12 +91,12 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
 }
 
 int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) {
-    auto * progress_bar = reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
+    auto & progress_bar = *reinterpret_cast<libdnf5::cli::progressbar::DownloadProgressBar *>(user_cb_data);
     std::string message = std::string(msg) + " - " + url;
     if (metadata) {
         message = message + " - " + metadata;
     }
-    progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+    multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, message);
     print();
     return ReturnCode::OK;
 }

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -35,7 +35,8 @@ void DownloadCallbacks::set_show_total_bar_limit(std::size_t limit) {
 void * DownloadCallbacks::add_new_download(
     [[maybe_unused]] void * user_data, const char * description, double total_to_download) {
     if (!multi_progress_bar) {
-        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+        multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+            libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE);
         multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
     }
     auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -125,7 +125,8 @@ void DownloadCB::add_new_download(sdbus::Signal & signal) {
         signal >> description;
         signal >> total_to_download;
         if (!multi_progress_bar) {
-            multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>();
+            multi_progress_bar = std::make_unique<libdnf5::cli::progressbar::MultiProgressBar>(
+                libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE);
             multi_progress_bar->set_total_bar_visible_limit(show_total_bar_limit);
         }
         auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(
@@ -259,7 +260,9 @@ void DownloadCB::key_import(sdbus::Signal & signal) {
     }
 }
 
-TransactionCB::TransactionCB(Context & context, sdbus::IConnection & connection) : DbusCallback(context, connection) {}
+TransactionCB::TransactionCB(Context & context, sdbus::IConnection & connection)
+    : DbusCallback(context, connection),
+      multi_progress_bar(libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE) {}
 
 
 void TransactionCB::register_signals() {

--- a/dnf5daemon-client/callbacks.cpp
+++ b/dnf5daemon-client/callbacks.cpp
@@ -141,10 +141,12 @@ void DownloadCB::end(sdbus::Signal & signal) {
     if (signature_valid(signal)) {
         std::string download_id;
         signal >> download_id;
-        auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+
+        auto progress_bar_ptr = find_progress_bar(download_id);
+        if (progress_bar_ptr == nullptr) {
             return;
         }
+        auto & progress_bar = *progress_bar_ptr;
 
         unsigned int status_i;
         std::string msg;
@@ -153,20 +155,20 @@ void DownloadCB::end(sdbus::Signal & signal) {
         auto status = static_cast<libdnf5::repo::DownloadCallbacks::TransferStatus>(status_i);
         switch (status) {
             case libdnf5::repo::DownloadCallbacks::TransferStatus::SUCCESSFUL:
-                progress_bar->set_total_ticks(progress_bar->get_ticks());
-                progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+                multi_progress_bar->bar_set_total_ticks(progress_bar, multi_progress_bar->bar_get_ticks(progress_bar));
+                multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
             case libdnf5::repo::DownloadCallbacks::TransferStatus::ALREADYEXISTS:
                 // skipping the download -> downloading 0 bytes
-                progress_bar->set_ticks(0);
-                progress_bar->set_total_ticks(0);
-                progress_bar->add_message(libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
-                progress_bar->start();
-                progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+                multi_progress_bar->bar_set_ticks(progress_bar, 0);
+                multi_progress_bar->bar_set_total_ticks(progress_bar, 0);
+                multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::SUCCESS, msg);
+                multi_progress_bar->bar_start(progress_bar);
+                multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
             case libdnf5::repo::DownloadCallbacks::TransferStatus::ERROR:
-                progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, msg);
-                progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::ERROR);
+                multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, msg);
+                multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
                 break;
         }
         print();
@@ -177,21 +179,25 @@ void DownloadCB::progress(sdbus::Signal & signal) {
     if (signature_valid(signal)) {
         std::string download_id;
         signal >> download_id;
-        auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+
+        auto progress_bar_ptr = find_progress_bar(download_id);
+        if (progress_bar_ptr == nullptr) {
             return;
         }
+        auto & progress_bar = *progress_bar_ptr;
+
         int64_t total_to_download;
         int64_t downloaded;
         signal >> total_to_download;
         signal >> downloaded;
         if (total_to_download > 0) {
-            progress_bar->set_total_ticks(total_to_download);
+            multi_progress_bar->bar_set_total_ticks(progress_bar, total_to_download);
         }
-        if (progress_bar->get_state() == libdnf5::cli::progressbar::ProgressBarState::READY) {
-            progress_bar->start();
+        if (multi_progress_bar->bar_get_state(progress_bar) == libdnf5::cli::progressbar::ProgressBarState::READY) {
+            multi_progress_bar->bar_start(progress_bar);
+            ;
         }
-        progress_bar->set_ticks(downloaded);
+        multi_progress_bar->bar_set_ticks(progress_bar, downloaded);
         print();
     }
 }
@@ -200,10 +206,13 @@ void DownloadCB::mirror_failure(sdbus::Signal & signal) {
     if (signature_valid(signal)) {
         std::string download_id;
         signal >> download_id;
-        auto progress_bar = find_progress_bar(download_id);
-        if (progress_bar == nullptr) {
+
+        auto progress_bar_ptr = find_progress_bar(download_id);
+        if (progress_bar_ptr == nullptr) {
             return;
         }
+        auto & progress_bar = *progress_bar_ptr;
+
         std::string msg;
         std::string url;
         std::string metadata;
@@ -215,7 +224,7 @@ void DownloadCB::mirror_failure(sdbus::Signal & signal) {
         if (!metadata.empty()) {
             message += " - " + metadata;
         }
-        progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, message);
+        multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, message);
         print();
     }
 }
@@ -313,15 +322,16 @@ void TransactionCB::register_signals() {
 }
 
 void TransactionCB::new_progress_bar(uint64_t total, const std::string & description) {
-    if (active_progress_bar && active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-        active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    if (active_progress_bar &&
+        multi_progress_bar.bar_get_state(*active_progress_bar) != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+        multi_progress_bar.bar_set_state(*active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
     }
     auto progress_bar =
         std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(static_cast<int64_t>(total), description);
-    progress_bar->set_auto_finish(false);
-    progress_bar->start();
     active_progress_bar = progress_bar.get();
     multi_progress_bar.add_bar(std::move(progress_bar));
+    multi_progress_bar.bar_set_auto_finish(*active_progress_bar, false);
+    multi_progress_bar.bar_start(*active_progress_bar);
 }
 
 void TransactionCB::verify_start(sdbus::Signal & signal) {
@@ -337,7 +347,7 @@ void TransactionCB::verify_progress(sdbus::Signal & signal) {
         uint64_t amount;
         signal >> amount;
 
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
         multi_progress_bar.print();
     }
 }
@@ -346,7 +356,7 @@ void TransactionCB::verify_end(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         uint64_t total;
         signal >> total;
-        active_progress_bar->set_ticks(static_cast<int64_t>(total));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(total));
         multi_progress_bar.print();
     }
 }
@@ -364,7 +374,7 @@ void TransactionCB::transaction_progress(sdbus::Signal & signal) {
         uint64_t amount;
         signal >> amount;
 
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
         multi_progress_bar.print();
     }
 }
@@ -373,7 +383,7 @@ void TransactionCB::transaction_end(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         uint64_t total;
         signal >> total;
-        active_progress_bar->set_ticks(static_cast<int64_t>(total));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(total));
         multi_progress_bar.print();
     }
 }
@@ -420,7 +430,7 @@ void TransactionCB::action_progress(sdbus::Signal & signal) {
         signal >> nevra;
         signal >> amount;
 
-        active_progress_bar->set_ticks(static_cast<int64_t>(amount));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(amount));
         multi_progress_bar.print();
     }
 }
@@ -431,7 +441,7 @@ void TransactionCB::action_end(sdbus::Signal & signal) {
         uint64_t total;
         signal >> nevra;
         signal >> total;
-        active_progress_bar->set_ticks(static_cast<int64_t>(total));
+        multi_progress_bar.bar_set_ticks(*active_progress_bar, static_cast<int64_t>(total));
         multi_progress_bar.print();
     }
 }
@@ -440,7 +450,8 @@ void TransactionCB::script_start(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         std::string nevra;
         signal >> nevra;
-        active_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "Running scriptlet: " + nevra);
+        multi_progress_bar.bar_add_message(
+            *active_progress_bar, libdnf5::cli::progressbar::MessageType::INFO, "Running scriptlet: " + nevra);
         multi_progress_bar.print();
     }
 }
@@ -449,7 +460,8 @@ void TransactionCB::script_stop(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         std::string nevra;
         signal >> nevra;
-        active_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::INFO, "Stop scriptlet: " + nevra);
+        multi_progress_bar.bar_add_message(
+            *active_progress_bar, libdnf5::cli::progressbar::MessageType::INFO, "Stop scriptlet: " + nevra);
         multi_progress_bar.print();
     }
 }
@@ -458,7 +470,8 @@ void TransactionCB::script_error(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         std::string nevra;
         signal >> nevra;
-        active_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, "Error in scriptlet: " + nevra);
+        multi_progress_bar.bar_add_message(
+            *active_progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, "Error in scriptlet: " + nevra);
         multi_progress_bar.print();
     }
 }
@@ -467,16 +480,18 @@ void TransactionCB::unpack_error(sdbus::Signal & signal) {
     if (signature_valid(signal) && active_progress_bar) {
         std::string nevra;
         signal >> nevra;
-        active_progress_bar->add_message(libdnf5::cli::progressbar::MessageType::ERROR, "Unpack error: " + nevra);
+        multi_progress_bar.bar_add_message(
+            *active_progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, "Unpack error: " + nevra);
         multi_progress_bar.print();
     }
 }
 
 void TransactionCB::finished(sdbus::Signal & signal) {
     if (signature_valid(signal)) {
-        if (active_progress_bar &&
-            active_progress_bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::ERROR) {
-            active_progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+        if (active_progress_bar && multi_progress_bar.bar_get_state(*active_progress_bar) !=
+                                       libdnf5::cli::progressbar::ProgressBarState::ERROR) {
+            multi_progress_bar.bar_set_state(
+                *active_progress_bar, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
         }
         multi_progress_bar.print();
     }

--- a/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
@@ -75,6 +75,71 @@ public:
     /// It can be greater than the current number of registered progress bars.
     std::size_t get_total_num_of_bars() const noexcept;
 
+    /// @name Methods to work with registered bars
+    /// Preferred way to modify a bar registered in this MultiProgressBar.
+    /// Use these instead of calling ProgressBar methods directly, so that
+    /// MultiProgressBar can track state changes and use them for rendering
+    /// optimizations. Calls on a finished bar are ignored for mutating methods.
+    /// @{
+
+    /// Returns the number of processed ticks.
+    int64_t bar_get_ticks(ProgressBar & bar) const noexcept;
+    /// Sets the number of processed ticks.
+    void bar_set_ticks(ProgressBar & bar, int64_t value);
+    /// Adds to the number of processed ticks.
+    void bar_add_ticks(ProgressBar & bar, int64_t value);
+
+    /// Returns the total number of ticks.
+    int64_t bar_get_total_ticks(ProgressBar & bar) const noexcept;
+    /// Sets the total number of ticks.
+    void bar_set_total_ticks(ProgressBar & bar, int64_t value);
+
+    /// Returns the display number of the bar.
+    int32_t bar_get_number(ProgressBar & bar) const noexcept;
+
+    /// Starts the bar (transitions from READY to STARTED).
+    void bar_start(ProgressBar & bar);
+    /// Returns the current state.
+    ProgressBarState bar_get_state(ProgressBar & bar) const noexcept;
+    /// Sets the state. Setting back to READY is not allowed.
+    void bar_set_state(ProgressBar & bar, ProgressBarState value);
+    /// Returns true if the bar has reached a terminal state (SUCCESS or ERROR).
+    bool bar_is_finished(ProgressBar & bar) const noexcept;
+    /// Returns true if the bar is in the ERROR state.
+    bool bar_is_failed(ProgressBar & bar) const noexcept;
+
+    /// Returns the description string.
+    std::string bar_get_description(ProgressBar & bar) const noexcept;
+    /// Sets the description string.
+    void bar_set_description(ProgressBar & bar, const std::string & value);
+
+    /// Adds a message to the bar.
+    void bar_add_message(ProgressBar & bar, MessageType type, const std::string & message);
+    /// Removes the last message.
+    void bar_pop_message(ProgressBar & bar);
+    /// Returns all messages.
+    const std::vector<ProgressBar::Message> & bar_get_messages(ProgressBar & bar) const noexcept;
+    /// Returns the message prefix string.
+    const std::string & bar_get_message_prefix(ProgressBar & bar) const noexcept;
+
+    /// Returns whether auto-finish is enabled.
+    bool bar_get_auto_finish(ProgressBar & bar) const noexcept;
+    /// Enables or disables auto-finish. Disable to manage the terminal state manually.
+    void bar_set_auto_finish(ProgressBar & bar, bool value);
+
+    /// Returns the percentage of ticks done (0–100).
+    int32_t bar_get_percent_done(ProgressBar & bar) const noexcept;
+    /// Returns the current (recent) speed in ticks per second.
+    int64_t bar_get_current_speed(ProgressBar & bar) const noexcept;
+    /// Returns the average speed in ticks per second.
+    int64_t bar_get_average_speed(ProgressBar & bar) const noexcept;
+    /// Returns elapsed time in seconds.
+    int64_t bar_get_elapsed_seconds(ProgressBar & bar) const noexcept;
+    /// Returns estimated remaining time in seconds.
+    int64_t bar_get_remaining_seconds(ProgressBar & bar) const noexcept;
+
+    /// @}
+
 private:
     class LIBDNF_CLI_LOCAL Impl;
     ImplPtr<Impl> p_impl;

--- a/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/multi_progress_bar.hpp
@@ -41,7 +41,19 @@ class LIBDNF_CLI_API MultiProgressBar {
 public:
     static constexpr std::size_t NEVER_VISIBLE_LIMIT = static_cast<std::size_t>(-1);
 
+    /// Controls when bar state changes are processed for rendering.
+    enum class TrackingMode {
+        ON_RENDER,  ///< All bars are scanned on every render to detect state changes.
+        ON_CHANGE   ///< State changes are tracked incrementally via bar_*() wrapper methods.
+                    ///< Much faster when many bars are registered but only a few are active.
+    };
+
+    /// Constructs a MultiProgressBar with the given tracking mode.
+    explicit MultiProgressBar(TrackingMode tracking_mode);
+
+    /// Constructs a MultiProgressBar with TrackingMode::ON_RENDER.
     explicit MultiProgressBar();
+
     ~MultiProgressBar();
 
     MultiProgressBar(const MultiProgressBar & src) = delete;
@@ -49,6 +61,9 @@ public:
 
     MultiProgressBar(MultiProgressBar && src) noexcept = delete;
     MultiProgressBar & operator=(MultiProgressBar && src) noexcept = delete;
+
+    /// Returns the tracking mode set at construction.
+    TrackingMode get_tracking_mode() const noexcept;
 
     void add_bar(std::unique_ptr<ProgressBar> && bar);
 

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -272,4 +272,148 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 }
 
 
+int64_t MultiProgressBar::bar_get_ticks(ProgressBar & bar) const noexcept {
+    return bar.get_ticks();
+}
+
+
+void MultiProgressBar::bar_set_ticks(ProgressBar & bar, int64_t value) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.set_ticks(value);
+}
+
+
+void MultiProgressBar::bar_add_ticks(ProgressBar & bar, int64_t value) {
+    bar_set_ticks(bar, bar.get_ticks() + value);
+}
+
+
+int64_t MultiProgressBar::bar_get_total_ticks(ProgressBar & bar) const noexcept {
+    return bar.get_total_ticks();
+}
+
+
+void MultiProgressBar::bar_set_total_ticks(ProgressBar & bar, int64_t value) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.set_total_ticks(value);
+}
+
+
+int32_t MultiProgressBar::bar_get_number(ProgressBar & bar) const noexcept {
+    return bar.get_number();
+}
+
+
+void MultiProgressBar::bar_start(ProgressBar & bar) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.start();
+}
+
+
+ProgressBarState MultiProgressBar::bar_get_state(ProgressBar & bar) const noexcept {
+    return bar.get_state();
+}
+
+
+bool MultiProgressBar::bar_is_finished(ProgressBar & bar) const noexcept {
+    return bar.is_finished();
+}
+
+
+bool MultiProgressBar::bar_is_failed(ProgressBar & bar) const noexcept {
+    return bar.is_failed();
+}
+
+
+void MultiProgressBar::bar_set_state(ProgressBar & bar, ProgressBarState value) {
+    if (bar.is_finished() || value == ProgressBarState::READY) {
+        return;
+    }
+    bar.set_state(value);
+}
+
+
+std::string MultiProgressBar::bar_get_description(ProgressBar & bar) const noexcept {
+    return bar.get_description();
+}
+
+
+void MultiProgressBar::bar_set_description(ProgressBar & bar, const std::string & value) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.set_description(value);
+}
+
+
+void MultiProgressBar::bar_add_message(ProgressBar & bar, MessageType type, const std::string & message) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.add_message(type, message);
+}
+
+
+void MultiProgressBar::bar_pop_message(ProgressBar & bar) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.pop_message();
+}
+
+
+const std::vector<ProgressBar::Message> & MultiProgressBar::bar_get_messages(ProgressBar & bar) const noexcept {
+    return bar.get_messages();
+}
+
+
+const std::string & MultiProgressBar::bar_get_message_prefix(ProgressBar & bar) const noexcept {
+    return bar.get_message_prefix();
+}
+
+
+bool MultiProgressBar::bar_get_auto_finish(ProgressBar & bar) const noexcept {
+    return bar.get_auto_finish();
+}
+
+
+void MultiProgressBar::bar_set_auto_finish(ProgressBar & bar, bool value) {
+    if (bar.is_finished()) {
+        return;
+    }
+    bar.set_auto_finish(value);
+}
+
+
+int32_t MultiProgressBar::bar_get_percent_done(ProgressBar & bar) const noexcept {
+    return bar.get_percent_done();
+}
+
+
+int64_t MultiProgressBar::bar_get_current_speed(ProgressBar & bar) const noexcept {
+    return bar.get_current_speed();
+}
+
+
+int64_t MultiProgressBar::bar_get_average_speed(ProgressBar & bar) const noexcept {
+    return bar.get_average_speed();
+}
+
+
+int64_t MultiProgressBar::bar_get_elapsed_seconds(ProgressBar & bar) const noexcept {
+    return bar.get_elapsed_seconds();
+}
+
+
+int64_t MultiProgressBar::bar_get_remaining_seconds(ProgressBar & bar) const noexcept {
+    return bar.get_remaining_seconds();
+}
+
+
 }  // namespace libdnf5::cli::progressbar

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -36,14 +36,21 @@ namespace libdnf5::cli::progressbar {
 
 class MultiProgressBar::Impl {
 public:
-    Impl();
+    Impl(TrackingMode tracking_mode);
+
+    const TrackingMode tracking_mode;
 
     std::size_t total_bar_visible_limit{0};
     std::vector<std::unique_ptr<ProgressBar>> bars_all;
     std::vector<ProgressBar *> bars_todo;
     std::size_t bars_done_count{0};
     DownloadProgressBar total;
+
     int64_t done_ticks{0};
+
+    int64_t inactive_ticks{0};
+    int64_t inactive_total_ticks{0};
+
     // Whether the last line was printed without a new line ending (such as an in progress bar)
     bool line_printed{false};
     std::size_t num_of_lines_to_clear{0};
@@ -75,23 +82,33 @@ BarNumberType cast_to_bar_number(auto value) {
 }  // namespace
 
 
-MultiProgressBar::Impl::Impl() : total(0, _("Total")) {
+MultiProgressBar::Impl::Impl(TrackingMode tracking_mode) : tracking_mode(tracking_mode), total(0, _("Total")) {
     total.set_auto_finish(false);
     total.start();
 }
 
 
-MultiProgressBar::MultiProgressBar() : p_impl(new Impl()) {
+MultiProgressBar::MultiProgressBar(TrackingMode tracking_mode) : p_impl(new Impl(tracking_mode)) {
     if (tty::is_interactive()) {
         std::cerr << tty::cursor_hide;
     }
 }
+
+
+MultiProgressBar::MultiProgressBar() : MultiProgressBar(TrackingMode::ON_RENDER) {}
+
 
 MultiProgressBar::~MultiProgressBar() {
     if (tty::is_interactive()) {
         std::cerr << tty::cursor_show;
     }
 }
+
+
+MultiProgressBar::TrackingMode MultiProgressBar::get_tracking_mode() const noexcept {
+    return p_impl->tracking_mode;
+}
+
 
 void MultiProgressBar::print() {
     std::cerr << *this;
@@ -115,9 +132,21 @@ void MultiProgressBar::add_bar(std::unique_ptr<ProgressBar> && bar) {
     auto next_number = cast_to_bar_number(p_impl->bars_all.size() + 1);
     bar->set_number(next_number);
 
+    auto * const registered_bar = bar.get();
+
     // register bar to MultiProgressBar
-    p_impl->bars_todo.push_back(bar.get());
     p_impl->bars_all.push_back(std::move(bar));
+    if (p_impl->tracking_mode == TrackingMode::ON_RENDER || registered_bar->get_state() != ProgressBarState::READY) {
+        p_impl->bars_todo.push_back(registered_bar);
+    } else {
+        // ON_CHANGE mode: track ticks for inactive bars (READY state, not yet in bars_todo)
+        if (const auto bar_ticks = registered_bar->get_ticks(); bar_ticks > 0) {
+            p_impl->inactive_ticks += bar_ticks;
+        }
+        if (const auto bar_total_ticks = registered_bar->get_total_ticks(); bar_total_ticks > 0) {
+            p_impl->inactive_total_ticks += bar_total_ticks;
+        }
+    }
 
     // update total (in [num/total]) in total progress bar
     auto registered_bars_count = next_number;
@@ -220,11 +249,15 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
     // then print the "total" progress bar
     if ((mbar.p_impl->bars_all.size() >= mbar.p_impl->total_bar_visible_limit) &&
-        (is_interactive || mbar.p_impl->bars_todo.empty())) {
+        (is_interactive || mbar.p_impl->bars_all.size() == mbar.p_impl->bars_done_count)) {
         // compute ticks and total_ticks for total progress bar
         // done bars can be unfinished -> add only processed ticks to both values
         int64_t ticks = mbar.p_impl->done_ticks;
         int64_t total_ticks = ticks;
+        if (mbar.p_impl->tracking_mode == MultiProgressBar::TrackingMode::ON_CHANGE) {
+            ticks += mbar.p_impl->inactive_ticks;
+            total_ticks += mbar.p_impl->inactive_total_ticks;
+        }
         for (auto & bar : mbar.p_impl->bars_todo) {
             if (const auto bar_total_ticks = bar->get_total_ticks(); bar_total_ticks > 0) {
                 total_ticks += bar_total_ticks;
@@ -248,7 +281,7 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
         mbar_total.set_total_ticks(total_ticks);
         mbar_total.set_ticks(ticks);
 
-        if (mbar.p_impl->bars_todo.empty()) {
+        if (mbar.p_impl->bars_all.size() == mbar.p_impl->bars_done_count) {
             // all bars have finished, set the "Total" bar as finished too according to their states
             mbar_total.set_state(ProgressBarState::SUCCESS);
         }
@@ -281,6 +314,10 @@ void MultiProgressBar::bar_set_ticks(ProgressBar & bar, int64_t value) {
     if (bar.is_finished()) {
         return;
     }
+    if (p_impl->tracking_mode == TrackingMode::ON_CHANGE && bar.get_state() == ProgressBarState::READY) {
+        const auto old_ticks = bar.get_ticks();
+        p_impl->inactive_ticks += (value > 0 ? value : 0) - (old_ticks > 0 ? old_ticks : 0);
+    }
     bar.set_ticks(value);
 }
 
@@ -299,6 +336,10 @@ void MultiProgressBar::bar_set_total_ticks(ProgressBar & bar, int64_t value) {
     if (bar.is_finished()) {
         return;
     }
+    if (p_impl->tracking_mode == TrackingMode::ON_CHANGE && bar.get_state() == ProgressBarState::READY) {
+        const auto old_ticks = bar.get_total_ticks();
+        p_impl->inactive_total_ticks += (value > 0 ? value : 0) - (old_ticks > 0 ? old_ticks : 0);
+    }
     bar.set_total_ticks(value);
 }
 
@@ -311,6 +352,15 @@ int32_t MultiProgressBar::bar_get_number(ProgressBar & bar) const noexcept {
 void MultiProgressBar::bar_start(ProgressBar & bar) {
     if (bar.is_finished()) {
         return;
+    }
+    if (p_impl->tracking_mode == TrackingMode::ON_CHANGE && bar.get_state() == ProgressBarState::READY) {
+        if (const auto bar_ticks = bar.get_ticks(); bar_ticks > 0) {
+            p_impl->inactive_ticks -= bar_ticks;
+        }
+        if (const auto bar_total_ticks = bar.get_total_ticks(); bar_total_ticks > 0) {
+            p_impl->inactive_total_ticks -= bar_total_ticks;
+        }
+        p_impl->bars_todo.push_back(&bar);
     }
     bar.start();
 }
@@ -334,6 +384,15 @@ bool MultiProgressBar::bar_is_failed(ProgressBar & bar) const noexcept {
 void MultiProgressBar::bar_set_state(ProgressBar & bar, ProgressBarState value) {
     if (bar.is_finished() || value == ProgressBarState::READY) {
         return;
+    }
+    if (p_impl->tracking_mode == TrackingMode::ON_CHANGE && bar.get_state() == ProgressBarState::READY) {
+        if (const auto bar_ticks = bar.get_ticks(); bar_ticks > 0) {
+            p_impl->inactive_ticks -= bar_ticks;
+        }
+        if (const auto bar_total_ticks = bar.get_total_ticks(); bar_total_ticks > 0) {
+            p_impl->inactive_total_ticks -= bar_total_ticks;
+        }
+        p_impl->bars_todo.push_back(&bar);
     }
     bar.set_state(value);
 }

--- a/libdnf5-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/multi_progress_bar.cpp
@@ -194,15 +194,15 @@ std::ostream & operator<<(std::ostream & stream, MultiProgressBar & mbar) {
 
     // then print incomplete
     for (auto & bar : mbar.p_impl->bars_todo) {
+        // skip bars that haven't started yet
+        if (bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::STARTED) {
+            continue;
+        }
+
         if (number < std::numeric_limits<decltype(number)>::max()) {
             ++number;
         }
         bar->set_number(number);
-
-        // skip printing bars that haven't started yet
-        if (bar->get_state() != libdnf5::cli::progressbar::ProgressBarState::STARTED) {
-            continue;
-        }
 
         if (!is_interactive) {
             bar->update();

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -147,3 +147,77 @@ void ProgressbarTest::test_multi_progress_bar_unfinished() {
         "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B | ???????\n";
     ASSERT_MATCHES(expected, oss.str());
 }
+
+void ProgressbarTest::test_multi_progress_bar_on_change() {
+    // ON_CHANGE variant of test_multi_progress_bar
+    // All bar access goes through bar_*() wrapper methods.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const bar1 = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.bar_set_ticks(*bar1, 10);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const bar2 = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.bar_set_ticks(*bar2, 10);
+    multi_progress_bar.bar_set_state(*bar2, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+}
+
+void ProgressbarTest::test_multi_progress_bar_on_change_unfinished() {
+    // ON_CHANGE variant of test_multi_progress_bar_unfinished
+    // All bar access goes through bar_*() wrapper methods.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const bar1 = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.bar_set_ticks(*bar1, 10);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const bar2 = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.bar_set_ticks(*bar2, 4);
+    multi_progress_bar.bar_start(*bar2);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected = "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+
+    // More iterations
+    multi_progress_bar.bar_set_ticks(*bar2, 5);
+    oss << multi_progress_bar;
+    multi_progress_bar.bar_set_ticks(*bar2, 6);
+    oss << multi_progress_bar;
+    expected = "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+
+    // Next iteration
+    multi_progress_bar.bar_set_ticks(*bar2, 10);
+    multi_progress_bar.bar_set_state(*bar2, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B | ???????\n";
+    ASSERT_MATCHES(expected, oss.str());
+}

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -31,6 +31,8 @@ class ProgressbarTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_download_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
+    CPPUNIT_TEST(test_multi_progress_bar_on_change);
+    CPPUNIT_TEST(test_multi_progress_bar_on_change_unfinished);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -42,6 +44,8 @@ public:
     void test_download_progress_bar();
     void test_multi_progress_bar();
     void test_multi_progress_bar_unfinished();
+    void test_multi_progress_bar_on_change();
+    void test_multi_progress_bar_on_change_unfinished();
 };
 
 

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -703,3 +703,240 @@ void ProgressbarInteractiveTest::test_multi_progress_bars_with_already_downloade
         "\\[2/3\\] Total                    40% | ????? ??B\\/s |   4.0   B | ???????";
     ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
 }
+
+void ProgressbarInteractiveTest::test_multi_progress_bar_on_change_finished() {
+    // ON_CHANGE variant of test_multi_progress_bar_with_total_finished
+    // All bar access goes through bar_*() wrapper methods.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const bar1 = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.bar_set_ticks(*bar1, 10);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const bar2 = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.bar_set_ticks(*bar2, 10);
+    multi_progress_bar.bar_set_state(*bar2, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B |  ??????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B |  ??????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B\\/s |  20.0   B |  ??????\n";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
+void ProgressbarInteractiveTest::test_multi_progress_bar_on_change_already_downloaded() {
+    // ON_CHANGE variant of test_multi_progress_bars_with_already_downloaded
+    // All bar access goes through bar_*() wrapper methods.
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto download_progress_bar3 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
+    auto * const bar1 = download_progress_bar1.get();
+    auto * const bar2 = download_progress_bar2.get();
+    auto * const bar3 = download_progress_bar3.get();
+
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.add_bar(std::move(download_progress_bar3));
+
+    // First download progress bar represents already downloaded package
+    multi_progress_bar.bar_set_ticks(*bar1, 0);
+    multi_progress_bar.bar_set_total_ticks(*bar1, 0);
+    multi_progress_bar.bar_add_message(*bar1, libdnf5::cli::progressbar::MessageType::SUCCESS, "Already Downloaded");
+    multi_progress_bar.bar_start(*bar1);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // Add another already downloaded package
+    multi_progress_bar.bar_set_ticks(*bar2, 0);
+    multi_progress_bar.bar_set_total_ticks(*bar2, 0);
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::SUCCESS, "Already Downloaded");
+    multi_progress_bar.bar_start(*bar2);
+    multi_progress_bar.bar_set_state(*bar2, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[2/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/3\\] Total                   ???% | ????? ??B\\/s |   0.0   B | ???????";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // In progress download
+    multi_progress_bar.bar_set_ticks(*bar3, 4);
+    multi_progress_bar.bar_start(*bar3);
+
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[2/3\\] test                    100% | ????? ??B\\/s |   0.0   B | ???????\n"
+        ">>> Already Downloaded\n"
+        "\\[3/3\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/3\\] Total                    40% | ????? ??B\\/s |   4.0   B | ???????";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
+void ProgressbarInteractiveTest::test_multi_progress_bars_on_change_with_messages_with_total() {
+    // ON_CHANGE variant of test_multi_progress_bars_with_messages_with_total
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const bar1 = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.bar_set_ticks(*bar1, 10);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const bar2 = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.bar_set_auto_finish(*bar2, false);
+    multi_progress_bar.bar_start(*bar2);
+    multi_progress_bar.bar_set_ticks(*bar2, 4);
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test もで 諤奯ゞ");
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        ">>> test message1\n"
+        ">>> test message2\n"
+        ">>> test もで 諤奯ゞ\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    oss << multi_progress_bar;
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[1/2\\] Total                    70% | ????? ??B\\/s |  14.0   B | ???????\n"
+        "\n"
+        "\n";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // new iteration
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    oss << multi_progress_bar;
+    multi_progress_bar.bar_pop_message(*bar2);
+    oss << multi_progress_bar;
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}
+
+void ProgressbarInteractiveTest::test_multi_progress_bars_on_change_with_messages() {
+    // ON_CHANGE variant of test_multi_progress_bars_with_messages
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar{
+        libdnf5::cli::progressbar::MultiProgressBar::TrackingMode::ON_CHANGE};
+    multi_progress_bar.set_total_bar_visible_limit(libdnf5::cli::progressbar::MultiProgressBar::NEVER_VISIBLE_LIMIT);
+
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    auto * const bar1 = download_progress_bar1.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.bar_set_ticks(*bar1, 10);
+    multi_progress_bar.bar_set_state(*bar1, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    auto * const bar2 = download_progress_bar2.get();
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    multi_progress_bar.bar_set_ticks(*bar2, 4);
+    multi_progress_bar.bar_start(*bar2);
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message2");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test こんにちは世界！");
+
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+    Pattern expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        ">>> test message1\n"
+        ">>> test message2\n"
+        ">>> test こんにちは世界！";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    oss << multi_progress_bar;
+
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "\n"
+        "\n";
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    // new iteration
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    oss << multi_progress_bar;
+    multi_progress_bar.bar_pop_message(*bar2);
+    oss << multi_progress_bar;
+
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                    40% | ????? ??B\\/s |   4.0   B | ???????\n"
+        "\n"
+        "\n";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    multi_progress_bar.bar_add_message(*bar2, libdnf5::cli::progressbar::MessageType::INFO, "test message1");
+    oss << multi_progress_bar;
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_pop_message(*bar2);
+    multi_progress_bar.bar_set_ticks(*bar2, 10);
+    multi_progress_bar.bar_set_state(*bar2, libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    oss << multi_progress_bar;
+    oss << "Complete!";
+
+    expected =
+        "\\[1/2\\] test1                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "\\[2/2\\] test2                   100% | ????? ??B\\/s |  10.0   B | ???????\n"
+        "Complete!\n"
+        "\n"
+        "";
+
+    ASSERT_MATCHES(expected, perform_control_sequences(oss.str()));
+}

--- a/test/libdnf5-cli/test_progressbar_interactive.hpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.hpp
@@ -38,6 +38,10 @@ class ProgressbarInteractiveTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_multi_progress_bar_with_short_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_messages);
     CPPUNIT_TEST(test_multi_progress_bars_with_already_downloaded);
+    CPPUNIT_TEST(test_multi_progress_bar_on_change_finished);
+    CPPUNIT_TEST(test_multi_progress_bar_on_change_already_downloaded);
+    CPPUNIT_TEST(test_multi_progress_bars_on_change_with_messages_with_total);
+    CPPUNIT_TEST(test_multi_progress_bars_on_change_with_messages);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -56,6 +60,10 @@ public:
     void test_multi_progress_bar_with_short_messages();
     void test_multi_progress_bars_with_messages();
     void test_multi_progress_bars_with_already_downloaded();
+    void test_multi_progress_bar_on_change_finished();
+    void test_multi_progress_bar_on_change_already_downloaded();
+    void test_multi_progress_bars_on_change_with_messages_with_total();
+    void test_multi_progress_bars_on_change_with_messages();
 };
 
 


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/2790

Follows up on https://github.com/rpm-software-management/dnf5/pull/2817 and https://github.com/rpm-software-management/dnf5/pull/2822.

Introduces `TrackingMode::ON_CHANGE` for MultiProgressBar. In the default `ON_RENDER` mode, all bars are scanned on every render to detect state changes. In the new `ON_CHANGE` mode, state changes are tracked incrementally via `bar_*()` wrapper methods, eliminating the per-render scan of inactive bars. This provides a significant speedup when many bars are registered but only a few are active at a time.

Unlike the previous optimizations, this approach requires callers to access registered bars through the new `bar_*()` wrapper methods instead of calling `ProgressBar` methods directly. This allows `MultiProgressBar` to track state changes and maintain cached tick sums for inactive bars.

## New API

- `TrackingMode` enum: `ON_RENDER` (default) / `ON_CHANGE`
- `bar_*()` wrapper methods for all `ProgressBar` operations (ticks, total_ticks, state, start, description, messages, auto-finish, stats).
  Mutating methods are no-ops on finished bars. `bar_set_state()` rejects transitions back to `READY`. Parameters accept `ProgressBar &` to prevent `nullptr`.

## Bug fix

- Fix bar number gaps caused by unstarted bars in the print-incomplete loop. Bars in READY state consumed a display number even though they were not printed.

## Usage

`dnf5::DownloadCallbacks`, `dnf5::RpmTransCB`, `manifest_plugin::DownloadCallbacks`, and dnf5daemon-client's `DownloadCB`
and `TransactionCB` were switched to use the `bar_*()` wrapper methods and `TrackingMode::ON_CHANGE`.

Unit tests for `ON_CHANGE` mode are included.