### PR TITLE
Set systemd inhibitor lock during transaction

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -300,6 +300,16 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``False``.
 
+.. _inhibit_shutdown_options-label:
+
+``inhibit_shutdown``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 will hold a systemd inhibitor lock to prevent the system from
+    shutting down or rebooting while a package transaction is in progress.
+
+    Default: ``True``.
+
 .. _installonlypkgs_options-label:
 
 ``installonlypkgs``

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -230,6 +230,8 @@ public:
     const OptionBool & get_build_cache_option() const;
     OptionBool & get_skip_system_repo_lock_option();
     const OptionBool & get_skip_system_repo_lock_option() const;
+    OptionBool & get_inhibit_shutdown_option();
+    const OptionBool & get_inhibit_shutdown_option() const;
     OptionEnum & get_persistence_option();
     const OptionEnum & get_persistence_option() const;
     OptionStringAppendList & get_usr_drift_protected_paths_option();

--- a/libdnf5/CMakeLists.txt
+++ b/libdnf5/CMakeLists.txt
@@ -7,6 +7,11 @@ if (NOT WITH_MODULEMD)
     list(REMOVE_ITEM LIBDNF5_SOURCES ${LIBDNF5_SOURCES_MODULES})
 endif()
 
+# exclude the systemd inhibitor source if WITH_SYSTEMD not defined
+if (NOT WITH_SYSTEMD)
+    list(REMOVE_ITEM LIBDNF5_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/utils/systemd_inhibit.cpp")
+endif()
+
 # gather all pkg-config requires and write them to a .pc file later
 list(APPEND LIBDNF5_PC_REQUIRES)
 list(APPEND LIBDNF5_PC_REQUIRES_PRIVATE)
@@ -126,6 +131,14 @@ pkg_check_modules(SQLite3 REQUIRED sqlite3>=3.35.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${SQLite3_MODULE_NAME}")
 target_link_libraries(libdnf5 PRIVATE ${SQLite3_LIBRARIES})
 target_link_libraries(libdnf5_iface INTERFACE ${SQLite3_LIBRARIES})
+
+if(WITH_SYSTEMD)
+    # libsystemd is loaded at runtime via dlopen (see utils/systemd_inhibit.cpp),
+    # so only its headers are needed here - no link-time dependency is added.
+    pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
+    target_include_directories(libdnf5_obj PRIVATE ${LIBSYSTEMD_INCLUDE_DIRS})
+    target_compile_definitions(libdnf5_obj PRIVATE WITH_SYSTEMD)
+endif()
 
 
 # sort the pkg-config requires and concatenate them into a string

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -37,6 +37,9 @@
 #include "transaction_package_impl.hpp"
 #include "utils/on_scope_exit.hpp"
 #include "utils/string.hpp"
+#ifdef WITH_SYSTEMD
+#include "utils/systemd_inhibit.hpp"
+#endif
 
 #include "libdnf5/base/active_transaction_info.hpp"
 #include "libdnf5/base/base.hpp"
@@ -1099,6 +1102,16 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     if (test_only || rpm_transaction_flags & RPMTRANS_FLAG_TEST) {
         return TransactionRunResult::SUCCESS;
     }
+
+#ifdef WITH_SYSTEMD
+    int inhibit_fd = libdnf5::utils::acquire_systemd_inhibitor_lock(*logger);
+    libdnf5::utils::OnScopeExit release_inhibitor_lock([inhibit_fd, logger]() noexcept {
+        if (inhibit_fd >= 0) {
+            close(inhibit_fd);
+            logger->debug("Released systemd inhibitor lock");
+        }
+    });
+#endif
 
     auto & plugins = base->p_impl->get_plugins();
     plugins.pre_transaction(*transaction);

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -1104,7 +1104,10 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     }
 
 #ifdef WITH_SYSTEMD
-    int inhibit_fd = libdnf5::utils::acquire_systemd_inhibitor_lock(*logger);
+    int inhibit_fd = -1;
+    if (config.get_inhibit_shutdown_option().get_value()) {
+        inhibit_fd = libdnf5::utils::acquire_systemd_inhibitor_lock(*logger);
+    }
     libdnf5::utils::OnScopeExit release_inhibitor_lock([inhibit_fd, logger]() noexcept {
         if (inhibit_fd >= 0) {
             close(inhibit_fd);

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -236,6 +236,7 @@ class ConfigMain::Impl {
     OptionBool protect_running_kernel{true};
     OptionBool build_cache{true};
     OptionBool skip_system_repo_lock{false};
+    OptionBool inhibit_shutdown{true};
     OptionEnum persistence{"auto", {"auto", "persist", "transient"}};
 
     OptionStringAppendList usr_drift_protected_paths{
@@ -420,6 +421,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("protect_running_kernel", protect_running_kernel);
     owner.opt_binds().add("build_cache", build_cache);
     owner.opt_binds().add("skip_system_repo_lock", skip_system_repo_lock);
+    owner.opt_binds().add("inhibit_shutdown", inhibit_shutdown);
     owner.opt_binds().add("persistence", persistence);
     owner.opt_binds().add("usr_drift_protected_paths", usr_drift_protected_paths);
 
@@ -1080,6 +1082,12 @@ OptionBool & ConfigMain::get_skip_system_repo_lock_option() {
 const OptionBool & ConfigMain::get_skip_system_repo_lock_option() const {
     return p_impl->skip_system_repo_lock;
 }
+OptionBool & ConfigMain::get_inhibit_shutdown_option() {
+    return p_impl->inhibit_shutdown;
+}
+const OptionBool & ConfigMain::get_inhibit_shutdown_option() const {
+    return p_impl->inhibit_shutdown;
+}
 
 OptionEnum & ConfigMain::get_persistence_option() {
     return p_impl->persistence;
@@ -1529,6 +1537,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(protect_running_kernel, other.protect_running_kernel);
     load_option(build_cache, other.build_cache);
     load_option(skip_system_repo_lock, other.skip_system_repo_lock);
+    load_option(inhibit_shutdown, other.inhibit_shutdown);
     load_option(persistence, other.persistence);
     load_option(usr_drift_protected_paths, other.usr_drift_protected_paths);
 

--- a/libdnf5/utils/systemd_inhibit.cpp
+++ b/libdnf5/utils/systemd_inhibit.cpp
@@ -1,0 +1,124 @@
+// Copyright Contributors to the DNF5 project.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "systemd_inhibit.hpp"
+
+#include "utils/library.hpp"
+
+#include <systemd/sd-bus.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <memory>
+
+namespace libdnf5::utils {
+
+namespace {
+
+// SONAME of libsystemd. Stable since the 2014 merge of libsystemd-journal,
+// libsystemd-login, libsystemd-id128, and libsystemd-daemon; sd_bus itself
+// never existed under any other name.
+constexpr const char * LIBSYSTEMD_SONAME = "libsystemd.so.0";
+
+// libsystemd is loaded via dlopen, so libdnf5 carries no link-time or runtime
+// dependency on it. The function prototypes are only used at compile time to
+// derive the correct pointer types; none of them are ever linked against.
+using TSdBusOpenSystem = decltype(&sd_bus_open_system);
+using TSdBusCallMethod = decltype(&sd_bus_call_method);
+using TSdBusMessageRead = decltype(&sd_bus_message_read);
+using TSdBusMessageUnref = decltype(&sd_bus_message_unref);
+using TSdBusUnref = decltype(&sd_bus_unref);
+using TSdBusErrorFree = decltype(&sd_bus_error_free);
+
+struct LibSystemd {
+    explicit LibSystemd(const std::string & path) : library(path) {
+        open_system = reinterpret_cast<TSdBusOpenSystem>(library.get_address("sd_bus_open_system"));
+        call_method = reinterpret_cast<TSdBusCallMethod>(library.get_address("sd_bus_call_method"));
+        message_read = reinterpret_cast<TSdBusMessageRead>(library.get_address("sd_bus_message_read"));
+        message_unref = reinterpret_cast<TSdBusMessageUnref>(library.get_address("sd_bus_message_unref"));
+        unref = reinterpret_cast<TSdBusUnref>(library.get_address("sd_bus_unref"));
+        error_free = reinterpret_cast<TSdBusErrorFree>(library.get_address("sd_bus_error_free"));
+    }
+
+    TSdBusOpenSystem open_system;
+    TSdBusCallMethod call_method;
+    TSdBusMessageRead message_read;
+    TSdBusMessageUnref message_unref;
+    TSdBusUnref unref;
+    TSdBusErrorFree error_free;
+    Library library;
+};
+
+// Resolved (or found unavailable) once per process.
+LibSystemd * get_libsystemd() {
+    static std::unique_ptr<LibSystemd> instance = []() -> std::unique_ptr<LibSystemd> {
+        try {
+            return std::make_unique<LibSystemd>(LIBSYSTEMD_SONAME);
+        } catch (const LibraryError &) {
+            return nullptr;
+        }
+    }();
+    return instance.get();
+}
+
+}  // namespace
+
+int acquire_systemd_inhibitor_lock(Logger & logger) {
+    auto * sd = get_libsystemd();
+    if (!sd) {
+        logger.debug("libsystemd is not available, skipping systemd inhibitor lock");
+        return -1;
+    }
+
+    sd_bus * bus = nullptr;
+    int r = sd->open_system(&bus);
+    if (r < 0) {
+        logger.warning("Failed to open systemd bus connection: {}", std::strerror(-r));
+        return -1;
+    }
+
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    sd_bus_message * reply = nullptr;
+    r = sd->call_method(
+        bus,
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+        "Inhibit",
+        &error,
+        &reply,
+        "ssss",
+        "shutdown",
+        "dnf5",
+        "Package transaction is running",
+        "block");
+    if (r < 0) {
+        logger.warning(
+            "Failed to acquire systemd inhibitor lock: {}", error.message ? error.message : std::strerror(-r));
+        sd->error_free(&error);
+        sd->unref(bus);
+        return -1;
+    }
+
+    int raw_fd = -1;
+    r = sd->message_read(reply, "h", &raw_fd);
+    int fd = -1;
+    if (r < 0) {
+        logger.warning("Failed to read systemd inhibitor lock file descriptor: {}", std::strerror(-r));
+    } else {
+        fd = dup(raw_fd);
+        if (fd < 0) {
+            logger.warning("Failed to dup systemd inhibitor lock file descriptor: {}", std::strerror(errno));
+        } else {
+            logger.debug("Acquired systemd inhibitor lock (fd={})", fd);
+        }
+    }
+
+    sd->message_unref(reply);
+    sd->unref(bus);
+    sd->error_free(&error);
+    return fd;
+}
+
+}  // namespace libdnf5::utils

--- a/libdnf5/utils/systemd_inhibit.hpp
+++ b/libdnf5/utils/systemd_inhibit.hpp
@@ -1,0 +1,24 @@
+// Copyright Contributors to the DNF5 project.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef _LIBDNF5_UTILS_SYSTEMD_INHIBIT_HPP
+#define _LIBDNF5_UTILS_SYSTEMD_INHIBIT_HPP
+
+#include "libdnf5/logger/logger.hpp"
+
+namespace libdnf5::utils {
+
+/// Acquires a systemd logind inhibitor lock ("shutdown", mode "block") that
+/// prevents the system from shutting down or rebooting.
+///
+/// libsystemd is loaded on demand via dlopen, so libdnf5 has no link-time or
+/// runtime dependency on it. If libsystemd is not present, or the lock cannot
+/// be acquired for any other reason, the failure is logged and -1 is returned
+/// — the caller is expected to treat this as non-fatal.
+///
+/// @return The lock file descriptor (release it with close()), or -1 on failure.
+int acquire_systemd_inhibitor_lock(Logger & logger);
+
+}  // namespace libdnf5::utils
+
+#endif


### PR DESCRIPTION
Acquire a systemd logind inhibitor lock to prevent system shutdown/reboot while a package transaction is in progress. The lock is held from just before pre_transaction plugin hooks run through the end of post_transaction hooks, covering RPM execution, system state update, and history database writes.

libsystemd is loaded on demand via dlopen (through the existing utils::Library helper used for plugin loading) and only the raw sd_bus C API is used, so libdnf5 gains no link-time or runtime dependency on it. If libsystemd is unavailable, or the lock cannot be acquired for any other reason, the failure is logged and the transaction proceeds normally.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2408