### PR TITLE
Include <cstring> wherever std::strcmp() is used

### DIFF
--- a/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
+++ b/dnf5-plugins/automatic_plugin/automatic_cmd_plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
+++ b/dnf5-plugins/config-manager_plugin/config-manager_cmd_plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
+++ b/dnf5-plugins/copr_plugin/copr_cmd_plugin.cpp
@@ -21,6 +21,8 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
+
 using namespace dnf5;
 
 namespace {

--- a/dnf5-plugins/manifest_plugin/manifest_cmd_plugin.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_cmd_plugin.cpp
@@ -5,6 +5,8 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
+
 using namespace dnf5;
 
 namespace {

--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting_cmd_plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
+++ b/dnf5-plugins/repoclosure_plugin/repoclosure_cmd_plugin.cpp
@@ -21,6 +21,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/dnf5-plugins/repomanage_plugin/repomanage_cmd_plugin.cpp
+++ b/dnf5-plugins/repomanage_plugin/repomanage_cmd_plugin.cpp
@@ -21,6 +21,8 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
+
 using namespace dnf5;
 
 namespace {

--- a/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
+++ b/dnf5-plugins/reposync_plugin/reposync_cmd_plugin.cpp
@@ -21,6 +21,7 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace dnf5;

--- a/libdnf5-plugins/appstream/appstream.cpp
+++ b/libdnf5-plugins/appstream/appstream.cpp
@@ -24,6 +24,7 @@
 #include <libdnf5/repo/repo.hpp>
 #include <libdnf5/repo/repo_query.hpp>
 
+#include <cstring>
 #include <iostream>
 
 using namespace libdnf5;

--- a/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
+++ b/libdnf5-plugins/expired-pgp-keys/expired-pgp-keys.cpp
@@ -34,10 +34,10 @@
 #include <rpm/rpmpgp.h>
 #endif
 #include <rpm/rpmts.h>
-#include <string.h>
 
 #include <chrono>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -227,7 +227,7 @@ void ExpiredPgpKeys::process_expired_pgp_keys(const libdnf5::base::Transaction &
         // (Or use lr_gpg_import_key_from_memory() directly?)
         auto key_tfile = libdnf5::utils::fs::TempFile("key");
         auto & key_ffile = key_tfile.open_as_file("w+");
-        key_ffile.write(raw_key, strlen(raw_key));
+        key_ffile.write(raw_key, std::strlen(raw_key));
         key_ffile.flush();
         free(raw_key);
 

--- a/libdnf5-plugins/local/local.cpp
+++ b/libdnf5-plugins/local/local.cpp
@@ -14,6 +14,7 @@
 #include <libdnf5/utils/fs/utils.hpp>
 #include <sys/wait.h>
 
+#include <cstring>
 
 constexpr const char * LOCAL_REPO_NAME_GPGCHECK{"_dnf_local"};
 constexpr const char * LOCAL_REPO_NAME_NOGPGCHECK{"_dnf_local_nogpgcheck"};

--- a/libdnf5-plugins/rhsm/rhsm.cpp
+++ b/libdnf5-plugins/rhsm/rhsm.cpp
@@ -24,6 +24,7 @@
 #include <rhsm/rhsm.h>
 #include <unistd.h>
 
+#include <cstring>
 
 using namespace libdnf5;
 

--- a/test/tutorial-templates/dnf5-plugin/template_cmd_plugin.cpp
+++ b/test/tutorial-templates/dnf5-plugin/template_cmd_plugin.cpp
@@ -2,6 +2,8 @@
 
 #include <dnf5/iplugin.hpp>
 
+#include <cstring>
+
 using namespace dnf5;
 
 namespace {

--- a/test/tutorial-templates/libdnf5-plugin/template.cpp
+++ b/test/tutorial-templates/libdnf5-plugin/template.cpp
@@ -3,6 +3,7 @@
 #include <libdnf5/plugin/iplugin.hpp>
 
 #include <algorithm>
+#include <cstring>
 
 using namespace libdnf5;
 


### PR DESCRIPTION
There are many places where this function is used that don't include the appropriate header. This actually causes a build failure with fmt 12.2.0, because it removed some includes from its headers.

Fix it by including <cstring> at least where std::strcmp() is used.