### PR TITLE
Fix a crash when a terminal width is forced to negative values

### DIFF
--- a/libdnf5-cli/tty.cpp
+++ b/libdnf5-cli/tty.cpp
@@ -36,7 +36,9 @@ int get_width() {
     char * columns = std::getenv("FORCE_COLUMNS");
     if (columns != nullptr) {
         try {
-            return std::stoi(columns);
+            auto value = std::stoi(columns);
+            if (value > 0)
+                return value;
         } catch (std::invalid_argument & ex) {
         } catch (std::out_of_range & ex) {
         }
@@ -44,7 +46,8 @@ int get_width() {
 
     struct winsize size;
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0) {
-        return size.ws_col;
+        if (size.ws_col > 0)
+            return size.ws_col;
     }
 
     return 80;

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
@@ -98,24 +99,27 @@ void ProgressbarTest::test_description_multi_byte_character() {
 
 void ProgressbarTest::test_narrow_terminal() {
     // If the terminal is too narrow, formatting a progressbar is difficult.
+    std::vector<const char *> columns = {"10", "0", "-1"};
 
-    setenv("FORCE_COLUMNS", "10", 1);
-    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
-    download_progress_bar1->set_ticks(10);
-    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    for (auto value : columns) {
+        setenv("FORCE_COLUMNS", value, 1);
+        auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+        download_progress_bar1->set_ticks(10);
+        download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
 
-    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
-    download_progress_bar2->set_ticks(10);
-    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+        auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+        download_progress_bar2->set_ticks(10);
+        download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
 
-    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
-    multi_progress_bar.add_bar(std::move(download_progress_bar1));
-    multi_progress_bar.add_bar(std::move(download_progress_bar2));
-    std::ostringstream oss;
-    oss << multi_progress_bar;
+        libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+        multi_progress_bar.add_bar(std::move(download_progress_bar1));
+        multi_progress_bar.add_bar(std::move(download_progress_bar2));
+        std::ostringstream oss;
+        oss << multi_progress_bar;
 
-    // The exact output is undefined, but it should not crash.
-    CPPUNIT_ASSERT(1);
+        // The exact output is undefined, but it should not crash.
+        CPPUNIT_ASSERT(1);
+    }
 }
 
 void ProgressbarTest::test_download_progress_bar() {


### PR DESCRIPTION
It leads to a crash when the value is used later:

    $ FORCE_COLUMNS=-1 dnf5 -y reinstall dontpanic
    terminate called after throwing an instance of 'std::length_error'
      what():  basic_string::_M_create

    Thread 1 "dnf5" received signal SIGABRT, Aborted.

This patch ignores non-positive values in the FORCE_COLUMNS environment variable and falls back to querying the terminal device.

This patch also guards from a kernel reporting 0 width. Then the code falls back to 80 columns as if the IOCTL failed.

This patch adds a unit test for the crash.