### PR TITLE
Remove libdnf5::base::Transaction::persistence to restore ABI

### DIFF
--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -227,7 +227,6 @@ private:
     std::optional<uint32_t> user_id;
     std::string comment;
     std::string description;
-    libdnf5::base::TransactionPersistence persistence = libdnf5::base::TransactionPersistence::UNKNOWN;
 
     /// Clear the recorded last scriptlet output
     LIBDNF_LOCAL void clear_last_script_output();

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -485,7 +485,7 @@ void Transaction::set_comment(const std::string & comment) {
 }
 
 void Transaction::set_persistence(libdnf5::base::TransactionPersistence persistence) {
-    this->persistence = persistence;
+    p_impl->persistence = persistence;
 }
 
 bool Transaction::check_gpg_signatures() {

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -32,6 +32,7 @@
 #include "libdnf5/base/transaction_group.hpp"
 #include "libdnf5/base/transaction_module.hpp"
 #include "libdnf5/base/transaction_package.hpp"
+#include "libdnf5/base/transaction_persistence.hpp"
 #include "libdnf5/module/module_sack.hpp"
 #include "libdnf5/rpm/package.hpp"
 #include "libdnf5/rpm/rpm_signature.hpp"
@@ -137,6 +138,8 @@ private:
 
     // history db transaction id
     int64_t history_db_id = 0;
+
+    libdnf5::base::TransactionPersistence persistence = libdnf5::base::TransactionPersistence::UNKNOWN;
 
     // whether also the command line repo packages should be downloaded to the destination
     bool download_local_pkgs{false};


### PR DESCRIPTION
93d42a2ffd9957aadb59f897771b890a09f8c927 commit ("bootc: Add transaction persistence field") broke ABI by adding "persistence" member to libdnf5::base::Transaction class. This unintentional ABI break caused crashing PackageKit daemon compiled against DNF5 5.4.2.1 and running againt DNF5 5.4.3.0.

This patch moves the member into a private
libdnf5::base::Transaction::Impl class.

Resolve: #2869

(I still sometimes observe crashes in packagekitd program, but I hope this fix is worth on its own.)