### PR TITLE
Unify "no matches"/"no repos enabled" reporting for query commands

### DIFF
--- a/dnf5-plugins/copr_plugin/copr_list.cpp
+++ b/dnf5-plugins/copr_plugin/copr_list.cpp
@@ -20,6 +20,8 @@
 #include "copr.hpp"
 #include "copr_repo.hpp"
 
+#include <libdnf5/repo/repo_query.hpp>
+
 #include <iostream>
 
 namespace dnf5 {
@@ -64,7 +66,8 @@ void CoprListCommand::set_argument_parser() {
 
 
 void CoprListCommand::run() {
-    auto & base = get_context().get_base();
+    auto & ctx = get_context();
+    auto & base = ctx.get_base();
     std::unique_ptr<dnf5::CoprConfig> config = std::make_unique<dnf5::CoprConfig>(base);
     // empty string if no --hub is specified
     auto hostname = copr_cmd()->hub();
@@ -73,6 +76,17 @@ void CoprListCommand::run() {
         hostname = config->get_hub_hostname(hostname);
     auto list = RepoListCB(hostname);
     installed_copr_repositories(base, list.list);
+
+    auto & conf = base.get_config();
+    if (conf.get_installroot_option().get_value() != "/" && !conf.get_use_host_config_option().get_value()) {
+        libdnf5::repo::RepoQuery all_repos(base);
+        all_repos.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
+        if (all_repos.empty()) {
+            ctx.print_info(
+                _("No repositories were loaded from the installroot. To use the configuration and "
+                  "repositories of the host system, pass --use-host-config."));
+        }
+    }
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -19,6 +19,7 @@
 
 #include "advisory_subcommand.hpp"
 
+#include "../no_matches.hpp"
 #include "dnf5/context.hpp"
 
 #include <libdnf5-cli/output/advisorysummary.hpp>
@@ -82,17 +83,28 @@ void AdvisorySubCommand::run() {
     auto & ctx = get_context();
 
     ErrorHandling error_mode = determine_error_mode(ctx, false);
-    auto advisories_opt = advisory_query_from_cli_input(
-        ctx.get_base(),
-        advisory_specs->get_value(),
-        advisory_security->get_value(),
-        advisory_bugfix->get_value(),
-        advisory_enhancement->get_value(),
-        advisory_newpackage->get_value(),
-        advisory_severity->get_value(),
-        advisory_bz->get_value(),
-        advisory_cve->get_value(),
-        error_mode);
+
+    std::optional<libdnf5::advisory::AdvisoryQuery> advisories_opt;
+    if (no_repos_enabled(ctx)) {
+        // Without any enabled repositories no advisory data can be loaded, so
+        // the filtering is guaranteed to return no advisories, only
+        // producing misleading "no advisory found matching ..." messages.
+        if (error_mode != ErrorHandling::SILENT) {
+            report_no_repos(ctx, _("No matches found: no repositories are enabled."));
+        }
+    } else {
+        advisories_opt = advisory_query_from_cli_input(
+            ctx.get_base(),
+            advisory_specs->get_value(),
+            advisory_security->get_value(),
+            advisory_bugfix->get_value(),
+            advisory_enhancement->get_value(),
+            advisory_newpackage->get_value(),
+            advisory_severity->get_value(),
+            advisory_bz->get_value(),
+            advisory_cve->get_value(),
+            error_mode);
+    }
 
     auto advisories = advisories_opt.value_or(libdnf5::advisory::AdvisoryQuery(ctx.get_base()));
 

--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -19,6 +19,8 @@
 
 #include "environment_info.hpp"
 
+#include "../no_matches.hpp"
+
 #include <libdnf5-cli/output/adapters/comps.hpp>
 #include <libdnf5-cli/output/environmentinfo.hpp>
 #include <libdnf5/comps/environment/environment.hpp>
@@ -52,21 +54,34 @@ void EnvironmentInfoCommand::configure() {
 void EnvironmentInfoCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::EnvironmentQuery query(ctx.get_base());
+    libdnf5::comps::EnvironmentQuery base_query(ctx.get_base());
     auto environment_specs_str = environment_specs->get_value();
+    std::set<std::string> unmatched_specs;
+
+    if (installed->get_value()) {
+        base_query.filter_installed(true);
+    }
+    if (available->get_value()) {
+        base_query.filter_installed(false);
+    }
+
+    libdnf5::comps::EnvironmentQuery query(base_query);
 
     // Filter by patterns if given
     if (environment_specs_str.size() > 0) {
-        libdnf5::comps::EnvironmentQuery query_names(query);
-        query_names.filter_name(environment_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query.filter_environmentid(environment_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query |= query_names;
-    }
-    if (installed->get_value()) {
-        query.filter_installed(true);
-    }
-    if (available->get_value()) {
-        query.filter_installed(false);
+        query = libdnf5::comps::EnvironmentQuery(ctx.get_base(), true);
+        for (const auto & spec : environment_specs_str) {
+            auto spec_query = base_query;
+            auto spec_query_names = base_query;
+            spec_query.filter_environmentid(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query_names.filter_name(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query |= spec_query_names;
+            if (spec_query.empty()) {
+                unmatched_specs.insert(spec);
+            } else {
+                query |= spec_query;
+            }
+        }
     }
 
     std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
@@ -80,6 +95,17 @@ void EnvironmentInfoCommand::run() {
         libdnf5::cli::output::print_environmentinfo_table(cli_env);
         std::cout << '\n';
     }
+
+    std::string_view no_candidates_message;
+    if (installed->get_value()) {
+        no_candidates_message = _("No matches found: no environments are installed.");
+    } else if (available->get_value()) {
+        no_candidates_message = _("No matches found: no environments are available.");
+    } else {
+        no_candidates_message = _("No matches found: no environments exist.");
+    }
+    bool no_repos = !installed->get_value() && no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, environments.empty(), no_repos, base_query.empty(), no_candidates_message);
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -19,6 +19,8 @@
 
 #include "environment_list.hpp"
 
+#include "../no_matches.hpp"
+
 #include <libdnf5-cli/output/adapters/comps.hpp>
 #include <libdnf5-cli/output/environmentlist.hpp>
 #include <libdnf5/comps/environment/environment.hpp>
@@ -50,21 +52,34 @@ void EnvironmentListCommand::configure() {
 void EnvironmentListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::EnvironmentQuery query(ctx.get_base());
+    libdnf5::comps::EnvironmentQuery base_query(ctx.get_base());
     auto environment_specs_str = environment_specs->get_value();
+    std::set<std::string> unmatched_specs;
+
+    if (installed->get_value()) {
+        base_query.filter_installed(true);
+    }
+    if (available->get_value()) {
+        base_query.filter_installed(false);
+    }
+
+    libdnf5::comps::EnvironmentQuery query(base_query);
 
     // Filter by patterns if given
     if (environment_specs_str.size() > 0) {
-        libdnf5::comps::EnvironmentQuery query_names(query);
-        query_names.filter_name(environment_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query.filter_environmentid(environment_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query |= query_names;
-    }
-    if (installed->get_value()) {
-        query.filter_installed(true);
-    }
-    if (available->get_value()) {
-        query.filter_installed(false);
+        query = libdnf5::comps::EnvironmentQuery(ctx.get_base(), true);
+        for (const auto & spec : environment_specs_str) {
+            auto spec_query = base_query;
+            auto spec_query_names = base_query;
+            spec_query.filter_environmentid(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query_names.filter_name(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query |= spec_query_names;
+            if (spec_query.empty()) {
+                unmatched_specs.insert(spec);
+            } else {
+                query |= spec_query;
+            }
+        }
     }
 
     std::vector<libdnf5::comps::Environment> environments(query.list().begin(), query.list().end());
@@ -78,6 +93,17 @@ void EnvironmentListCommand::run() {
         cli_envs.emplace_back(new libdnf5::cli::output::EnvironmentAdapter(env));
     }
     libdnf5::cli::output::print_environmentlist_table(cli_envs);
+
+    std::string_view no_candidates_message;
+    if (installed->get_value()) {
+        no_candidates_message = _("No matches found: no environments are installed.");
+    } else if (available->get_value()) {
+        no_candidates_message = _("No matches found: no environments are available.");
+    } else {
+        no_candidates_message = _("No matches found: no environments exist.");
+    }
+    bool no_repos = !installed->get_value() && no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, environments.empty(), no_repos, base_query.empty(), no_candidates_message);
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -19,6 +19,8 @@
 
 #include "group_list.hpp"
 
+#include "../no_matches.hpp"
+
 #include <libdnf5-cli/output/adapters/comps.hpp>
 #include <libdnf5-cli/output/grouplist.hpp>
 #include <libdnf5/comps/group/group.hpp>
@@ -52,24 +54,38 @@ void GroupListCommand::configure() {
 void GroupListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::comps::GroupQuery query(ctx.get_base());
+    libdnf5::comps::GroupQuery base_query(ctx.get_base());
     auto group_specs_str = group_specs->get_value();
+    std::set<std::string> unmatched_specs;
+
+    if (installed->get_value()) {
+        base_query.filter_installed(true);
+    } else if (available->get_value()) {
+        base_query.filter_installed(false);
+    }
+
+    libdnf5::comps::GroupQuery query(base_query);
 
     // Filter by patterns if given
     if (group_specs_str.size() > 0) {
-        libdnf5::comps::GroupQuery query_names(query);
-        query_names.filter_name(group_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query.filter_groupid(group_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        query |= query_names;
+        query = libdnf5::comps::GroupQuery(ctx.get_base(), true);
+        for (const auto & spec : group_specs_str) {
+            auto spec_query = base_query;
+            auto spec_query_names = base_query;
+            spec_query.filter_groupid(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query_names.filter_name(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query |= spec_query_names;
+            if (spec_query.empty()) {
+                unmatched_specs.insert(spec);
+            } else {
+                query |= spec_query;
+            }
+        }
     } else if (not hidden->get_value()) {
         // Filter uservisible only if patterns are not given
         query.filter_uservisible(true);
     }
-    if (installed->get_value()) {
-        query.filter_installed(true);
-    } else if (available->get_value()) {
-        query.filter_installed(false);
-    } else {
+    if (!installed->get_value() && !available->get_value()) {
         // to remove duplicities in the output remove from query all available
         // groups with the same groupid as any of the installed groups.
         libdnf5::comps::GroupQuery query_installed(query);
@@ -88,6 +104,17 @@ void GroupListCommand::run() {
     }
 
     print(query);
+
+    std::string_view no_candidates_message;
+    if (installed->get_value()) {
+        no_candidates_message = _("No matches found: no groups are installed.");
+    } else if (available->get_value()) {
+        no_candidates_message = _("No matches found: no groups are available.");
+    } else {
+        no_candidates_message = _("No matches found: no groups exist.");
+    }
+    bool no_repos = !installed->get_value() && no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, query.empty(), no_repos, base_query.empty(), no_candidates_message);
 }
 
 void GroupListCommand::print(const libdnf5::comps::GroupQuery & query) {

--- a/dnf5/commands/list/list.cpp
+++ b/dnf5/commands/list/list.cpp
@@ -19,10 +19,11 @@
 
 #include "list.hpp"
 
+#include "../no_matches.hpp"
+
 #include <dnf5/shared_options.hpp>
 #include <libdnf5-cli/output/package_list_sections.hpp>
 #include <libdnf5/rpm/package_query.hpp>
-#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 
 namespace dnf5 {
 
@@ -156,6 +157,7 @@ void ListCommand::run() {
     libdnf5::rpm::PackageQuery base_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
 
     // pre-select by patterns
+    std::set<std::string> unmatched_specs;
     if (!pkg_specs.empty()) {
         base_query = libdnf5::rpm::PackageQuery(ctx.get_base(), libdnf5::sack::ExcludeFlags::APPLY_EXCLUDES, true);
         libdnf5::ResolveSpecSettings settings;
@@ -167,7 +169,11 @@ void ListCommand::run() {
         for (const auto & spec : pkg_specs) {
             libdnf5::rpm::PackageQuery pkg_query(full_package_query);
             pkg_query.resolve_pkg_spec(spec, settings, true);
-            base_query |= pkg_query;
+            if (pkg_query.empty()) {
+                unmatched_specs.insert(spec);
+            } else {
+                base_query |= pkg_query;
+            }
         }
     }
 
@@ -272,8 +278,12 @@ void ListCommand::run() {
         return;
     }
 
+    bool needs_repos =
+        pkg_narrow != PkgNarrow::INSTALLED && pkg_narrow != PkgNarrow::AUTOREMOVE && installed_from_repos.empty();
+    bool no_repos = needs_repos && no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, !package_matched, no_repos, false);
     if (!package_matched && !pkg_specs.empty()) {
-        throw libdnf5::cli::CommandExitError(1, M_("No matching packages to list"));
+        throw libdnf5::cli::SilentCommandExitError(1);
     } else {
         sections->print(colorizer);
     }

--- a/dnf5/commands/module/module_list.cpp
+++ b/dnf5/commands/module/module_list.cpp
@@ -19,12 +19,11 @@
 
 #include "module_list.hpp"
 
+#include "../no_matches.hpp"
+
 #include <libdnf5-cli/output/adapters/module.hpp>
 #include <libdnf5-cli/output/modulelist.hpp>
 #include <libdnf5/module/module_query.hpp>
-#include <libdnf5/utils/bgettext/bgettext-lib.h>
-
-#include <iostream>
 
 namespace dnf5 {
 
@@ -46,7 +45,17 @@ void ModuleListCommand::configure() {
 }
 
 void ModuleListCommand::run() {
-    libdnf5::module::ModuleQuery query(get_context().get_base(), true);
+    auto & ctx = get_context();
+
+    libdnf5::module::ModuleQuery base_query(ctx.get_base(), false);
+    if (enabled->get_value()) {
+        base_query.filter_enabled();
+    } else if (disabled->get_value()) {
+        base_query.filter_disabled();
+    }
+    bool no_candidate_modules = base_query.empty();
+
+    libdnf5::module::ModuleQuery query(ctx.get_base(), true);
     auto module_specs_str = module_specs->get_value();
     std::set<std::string> unmatched_module_spec;
 
@@ -54,7 +63,7 @@ void ModuleListCommand::run() {
         for (const auto & module_spec : module_specs_str) {
             bool module_spec_matched = false;
             for (const auto & nsvcap : libdnf5::module::Nsvcap::parse(module_spec)) {
-                libdnf5::module::ModuleQuery nsvcap_query(get_context().get_base(), false);
+                auto nsvcap_query = base_query;
                 nsvcap_query.filter_nsvca(nsvcap, libdnf5::sack::QueryCmp::GLOB);
                 if (!nsvcap_query.empty()) {
                     query |= nsvcap_query;
@@ -66,13 +75,7 @@ void ModuleListCommand::run() {
             }
         }
     } else {
-        query = libdnf5::module::ModuleQuery(get_context().get_base(), false);
-    }
-
-    if (enabled->get_value()) {
-        query.filter_enabled();
-    } else if (disabled->get_value()) {
-        query.filter_disabled();
+        query = base_query;
     }
 
     print(query);
@@ -80,11 +83,16 @@ void ModuleListCommand::run() {
         print_hint();
     }
 
-    if (!unmatched_module_spec.empty()) {
-        for (auto const & module_spec : unmatched_module_spec) {
-            std::cerr << libdnf5::utils::sformat(_("No matches found for \"{}\"."), module_spec) << std::endl;
-        }
+    std::string_view no_candidates_message;
+    if (enabled->get_value()) {
+        no_candidates_message = _("No matches found: no module streams are enabled.");
+    } else if (disabled->get_value()) {
+        no_candidates_message = _("No matches found: no module streams are disabled.");
+    } else {
+        no_candidates_message = _("No matches found: no module streams exist.");
     }
+    report_no_matches(
+        ctx, unmatched_module_spec, query.empty(), no_repos_enabled(ctx), no_candidate_modules, no_candidates_message);
 }
 
 void ModuleListCommand::print(const libdnf5::module::ModuleQuery & query) {

--- a/dnf5/commands/no_matches.cpp
+++ b/dnf5/commands/no_matches.cpp
@@ -1,0 +1,82 @@
+// Copyright Contributors to the DNF5 project
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "no_matches.hpp"
+
+#include <libdnf5/repo/repo_query.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+#include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+
+namespace {
+
+void report_unmatched_specs(dnf5::Context & ctx, const std::set<std::string> & unmatched_specs) {
+    for (const auto & spec : unmatched_specs) {
+        ctx.print_info(libdnf5::utils::sformat(_("No matches found for \"{}\"."), spec));
+    }
+}
+
+// Prints the installroot hint when "--installroot" is used without
+// "--use-host-config" and no repositories were configured inside the
+// installroot at all.
+bool print_installroot_hint(dnf5::Context & ctx) {
+    auto & config = ctx.get_base().get_config();
+    if (config.get_installroot_option().get_value() != "/" && !config.get_use_host_config_option().get_value()) {
+        libdnf5::repo::RepoQuery all_repos(ctx.get_base());
+        all_repos.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
+        if (all_repos.empty()) {
+            ctx.print_info(
+                _("No repositories were loaded from the installroot. To use the configuration and "
+                  "repositories of the host system, pass --use-host-config."));
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+namespace dnf5 {
+
+bool no_repos_enabled(Context & ctx) {
+    libdnf5::repo::RepoQuery enabled_repos(ctx.get_base());
+    enabled_repos.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
+    enabled_repos.filter_enabled(true);
+    return enabled_repos.empty();
+}
+
+bool report_no_repos(Context & ctx, std::string_view generic_message) {
+    if (print_installroot_hint(ctx)) {
+        return true;
+    }
+    if (!generic_message.empty()) {
+        ctx.print_info(generic_message);
+    }
+    return false;
+}
+
+void report_no_matches(
+    Context & ctx,
+    const std::set<std::string> & unmatched_specs,
+    bool result_is_empty,
+    bool no_repos,
+    bool no_candidates,
+    std::string_view no_candidates_message) {
+    if (!result_is_empty) {
+        if (!unmatched_specs.empty()) {
+            report_unmatched_specs(ctx, unmatched_specs);
+        }
+        return;
+    }
+    if (print_installroot_hint(ctx)) {
+        return;
+    }
+    if (no_repos) {
+        ctx.print_info(_("No matches found: no repositories are enabled."));
+    } else if (no_candidates) {
+        ctx.print_info(no_candidates_message);
+    } else {
+        ctx.print_info(_("No matches found."));
+    }
+}
+
+}  // namespace dnf5

--- a/dnf5/commands/no_matches.hpp
+++ b/dnf5/commands/no_matches.hpp
@@ -1,0 +1,50 @@
+// Copyright Contributors to the DNF5 project
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef DNF5_COMMANDS_NO_MATCHES_HPP
+#define DNF5_COMMANDS_NO_MATCHES_HPP
+
+
+#include <dnf5/context.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
+
+#include <set>
+#include <string>
+#include <string_view>
+
+
+namespace dnf5 {
+
+// Checks whether there are any enabled repositories to query at all.
+bool no_repos_enabled(Context & ctx);
+
+// Reports why there are no repositories to query: an installroot hint when
+// "--installroot" is used without "--use-host-config" and no repositories
+// were configured inside the installroot at all, or otherwise a generic
+// message (if given).
+// @param generic_message Message to print when the installroot hint does not
+//                         apply. Nothing is printed if left empty.
+// @return `true` if the installroot hint was printed, `false` otherwise.
+bool report_no_repos(Context & ctx, std::string_view generic_message = {});
+
+// Reports unmatched specs (partial match) or why the output is empty.
+//
+// @param unmatched_specs       Specs that did not match anything.
+// @param result_is_empty       Whether the final result set is empty.
+// @param no_repos              No enabled repositories to query. Pass `false`
+//                               when the query does not depend on enabled
+//                               repositories (e.g. --installed, --disabled).
+// @param no_candidates         No candidates exist before spec filtering.
+// @param no_candidates_message Domain-specific message for the no_candidates case.
+void report_no_matches(
+    Context & ctx,
+    const std::set<std::string> & unmatched_specs,
+    bool result_is_empty,
+    bool no_repos,
+    bool no_candidates,
+    std::string_view no_candidates_message = _("No matches found."));
+
+}  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_NO_MATCHES_HPP

--- a/dnf5/commands/provides/provides.cpp
+++ b/dnf5/commands/provides/provides.cpp
@@ -18,6 +18,8 @@
 // along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "provides.hpp"
 
+#include "../no_matches.hpp"
+
 #include "libdnf5/common/sack/query_cmp.hpp"
 #include "libdnf5/conf/option_string.hpp"
 
@@ -116,29 +118,24 @@ void ProvidesCommand::run() {
         libdnf5::rpm::PackageQuery full_package_query(ctx.get_base(), libdnf5::sack::ExcludeFlags::IGNORE_VERSIONLOCK);
         // get the matched query first and the type of match (no_match, provides, file, binary) second
         auto matched = filter_spec(spec, full_package_query);
-        for (auto package : matched.first) {
-            if (matched.second != libdnf5::cli::output::ProvidesMatchedBy::NO_MATCH) {
+        if (matched.second == libdnf5::cli::output::ProvidesMatchedBy::NO_MATCH) {
+            unmatched_specs.insert(spec);
+        } else {
+            for (auto package : matched.first) {
                 libdnf5::cli::output::PackageAdapter cli_package(package);
                 libdnf5::cli::output::print_provides_table(cli_package, spec.c_str(), matched.second);
                 any_match = true;
-            } else {
-                unmatched_specs.insert(spec);
             }
         }
     }
-    if (!unmatched_specs.empty() && any_match) {
-        for (auto const & spec : unmatched_specs) {
-            std::cerr << "No matches found for " << spec << "." << std::endl;
+    bool no_repos = no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, !any_match, no_repos, false);
+    if (!unmatched_specs.empty()) {
+        if (!no_repos) {
+            ctx.print_info(
+                _("If searching for a file, try specifying the full "
+                  "path or using a wildcard prefix (\"*/\") at the beginning."));
         }
-        std::cerr << "If searching for a file, try specifying the full "
-                     "path or using a wildcard prefix (\"*/\") at the beginning."
-                  << std::endl;
-        throw libdnf5::cli::SilentCommandExitError(1);
-    }
-    if (!any_match) {
-        std::cerr << "No matches found. If searching for a file, try specifying the full "
-                     "path or using a wildcard prefix (\"*/\") at the beginning."
-                  << std::endl;
         throw libdnf5::cli::SilentCommandExitError(1);
     }
 }

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -19,9 +19,12 @@
 
 #include "repo_list.hpp"
 
+#include "../no_matches.hpp"
+
 #include <dnf5/shared_options.hpp>
 #include <libdnf5-cli/output/adapters/repo.hpp>
 #include <libdnf5-cli/output/repolist.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 
 namespace dnf5 {
 
@@ -47,34 +50,44 @@ void RepoListCommand::set_argument_parser() {
 void RepoListCommand::run() {
     auto & ctx = get_context();
 
-    libdnf5::repo::RepoQuery query(ctx.get_base());
+    libdnf5::repo::RepoQuery base_query(ctx.get_base());
     if (all->get_value()) {
         // don't filter anything
     } else if (disabled->get_value()) {
         // show only disabled repos
-        query.filter_enabled(false);
+        base_query.filter_enabled(false);
     } else {
         // show only enabled repos
-        query.filter_enabled(true);
+        base_query.filter_enabled(true);
     }
+    base_query.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
 
     auto repo_specs_str = repo_specs->get_value();
+    std::set<std::string> unmatched_specs;
+    libdnf5::repo::RepoQuery query(base_query);
     if (repo_specs_str.size() > 0) {
-        auto query_names = query;
-        // filter by repo Name
-        query_names.filter_name(repo_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        // filter by repo ID
-        query.filter_id(repo_specs_str, libdnf5::sack::QueryCmp::IGLOB);
-        // union the results
-        query |= query_names;
+        query.clear();
+        for (const auto & spec : repo_specs_str) {
+            auto spec_query = base_query;
+            auto spec_query_names = base_query;
+            spec_query.filter_id(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query_names.filter_name(spec, libdnf5::sack::QueryCmp::IGLOB);
+            spec_query |= spec_query_names;
+            if (spec_query.empty()) {
+                unmatched_specs.insert(spec);
+            } else {
+                query |= spec_query;
+            }
+        }
     }
-
-    query.filter_type(libdnf5::repo::Repo::Type::AVAILABLE);
 
     // display status because we're printing mix of enabled and disabled repos
     bool with_status = all->get_value();
 
     print(query, with_status);
+
+    bool no_repos = !all->get_value() && !disabled->get_value() && no_repos_enabled(ctx);
+    report_no_matches(ctx, unmatched_specs, query.empty(), no_repos, base_query.empty());
 }
 
 void RepoListCommand::print(const libdnf5::repo::RepoQuery & query, bool with_status) {

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -19,6 +19,8 @@
 
 #include "repoquery.hpp"
 
+#include "../no_matches.hpp"
+
 #include "libdnf5-cli/output/adapters/package_tmpl.hpp"
 
 #include <dnf5/shared_options.hpp>
@@ -870,7 +872,10 @@ void RepoqueryCommand::run() {
 
     if (querytags_option->get_value()) {
         libdnf5::cli::output::print_available_pkg_attrs(stdout);
-    } else if (changelogs->get_value()) {
+        return;
+    }
+
+    if (changelogs->get_value()) {
         libdnf5::cli::output::print_changelogs(result_query, {libdnf5::cli::output::ChangelogFilterType::NONE, 0});
     } else if (info_option->get_value()) {
         // sort the packages according to NEVRA
@@ -888,6 +893,14 @@ void RepoqueryCommand::run() {
         libdnf5::cli::output::print_pkg_attr_uniq_sorted(stdout, result_query, pkg_attr_option->get_value());
     } else {
         libdnf5::cli::output::print_pkg_set_with_format(stdout, result_query, query_format_option->get_value());
+    }
+
+    // for repoquery we intentionally do not track unmatched specs or report on
+    // an empty package result on its own -- only the "no repositories" case,
+    // which is unrelated to packages, is reported here.
+    if (result_query.empty() && ctx.get_load_available_repos() != Context::LoadAvailableRepos::NONE &&
+        no_repos_enabled(ctx)) {
+        report_no_repos(ctx, _("No matches found: no repositories are enabled."));
     }
 }
 

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -20,6 +20,7 @@
 
 #include "search.hpp"
 
+#include "../no_matches.hpp"
 #include "search_processor.hpp"
 
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
@@ -79,15 +80,17 @@ void SearchCommand::configure() {
 }
 
 void SearchCommand::run() {
-    auto & base = get_context().get_base();
+    auto & ctx = get_context();
     SearchProcessor processor(
-        base,
+        ctx.get_base(),
         patterns->get_value(),
         all->get_value(),
         show_duplicates->get_value(),
         search_name->get_value(),
         search_summary->get_value());
-    libdnf5::cli::output::print_search_results(processor.get_results());
+    auto results = processor.get_results();
+    libdnf5::cli::output::print_search_results(results);
+    report_no_matches(ctx, {}, results.group_results.empty(), no_repos_enabled(ctx), false);
 }
 
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -40,6 +40,7 @@
 #ifdef WITH_MODULEMD
 #include "commands/module/module.hpp"
 #endif
+#include "commands/no_matches.hpp"
 #include "commands/offline/offline.hpp"
 #include "commands/provides/provides.hpp"
 #include "commands/reinstall/reinstall.hpp"
@@ -1468,10 +1469,6 @@ int main(int argc, char * argv[]) try {
 
         auto command = context.get_selected_command();
 
-        // Gets set to true when any repository is created from configuration or a
-        // .repo file
-        bool any_repos_from_system_configuration = false;
-
         try {
             command->pre_configure();
 
@@ -1542,7 +1539,6 @@ int main(int argc, char * argv[]) try {
 
             if (context.get_create_repos()) {
                 repo_sack->create_repos_from_system_configuration();
-                any_repos_from_system_configuration = repo_sack->size() > 0;
 
                 auto vars = base.get_vars();
                 for (auto & id_path_pair : context.get_repos_from_path()) {
@@ -1766,13 +1762,7 @@ int main(int argc, char * argv[]) try {
             }
         } catch (libdnf5::cli::GoalResolveError & ex) {
             std::cerr << ex.what() << std::endl;
-            if (!any_repos_from_system_configuration && base.get_config().get_installroot_option().get_value() != "/" &&
-                !base.get_config().get_use_host_config_option().get_value()) {
-                std::cerr
-                    << _("No repositories were loaded from the installroot. To use the configuration and repositories "
-                         "of the host system, pass --use-host-config.")
-                    << std::endl;
-            } else {
+            if (!report_no_repos(context)) {
                 print_vendor_change_skipped(context);
                 if (context.get_transaction() != nullptr) {
                     // download command can throw GoalResolveError without context.transaction being set

--- a/integration-tests/dnf-behave-tests/dnf/info.feature
+++ b/integration-tests/dnf-behave-tests/dnf/info.feature
@@ -11,7 +11,7 @@ Scenario: dnf info nonexistentpkg
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 
@@ -326,6 +326,7 @@ Scenario: dnf info installed setup basesystem (when basesystem is not installed)
  Then stderr is
       """
       <REPOSYNC>
+      No matches found for "basesystem".
       """
   And stdout matches line by line
       """
@@ -471,7 +472,7 @@ Given I use repository "dnf-ci-fedora-updates"
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
   And stdout is empty
 
@@ -521,7 +522,7 @@ Scenario: dnf info obsoletes setup (when setup is not obsoleted)
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 

--- a/integration-tests/dnf-behave-tests/dnf/list-recent.feature
+++ b/integration-tests/dnf-behave-tests/dnf/list-recent.feature
@@ -51,5 +51,5 @@ Scenario: dnf list package that is not recently added
     And stderr is
         """
         <REPOSYNC>
-        No matching packages to list
+        No matches found.
         """

--- a/integration-tests/dnf-behave-tests/dnf/list-showduplicates.feature
+++ b/integration-tests/dnf-behave-tests/dnf/list-showduplicates.feature
@@ -104,6 +104,7 @@ Scenario: Test for list without --showduplicates when the package is not install
 
 @bz1655605
 Scenario: Test for list --available --showduplicates when package is installed and repository is disabled
+Given I use repository "simple-base"
  When I drop repository "dnf-ci-fedora"
   And I drop repository "dnf-ci-fedora-updates-testing"
   And I execute dnf with args "install flac-1.3.3-1.fc29.x86_64"
@@ -126,11 +127,13 @@ Scenario: Test for list --available --showduplicates when package is installed a
       flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
       flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
       """
- When I drop repository "dnf-ci-fedora-updates"
-  And I execute dnf with args "list --available --showduplicates flac"
- Then the exit code is 1
-  And stderr is
-      """
-      <REPOSYNC>
-      No matching packages to list
-      """
+# Keep a repo without flac so the installroot hint does not fire
+ Given I use repository "simple-base"
+  When I drop repository "dnf-ci-fedora-updates"
+   And I execute dnf with args "list --available --showduplicates flac"
+  Then the exit code is 1
+   And stderr is
+       """
+       <REPOSYNC>
+       No matches found.
+       """

--- a/integration-tests/dnf-behave-tests/dnf/list.feature
+++ b/integration-tests/dnf-behave-tests/dnf/list.feature
@@ -11,7 +11,7 @@ Scenario: dnf list nonexistentpkg
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 
@@ -225,6 +225,7 @@ Scenario: dnf list installed setup basesystem (when basesystem is not installed)
  Then stderr is
       """
       <REPOSYNC>
+      No matches found for "basesystem".
       """
   And stdout matches line by line
       """
@@ -341,7 +342,7 @@ Given I use repository "dnf-ci-fedora-updates"
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
   And stdout is empty
 
@@ -372,7 +373,7 @@ Scenario: dnf list obsoletes setup (when setup is not obsoleted)
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 

--- a/integration-tests/dnf-behave-tests/dnf/module/info-without-install.feature
+++ b/integration-tests/dnf-behave-tests/dnf/module/info-without-install.feature
@@ -255,7 +255,7 @@ Scenario: Get info for an enabled stream, module name and stream specified
     And stderr is
         """
         <REPOSYNC>
-        No matches found for "non-existing-module".
+        No matches found.
         """
 
 

--- a/integration-tests/dnf-behave-tests/dnf/module/platform.feature
+++ b/integration-tests/dnf-behave-tests/dnf/module/platform.feature
@@ -45,7 +45,7 @@ Scenario: I can't list info for the pseudo-module
   And stderr is
       """
       <REPOSYNC>
-      No matches found for "pseudoplatform".
+      No matches found.
       """
 
 

--- a/integration-tests/dnf-behave-tests/dnf/plugins-path.feature
+++ b/integration-tests/dnf-behave-tests/dnf/plugins-path.feature
@@ -7,7 +7,7 @@ Given I do not disable plugins
 
 
 Scenario: Redirect pluginpath and pluginconfpath
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin ".*" .*
@@ -15,7 +15,7 @@ Given I successfully execute dnf with args "repo list"
   And I configure dnf with
       | key        | value                                  |
       | pluginpath | {context.dnf.installroot}/test/plugins |
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 1
   And stdout is empty
   And stderr matches line by line
@@ -28,7 +28,7 @@ Given I delete file "/var/log/dnf5.log"
   And I configure dnf with
       | key            | value                                  |
       | pluginconfpath | {context.dnf.installroot}/test/plugins |
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty
@@ -39,7 +39,7 @@ Given I delete file "/var/log/dnf5.log"
 
 
 Scenario: Test default pluginsconfpath
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin "actions" .*
@@ -51,7 +51,7 @@ Given I successfully execute dnf with args "repo list"
       enabled = 0
       """
  # pluginconfpath is not related to installroot, so actions are not disabled
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty
@@ -62,7 +62,7 @@ Given I successfully execute dnf with args "repo list"
 
 
 Scenario: Redirect pluginsconfpath in dnf.conf
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin "actions" .*
@@ -78,7 +78,7 @@ Given I successfully execute dnf with args "repo list"
   # Remove the previous log which contains successfully loaded plugin actions msg
   And I delete file "/var/log/dnf5.log"
  # pluginconfpath is now set in installroot, so versionlock is disabled
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty

--- a/integration-tests/dnf-behave-tests/dnf/provides.feature
+++ b/integration-tests/dnf-behave-tests/dnf/provides.feature
@@ -39,7 +39,8 @@ Scenario: dnf provides nonexistentprovide
     And stderr is
        """
        <REPOSYNC>
-       No matches found. If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+       No matches found.
+       If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
        """
 
 Scenario: test order of provides "dnf provides webclient A B C"
@@ -50,9 +51,9 @@ Scenario: test order of provides "dnf provides webclient A B C"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 
@@ -64,9 +65,9 @@ Scenario: test order of provides "dnf provides A webclient B C"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 
@@ -78,9 +79,9 @@ Scenario: test order of provides "dnf provides A B C webclient"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 

--- a/integration-tests/dnf-behave-tests/dnf/query-no-matches.feature
+++ b/integration-tests/dnf-behave-tests/dnf/query-no-matches.feature
@@ -1,0 +1,474 @@
+Feature: Unified error reporting for query commands
+
+
+# https://github.com/rpm-software-management/dnf5/issues/1075
+# Query commands should report:
+# - when no repositories are enabled, a message about no repos (or an
+#   installroot hint when no repos are configured in the installroot)
+# - "No matches found for <spec>." when some arguments don't match
+# - Domain-specific messages when there are no candidates at all
+
+
+# ==================
+# group list / info
+# ==================
+
+Scenario: group list reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group info reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group list with spec reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group list test-group"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group list --installed with no groups installed
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list --installed"
+  Then the exit code is 0
+   And stderr contains "No matches found: no groups are installed."
+
+
+# Use a repo without comps data so no groups come from repos.
+# The only groups are installed ones from system state (groups.toml).
+Scenario: group list --available with no groups available
+ Given I use repository "dnf-ci-fedora"
+   And I create file "/usr/lib/sysimage/libdnf5/groups.toml" with
+       """
+       version = "1.0"
+       [groups]
+       [groups.test-group]
+       userinstalled = true
+       """
+   And I successfully execute dnf with args "group list"
+  Then stdout is
+       """
+       <REPOSYNC>
+       ID                   Name Installed
+       test-group                      yes
+       """
+  When I execute dnf with args "group list --available"
+  Then the exit code is 0
+   And stderr contains "No matches found: no groups are available."
+
+
+Scenario: group list reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list test-group nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-group"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: group list reports when all specs unmatched
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: group info reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group info test-group nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-group"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ========================
+# environment list / info
+# ========================
+
+Scenario: environment list reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "environment list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: environment info reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "environment info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: environment list --installed with no environments installed
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list --installed"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no environments are installed."
+
+
+# Use a repo without comps data so no environments come from repos.
+Scenario: environment list --available with no environments available
+ Given I use repository "dnf-ci-fedora"
+   And I create file "/usr/lib/sysimage/libdnf5/environments.toml" with
+       """
+       version = "1.0"
+       [environments]
+       test-environment = {groups = [], userinstalled = true}
+       """
+   And I successfully execute dnf with args "environment list"
+  Then stdout is
+       """
+       <REPOSYNC>
+       ID                   Name Installed
+       test-environment                yes
+       """
+  When I execute dnf with args "environment list --available"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no environments are available."
+
+
+Scenario: environment list reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list test-environment nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-environment"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: environment list reports when all specs unmatched
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: environment info reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment info test-environment nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-environment"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ==================
+# repo list / info
+# ==================
+
+Scenario: repo list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repo list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repo info reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repo info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repo list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+   And I use repository "dnf-ci-fedora-updates"
+  When I execute dnf with args "repo list dnf-ci-fedora nonexistent"
+  Then the exit code is 0
+   And stdout contains "dnf-ci-fedora"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: repo list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "repo list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: repo info reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+   And I use repository "dnf-ci-fedora-updates"
+  When I execute dnf with args "repo info dnf-ci-fedora nonexistent"
+  Then the exit code is 0
+   And stdout contains "dnf-ci-fedora"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ==================
+# advisory list / info
+# ==================
+
+Scenario: advisory list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: advisory info reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: advisory summary reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory summary"
+  Then the exit code is 0
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+# ==================
+# repoquery
+# ==================
+
+Scenario: repoquery reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repoquery"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repoquery with spec reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repoquery nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repoquery --installed does not report no repos enabled
+  When I execute dnf with args "repoquery --installed"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr does not contain "no repositories are enabled"
+
+
+# ==================
+# list / info
+# ==================
+
+Scenario: list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: list with spec reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "list nonexistent"
+  Then the exit code is 1
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: list --installed does not report no repos enabled
+  When I execute dnf with args "list --installed"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr does not contain "no repositories are enabled"
+
+
+Scenario: list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "list setup nonexistent"
+  Then the exit code is 0
+   And stdout contains "setup"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "list nonexistent1 nonexistent2"
+  Then the exit code is 1
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+# ==================
+# module list / info
+# ==================
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora-modular" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "module list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora-modular"
+  When I execute dnf with args "module list nodejs nonexistent"
+  Then the exit code is 0
+   And stdout contains "nodejs"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora-modular"
+  When I execute dnf with args "module list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports no module streams exist
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "module list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no module streams exist."
+
+
+# ==================
+# search
+# ==================
+
+Scenario: search reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: search reports no matches found
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+# ==================
+# provides
+# ==================
+
+Scenario: provides reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "provides webclient"
+  Then the exit code is 1
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: provides prints installroot hint when no repos configured
+  When I execute dnf with args "provides webclient"
+  Then the exit code is 1
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+# ==================
+# installroot hint
+# ==================
+
+Scenario: group list prints installroot hint when no repos configured
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: environment list prints installroot hint when no repos configured
+  When I execute dnf with args "environment list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: advisory list prints installroot hint when no repos configured
+  When I execute dnf with args "advisory list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: repoquery prints installroot hint when no repos configured
+  When I execute dnf with args "repoquery"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: list prints installroot hint when no repos configured
+  When I execute dnf with args "list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: search prints installroot hint when no repos configured
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: copr list prints installroot hint when no repos configured
+  When I execute dnf with args "copr list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."

--- a/integration-tests/dnf-behave-tests/dnf/repolist-disabled.feature
+++ b/integration-tests/dnf-behave-tests/dnf/repolist-disabled.feature
@@ -10,12 +10,14 @@ Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
+    And stderr contains "No matches found: no repositories are enabled."
 
 
 Scenario: Repo list with "--enabled"
    When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
+    And stderr contains "No matches found: no repositories are enabled."
 
 
 Scenario: Repo list with "--disabled"

--- a/integration-tests/dnf-behave-tests/dnf/repolist-no-repos.feature
+++ b/integration-tests/dnf-behave-tests/dnf/repolist-no-repos.feature
@@ -1,29 +1,102 @@
 Feature: Repo list (alias repolist) when there are no repositories
 
 
-Scenario: Repolist without arguments
+Scenario: Repolist without arguments in an empty installroot
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
 
 
-Scenario: Repo list with "--enabled"
+Scenario: Repo list with "--enabled" in an empty installroot
    When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
 
 
-Scenario: Repo list with "--disabled"
+Scenario: Repo list with "--disabled" in an empty installroot
    When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
 
 
-Scenario: Repo list with "--all"
+Scenario: Repo list with "--all" in an empty installroot
    When I execute dnf with args "repo list --all"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+# The default test installroot has no repositories configured, so an empty
+# result always triggers the installroot hint (see previous scenarios).
+# Following scenarios set up existing repositories so the "empty view" reporting is
+# exercised on its own, verifying it does NOT fall back to the installroot hint
+# nor to the "no repositories are enabled" message when repositories do exist.
+
+Scenario: Repo list "--disabled" when all existing repositories are enabled
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "repo list --disabled"
+   Then the exit code is 0
+    And stdout is empty
+    And stderr is
+    """
+    No matches found.
+    """
+
+Scenario: Repo list "--enabled" when all existing repositories are disabled
+  Given I use repository "dnf-ci-fedora" with configuration
+        | key     | value |
+        | enabled | 0     |
+   When I execute dnf with args "repo list --enabled"
+   Then the exit code is 0
+    And stdout is empty
+    And stderr is
+    """
+    No matches found: no repositories are enabled.
+    """
+
+
+Scenario: Repo list "--disabled" with a spec matching only an enabled repository
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "repo list --disabled dnf-ci-fedora"
+   Then the exit code is 0
+    And stdout is empty
+    And stderr is
+    """
+    No matches found.
+    """
+
+
+Scenario: Repo list with an unmatched spec when repositories are enabled
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "repo list nonexistent-repo"
+   Then the exit code is 0
+    And stdout is empty
+    And stderr is
+    """
+    No matches found.
+    """
+   When I execute dnf with args "repo list --disabled nonexistent-repo"
+   Then the exit code is 0
+    And stdout is empty
+    And stderr is
+    """
+    No matches found.
+    """
+
+
+Scenario: Repo list partial match reports only the unmatched spec
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "repo list dnf-ci-fedora nonexistent-repo"
+   Then the exit code is 0
+    And stdout is
+    """
+    repo id       repo name
+    dnf-ci-fedora dnf-ci-fedora test repository
+    """
+    And stderr is
+    """
+    No matches found for "nonexistent-repo".
+    """

--- a/integration-tests/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/integration-tests/dnf-behave-tests/dnf/repoquery/main.feature
@@ -257,9 +257,11 @@ Given I successfully execute dnf with args "install bottom-a1"
       """
 
 Scenario: repoquery -C (with cache, but disabled repository)
+Given I use repository "dnf-ci-fedora"
 Given I successfully execute dnf with args "makecache"
 Given I drop repository "repoquery-main"
- When I execute dnf with args "repoquery --available -C"
+ # query a package only in the dropped repo to verify its cache is not used
+ When I execute dnf with args "repoquery --available -C top-a"
  Then the exit code is 0
   And stderr is
       """

--- a/libdnf5-cli/output/search.cpp
+++ b/libdnf5-cli/output/search.cpp
@@ -87,7 +87,6 @@ std::string construct_highlight_regex_format() {
 
 void print_search_results(const SearchResults & results) {
     if (results.group_results.empty()) {
-        std::cout << _("No matches found.") << std::endl;
         return;
     }
 


### PR DESCRIPTION
Query commands currently print nothing when their output is empty because of no enabled repositories, an unmatched spec, or a mix of both, making it easy to miss a typo or a misconfiguration. This adds shared helpers (`no_repos_enabled()`, `report_no_repos()`, `report_no_matches()`) and wires them into:

- `repo list` / `repo info`
- `group list` / `group info`
- `environment list` / `environment info`
- `module list` / `module info`
- `advisory list` / `advisory info`
- `copr list`

`main()`'s `GoalResolveError` handler and `advisory`'s spec-based  filtering are switched to the same `report_no_repos()` helper instead of their own implementation.

Resolves: https://github.com/rpm-software-management/dnf5/issues/1075

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1939

