### PR TITLE
Add group summary subcommand

### DIFF
--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -23,6 +23,7 @@
 #include "group_install.hpp"
 #include "group_list.hpp"
 #include "group_remove.hpp"
+#include "group_summary.hpp"
 #include "group_upgrade.hpp"
 
 #include <dnf5/shared_options.hpp>
@@ -45,6 +46,7 @@ void GroupCommand::register_subcommands() {
     auto * query_commands_group = get_context().get_argument_parser().add_new_group("group_query_commands");
     query_commands_group->set_header("Query Commands:");
     get_argument_parser_command()->register_group(query_commands_group);
+    register_subcommand(std::make_unique<GroupSummaryCommand>(get_context()), query_commands_group);
     register_subcommand(std::make_unique<GroupListCommand>(get_context()), query_commands_group);
     register_subcommand(std::make_unique<GroupInfoCommand>(get_context()), query_commands_group);
     // software management commands

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -25,6 +25,8 @@
 #include <libdnf5/comps/group/query.hpp>
 #include <libdnf5/conf/const.hpp>
 
+#include <iostream>
+
 namespace dnf5 {
 
 using namespace libdnf5::cli;
@@ -100,6 +102,15 @@ void GroupListCommand::print(const libdnf5::comps::GroupQuery & query) {
         items.emplace_back(new libdnf5::cli::output::GroupAdapter(obj));
     }
     libdnf5::cli::output::print_grouplist_table(items);
+
+    std::size_t installed_count = 0;
+    for (const auto & item : items) {
+        if (item->get_installed()) {
+            ++installed_count;
+        }
+    }
+    std::cout << "Groups: " << items.size() << " (Installed " << installed_count << ", Available "
+              << items.size() - installed_count << ")" << std::endl;
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/group/group_summary.cpp
+++ b/dnf5/commands/group/group_summary.cpp
@@ -1,0 +1,36 @@
+// Copyright Contributors to the DNF5 project.
+// Copyright Contributors to the libdnf project.
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+//
+// Libdnf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Libdnf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "group_summary.hpp"
+
+#include <libdnf5-cli/output/groupsummary.hpp>
+
+namespace dnf5 {
+
+void GroupSummaryCommand::set_argument_parser() {
+    GroupListCommand::set_argument_parser();
+    get_argument_parser_command()->set_description(
+        "Display summary statistics about groups, packages and repositories");
+}
+
+void GroupSummaryCommand::print(const libdnf5::comps::GroupQuery & query) {
+    libdnf5::cli::output::print_groupsummary_table(get_context().get_base(), query);
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/group/group_summary.hpp
+++ b/dnf5/commands/group/group_summary.hpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the DNF5 project.
+// Copyright Contributors to the libdnf project.
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+//
+// Libdnf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Libdnf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef DNF5_COMMANDS_GROUP_GROUP_SUMMARY_HPP
+#define DNF5_COMMANDS_GROUP_GROUP_SUMMARY_HPP
+
+#include "group_list.hpp"
+
+namespace dnf5 {
+
+
+class GroupSummaryCommand : public GroupListCommand {
+public:
+    explicit GroupSummaryCommand(Context & context) : GroupListCommand(context, "summary") {}
+    void set_argument_parser() override;
+
+private:
+    void print(const libdnf5::comps::GroupQuery & query) override;
+};
+
+
+}  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_GROUP_GROUP_SUMMARY_HPP

--- a/doc/commands/group.8.rst
+++ b/doc/commands/group.8.rst
@@ -27,7 +27,7 @@
 Synopsis
 ========
 
-``dnf5 group {list|info} [options] [<group-spec>...]``
+``dnf5 group {summary|list|info} [options] [<group-spec>...]``
 
 ``dnf5 group {install|remove|upgrade} [options] <group-spec|environment-spec>...``
 
@@ -47,6 +47,13 @@ environments match, only groups are affected.
 
 Subcommands
 ===========
+
+``summary``
+    Display summary statistics including counts of installed and available
+    groups and environments, package counts, total installed size, number of
+    enabled repositories, and the time of the last transaction.
+    With a spec, limit the group and environment counts to matching entries.
+    The command accepts the same options as the ``list`` subcommand.
 
 ``list``
     List all matching groups, either among installed or available groups. If
@@ -96,8 +103,8 @@ Subcommands
 
     In case both groups and environments match, only groups are affected.
 
-Options for ``list`` and ``info``
-=================================
+Options for ``summary``, ``list`` and ``info``
+===============================================
 
 ``--available``
     | Show only available groups. Those which are not installed, but known to ``DNF5``.

--- a/include/libdnf5-cli/output/groupsummary.hpp
+++ b/include/libdnf5-cli/output/groupsummary.hpp
@@ -1,0 +1,35 @@
+// Copyright Contributors to the DNF5 project.
+// Copyright Contributors to the libdnf project.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+//
+// Libdnf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// Libdnf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+
+#ifndef LIBDNF5_CLI_OUTPUT_GROUPSUMMARY_HPP
+#define LIBDNF5_CLI_OUTPUT_GROUPSUMMARY_HPP
+
+#include "libdnf5-cli/defs.h"
+
+#include <libdnf5/base/base.hpp>
+#include <libdnf5/comps/group/query.hpp>
+
+namespace libdnf5::cli::output {
+
+LIBDNF_CLI_API void print_groupsummary_table(libdnf5::Base & base, const libdnf5::comps::GroupQuery & query);
+
+}  // namespace libdnf5::cli::output
+
+#endif  // LIBDNF5_CLI_OUTPUT_GROUPSUMMARY_HPP

--- a/libdnf5-cli/output/groupsummary.cpp
+++ b/libdnf5-cli/output/groupsummary.cpp
@@ -1,0 +1,113 @@
+// Copyright Contributors to the DNF5 project.
+// Copyright Contributors to the libdnf project.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+//
+// Libdnf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// Libdnf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+
+#include "libdnf5-cli/output/groupsummary.hpp"
+
+#include "key_value_table.hpp"
+
+#include <libdnf5-cli/utils/units.hpp>
+#include <libdnf5/comps/environment/query.hpp>
+#include <libdnf5/repo/repo.hpp>
+#include <libdnf5/repo/repo_query.hpp>
+#include <libdnf5/rpm/package.hpp>
+#include <libdnf5/rpm/package_query.hpp>
+#include <libdnf5/transaction/transaction_history.hpp>
+
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace libdnf5::cli::output {
+
+void print_groupsummary_table(libdnf5::Base & base, const libdnf5::comps::GroupQuery & query) {
+    KeyValueTable output_table;
+
+    // Groups
+    libdnf5::comps::GroupQuery query_installed(query);
+    query_installed.filter_installed(true);
+    const auto groups_installed = query_installed.size();
+    auto groups_row = output_table.add_line("Groups", query.size(), nullptr);
+    output_table.add_line("Installed", groups_installed, nullptr, groups_row);
+    output_table.add_line("Available", query.size() - groups_installed, nullptr, groups_row);
+
+    // Environments
+    libdnf5::comps::EnvironmentQuery env_query(base);
+    libdnf5::comps::EnvironmentQuery env_installed(env_query);
+    env_installed.filter_installed(true);
+    const auto envs_installed = env_installed.size();
+    auto envs_row = output_table.add_line("Environments", env_query.size(), nullptr);
+    output_table.add_line("Installed", envs_installed, nullptr, envs_row);
+    output_table.add_line("Available", env_query.size() - envs_installed, nullptr, envs_row);
+
+    // Packages
+    libdnf5::rpm::PackageQuery pkg_installed(base);
+    pkg_installed.filter_installed();
+    const auto pkgs_installed = pkg_installed.size();
+
+    libdnf5::rpm::PackageQuery pkg_available(base);
+    pkg_available.filter_available();
+    const auto pkgs_available = pkg_available.size();
+
+    libdnf5::rpm::PackageQuery pkg_user(base);
+    pkg_user.filter_userinstalled();
+    const auto pkgs_user = pkg_user.size();
+
+    auto pkgs_row = output_table.add_line("Packages", pkgs_installed + pkgs_available, nullptr);
+    output_table.add_line("Installed", pkgs_installed, nullptr, pkgs_row);
+    output_table.add_line("Available", pkgs_available, nullptr, pkgs_row);
+    output_table.add_line("User-installed", pkgs_user, nullptr, pkgs_row);
+
+    // Installed size
+    unsigned long long total_install_size = 0;
+    for (const auto & pkg : pkg_installed) {
+        total_install_size += pkg.get_install_size();
+    }
+    auto [size_value, size_unit] = libdnf5::cli::utils::units::to_size(static_cast<int64_t>(total_install_size));
+    std::ostringstream size_str;
+    size_str << std::fixed << std::setprecision(1) << size_value << " " << size_unit;
+    output_table.add_line("Installed Size", size_str.str(), nullptr);
+
+    // Repositories
+    libdnf5::repo::RepoQuery repo_query(base);
+    repo_query.filter_enabled(true);
+    repo_query.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
+    output_table.add_line("Enabled Repositories", repo_query.size(), nullptr);
+
+    // Last transaction
+    try {
+        libdnf5::transaction::TransactionHistory history(base);
+        auto transactions = history.list_all_transactions();
+        if (!transactions.empty()) {
+            auto & latest = transactions.back();
+            auto dt_end = latest.get_dt_end();
+            if (dt_end > 0) {
+                auto time = static_cast<std::time_t>(dt_end);
+                std::ostringstream time_str;
+                time_str << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S");
+                output_table.add_line("Last Transaction", time_str.str(), nullptr);
+            }
+        }
+    } catch (...) {
+    }
+
+    output_table.print();
+}
+
+}  // namespace libdnf5::cli::output


### PR DESCRIPTION
Implement the `group summary` subcommand displaying system-wide statistics: installed/available groups and environments, package counts with user-installed breakdown, total installed size, enabled repository count, and last transaction time.

Also add a count footer to `group list` showing installed/available totals after the table output.

Resolves: https://github.com/rpm-software-management/dnf5/issues/138