### PR TITLE
manifest: Check checksum of packages to be installed

### DIFF
--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -148,6 +148,44 @@ void load_host_repos(dnf5::Context & ctx, libdnf5::Base & base) {
     repo_sack->create_repos_from_paths(repos_from_path, libdnf5::Option::Priority::COMMANDLINE);
 }
 
+std::pair<libdnf5::rpm::PackageSet, std::vector<std::string>> get_packages_from_manifest(
+    libdnf5::Base & base, libpkgmanifest::manifest::Manifest & manifest, bool with_srpm) {
+    const auto & arch = base.get_vars()->get_value("arch");
+    libdnf5::rpm::PackageSet packages(base);
+    std::vector<std::string> errors;
+    for (auto & manifest_pkg : manifest.get_packages().get(arch, with_srpm)) {
+        libdnf5::rpm::PackageQuery query{base};
+        query.filter_repo_id(manifest_pkg.get_repo_id());
+        const auto & nevra = nevra_manifest_to_dnf(manifest_pkg.get_nevra());
+        query.filter_nevra(nevra);
+        if (query.empty()) {
+            errors.push_back(libdnf5::utils::sformat(_("No package {} available."), to_nevra_string(nevra)));
+            continue;
+        }
+        const auto & checksum = manifest_pkg.get_checksum();
+        const auto & checksum_digest = checksum.get_digest();
+        if (!checksum_digest.empty()) {
+            libdnf5::rpm::Checksum::Type checksum_type;
+            try {
+                checksum_type = checksum_method_manifest_to_dnf(checksum.get_method());
+            } catch (const libdnf5::RuntimeError & ex) {
+                errors.push_back(libdnf5::utils::sformat(
+                    _("Package {} has checksum with unsupported method: {}"), to_nevra_string(nevra), ex.what()));
+                continue;
+            }
+            query.filter_checksum(checksum_digest, checksum_type);
+            if (query.empty()) {
+                errors.push_back(libdnf5::utils::sformat(
+                    _("No package {} with checksum {} available."), to_nevra_string(nevra), checksum_digest));
+                continue;
+            }
+        }
+        packages.add(*query.begin());
+    }
+
+    return {packages, errors};
+}
+
 class KeyImportRepoCB : public libdnf5::repo::RepoCallbacks2_1 {
 public:
     explicit KeyImportRepoCB(libdnf5::ConfigMain & config) : config(&config) {}

--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -54,6 +54,28 @@ libpkgmanifest::manifest::ChecksumMethod checksum_method_rpm_to_manifest(libdnf5
     }
 }
 
+libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method) {
+    switch (method) {
+        case libpkgmanifest::manifest::ChecksumMethod::SHA1:
+            return libdnf5::rpm::Checksum::Type::SHA1;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA224:
+            return libdnf5::rpm::Checksum::Type::SHA224;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA256:
+            return libdnf5::rpm::Checksum::Type::SHA256;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA384:
+            return libdnf5::rpm::Checksum::Type::SHA384;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA512:
+            return libdnf5::rpm::Checksum::Type::SHA512;
+        case libpkgmanifest::manifest::ChecksumMethod::MD5:
+            return libdnf5::rpm::Checksum::Type::MD5;
+        case libpkgmanifest::manifest::ChecksumMethod::CRC32:
+        case libpkgmanifest::manifest::ChecksumMethod::CRC64:
+            throw libdnf5::RuntimeError(M_("Manifest checksum method (CRC) is not supported for RPM package lookup"));
+        default:
+            throw libdnf5::RuntimeError(M_("Unsupported manifest checksum method for RPM package lookup"));
+    }
+}
+
 std::string get_pkg_location(libdnf5::Base & base, const libdnf5::rpm::Package & dnf_pkg) {
     std::optional<std::string> system_repo_id;
     if (base.get_repo_sack()->has_system_repo()) {

--- a/dnf5-plugins/manifest_plugin/manifest.hpp
+++ b/dnf5-plugins/manifest_plugin/manifest.hpp
@@ -21,6 +21,8 @@ std::vector<libdnf5::rpm::Package> sort_pkgs(std::vector<libdnf5::rpm::Package> 
 
 libdnf5::rpm::Nevra nevra_manifest_to_dnf(const libpkgmanifest::manifest::Nevra & manifest_nevra);
 
+libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method);
+
 std::filesystem::path get_manifest_path(libdnf5::OptionPath & option, const std::string & arch);
 
 void set_repo_callbacks(libdnf5::Base & base);

--- a/dnf5-plugins/manifest_plugin/manifest.hpp
+++ b/dnf5-plugins/manifest_plugin/manifest.hpp
@@ -29,6 +29,9 @@ void set_repo_callbacks(libdnf5::Base & base);
 
 void load_host_repos(dnf5::Context & ctx, libdnf5::Base & base);
 
+std::pair<libdnf5::rpm::PackageSet, std::vector<std::string>> get_packages_from_manifest(
+    libdnf5::Base & base, libpkgmanifest::manifest::Manifest & manifest, bool with_srpm = false);
+
 namespace dnf5 {
 
 class ManifestCommand : public Command {

--- a/dnf5-plugins/manifest_plugin/manifest_download.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_download.cpp
@@ -20,33 +20,6 @@
 using namespace libdnf5::cli;
 
 
-namespace {
-
-libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method) {
-    switch (method) {
-        case libpkgmanifest::manifest::ChecksumMethod::SHA1:
-            return libdnf5::rpm::Checksum::Type::SHA1;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA224:
-            return libdnf5::rpm::Checksum::Type::SHA224;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA256:
-            return libdnf5::rpm::Checksum::Type::SHA256;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA384:
-            return libdnf5::rpm::Checksum::Type::SHA384;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA512:
-            return libdnf5::rpm::Checksum::Type::SHA512;
-        case libpkgmanifest::manifest::ChecksumMethod::MD5:
-            return libdnf5::rpm::Checksum::Type::MD5;
-        case libpkgmanifest::manifest::ChecksumMethod::CRC32:
-        case libpkgmanifest::manifest::ChecksumMethod::CRC64:
-            throw libdnf5::RuntimeError(M_("Manifest checksum method (CRC) is not supported for RPM package lookup"));
-        default:
-            throw libdnf5::RuntimeError(M_("Unsupported manifest checksum method for RPM package lookup"));
-    }
-}
-
-}  // namespace
-
-
 namespace dnf5 {
 
 void ManifestDownloadCommand::set_argument_parser() {

--- a/dnf5-plugins/manifest_plugin/manifest_download.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_download.cpp
@@ -109,24 +109,18 @@ void ManifestDownloadCommand::download_packages(
     libdnf5::repo::PackageDownloader downloader{*base};
     downloader.force_keep_packages(true);
 
-    for (auto & manifest_pkg : manifest.get_packages().get(arch, srpm_option->get_value())) {
-        libdnf5::rpm::PackageQuery query{*base};
-        query.filter_repo_id(manifest_pkg.get_repo_id());
-        const auto & nevra = nevra_manifest_to_dnf(manifest_pkg.get_nevra());
-        query.filter_nevra(nevra);
-        if (query.empty()) {
-            throw libdnf5::cli::CommandExitError(1, M_("No package {} available."), to_nevra_string(nevra));
+    const auto result = get_packages_from_manifest(*base, manifest, srpm_option->get_value());
+    const auto & packages = result.first;
+    const auto & errors = result.second;
+
+    if (!errors.empty()) {
+        for (const auto & error : errors) {
+            ctx.print_error(error);
         }
-        const auto & checksum = manifest_pkg.get_checksum();
-        const auto & checksum_digest = checksum.get_digest();
-        if (!checksum_digest.empty()) {
-            query.filter_checksum(checksum_digest, checksum_method_manifest_to_dnf(checksum.get_method()));
-            if (query.empty()) {
-                throw libdnf5::cli::CommandExitError(
-                    1, M_("No package {} with checksum {} available."), to_nevra_string(nevra), checksum_digest);
-            }
-        }
-        const auto & pkg = *query.begin();
+        throw libdnf5::cli::CommandExitError(1, M_("Some packages from the manifest were not found."));
+    }
+
+    for (const auto & pkg : packages) {
         const auto & pkg_arch = pkg.get_arch();
         // If split per arch, download noarch/src packages into separate subdirectories.
         if (per_arch_option->get_value()) {

--- a/dnf5-plugins/manifest_plugin/manifest_install.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_install.cpp
@@ -57,12 +57,19 @@ void ManifestInstallCommand::run() {
     auto & ctx = get_context();
     auto & base = ctx.get_base();
 
-    auto * goal = ctx.get_goal();
-    const auto & arch = base.get_vars()->get_value("arch");
-    for (auto & manifest_pkg : manifest.get_packages().get(arch)) {
-        libdnf5::GoalJobSettings settings;
-        settings.set_to_repo_ids({manifest_pkg.get_repo_id()});
-        goal->add_install(manifest_pkg.get_nevra().to_string(), settings);
+    const auto result = get_packages_from_manifest(base, manifest);
+    const auto & packages = result.first;
+    const auto & errors = result.second;
+
+    if (!errors.empty()) {
+        for (const auto & error : errors) {
+            ctx.print_error(error);
+        }
+        throw libdnf5::cli::CommandExitError(1, M_("Some packages from the manifest were not found."));
+    }
+
+    for (const auto & pkg : packages) {
+        ctx.get_goal()->add_rpm_install(pkg);
     }
 }
 

--- a/doc/dnf5_plugins/manifest.8.rst
+++ b/doc/dnf5_plugins/manifest.8.rst
@@ -65,6 +65,9 @@ For working with RPM package manifest files using the `libpkgmanifest <https://g
 ``install``
     Install all packages specified in the manifest file.
 
+    If checksums are specified, install only the packages that match both the
+    NEVRAs and checksums, otherwise, match only the NEVRAs.
+
 ---------
 Arguments
 ---------


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/SWM-8370

Previously, there was no check that the package checksum matches
the checksum provided in the manifest file, now it's required that
the checksum matches, so it cannot happen that a package with the
same nevra but different content would be installed.

Since a significant portion of the code was the same between the
download and install command, the `get_packages_from_manifest` function
was added for getting the packages from the manifest file. However,
this also means a change for the download command regarding error
handling - previously, the command threw error for the first missing
package, now it gathers all errors and prints them together.