### PR TITLE
repo: Deprecate protected_packages config option

### DIFF
--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -77,8 +77,11 @@ public:
     const OptionChild<OptionString> & get_username_option() const;
     OptionChild<OptionString> & get_password_option();
     const OptionChild<OptionString> & get_password_option() const;
-    OptionChild<OptionStringAppendList> & get_protected_packages_option();
-    const OptionChild<OptionStringAppendList> & get_protected_packages_option() const;
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] OptionChild<OptionStringAppendList> & get_protected_packages_option();
+    /// @deprecated The option does nothing
+    [[deprecated("The option does nothing")]] const OptionChild<OptionStringAppendList> &
+    get_protected_packages_option() const;
     /// @deprecated Use get_pkg_gpgcheck_option()
     [[deprecated("Use get_pkg_gpgcheck_option()")]]
     OptionChild<OptionBool> & get_gpgcheck_option();

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -327,9 +327,11 @@ const OptionChild<OptionString> & ConfigRepo::get_password_option() const {
 }
 
 OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_option() {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->protected_packages;
 }
 const OptionChild<OptionStringAppendList> & ConfigRepo::get_protected_packages_option() const {
+    LIBDNF5_DEPRECATED("The option does nothing");
     return p_impl->protected_packages;
 }
 


### PR DESCRIPTION
Although `protected_packages` is defined also at the repository level,
it is not implemented or used in libdnf5, nor was it in dnf4.

This option only makes sense as a main configuration option.