### PR TITLE
Fix aliging unicode descriptions in a progressbar

### DIFF
--- a/include/libdnf5-cli/progressbar/progress_bar.hpp
+++ b/include/libdnf5-cli/progressbar/progress_bar.hpp
@@ -91,6 +91,8 @@ public:
     // description
     std::string get_description() const noexcept;
     void set_description(const std::string & value);
+    // How many columns the description occupies.
+    std::size_t get_description_width() const noexcept;
 
     // messages
     void add_message(MessageType type, const std::string & message);

--- a/include/libdnf5-cli/progressbar/widgets/widget.hpp
+++ b/include/libdnf5-cli/progressbar/widgets/widget.hpp
@@ -40,7 +40,13 @@ public:
     void set_bar(ProgressBar * value) { bar = value; }
 
     virtual std::size_t get_total_width() const noexcept = 0;
+    // Return a textual representation of the widget, right-padded to the
+    // total width. The representation can overflow the total width if the
+    // underlying progressbar element is longer.
     virtual std::string to_string() const = 0;
+    // Like to_string() but always occupying total width columns (overlong
+    // string will be clamped, shorter string right-padded with spaces).
+    std::string to_spanned_string() const;
 
     const std::string & get_delimiter_before() const noexcept { return delimiter_before; }
     void set_delimiter_before(const std::string & value) { delimiter_before = value; }

--- a/libdnf5-cli/progressbar/download_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/download_progress_bar.cpp
@@ -143,10 +143,10 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
     }
 
     std::size_t terminal_width = static_cast<std::size_t>(tty::get_width());
-
-    // if bar doesn't fit terminal width, hide progress widget
     std::size_t bar_width = get_bar_width(widgets);
-    if (bar_width > terminal_width) {
+
+    // if bar is finished or doesn't fit terminal width, hide the progress widget
+    if (get_state() != ProgressBarState::STARTED || bar_width > terminal_width) {
         widgets.erase(std::remove(widgets.begin(), widgets.end(), &p_impl->progress_widget), widgets.end());
         bar_width = get_bar_width(widgets);
     }
@@ -164,20 +164,17 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
         bar_width = get_bar_width(widgets);
     }
 
-    // if bar is finished, hide the progress widget
-    if (get_state() != ProgressBarState::STARTED) {
-        widgets.erase(std::remove(widgets.begin(), widgets.end(), &p_impl->progress_widget), widgets.end());
-        bar_width = get_bar_width(widgets);
-    }
-
     // if bar doesn't fit terminal width, reduce description width
     if (bar_width > terminal_width) {
         p_impl->description_widget.set_total_width(
             p_impl->description_widget.get_total_width() + terminal_width - bar_width);
         bar_width = get_bar_width(widgets);
     }
-
-    if (bar_width < terminal_width) {
+    // or stretch the description width if hiding widgets reclaimed space
+    // XXX: This makes the bar span over the terminal width even if no
+    // description needs so much space. Some pople might find it wasteful and
+    // ugly.
+    else if (bar_width < terminal_width) {
         p_impl->description_widget.set_total_width(
             p_impl->description_widget.get_total_width() + terminal_width - bar_width);
         bar_width = get_bar_width(widgets);

--- a/libdnf5-cli/progressbar/download_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/download_progress_bar.cpp
@@ -23,7 +23,6 @@
 #include "libdnf5-cli/tty.hpp"
 
 #include <algorithm>
-#include <iomanip>
 
 
 namespace libdnf5::cli::progressbar {
@@ -204,11 +203,7 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
     }
 
     for (Widget * widget : widgets) {
-        stream << std::left;
-        // if string is shorter, fill the widget's space with spaces
-        stream << std::setw(static_cast<int>(widget->get_total_width()));
-        // print only the part of the string that fits the widget width
-        stream << widget->to_string().substr(0, widget->get_total_width());
+        stream << widget->to_spanned_string();
     }
 
     if (color_used) {

--- a/libdnf5-cli/progressbar/download_progress_bar.cpp
+++ b/libdnf5-cli/progressbar/download_progress_bar.cpp
@@ -166,9 +166,17 @@ void DownloadProgressBar::to_stream(std::ostream & stream) {
 
     // if bar doesn't fit terminal width, reduce description width
     if (bar_width > terminal_width) {
-        p_impl->description_widget.set_total_width(
-            p_impl->description_widget.get_total_width() + terminal_width - bar_width);
-        bar_width = get_bar_width(widgets);
+        auto description_width = p_impl->description_widget.get_total_width();
+        auto overflow = bar_width - terminal_width;
+        // but only if the reduction would left something from the description,
+        // to prevent an integer overflow.
+        if (description_width > overflow) {
+            p_impl->description_widget.set_total_width(description_width - overflow);
+            bar_width = get_bar_width(widgets);
+        } else {
+            // As much as reduced, the bar cannot fit into the terminal.
+            // Just leave it as it is.
+        }
     }
     // or stretch the description width if hiding widgets reclaimed space
     // XXX: This makes the bar span over the terminal width even if no

--- a/libdnf5-cli/progressbar/progress_bar.cpp
+++ b/libdnf5-cli/progressbar/progress_bar.cpp
@@ -18,10 +18,17 @@
 // along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
+// For wcwidth()
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
+
 #include "libdnf5-cli/progressbar/progress_bar.hpp"
 
-#include <optional>
+#include <wchar.h>
 
+#include <cwchar>
+#include <optional>
 
 namespace libdnf5::cli::progressbar {
 
@@ -33,8 +40,12 @@ public:
         std::size_t padding;
     };
 
+    void update_description_width() noexcept;
+
     explicit Impl(int64_t total_ticks) : total_ticks{total_ticks} {}
-    Impl(int64_t total_ticks, const std::string & description) : total_ticks{total_ticks}, description{description} {}
+    Impl(int64_t total_ticks, const std::string & description) : total_ticks{total_ticks}, description{description} {
+        update_description_width();
+    }
 
     const MessageMetrics & get_message_metrics(
         std::size_t terminal_width, std::string_view message, std::size_t message_index) noexcept;
@@ -49,6 +60,7 @@ public:
 
     // description
     std::string description;
+    std::size_t description_width = 0;
 
     // messages
     std::vector<ProgressBar::Message> messages;
@@ -119,6 +131,27 @@ const ProgressBar::Impl::MessageMetrics & ProgressBar::Impl::get_message_metrics
     return messages_metrics_cache.at(message_index).value();
 }
 
+void ProgressBar::Impl::update_description_width() noexcept {
+    description_width = 0;
+    std::mbstate_t mbstate = std::mbstate_t();
+    const char * start = description.data();
+    std::size_t size = description.size();
+
+    while (size > 0) {
+        wchar_t wc;
+        auto bytes_consumed = std::mbrtowc(&wc, start, size, &mbstate);
+        if (bytes_consumed == 0 || bytes_consumed >= SIZE_MAX - 1) {
+            // TODO: Trim the description on first invalid multi-byte character?
+            break;
+        }
+        auto wc_width = wcwidth(wc);
+        if (wc_width >= 0) {  // Ignore -1 for non-printable characters.
+            description_width += static_cast<std::size_t>(wc_width);
+        }
+        start += bytes_consumed;
+        size -= bytes_consumed;
+    }
+}
 
 ProgressBar::~ProgressBar() = default;
 
@@ -178,8 +211,13 @@ std::string ProgressBar::get_description() const noexcept {
     return p_impl->description;
 }
 
+std::size_t ProgressBar::get_description_width() const noexcept {
+    return p_impl->description_width;
+}
+
 void ProgressBar::set_description(const std::string & value) {
     p_impl->description = value;
+    p_impl->update_description_width();
 }
 
 void ProgressBar::add_message(MessageType type, const std::string & message) {
@@ -244,6 +282,7 @@ void ProgressBar::reset() {
     p_impl->number = 0;
     p_impl->total = 0;
     p_impl->description = "";
+    p_impl->description_width = 0;
     p_impl->messages.clear();
     p_impl->state = ProgressBarState::READY;
     p_impl->percent_done = -1;

--- a/libdnf5-cli/progressbar/widgets/description.cpp
+++ b/libdnf5-cli/progressbar/widgets/description.cpp
@@ -24,7 +24,7 @@
 
 #include "libdnf5-cli/progressbar/progress_bar.hpp"
 
-#include <iomanip>
+#include <string>
 
 
 namespace libdnf5::cli::progressbar {
@@ -34,7 +34,7 @@ std::size_t DescriptionWidget::get_total_width() const noexcept {
     if (width > 0) {
         return width + get_delimiter_before().size();
     }
-    return get_bar()->get_description().size() + get_delimiter_before().size();
+    return get_bar()->get_description_width() + get_delimiter_before().size();
 }
 
 
@@ -47,12 +47,14 @@ std::string DescriptionWidget::to_string() const {
     if (!get_visible()) {
         return "";
     }
-    std::ostringstream ss;
-    ss << get_delimiter_before();
-    ss << std::left;
-    ss << std::setw(static_cast<int>(get_total_width() - get_delimiter_before().size()));
-    ss << get_bar()->get_description();
-    return ss.str();
+    std::string output = get_delimiter_before() + get_bar()->get_description();
+    // Pad the text with spaces to fill the designed width.
+    auto text_width = get_delimiter_before().size() + get_bar()->get_description_width();
+    auto designed_width = get_total_width();
+    if (text_width < designed_width) {
+        output.append(std::string(designed_width - text_width, ' '));
+    }
+    return output;
 }
 
 

--- a/libdnf5-cli/progressbar/widgets/description.cpp
+++ b/libdnf5-cli/progressbar/widgets/description.cpp
@@ -39,7 +39,14 @@ std::size_t DescriptionWidget::get_total_width() const noexcept {
 
 
 void DescriptionWidget::set_total_width(std::size_t value) {
-    set_width(value - get_delimiter_before().size());
+    auto delimiter_before_size = get_delimiter_before().size();
+    if (value < delimiter_before_size + 1) {
+        // Clamp total width from bottom because 0 "width" has special meaning
+        // (see get_total_width()) and to prevent from an integer underflow.
+        set_width(1);
+    } else {
+        set_width(value - delimiter_before_size);
+    }
 }
 
 

--- a/libdnf5-cli/progressbar/widgets/widget.cpp
+++ b/libdnf5-cli/progressbar/widgets/widget.cpp
@@ -18,11 +18,18 @@
 // along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
+// For wcwidth()
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
+
 #include "libdnf5-cli/progressbar/widgets/widget.hpp"
 
+#include <wchar.h>
+
+#include <cwchar>
 #include <iostream>
 #include <string>
-
 
 namespace libdnf5::cli::progressbar {
 
@@ -30,6 +37,45 @@ namespace libdnf5::cli::progressbar {
 std::ostream & operator<<(std::ostream & stream, Widget & widget) {
     stream << widget.to_string();
     return stream;
+}
+
+std::string Widget::to_spanned_string() const {
+    std::string spanned_text;
+    auto text = to_string();
+    auto designed_width = get_total_width();
+
+    std::size_t text_width = 0;
+    std::mbstate_t mbstate = std::mbstate_t();
+    const char * start = text.data();
+    std::size_t size = text.size();
+
+    // Crop the text to the designed widget width
+    while (size > 0) {
+        wchar_t wc;
+        auto bytes_consumed = std::mbrtowc(&wc, start, size, &mbstate);
+        if (bytes_consumed == 0 || bytes_consumed >= static_cast<std::size_t>(-2)) {
+            // Null character or an invalid multi-byte character encountered.
+            break;
+        }
+        auto wc_width = wcwidth(wc);
+        if (wc_width >= 0) {  // Ignore -1 for non-printable characters.
+            if (text_width + static_cast<std::size_t>(wc_width) > designed_width) {
+                // Stop before exceeding the designed width
+                break;
+            }
+            text_width += static_cast<std::size_t>(wc_width);
+        }
+        start += bytes_consumed;
+        size -= bytes_consumed;
+    }
+    spanned_text = text.substr(0, text.size() - size);
+
+    // Fill the rest of the spanned text with spaces
+    if (text_width < designed_width) {
+        spanned_text.append(designed_width - text_width, ' ');
+    }
+
+    return spanned_text;
 }
 
 

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -96,6 +96,28 @@ void ProgressbarTest::test_description_multi_byte_character() {
     ASSERT_MATCHES(expected, oss.str());
 }
 
+void ProgressbarTest::test_narrow_terminal() {
+    // If the terminal is too narrow, formatting a progressbar is difficult.
+
+    setenv("FORCE_COLUMNS", "10", 1);
+    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+    download_progress_bar1->set_ticks(10);
+    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+    download_progress_bar2->set_ticks(10);
+    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+    multi_progress_bar.add_bar(std::move(download_progress_bar1));
+    multi_progress_bar.add_bar(std::move(download_progress_bar2));
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    // The exact output is undefined, but it should not crash.
+    CPPUNIT_ASSERT(1);
+}
+
 void ProgressbarTest::test_download_progress_bar() {
     // In non interactive mode download progress bar is printed only when finished.
 

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -46,7 +46,7 @@ void ProgressbarTest::tearDown() {
     unsetenv("FORCE_COLUMNS");
 }
 
-void ProgressbarTest::test_progress_bar_multi_byte_character() {
+void ProgressbarTest::test_message_multi_byte_character() {
     auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
     progress_bar->set_ticks(4);
     progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -24,9 +24,12 @@
 
 #include <libdnf5-cli/progressbar/download_progress_bar.hpp>
 #include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
+#include <libdnf5-cli/progressbar/progress_bar.hpp>
 
 #include <clocale>
 #include <cstring>
+#include <memory>
+#include <sstream>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
@@ -57,6 +60,40 @@ void ProgressbarTest::test_message_multi_byte_character() {
     auto num_lines = progress_bar->calculate_messages_terminal_lines(106);
     std::size_t expected = strcmp(setlocale(LC_ALL, NULL), "C") == 0 ? 1U : 2U;
     CPPUNIT_ASSERT_EQUAL(expected, num_lines);
+}
+
+void ProgressbarTest::test_description_multi_byte_character() {
+    auto short_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "短い");
+    short_bar->set_ticks(10);
+    short_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    auto overlong_bar =
+        std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "パッケージ ファイルを検証");
+    overlong_bar->set_ticks(10);
+    overlong_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+
+    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+    multi_progress_bar.add_bar(std::move(short_bar));
+    multi_progress_bar.add_bar(std::move(overlong_bar));
+    std::ostringstream oss;
+    oss << multi_progress_bar;
+
+    // Anything after a non-ASCII character in C locale is invalid, hence discarded.
+    Pattern ascii_expected =
+        "\\[1/2\\]                         100% | ????? ??B/s |  10.0   B | ???????\n"
+        "\\[2/2\\]                         100% | ????? ??B/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B/s |  20.0   B | ???????\n";
+    // First description shorter than the widget is properly padded and the
+    // column delimeters are properly aligned.
+    // Second description longer than the widget is properly truncated.
+    Pattern utf8_expected =
+        "\\[1/2\\] 短い                    100% | ????? ??B/s |  10.0   B | ???????\n"
+        "\\[2/2\\] パッケージ ファイルを検 100% | ????? ??B/s |  10.0   B | ???????\n"
+        "----------------------------------------------------------------------\n"
+        "\\[2/2\\] Total                   100% | ????? ??B/s |  20.0   B | ???????\n";
+
+    Pattern expected = (strcmp(setlocale(LC_ALL, NULL), "C") == 0) ? ascii_expected : utf8_expected;
+    ASSERT_MATCHES(expected, oss.str());
 }
 
 void ProgressbarTest::test_download_progress_bar() {

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -27,7 +27,7 @@
 class ProgressbarTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(ProgressbarTest);
 
-    CPPUNIT_TEST(test_progress_bar_multi_byte_character);
+    CPPUNIT_TEST(test_message_multi_byte_character);
     CPPUNIT_TEST(test_download_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
@@ -40,7 +40,7 @@ public:
     void setUp() override;
     void tearDown() override;
 
-    void test_progress_bar_multi_byte_character();
+    void test_message_multi_byte_character();
     void test_download_progress_bar();
     void test_multi_progress_bar();
     void test_multi_progress_bar_unfinished();

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -29,6 +29,7 @@ class ProgressbarTest : public CppUnit::TestCase {
 
     CPPUNIT_TEST(test_message_multi_byte_character);
     CPPUNIT_TEST(test_description_multi_byte_character);
+    CPPUNIT_TEST(test_narrow_terminal);
     CPPUNIT_TEST(test_download_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
@@ -43,6 +44,7 @@ public:
 
     void test_message_multi_byte_character();
     void test_description_multi_byte_character();
+    void test_narrow_terminal();
     void test_download_progress_bar();
     void test_multi_progress_bar();
     void test_multi_progress_bar_unfinished();

--- a/test/libdnf5-cli/test_progressbar.hpp
+++ b/test/libdnf5-cli/test_progressbar.hpp
@@ -28,6 +28,7 @@ class ProgressbarTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(ProgressbarTest);
 
     CPPUNIT_TEST(test_message_multi_byte_character);
+    CPPUNIT_TEST(test_description_multi_byte_character);
     CPPUNIT_TEST(test_download_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar);
     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
@@ -41,6 +42,7 @@ public:
     void tearDown() override;
 
     void test_message_multi_byte_character();
+    void test_description_multi_byte_character();
     void test_download_progress_bar();
     void test_multi_progress_bar();
     void test_multi_progress_bar_unfinished();


### PR DESCRIPTION
This patch set fixes #2838.

It adds two new public method:

* `libdnf5::cli::progressbar::ProgressBar::get_description_width()` to obtain a chached column-width of a bar description.
* `libdnf5::cli::progressbar::Widget::to_spanned_string()` to produce properly aligned widgets with respect to multi-byte and wide characters. I added a new method instead of fixing the previously used to_string() function because the old function did not truncated overlong descriptions and changing that would break compability since it is a public API.

I also fixes `libdnf5::cli::progressbar::Widget::to_string()` to correctly count columns.

It also adds a unit test.