### PR TITLE
doc: Clarify option placement rules for general vs command-specific options

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -21,6 +21,27 @@ Options that cannot be applied to all commands or may be applicable but have no 
 Examples: ``--best``, ``--no-best`` are only relevant to several transaction commands.
 
 
+Option placement
+^^^^^^^^^^^^^^^^
+In DNF4, all options could typically be placed either before or after the command name on the command line.
+In DNF5, there is a distinction between general options and command-specific options:
+
+  * **General options** (such as ``--disable-repo``, ``--enable-repo``, ``--setopt``, ``--repo``) apply globally and can be placed either before or after the command name.
+  * **Command-specific options** (such as ``--downloadonly``, ``--skip-broken``, ``--allowerasing``) are only accepted after the command name.
+
+For example, both of the following are valid because ``--disable-repo`` is a general option::
+
+    dnf5 --disable-repo=updates install netcat
+    dnf5 install --disable-repo=updates netcat
+
+However, ``--downloadonly`` is a command-specific option for the ``install`` command, so only the first form works::
+
+    dnf5 install --downloadonly netcat
+    dnf5 --downloadonly install netcat  # error: unknown argument
+
+See the :ref:`main man page <command_ref-label>` for the list of general options and individual command man pages for their specific options.
+
+
 Options renaming
 ^^^^^^^^^^^^^^^^
 Renaming boolean options to the following formats:

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -35,7 +35,7 @@
 Synopsis
 ========
 
-``dnf5 <command> [options] [<args>...]``
+``dnf5 [general options] <command> [command options] [<args>...]``
 
 
 Description
@@ -178,7 +178,10 @@ These are available after installing the ``dnf5-plugins`` package.
 Options
 =======
 
-Following options are applicable in the general context for any ``dnf5`` command:
+Following options are applicable in the general context for any ``dnf5`` command.
+These general options can be placed either before or after the command name on the command line.
+Command-specific options (such as ``--downloadonly`` or ``--skip-broken``) are only accepted after the command name.
+See the individual command's man page for a list of its specific options.
 
 .. _assumeno_option_ref-label:
 


### PR DESCRIPTION
In DNF5, general options (e.g. --disable-repo) can be placed before or after the command name, but command-specific options (e.g. --downloadonly) must come after. This was undocumented and caused user confusion.

So, I updated the synopsis in the main man page to reflect the two option types, added explanatory text to the Options section, and added an "Option placement" subsection to the DNF4-to-DNF5 changes doc with examples.

Closes: SWMBZBUGSM-240