### PR TITLE
Fix build failures on 32-bit platforms

### DIFF
--- a/dnf5-plugins/reposync_plugin/reposync.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync.cpp
@@ -244,7 +244,7 @@ ReposyncCommand::download_list_type ReposyncCommand::get_packages_list(const lib
     }
 
     if (min_buildtime_option->get_arg()->get_parse_count() >= 1) {
-        query.filter_recent(min_buildtime_option->get_value());
+        query.filter_recent(static_cast<time_t>(min_buildtime_option->get_value()));
     }
 
     if (!arch_option.empty()) {

--- a/dnf5daemon-server/services/history/history.cpp
+++ b/dnf5daemon-server/services/history/history.cpp
@@ -34,7 +34,10 @@
 #include <libdnf5/utils/format.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
+#include <cstddef>
+#include <limits>
 #include <unordered_map>
+#include <utility>
 
 namespace {
 
@@ -410,8 +413,10 @@ sdbus::MethodReply History::list(sdbus::MethodCall & call) {
     }
 
     // Apply limit
-    if (limit > 0 && transactions.size() > static_cast<size_t>(limit)) {
-        transactions.erase(transactions.begin() + limit, transactions.end());
+    if (limit > 0 && std::cmp_less(limit, std::numeric_limits<size_t>::max()) &&
+        std::cmp_less(limit, std::numeric_limits<ptrdiff_t>::max()) &&
+        transactions.size() > static_cast<size_t>(limit)) {
+        transactions.erase(transactions.begin() + static_cast<ptrdiff_t>(limit), transactions.end());
     }
 
     // Build output

--- a/libdnf5-cli/session.cpp
+++ b/libdnf5-cli/session.cpp
@@ -22,7 +22,9 @@
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
 #include <chrono>
+#include <limits>
 #include <sstream>
+#include <utility>
 
 namespace libdnf5::cli::session {
 
@@ -257,7 +259,17 @@ DateOption::DateOption(
                     throw libdnf5::cli::ArgumentParserError(
                         M_("Invalid date passed: \"{}\". Dates in \"YYYY-MM-DD\" format are expected"), value);
                 }
-                return tp.time_since_epoch().count();
+                // This option should have used time_t because it is used
+                // elsewhere, e.g. in PackageQuery::filter_recent().
+                // Therefore reject out-of-range values right now instead of
+                // dealing with the overflows throughout the code.
+                auto numeric_value = tp.time_since_epoch().count();
+                if (std::cmp_less(numeric_value, std::numeric_limits<time_t>::lowest()) ||
+                    std::cmp_greater(numeric_value, std::numeric_limits<time_t>::max())) {
+                    throw libdnf5::cli::ArgumentParserError(
+                        M_("\"{}\" date cannot be represented by time_t type on this platform"), value);
+                }
+                return numeric_value;
             }))));
     arg->link_value(conf);
 


### PR DESCRIPTION
Building on i686 failed:

    /builddir/build/BUILD/dnf5-5.4.3.0-build/dnf5-5.4.3.0/dnf5daemon-server/services/history/history.cpp: In member function ‘sdbus::MethodReply History::list(sdbus::MethodCall&)’:
    /builddir/build/BUILD/dnf5-5.4.3.0-build/dnf5-5.4.3.0/dnf5daemon-server/services/history/history.cpp:414:51: error: conversion from ‘long long int’ to ‘__gnu_cxx::__normal_iterator<libdnf5::transaction::Transaction*, std::vector<libdnf5::transaction::Transaction> >::difference_type’ {aka ‘int’} may change value [-Werror=conversion]
      414 |         transactions.erase(transactions.begin() + limit, transactions.end());
	  |                                                   ^~~~~

and:

        /builddir/build/BUILD/dnf5-5.4.3.0-build/dnf5-5.4.3.0/dnf5-plugins/reposync_plugin/reposync.cpp: In member function ‘dnf5::ReposyncCommand::download_list_type dnf5::ReposyncCommand::get_packages_list(const libdnf5::repo::Repo&)’:
        /builddir/build/BUILD/dnf5-5.4.3.0-build/dnf5-5.4.3.0/dnf5-plugins/reposync_plugin/reposync.cpp:247:60: error: conversion from ‘int64_t’ {aka ‘long long int’} to ‘time_t’ {aka ‘long int’} may change value [-Werror=conversion]
          247 |         query.filter_recent(min_buildtime_option->get_value());
              |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~

This is a minimal fix. Especially the second case could be fixed differently if we decided to enhance API or break it.

An example of the failures: https://koji.fedoraproject.org/koji/taskinfo?taskID=149034627, https://koji.fedoraproject.org/koji/taskinfo?taskID=149037034
A scratch build with the fix: https://koji.fedoraproject.org/koji/taskinfo?taskID=149070069