### PR TITLE
offline: Drop ConditionPathExists=/system-update

### DIFF
--- a/dnf5/config/systemd/system/dnf5-offline-transaction.service
+++ b/dnf5/config/systemd/system/dnf5-offline-transaction.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Offline upgrades/transactions using DNF 5
-ConditionPathExists=/system-update
 Documentation=https://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 
 DefaultDependencies=no


### PR DESCRIPTION
The condition is redundant: the unit is only reachable via system-update.target, which systemd itself only isolates into when /system-update already exists.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2773