### PR TITLE
Rename FORCE_COLUMNS environment variable to DNF5_FORCE_COLUMNS

### DIFF
--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -443,6 +443,12 @@ Files
 Environment
 ===========
 
+``DNF5_FORCE_COLUMNS``
+    Override a terminal width used for rendering progress bars and other
+    tabular data.  The value should be a positive integer.  If it is unset or
+    invalid, the width will be detected from a terminal device connected to
+    the standard output.  If the detection fails, 80 columns will be assumed.
+
 ``DNF5_FORCE_INTERACTIVE``
     Override interactivity of the connected standard input/output. Set to `0` to pretend
     that the input/output is not connected to an interactive terminal and DNF5

--- a/libdnf5-cli/tty.cpp
+++ b/libdnf5-cli/tty.cpp
@@ -36,7 +36,9 @@ int get_width() {
     char * columns = std::getenv("FORCE_COLUMNS");
     if (columns != nullptr) {
         try {
-            return std::stoi(columns);
+            auto value = std::stoi(columns);
+            if (value > 0)
+                return value;
         } catch (std::invalid_argument & ex) {
         } catch (std::out_of_range & ex) {
         }
@@ -44,7 +46,8 @@ int get_width() {
 
     struct winsize size;
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0) {
-        return size.ws_col;
+        if (size.ws_col > 0)
+            return size.ws_col;
     }
 
     return 80;

--- a/libdnf5-cli/tty.cpp
+++ b/libdnf5-cli/tty.cpp
@@ -31,9 +31,14 @@ namespace libdnf5::cli::tty {
 
 
 int get_width() {
-    // Use a custom "FORCE_COLUMNS" variable for testing purposes.
+    // Use a custom "DNF5_FORCE_COLUMNS" variable for testing purposes.
     // "COLUMNS" is overwritten in a sub-shell and that makes testing more difficult
-    char * columns = std::getenv("FORCE_COLUMNS");
+    char * columns = std::getenv("DNF5_FORCE_COLUMNS");
+    if (!columns) {
+        // TODO: Remove this private, obsolete variable once CI tests migrate
+        // to DNF5_FORCE_COLUMNS variable.
+        columns = std::getenv("FORCE_COLUMNS");
+    }
     if (columns != nullptr) {
         try {
             auto value = std::stoi(columns);

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -39,7 +39,7 @@ void ProgressbarTest::setUp() {
     // MultiProgressBar behaves differently depending on interactivity
     setenv("DNF5_FORCE_INTERACTIVE", "0", 1);
     // Force columns to 70 to make output independent of where it is run
-    setenv("FORCE_COLUMNS", "70", 1);
+    setenv("DNF5_FORCE_COLUMNS", "70", 1);
     // Wide characters do not work at all until we set locales in the code
     // Different locale variants are parameterized in ctest
     setlocale(LC_ALL, "");
@@ -47,7 +47,7 @@ void ProgressbarTest::setUp() {
 
 void ProgressbarTest::tearDown() {
     unsetenv("DNF5_FORCE_INTERACTIVE");
-    unsetenv("FORCE_COLUMNS");
+    unsetenv("DNF5_FORCE_COLUMNS");
 }
 
 void ProgressbarTest::test_message_multi_byte_character() {
@@ -102,7 +102,7 @@ void ProgressbarTest::test_narrow_terminal() {
     std::vector<const char *> columns = {"10", "0", "-1"};
 
     for (auto value : columns) {
-        setenv("FORCE_COLUMNS", value, 1);
+        setenv("DNF5_FORCE_COLUMNS", value, 1);
         auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
         download_progress_bar1->set_ticks(10);
         download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);

--- a/test/libdnf5-cli/test_progressbar.cpp
+++ b/test/libdnf5-cli/test_progressbar.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
@@ -98,24 +99,27 @@ void ProgressbarTest::test_description_multi_byte_character() {
 
 void ProgressbarTest::test_narrow_terminal() {
     // If the terminal is too narrow, formatting a progressbar is difficult.
+    std::vector<const char *> columns = {"10", "0", "-1"};
 
-    setenv("FORCE_COLUMNS", "10", 1);
-    auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
-    download_progress_bar1->set_ticks(10);
-    download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+    for (auto value : columns) {
+        setenv("FORCE_COLUMNS", value, 1);
+        auto download_progress_bar1 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test1");
+        download_progress_bar1->set_ticks(10);
+        download_progress_bar1->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
 
-    auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
-    download_progress_bar2->set_ticks(10);
-    download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
+        auto download_progress_bar2 = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test2");
+        download_progress_bar2->set_ticks(10);
+        download_progress_bar2->set_state(libdnf5::cli::progressbar::ProgressBarState::SUCCESS);
 
-    libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
-    multi_progress_bar.add_bar(std::move(download_progress_bar1));
-    multi_progress_bar.add_bar(std::move(download_progress_bar2));
-    std::ostringstream oss;
-    oss << multi_progress_bar;
+        libdnf5::cli::progressbar::MultiProgressBar multi_progress_bar;
+        multi_progress_bar.add_bar(std::move(download_progress_bar1));
+        multi_progress_bar.add_bar(std::move(download_progress_bar2));
+        std::ostringstream oss;
+        oss << multi_progress_bar;
 
-    // The exact output is undefined, but it should not crash.
-    CPPUNIT_ASSERT(1);
+        // The exact output is undefined, but it should not crash.
+        CPPUNIT_ASSERT(1);
+    }
 }
 
 void ProgressbarTest::test_download_progress_bar() {

--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
+++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
@@ -150,7 +150,7 @@ void ProgressbarInteractiveTest::setUp() {
     // MultiProgressBar behaves differently depending on interactivity
     setenv("DNF5_FORCE_INTERACTIVE", "1", 1);
     // Force columns to 70 to make output independent of where it is run
-    setenv("FORCE_COLUMNS", "70", 1);
+    setenv("DNF5_FORCE_COLUMNS", "70", 1);
     // Wide characters do not work at all until we set locales in the code
     // Different locale variants are parameterized in ctest
     setlocale(LC_ALL, "");
@@ -158,7 +158,7 @@ void ProgressbarInteractiveTest::setUp() {
 
 void ProgressbarInteractiveTest::tearDown() {
     unsetenv("DNF5_FORCE_INTERACTIVE");
-    unsetenv("FORCE_COLUMNS");
+    unsetenv("DNF5_FORCE_COLUMNS");
 }
 
 void ProgressbarInteractiveTest::test_perform_control_sequences() {


### PR DESCRIPTION
Rename FORCE_COLUMNS environment to DNF5_FORCE_COLUMNS
    
There are two reasons for the rename:
    
(1) The old FORCE_COLUMNS name was not name-spaced, possibly clashing
with other tools.
    
(2) Users sometimes asked how to change the width of the transaction
table and we had to point them to the undocumented environment
variable.
    
This patch renames the variable to DNF5_FORCE_COLUMNS and documents it
in dnf5(8) manual. The old variable is kept as an undocumented fallback
and will be removed after porting DNF CI tests to the new variable
name.
