### PR TITLE
conf: Fix OptionStringContainer::add_item and clarify set()/add() semantics for append options, unit tests included

### DIFF
--- a/libdnf5/conf/option_string_list.cpp
+++ b/libdnf5/conf/option_string_list.cpp
@@ -321,13 +321,8 @@ void OptionStringContainer<T, IsAppend>::add(Priority priority, const std::strin
 
 template <typename T, bool IsAppend>
 void OptionStringContainer<T, IsAppend>::add_item(Priority priority, const std::string & item) {
-    assert_not_locked();
-
-    test_item(item);
-    p_impl->value.insert(p_impl->value.end(), item);
-    if (get_priority() < priority) {
-        set_priority(priority);
-    }
+    T items{item};
+    add(priority, items);
 }
 
 template <typename T, bool IsAppend>

--- a/libdnf5/conf/option_string_list.cpp
+++ b/libdnf5/conf/option_string_list.cpp
@@ -36,28 +36,35 @@ public:
         : icase(false),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
+          value_append({{Option::Priority::DEFAULT, {std::move(default_value), false}}}) {};
     Impl(T && default_value, std::string && regex, bool icase)
         : regex(std::move(regex)),
           icase(icase),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
+          value_append({{Option::Priority::DEFAULT, {std::move(default_value), false}}}) {};
     Impl(T && default_value, std::string && regex, bool icase, std::string && delimiters)
         : regex(std::move(regex)),
           icase(icase),
           delimiters(std::move(delimiters)),
           default_value(default_value),
           value(default_value),
-          value_append({{Option::Priority::DEFAULT, std::move(default_value)}}) {};
+          value_append({{Option::Priority::DEFAULT, {std::move(default_value), false}}}) {};
 
-    // For append options the method stores the value to value_append multimap and
-    // then recalculates this->value.
-    // For plain container it directly stores the value to this->value.
-    void set_value(Priority priority, const ValueType & value);
+    // For append options, the method stores the value in the `value_append` multimap
+    // and recalculates `this->value`. If `empty_remove_existing` is true, an empty value
+    // (or a first empty item) signals to clear all existing items from the final value
+    // before adding new ones.
+    // For plain containers, it directly assigns the value to `this->value`.
+    void set_value(Priority priority, const ValueType & value, bool empty_remove_existing);
 
 private:
     friend OptionStringContainer;
+
+    struct AppendEntry {
+        ValueType items;
+        bool remove_existing;
+    };
 
     std::optional<std::regex> regex_matcher;
     std::string regex;
@@ -70,35 +77,31 @@ private:
     // The items in the multimap are kept sorted according to the key (here,
     // Priority), ensuring correct behavior of resetting the value using an
     // empty item.
-    std::multimap<Priority, ValueType> value_append;
+    std::multimap<Priority, AppendEntry> value_append;
 };
 
 template <typename T, bool IsAppend>
-void OptionStringContainer<T, IsAppend>::Impl::set_value(Priority priority, const ValueType & value) {
+void OptionStringContainer<T, IsAppend>::Impl::set_value(
+    Priority priority, const ValueType & value, bool empty_remove_existing) {
     if (IsAppend) {
-        value_append.insert({priority, value});
+        // if empty_remove_existing == true then empty value or first empty item clears
+        // remove existing items from the result
+        const bool remove_existing = empty_remove_existing && (value.empty() || value.begin()->empty());
+        value_append.insert({priority, {value, remove_existing}});
 
-        // Compute the actual value of the append option by traversing all
-        // change attempts in priority order (ensured by multimap) and either
-        // adding the items to the end of the list or clearing the list.
+        // Determine the final value of the append option by processing change attempts
+        // in priority order (guaranteed by the multimap) and appending items to the list.
+        // If `remove_existing` is true, all previously collected values in the result
+        // are cleared before inserting new items and empty items are skipped.
         ValueType retval{};
-        for (const auto & [priority, values] : value_append) {
-            if (values.empty()) {
-                // setting to empty value clears the result
+        for (const auto & [priority, append_entry] : value_append) {
+            if (append_entry.remove_existing) {
                 retval.clear();
-                continue;
             }
-            bool first = true;
-            for (const auto & item : values) {
-                if (item.empty()) {
-                    // if the first item in the list is empty, clear the result
-                    if (first) {
-                        retval.clear();
-                    }
-                } else {
+            for (const auto & item : append_entry.items) {
+                if (!append_entry.remove_existing || !item.empty()) {
                     retval.insert(retval.end(), item);
                 }
-                first = false;
             }
         }
         this->value = retval;
@@ -126,7 +129,7 @@ OptionStringContainer<T, IsAppend>::OptionStringContainer(const std::string & de
     : Option(Priority::DEFAULT),
       p_impl(new Impl({})) {
     p_impl->default_value = from_string(default_value);
-    p_impl->set_value(Priority::DEFAULT, p_impl->default_value);
+    p_impl->set_value(Priority::DEFAULT, p_impl->default_value, false);
 }
 
 template <typename T, bool IsAppend>
@@ -137,7 +140,7 @@ OptionStringContainer<T, IsAppend>::OptionStringContainer(
     init_regex_matcher();
     p_impl->default_value = from_string(default_value);
     test(p_impl->default_value);
-    p_impl->set_value(Priority::DEFAULT, p_impl->default_value);
+    p_impl->set_value(Priority::DEFAULT, p_impl->default_value, false);
 }
 
 template <typename T, bool IsAppend>
@@ -268,12 +271,15 @@ void OptionStringContainer<T, IsAppend>::set(Priority priority, const ValueType 
     assert_not_locked();
 
     if (IsAppend) {
-        // for append options set is the same as add
-        add(priority, value);
+        test(value);
+        p_impl->set_value(priority, value, true);
+        if (priority >= get_priority()) {
+            set_priority(priority);
+        }
     } else {
         if (priority >= get_priority()) {
             test(value);
-            p_impl->set_value(priority, value);
+            p_impl->set_value(priority, value, true);
             set_priority(priority);
         }
     }
@@ -300,7 +306,7 @@ void OptionStringContainer<T, IsAppend>::add(Priority priority, const ValueType 
 
     test(items);
     if (IsAppend) {
-        p_impl->set_value(priority, items);
+        p_impl->set_value(priority, items, false);
         if (priority >= get_priority()) {
             set_priority(priority);
         }

--- a/test/libdnf5/conf/test_option.cpp
+++ b/test/libdnf5/conf/test_option.cpp
@@ -619,13 +619,22 @@ void OptionTest::test_options_string_append_list() {
     CPPUNIT_ASSERT_EQUAL(
         (std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg5", "Pkg6", "Pkg7", "Pkg8", "Pkg3"}), option.get_value());
 
-    // I can clear the option using an empty first item (values with higher priority
+    // I can clear the option using `set` with an empty first item (values with higher priority
     // are also appended)
     option.set(Option::Priority::MAINCONFIG, ",Pkg5");
     CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3"}), option.get_value());
     // empty item on other than first place is skipped and does not clear the value
     option.set(Option::Priority::COMMANDLINE, "Pkg6, ,Pkg7");
     CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3", "Pkg6", "Pkg7"}), option.get_value());
+    // `add` never clear existing items.
+    option.add(Option::Priority::COMMANDLINE, "");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3", "Pkg6", "Pkg7"}), option.get_value());
+    // `add` never clear existing items. Empty value is added.
+    option.add(Option::Priority::COMMANDLINE, ",");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3", "Pkg6", "Pkg7", ""}), option.get_value());
+    // `add_item` never clear existing items. Empty value is added.
+    option.add_item(Option::Priority::COMMANDLINE, "");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg5", "Pkg3", "Pkg6", "Pkg7", "", ""}), option.get_value());
     // I can clear the option an using empty value
     option.set(Option::Priority::COMMANDLINE, "");
     CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{}), option.get_value());

--- a/test/libdnf5/conf/test_option.cpp
+++ b/test/libdnf5/conf/test_option.cpp
@@ -603,6 +603,22 @@ void OptionTest::test_options_string_append_list() {
     // values are evaluated ordered by the priority
     option.set(Option::Priority::MAINCONFIG, "Pkg4");
     CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg3"}), option.get_value());
+    // values are evaluated ordered by the priority
+    option.add(Option::Priority::MAINCONFIG, "Pkg5");
+    CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg5", "Pkg3"}), option.get_value());
+    // value added by add is preserved after set
+    option.set(Option::Priority::MAINCONFIG, "Pkg6");
+    CPPUNIT_ASSERT_EQUAL(
+        (std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg5", "Pkg6", "Pkg3"}), option.get_value());
+    // values are evaluated ordered by the priority
+    option.add_item(Option::Priority::MAINCONFIG, "Pkg7");
+    CPPUNIT_ASSERT_EQUAL(
+        (std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg5", "Pkg6", "Pkg7", "Pkg3"}), option.get_value());
+    // value added by add_item is preserved after set
+    option.set(Option::Priority::MAINCONFIG, "Pkg8");
+    CPPUNIT_ASSERT_EQUAL(
+        (std::vector<std::string>{"Pkg1", "Pkg2", "Pkg4", "Pkg5", "Pkg6", "Pkg7", "Pkg8", "Pkg3"}), option.get_value());
+
     // I can clear the option using an empty first item (values with higher priority
     // are also appended)
     option.set(Option::Priority::MAINCONFIG, ",Pkg5");


### PR DESCRIPTION
This PR fixes bugs in `OptionStringContainer` that were introduced in commit 26c2b112f ("conf: New classes for append options") and clarifies the semantic difference between `set()` and `add()` methods for append options.

### Problems Fixed

1. **`add_item()` was not updated for new append logic** (commit 26c2b112f)
    - When append option support was added, `add()` method got new priority-based logic
    - `add_item()` was overlooked and continued using old direct insertion
    - This caused `add_item()` to bypass priority handling and not work correctly with append options

2. **Confusing `set()` vs `add()` semantics**
    - Previously, both `set()` and `add()` would clear existing items on empty value/first empty item
    - This made them functionally equivalent for append options, which was semantically incorrect
    - The distinction between "replace" (set) and "append" (add) was lost

### Changes

1. Fix `add_item()` to delegate to `add()`

2. Distinguish set() and add() behavior

   set() - Replace semantics:
   - An empty value or first empty item clears all existing items
   - All empty items are filtered out from the result
  
   add() - Append semantics:
   - Never clears existing items
   - Adds all new items including empty ones

   Examples (OptionStringAppendList option):
   ```
   // set() clears on first empty item and filters all empty items:
   option.set(COMMANDLINE, {""});               // value = [] (cleared!)
   option.set(COMMANDLINE, {"", "pkg1", ""});   // value = ["pkg1"]

   // add() never clears and keeps all items including empty:
   option.add(RUNTIME, {""});                   // value = [""] (empty item appended)
   option.add(RUNTIME, {"", "pkg1", ""});       // value = ["", "pkg1", ""]
   ```

Unit tests included