### PR TITLE
Automatically retry transaction resolution with filelists metadata

### DIFF
--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1103,6 +1103,11 @@ static void print_resolve_hints(dnf5::Context & context) {
     auto transaction_problems = context.get_transaction()->get_problems();
     auto * command = context.get_selected_command()->get_argument_parser_command();
 
+    // Inform the user that extra metadata was downloaded
+    if (context.get_transaction()->get_filelists_auto_loaded()) {
+        context.print_info(_("Automatically downloaded and loaded filelists metadata to retry dependency resolution."));
+    }
+
     // hint --skip-unavailable if a package was not found
     if ((transaction_problems & libdnf5::GoalProblem::NOT_FOUND) == libdnf5::GoalProblem::NOT_FOUND &&
         !conf.get_skip_unavailable_option().get_value()) {

--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -243,6 +243,21 @@ repository configuration file should aside from repo ID consists of baseurl, met
 
     Default: ``[]``.
 
+.. _filelists_auto_load_options-label:
+
+``filelists_auto_load``
+    :ref:`boolean <boolean-label>`
+
+    Whether to automatically download and load ``filelists`` metadata (see
+    :ref:`optional_metadata_types <optional_metadata_types_options-label>`, not loaded by
+    default) and retry dependency resolution when it looks like an unresolved file-based
+    dependency (e.g. ``Requires: /usr/lib/foo``) might be the cause. Set to ``False`` to
+    disable this automatic retry (e.g. on a bandwidth-constrained connection, since
+    filelists metadata can be large) and keep the previous behavior of failing or hinting
+    at ``--setopt=optional_metadata_types=filelists`` instead.
+
+    Default: ``True``.
+
 .. _gpgcheck_options-label:
 
 ``gpgcheck``

--- a/include/libdnf5/base/goal.hpp
+++ b/include/libdnf5/base/goal.hpp
@@ -417,6 +417,12 @@ public:
 
 private:
     LIBDNF_LOCAL rpm::PackageId get_running_kernel_internal();
+
+    /// Downloads and loads filelists metadata (not loaded by default) for enabled available
+    /// repos, to retry dependency resolution after a solver problem suggested it's needed.
+    /// Returns whether any new data was actually loaded (see goal.cpp for full details).
+    LIBDNF_LOCAL bool try_auto_load_filelists();
+
     class LIBDNF_LOCAL Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -108,6 +108,10 @@ public:
     /// @return list of packages skipped due to vendor change restriction, paired with installed vendor string
     const std::vector<std::pair<libdnf5::rpm::Package, std::string>> & get_vendor_change_skipped_packages() const;
 
+    /// @return `true` if filelists metadata was automatically downloaded and loaded to retry dependency resolution
+    /// @since 5.4.4
+    bool get_filelists_auto_loaded() const;
+
     /// @return `true` if the transaction is empty.
     bool empty() const;
 

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -66,6 +66,11 @@ public:
     Transaction(Transaction && transaction);
     ~Transaction();
 
+    /// @since 5.4.4
+    Transaction & operator=(const Transaction & transaction);
+    /// @since 5.4.4
+    Transaction & operator=(Transaction && transaction) noexcept;
+
     /// Return basic overview about result of resolving transaction.
     /// To get complete information, use get_resolve_logs().
     libdnf5::GoalProblem get_problems();

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -102,6 +102,8 @@ public:
     const OptionStringList & get_group_package_types_option() const;
     OptionStringAppendSet & get_optional_metadata_types_option();
     const OptionStringAppendSet & get_optional_metadata_types_option() const;
+    OptionBool & get_filelists_auto_load_option();
+    const OptionBool & get_filelists_auto_load_option() const;
     OptionBool & get_use_host_config_option();
     const OptionBool & get_use_host_config_option() const;
 

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -34,6 +34,11 @@
 #include <memory>
 
 
+namespace libdnf5 {
+class Goal;
+}
+
+
 namespace libdnf5::solv {
 class Pool;
 }
@@ -314,6 +319,11 @@ public:
     // @replaces libdnf:repo/Repo.hpp:method:Repo.downloadMetadata(const std::string & destdir)
     void download_metadata(const std::string & destdir);
 
+    /// Downloads repository metadata, using a custom download progress bar
+    /// description (e.g. to distinguish a metadata-type-specific download)
+    /// @since 5.4.4
+    void download_metadata(const std::string & destdir, const std::string & description);
+
     /// Returns a list of pairs of the rpmmd type and filename of the Appstream data of the repo
     std::vector<std::pair<std::string, std::string>> get_appstream_metadata() const;
 
@@ -326,11 +336,19 @@ private:
     friend class PackageDownloader;
     friend class RepoDownloader;
     friend class solv::Pool;
+    friend class libdnf5::Goal;
 
     /// Loads the repository objects into sacks.
     ///
     /// Also writes the libsolv's solv/solvx cache files.
     LIBDNF_LOCAL void load();
+
+    /// Downloads and loads filelists metadata if they wasn't requested when
+    /// this repository was originally loaded (e.g. because dependency
+    /// resolution later determined it's needed).
+    ///
+    /// @return `true` if new data was loaded into the pool, `false` if nothing changed.
+    LIBDNF_LOCAL bool load_filelists_metadata();
 
     LIBDNF_LOCAL void add_libsolv_testcase(const std::string & path);
 

--- a/integration-tests/dnf-behave-tests/dnf/filelists-auto-load.feature
+++ b/integration-tests/dnf-behave-tests/dnf/filelists-auto-load.feature
@@ -1,0 +1,65 @@
+Feature: Test the automatic filelists metadata retry
+
+# RequiresFileDep requires /var/ProvidesFileDep, a file provided only by
+# ProvidesFileDep and only discoverable via filelists metadata (/var isn't
+# among the standard directories primary metadata auto-generates file
+# provides for). optional_metadata_types is deliberately kept to
+# comps,updateinfo so filelists is never loaded upfront.
+
+Background: Set dnf for strict behavior
+  Given I use repository "resolve-hints"
+    And I configure dnf with
+        | key                       | value             |
+        | best                      | True              |
+        | skip_unavailable          | False             |
+        | skip_broken               | False             |
+        | optional_metadata_types   | comps,updateinfo  |
+
+Scenario: A missing file dependency is automatically resolved by loading filelists metadata
+   When I execute dnf with args "install RequiresFileDep"
+   Then the exit code is 0
+    And Transaction is following
+        | Action      | Package                        |
+        | install     | RequiresFileDep-0:1.0-1.noarch |
+        | install-dep | ProvidesFileDep-0:1.0-1.noarch |
+    And stderr contains "Automatically downloaded and loaded filelists metadata to retry dependency resolution."
+
+Scenario: filelists_auto_load=False disables the automatic retry
+  Given I configure dnf with
+        | key                 | value |
+        | filelists_auto_load | False |
+   When I execute dnf with args "install RequiresFileDep"
+   Then the exit code is 1
+    And stderr is
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: conflicting requests
+          - nothing provides /var/ProvidesFileDep needed by RequiresFileDep-1.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --setopt=optional_metadata_types=filelists to load additional filelists metadata
+          --skip-broken to skip uninstallable packages
+        """
+
+Scenario: Preloading filelists metadata upfront skips the automatic retry
+   When I execute dnf with args "install RequiresFileDep --setopt=optional_metadata_types=filelists"
+   Then the exit code is 0
+    And Transaction is following
+        | Action      | Package                        |
+        | install     | RequiresFileDep-0:1.0-1.noarch |
+        | install-dep | ProvidesFileDep-0:1.0-1.noarch |
+    And stderr does not contain "Automatically downloaded and loaded filelists metadata to retry dependency resolution."
+
+Scenario: The automatic retry still fails for a file dependency no repository provides
+   When I execute dnf with args "install RequiresMissingFileDep"
+   Then the exit code is 1
+    And stderr is
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: conflicting requests
+          - nothing provides /var/MissingFileDep needed by RequiresMissingFileDep-1.0-1.noarch from resolve-hints
+        Automatically downloaded and loaded filelists metadata to retry dependency resolution.
+        You can try to add to command line:
+          --skip-broken to skip uninstallable packages
+        """

--- a/integration-tests/dnf-behave-tests/dnf/resolve-hints.feature
+++ b/integration-tests/dnf-behave-tests/dnf/resolve-hints.feature
@@ -110,7 +110,7 @@ Scenario: --allowerasing is not printed if the option is already present
         """
 
 Scenario: filelists metadata is hinted on missing file dependency
-   When I execute dnf with args "install DoesNotExist RequiresFileDep"
+   When I execute dnf with args "install --setopt=filelists_auto_load=false DoesNotExist RequiresFileDep"
    Then the exit code is 1
     And stderr is
         """

--- a/integration-tests/dnf-behave-tests/fixtures/specs/resolve-hints/RequiresMissingFileDep-1.0-1.spec
+++ b/integration-tests/dnf-behave-tests/fixtures/specs/resolve-hints/RequiresMissingFileDep-1.0-1.spec
@@ -1,0 +1,16 @@
+Name: RequiresMissingFileDep
+Version: 1.0
+Release: 1
+Summary: Made up package
+BuildArch: noarch
+Requires: /var/MissingFileDep
+
+License: GPLv3+
+Url: None
+
+%description
+RequiresMissingFileDep description
+
+%files
+
+%changelog

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -41,9 +41,11 @@
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/comps/environment/query.hpp"
 #include "libdnf5/comps/group/query.hpp"
+#include "libdnf5/conf/const.hpp"
 #ifdef WITH_MODULEMD
 #include "libdnf5/module/module_errors.hpp"
 #endif
+#include "libdnf5/repo/repo_query.hpp"
 #include "libdnf5/rpm/package_query.hpp"
 #include "libdnf5/rpm/reldep.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
@@ -58,6 +60,31 @@
 #include <unordered_map>
 
 namespace {
+
+// Whether any resolve log looks like it could be an unresolved file-based
+// dependency (a `Requires: /some/path` with no provider), which filelists
+// metadata (not loaded by default, see METADATA_TYPE_FILELISTS) might be able
+// to resolve. Covers both a hard SOLVER_ERROR and the strict-mode/no-best case
+// (SOLVER_PROBLEM_STRICT_RESOLVEMENT).
+bool has_file_dependency_problem(const std::vector<libdnf5::base::LogEvent> & resolve_logs) {
+    for (const auto & resolve_log : resolve_logs) {
+        if (resolve_log.get_problem() != libdnf5::GoalProblem::SOLVER_ERROR &&
+            resolve_log.get_problem() != libdnf5::GoalProblem::SOLVER_PROBLEM_STRICT_RESOLVEMENT) {
+            continue;
+        }
+        for (const auto & problem : resolve_log.get_solver_problems()->get_problems()) {
+            for (const auto & [rule, params] : problem) {
+                if ((rule == libdnf5::ProblemRules::RULE_PKG_NOTHING_PROVIDES_DEP ||
+                     rule == libdnf5::ProblemRules::RULE_JOB_NOTHING_PROVIDES_DEP) &&
+                    !params.empty() && params[0].starts_with('/')) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 
 void add_obsoletes_to_data(const libdnf5::rpm::PackageQuery & base_query, libdnf5::rpm::PackageSet & data) {
     libdnf5::rpm::PackageQuery data_query(data);
@@ -3464,41 +3491,89 @@ bool Goal::get_allow_erasing() const {
     return p_impl->allow_erasing;
 }
 
+bool Goal::try_auto_load_filelists() {
+    auto & base = p_impl->base;
+    auto & cfg_main = base->get_config();
+    if (!cfg_main.get_filelists_auto_load_option().get_value()) {
+        return false;
+    }
+    auto & optional_metadata_option = cfg_main.get_optional_metadata_types_option();
+    auto optional_metadata = optional_metadata_option.get_value();
+    if (optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS) ||
+        optional_metadata.contains(libdnf5::METADATA_TYPE_ALL)) {
+        // Already loaded (or requested) - nothing more to try.
+        return false;
+    }
+    optional_metadata_option.add(Option::Priority::RUNTIME, std::set<std::string>{libdnf5::METADATA_TYPE_FILELISTS});
+
+    auto & logger = *base->get_logger();
+    std::set<std::string> loaded_repo_ids;
+    repo::RepoQuery repos(base);
+    repos.filter_enabled(true);
+    repos.filter_type(repo::Repo::Type::AVAILABLE);
+    for (auto & repo : repos) {
+        try {
+            if (repo->load_filelists_metadata()) {
+                loaded_repo_ids.insert(repo->get_id());
+            }
+        } catch (const std::exception & ex) {
+            logger.warning(
+                "Automatic filelists retry: failed to load filelists for repo \"{}\": {}", repo->get_id(), ex.what());
+        }
+    }
+
+    if (loaded_repo_ids.empty()) {
+        return false;
+    }
+
+    // The filtered file-provides pool flag was set based on the original (filelists-off)
+    // state (see RepoSack::Impl::load_repos_common); with filelists now loaded it must be
+    // cleared, otherwise file-provides matching stays wrongly restricted to standard dirs.
+    // (provides were already invalidated per-repo inside the successful load_filelists_metadata()
+    // calls above.)
+    set_rpm_pool_flag(base, POOL_FLAG_ADDFILEPROVIDESFILTERED, 0);
+
+    logger.info(
+        "Automatically downloaded and loaded filelists metadata for repositories: {} to retry dependency resolution.",
+        utils::string::join(loaded_repo_ids, ", "));
+
+    return true;
+}
+
 base::Transaction Goal::resolve() {
     libdnf_user_assert(p_impl->base->is_initialized(), "Base instance was not fully initialized by Base::setup()");
 
-    p_impl->rpm_goal = rpm::solv::GoalPrivate(p_impl->base);
+    auto sack = p_impl->base->get_rpm_package_sack();
+    auto & cfg_main = p_impl->base->get_config();
 
-    base::Transaction transaction(p_impl->base);
-    auto ret = GoalProblem::NO_PROBLEM;
+    // --- One-time setup, executed exactly once
+    base::Transaction setup_transaction(p_impl->base);
+    auto setup_ret = GoalProblem::NO_PROBLEM;
 
     // Transaction replay has to be added first because it only adds to other vectors
     // of specs, it doesn't resolve anything. Therefore it doesn't need any Sacks to be ready.
     // In fact given that it can add to rpm_filepaths it has to be added before `add_paths_to_goal()`
     // and thus before the provides are computed.
     // Both serialized and reverted transactions use TransactionReplay.
-    ret |= p_impl->add_serialized_transaction_to_goal(transaction);
-    ret |= p_impl->resolve_reverted_transactions(transaction);
-    ret |= p_impl->resolve_redo_transaction(transaction);
+    setup_ret |= p_impl->add_serialized_transaction_to_goal(setup_transaction);
+    setup_ret |= p_impl->resolve_reverted_transactions(setup_transaction);
+    setup_ret |= p_impl->resolve_redo_transaction(setup_transaction);
 
     p_impl->add_paths_to_goal();
-
-    auto sack = p_impl->base->get_rpm_package_sack();
 
     sack->p_impl->recompute_considered_in_pool();
     sack->p_impl->make_provides_ready();
 
-
 #ifdef WITH_MODULEMD
     module::ModuleSack & module_sack = *p_impl->base->get_module_sack();
-    ret |= p_impl->add_module_specs_to_goal(transaction);
+    setup_ret |= p_impl->add_module_specs_to_goal(setup_transaction);
 
     // Check for switched module streams
-    if (!p_impl->base->get_config().get_module_stream_switch_option().get_value()) {
+    if (!cfg_main.get_module_stream_switch_option().get_value()) {
         auto switched_streams = module_sack.p_impl->module_db->get_all_newly_switched_streams();
         if (!switched_streams.empty()) {
             for (auto item : switched_streams) {
-                transaction.p_impl->add_resolve_log(
+                setup_transaction.p_impl->add_resolve_log(
                     GoalAction::ENABLE,
                     GoalProblem::MODULE_CANNOT_SWITH_STREAMS,
                     GoalJobSettings(),
@@ -3507,7 +3582,7 @@ base::Transaction Goal::resolve() {
                     {"0:" + item.second.first, "1:" + item.second.second},
                     libdnf5::Logger::Level::ERROR);
             }
-            ret |= GoalProblem::MODULE_CANNOT_SWITH_STREAMS;
+            setup_ret |= GoalProblem::MODULE_CANNOT_SWITH_STREAMS;
         }
     }
     // Resolve modules
@@ -3517,123 +3592,155 @@ base::Transaction Goal::resolve() {
 
     if (module_error != GoalProblem::NO_PROBLEM) {
         // Report problems from the module solver
-        transaction.p_impl->add_resolve_log(module_error, module_solver_problems);
+        setup_transaction.p_impl->add_resolve_log(module_error, module_solver_problems);
 
         // Ignore MODULE_SOLVER_ERROR_DEFAULTS and MODULE_SOLVER_ERROR_LATEST with best=false
         // Other errors (MODULE_SOLVER_ERROR and MODULE_SOLVER_ERROR_LATEST with best=true) are returned
         if (module_error != GoalProblem::MODULE_SOLVER_ERROR_DEFAULTS &&
-            (module_error != GoalProblem::MODULE_SOLVER_ERROR_LATEST ||
-             p_impl->base->get_config().get_best_option().get_value())) {
-            ret |= module_error;
+            (module_error != GoalProblem::MODULE_SOLVER_ERROR_LATEST || cfg_main.get_best_option().get_value())) {
+            setup_ret |= module_error;
         }
     }
 
     module_sack.p_impl->enable_dependent_modules();
 #endif
 
+    // Protected packages only depend on config which a filelists retry cannot
+    // change, so the query is computed once and reused by both attempts.
+    auto & protected_packages = cfg_main.get_protected_packages_option().get_value();
+    rpm::PackageQuery protected_query(p_impl->base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
+    protected_query.filter_name(protected_packages);
 
-    // TODO(jmracek) Apply comps second or later
-    // TODO(jmracek) Reset rpm_goal, setup rpm-goal flags according to conf, (allow downgrade), obsoletes, vendor, ...
-    ret |= p_impl->add_specs_to_goal(transaction);
-    p_impl->add_rpms_to_goal(transaction);
+    auto & installonly_packages = cfg_main.get_installonlypkgs_option().get_value();
+    auto installonly_limit = cfg_main.get_installonly_limit_option().get_value();
 
-    // Resolve group specs to group/environment queries first for two reasons:
-    // 1. group spec can also contain an environmental groups
-    // 2. group removal needs a list of all groups being removed to correctly remove packages
-    ret |= p_impl->resolve_group_specs(p_impl->group_specs, transaction);
+    // User-installed packages are computed lazily on the first attempt that
+    // needs it, then reused on the retry.
+    std::optional<libdnf5::solv::IdQueue> user_installed_packages;
 
-    // Handle environments before groups because they will add/remove groups
-    p_impl->add_resolved_environment_specs_to_goal(transaction);
+    // --- Repeatable: rebuilds the solver job from scratch and solves. Called
+    // a second time only if the first attempt's failure looks like an
+    // unresolved file-based dependency that loading filelists metadata might
+    // fix ---
+    auto resolve_attempt = [&](bool is_filelists_retry) {
+        // Each attempt gets its own Transaction, copied from the one-time setup results so any
+        // setup-phase resolve logs and problems are preserved regardless of which attempt is
+        // ultimately returned.
+        base::Transaction transaction(setup_transaction);
+        auto ret = setup_ret;
 
-    // Then handle groups
-    p_impl->add_resolved_group_specs_to_goal(transaction);
+        p_impl->rpm_goal = rpm::solv::GoalPrivate(p_impl->base);
 
-    ret |= p_impl->add_reason_change_specs_to_goal(transaction);
+        ret |= p_impl->add_specs_to_goal(transaction);
+        p_impl->add_rpms_to_goal(transaction);
 
-    auto & cfg_main = p_impl->base->get_config();
-    // Set goal flags
-    p_impl->rpm_goal.set_allow_vendor_change(cfg_main.get_allow_vendor_change_option().get_value());
-    p_impl->rpm_goal.set_allow_erasing(p_impl->allow_erasing);
-    p_impl->rpm_goal.set_install_weak_deps(cfg_main.get_install_weak_deps_option().get_value());
-    p_impl->rpm_goal.set_allow_downgrade(cfg_main.get_allow_downgrade_option().get_value());
+        // Resolve group specs to group/environment queries first for two reasons:
+        // 1. group spec can also contain an environmental groups
+        // 2. group removal needs a list of all groups being removed to correctly remove packages
+        ret |= p_impl->resolve_group_specs(p_impl->group_specs, transaction);
 
-    if (cfg_main.get_protect_running_kernel_option().get_value()) {
-        p_impl->rpm_goal.set_protected_running_kernel(sack->p_impl->get_running_kernel_id());
-    }
+        // Handle environments before groups because they will add/remove groups
+        p_impl->add_resolved_environment_specs_to_goal(transaction);
 
-    // Set user-installed packages (installed packages with reason USER or GROUP)
-    // proceed only if the transaction could result in removal of unused dependencies
-    if (p_impl->rpm_goal.is_clean_deps_present()) {
-        libdnf5::solv::IdQueue user_installed_packages;
-        rpm::PackageQuery installed_query(p_impl->base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
-        installed_query.filter_installed();
-        for (const auto & pkg : installed_query) {
-            if (pkg.get_reason() > transaction::TransactionItemReason::DEPENDENCY) {
-                user_installed_packages.push_back(pkg.get_id().id);
+        // Then handle groups
+        p_impl->add_resolved_group_specs_to_goal(transaction);
+
+        ret |= p_impl->add_reason_change_specs_to_goal(transaction);
+
+        // Set goal flags
+        p_impl->rpm_goal.set_allow_vendor_change(cfg_main.get_allow_vendor_change_option().get_value());
+        p_impl->rpm_goal.set_allow_erasing(p_impl->allow_erasing);
+        p_impl->rpm_goal.set_install_weak_deps(cfg_main.get_install_weak_deps_option().get_value());
+        p_impl->rpm_goal.set_allow_downgrade(cfg_main.get_allow_downgrade_option().get_value());
+
+        if (cfg_main.get_protect_running_kernel_option().get_value()) {
+            p_impl->rpm_goal.set_protected_running_kernel(sack->p_impl->get_running_kernel_id());
+        }
+
+        // Set user-installed packages (installed packages with reason USER or GROUP)
+        // proceed only if the transaction could result in removal of unused dependencies
+        if (p_impl->rpm_goal.is_clean_deps_present()) {
+            if (!user_installed_packages) {
+                libdnf5::solv::IdQueue installed_ids;
+                rpm::PackageQuery installed_query(p_impl->base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
+                installed_query.filter_installed();
+                for (const auto & pkg : installed_query) {
+                    if (pkg.get_reason() > transaction::TransactionItemReason::DEPENDENCY) {
+                        installed_ids.push_back(pkg.get_id().id);
+                    }
+                }
+                user_installed_packages = std::move(installed_ids);
+            }
+            p_impl->rpm_goal.set_user_installed_packages(*user_installed_packages);
+        }
+
+        p_impl->rpm_goal.add_protected_packages(*protected_query.p_impl);
+
+        p_impl->rpm_goal.set_installonly(installonly_packages);
+        p_impl->rpm_goal.set_installonly_limit(installonly_limit);
+
+        // Set exclude weak dependencies from configuration
+        {
+            p_impl->set_exclude_from_weak(cfg_main.get_exclude_from_weak_option().get_value());
+            if (cfg_main.get_exclude_from_weak_autodetect_option().get_value()) {
+                p_impl->autodetect_unsatisfied_installed_weak_dependencies();
             }
         }
-        p_impl->rpm_goal.set_user_installed_packages(std::move(user_installed_packages));
-    }
 
-    // Add protected packages
-    {
-        auto & protected_packages = cfg_main.get_protected_packages_option().get_value();
-        rpm::PackageQuery protected_query(p_impl->base, rpm::PackageQuery::ExcludeFlags::IGNORE_EXCLUDES);
-        protected_query.filter_name(protected_packages);
-        p_impl->rpm_goal.add_protected_packages(*protected_query.p_impl);
-    }
+        auto & pool = get_rpm_pool(p_impl->base);
+        pool.get_incoming_vendor_bypassed_solvables() = p_impl->incoming_vendor_bypassed_solvables;
+        pool.clear_blocked_vendor_changes();
 
-    // Set installonly packages
-    {
-        auto & installonly_packages = cfg_main.get_installonlypkgs_option().get_value();
-        p_impl->rpm_goal.set_installonly(installonly_packages);
-        p_impl->rpm_goal.set_installonly_limit(cfg_main.get_installonly_limit_option().get_value());
-    }
+        ret |= p_impl->rpm_goal.resolve();
 
-    // Set exclude weak dependencies from configuration
-    {
-        p_impl->set_exclude_from_weak(cfg_main.get_exclude_from_weak_option().get_value());
-        if (cfg_main.get_exclude_from_weak_autodetect_option().get_value()) {
-            p_impl->autodetect_unsatisfied_installed_weak_dependencies();
+        // Write debug solver data
+        // Note: Modules debug data are handled separately when resolving module goal in ModuleSack::Impl::module_solve()
+        if (cfg_main.get_debug_solver_option().get_value()) {
+            // The retry writes to distinctly-suffixed directories instead of the plain ones, so
+            // it doesn't silently overwrite the original failing attempt's dump with the
+            // retried one - both remain available for inspection.
+            const std::string suffix = is_filelists_retry ? "-filelists-retry" : "";
+            auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value());
+            auto pkgs_debug_dir = std::filesystem::absolute(debug_dir / ("packages" + suffix));
+            auto comps_debug_dir = std::filesystem::absolute(debug_dir / ("comps" + suffix));
+
+            // Ensures the presence of the directories.
+            std::filesystem::create_directories(pkgs_debug_dir);
+            std::filesystem::create_directories(comps_debug_dir);
+
+            p_impl->rpm_goal.write_debugdata(pkgs_debug_dir);
+            p_impl->base->get_repo_sack()->dump_comps_debugdata(comps_debug_dir);
+
+            transaction.p_impl->add_resolve_log(
+                GoalAction::RESOLVE,
+                GoalProblem::WRITE_DEBUG,
+                {},
+                libdnf5::transaction::TransactionItemType::PACKAGE,
+                "",
+                {std::filesystem::canonical(debug_dir)},
+                libdnf5::Logger::Level::WARNING);
         }
-    }
 
-    auto & pool = get_rpm_pool(p_impl->base);
-    pool.get_incoming_vendor_bypassed_solvables() = p_impl->incoming_vendor_bypassed_solvables;
-    pool.clear_blocked_vendor_changes();
-
-    ret |= p_impl->rpm_goal.resolve();
-
-    // Write debug solver data
-    // Note: Modules debug data are handled separately when resolving module goal in ModuleSack::Impl::module_solve()
-    if (cfg_main.get_debug_solver_option().get_value()) {
-        auto debug_dir = std::filesystem::path(cfg_main.get_debugdir_option().get_value());
-        auto pkgs_debug_dir = std::filesystem::absolute(debug_dir / "packages");
-        auto comps_debug_dir = std::filesystem::absolute(debug_dir / "comps");
-
-        // Ensures the presence of the directories.
-        std::filesystem::create_directories(pkgs_debug_dir);
-        std::filesystem::create_directories(comps_debug_dir);
-
-        p_impl->rpm_goal.write_debugdata(pkgs_debug_dir);
-        p_impl->base->get_repo_sack()->dump_comps_debugdata(comps_debug_dir);
-
-        transaction.p_impl->add_resolve_log(
-            GoalAction::RESOLVE,
-            GoalProblem::WRITE_DEBUG,
-            {},
-            libdnf5::transaction::TransactionItemType::PACKAGE,
-            "",
-            {std::filesystem::canonical(debug_dir)},
-            libdnf5::Logger::Level::WARNING);
-    }
-
-    transaction.p_impl->set_transaction(
-        p_impl->rpm_goal,
+        transaction.p_impl->set_transaction(
+            p_impl->rpm_goal,
 #ifdef WITH_MODULEMD
-        module_sack,
+            module_sack,
 #endif
-        ret);
+            ret);
+
+        return transaction;
+    };
+
+    auto transaction = resolve_attempt(false);
+
+    // If the failure looks like it could be an unresolved file-based dependency, try loading
+    // filelists metadata and re-resolving once before reporting it.
+    if (has_file_dependency_problem(transaction.get_resolve_logs()) && try_auto_load_filelists()) {
+        sack->p_impl->recompute_considered_in_pool();
+        sack->p_impl->make_provides_ready();
+        transaction = resolve_attempt(true);
+        transaction.p_impl->filelists_auto_loaded = true;
+    }
 
     auto & plugins = p_impl->base->p_impl->get_plugins();
     plugins.goal_resolved(transaction);

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -193,6 +193,25 @@ Transaction::Transaction(Transaction && transaction) : p_impl(std::move(transact
     p_impl->transaction = this;
 }
 
+Transaction & Transaction::operator=(const Transaction & src) {
+    if (this != &src) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl = std::make_unique<Impl>(*this, *src.p_impl);
+        }
+    }
+    return *this;
+}
+
+Transaction & Transaction::operator=(Transaction && src) noexcept {
+    if (this != &src) {
+        p_impl = std::move(src.p_impl);
+        p_impl->transaction = this;
+    }
+    return *this;
+}
+
 Transaction::~Transaction() = default;
 
 Transaction::Impl::~Impl() {
@@ -224,12 +243,24 @@ Transaction::Impl::Impl(Transaction & transaction, const Impl & src)
       signature_problems(src.signature_problems),
       broken_dependency_packages(src.broken_dependency_packages),
       conflicting_packages(src.conflicting_packages),
-      vendor_change_skipped_packages(src.vendor_change_skipped_packages) {
+      vendor_change_skipped_packages(src.vendor_change_skipped_packages),
+      rpm_reason_overrides(src.rpm_reason_overrides),
+      rpm_replays_nevra_cache(src.rpm_replays_nevra_cache) {
 }
 
 Transaction::Impl & Transaction::Impl::operator=(const Impl & other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    auto * new_libsolv_transaction =
+        other.libsolv_transaction ? transaction_create_clone(other.libsolv_transaction) : nullptr;
+    if (libsolv_transaction) {
+        transaction_free(libsolv_transaction);
+    }
+    libsolv_transaction = new_libsolv_transaction;
+
     base = other.base;
-    libsolv_transaction = other.libsolv_transaction ? transaction_create_clone(other.libsolv_transaction) : nullptr;
     problems = other.problems;
     rpm_signature = other.rpm_signature;
     packages = other.packages;
@@ -245,6 +276,8 @@ Transaction::Impl & Transaction::Impl::operator=(const Impl & other) {
     broken_dependency_packages = other.broken_dependency_packages;
     conflicting_packages = other.conflicting_packages;
     vendor_change_skipped_packages = other.vendor_change_skipped_packages;
+    rpm_reason_overrides = other.rpm_reason_overrides;
+    rpm_replays_nevra_cache = other.rpm_replays_nevra_cache;
     return *this;
 }
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -244,6 +244,7 @@ Transaction::Impl::Impl(Transaction & transaction, const Impl & src)
       broken_dependency_packages(src.broken_dependency_packages),
       conflicting_packages(src.conflicting_packages),
       vendor_change_skipped_packages(src.vendor_change_skipped_packages),
+      filelists_auto_loaded(src.filelists_auto_loaded),
       rpm_reason_overrides(src.rpm_reason_overrides),
       rpm_replays_nevra_cache(src.rpm_replays_nevra_cache) {
 }
@@ -276,6 +277,7 @@ Transaction::Impl & Transaction::Impl::operator=(const Impl & other) {
     broken_dependency_packages = other.broken_dependency_packages;
     conflicting_packages = other.conflicting_packages;
     vendor_change_skipped_packages = other.vendor_change_skipped_packages;
+    filelists_auto_loaded = other.filelists_auto_loaded;
     rpm_reason_overrides = other.rpm_reason_overrides;
     rpm_replays_nevra_cache = other.rpm_replays_nevra_cache;
     return *this;
@@ -460,6 +462,10 @@ std::vector<libdnf5::rpm::Package> Transaction::get_conflicting_packages() const
 const std::vector<std::pair<libdnf5::rpm::Package, std::string>> & Transaction::get_vendor_change_skipped_packages()
     const {
     return p_impl->vendor_change_skipped_packages;
+}
+
+bool Transaction::get_filelists_auto_loaded() const {
+    return p_impl->filelists_auto_loaded;
 }
 
 std::string Transaction::transaction_result_to_string(const TransactionRunResult result) {

--- a/libdnf5/base/transaction_impl.hpp
+++ b/libdnf5/base/transaction_impl.hpp
@@ -135,6 +135,7 @@ private:
     std::vector<libdnf5::rpm::Package> broken_dependency_packages;
     std::vector<libdnf5::rpm::Package> conflicting_packages;
     std::vector<std::pair<libdnf5::rpm::Package, std::string>> vendor_change_skipped_packages;
+    bool filelists_auto_loaded{false};
 
     // history db transaction id
     int64_t history_db_id = 0;

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -145,6 +145,7 @@ class ConfigMain::Impl {
     OptionStringList group_package_types{GROUP_PACKAGE_TYPES};
     OptionStringAppendSet optional_metadata_types{
         OptionStringAppendSet::ValueType{libdnf5::METADATA_TYPE_COMPS, libdnf5::METADATA_TYPE_UPDATEINFO}};
+    OptionBool filelists_auto_load{true};
     OptionNumber<std::uint32_t> installonly_limit{3, 0, [](const std::string & value) -> std::uint32_t {
                                                       if (value == "<off>") {
                                                           return 0;
@@ -484,6 +485,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("deltarpm_percentage", deltarpm_percentage);
     owner.opt_binds().add("skip_if_unavailable", skip_if_unavailable);
     owner.opt_binds().add("optional_metadata_types", optional_metadata_types);
+    owner.opt_binds().add("filelists_auto_load", filelists_auto_load);
 }
 
 ConfigMain::ConfigMain() {
@@ -690,6 +692,13 @@ OptionStringAppendSet & ConfigMain::get_optional_metadata_types_option() {
 }
 const OptionStringAppendSet & ConfigMain::get_optional_metadata_types_option() const {
     return p_impl->optional_metadata_types;
+}
+
+OptionBool & ConfigMain::get_filelists_auto_load_option() {
+    return p_impl->filelists_auto_load;
+}
+const OptionBool & ConfigMain::get_filelists_auto_load_option() const {
+    return p_impl->filelists_auto_load;
 }
 
 OptionNumber<std::uint32_t> & ConfigMain::get_installonly_limit_option() {
@@ -1476,6 +1485,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(installonlypkgs, other.installonlypkgs);
     load_option(group_package_types, other.group_package_types);
     load_option(optional_metadata_types, other.optional_metadata_types);
+    load_option(filelists_auto_load, other.filelists_auto_load);
     load_option(installonly_limit, other.installonly_limit);
     load_option(tsflags, other.tsflags);
     load_option(assumeyes, other.assumeyes);

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -30,6 +30,7 @@ constexpr const char * REPOID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmno
 #include "libdnf5/common/exception.hpp"
 #include "libdnf5/conf/const.hpp"
 #include "libdnf5/utils/bgettext/bgettext-mark-domain.h"
+#include "libdnf5/utils/format.hpp"
 #include "libdnf5/utils/fs/utils.hpp"
 
 extern "C" {
@@ -231,8 +232,12 @@ bool Repo::is_in_sync() {
 
 
 void Repo::download_metadata(const std::string & destdir) {
+    download_metadata(destdir, {});
+}
+
+void Repo::download_metadata(const std::string & destdir, const std::string & description) {
     RepoDownloader repo_downloader{};
-    repo_downloader.add(*this, destdir, NULL);
+    repo_downloader.add(*this, destdir, NULL, description);
     // If there is an error there should be only the one map key (this repo) in the returned
     // unordered map but iterate through all keys to be safe.
     for (auto & [repo, errs] : repo_downloader.download()) {
@@ -246,6 +251,38 @@ void Repo::download_metadata(const std::string & destdir) {
                 libdnf5::utils::string::join(errs, ", "));
         }
     }
+}
+
+bool Repo::load_filelists_metadata() {
+    // Assumes the caller (Goal::try_auto_load_filelists()) has already added filelists to the
+    // optional_metadata_types option.
+    auto optional_metadata = p_impl->config.get_main_config().get_optional_metadata_types_option().get_value();
+    const bool all_metadata = optional_metadata.contains(libdnf5::METADATA_TYPE_ALL);
+    if (!all_metadata && !optional_metadata.contains(libdnf5::METADATA_TYPE_FILELISTS)) {
+        return false;
+    }
+
+    if (p_impl->downloader->get_metadata_path(libdnf5::METADATA_TYPE_FILELISTS).empty()) {
+        if (p_impl->sync_strategy == SyncStrategy::ONLY_CACHE) {
+            return false;
+        }
+        auto display_name = get_name();
+        if (display_name.empty()) {
+            display_name = get_id();
+        }
+        download_metadata(get_cachedir(), utils::sformat("Filelists for {}", display_name));
+        // Re-scan the (now updated) local cache to refresh metadata_paths.
+        read_metadata_cache();
+        if (p_impl->downloader->get_metadata_path(libdnf5::METADATA_TYPE_FILELISTS).empty()) {
+            // The repository genuinely doesn't offer filelists metadata.
+            return false;
+        }
+    }
+
+    p_impl->solv_repo->load_repo_ext(RepodataType::FILELISTS, *p_impl->downloader.get());
+    p_impl->solv_repo->set_needs_internalizing();
+    p_impl->base->get_rpm_package_sack()->p_impl->invalidate_provides();
+    return true;
 }
 
 void Repo::load() {

--- a/libdnf5/repo/repo_downloader.cpp
+++ b/libdnf5/repo/repo_downloader.cpp
@@ -226,7 +226,10 @@ LibrepoError::LibrepoError(std::unique_ptr<GError> && lr_error)
 
 
 void RepoDownloader::add(
-    libdnf5::repo::Repo & repo, const std::string & destdir, std::function<repo_loading_func> load_repo) try {
+    libdnf5::repo::Repo & repo,
+    const std::string & destdir,
+    std::function<repo_loading_func> load_repo,
+    const std::string & description_override) try {
     auto & cbd = callback_data.emplace_back();
     cbd.repo = repo.get_weak_ptr();
     cbd.destination = destdir;
@@ -239,12 +242,19 @@ void RepoDownloader::add(
     auto * download_callbacks = cbd.repo->get_base()->get_download_callbacks();
     auto & config = cbd.repo->get_config();
     if (download_callbacks) {
-        cbd.user_cb_data = download_callbacks->add_new_download(
-            download_data.user_data,
-            !config.get_name_option().get_value().empty()
-                ? config.get_name_option().get_value().c_str()
-                : (!config.get_id().empty() ? config.get_id().c_str() : "unknown"),
-            -1);
+        const auto & repo_name = config.get_name_option().get_value();
+        const auto repo_id = config.get_id();
+        const char * description;
+        if (!description_override.empty()) {
+            description = description_override.c_str();
+        } else if (!repo_name.empty()) {
+            description = repo_name.c_str();
+        } else if (!repo_id.empty()) {
+            description = repo_id.c_str();
+        } else {
+            description = "unknown";
+        }
+        cbd.user_cb_data = download_callbacks->add_new_download(download_data.user_data, description, -1);
         cbd.prev_total_to_download = 0;
         cbd.prev_downloaded = 0;
         cbd.sum_prev_downloaded = 0;

--- a/libdnf5/repo/repo_downloader.hpp
+++ b/libdnf5/repo/repo_downloader.hpp
@@ -64,7 +64,13 @@ public:
     static LibrepoHandle & get_cached_handle(Repo & repo);
 
     /// Adds repos for which metadata will be downloaded in parallel
-    void add(libdnf5::repo::Repo & repo, const std::string & destdir, std::function<repo_loading_func> load_repo);
+    /// @param description_override If non-empty, used as the download progress description
+    ///        instead of the repo's configured name.
+    void add(
+        libdnf5::repo::Repo & repo,
+        const std::string & destdir,
+        std::function<repo_loading_func> load_repo,
+        const std::string & description_override = {});
 
     // For each repo downloads metalink (or repomd if no metalink) and
     // checks with local files if the repo needs to be downloaded.

--- a/libdnf5/repo/solv_repo.cpp
+++ b/libdnf5/repo/solv_repo.cpp
@@ -330,11 +330,15 @@ void SolvRepo::load_repo_ext(RepodataType type, const DownloadData & download_da
 }
 
 void SolvRepo::load_repo_ext(RepodataType type, const std::string & in_type_name, const DownloadData & download_data) {
+    std::string type_name = in_type_name.empty() ? repodata_type_to_name(type) : in_type_name;
+
+    if (loaded_ext_type_names.contains(type_name)) {
+        return;
+    }
+
     auto & logger = *base->get_logger();
     solv::Pool & pool = type == RepodataType::COMPS ? static_cast<solv::Pool &>(get_comps_pool(base))
                                                     : static_cast<solv::Pool &>(get_rpm_pool(base));
-
-    std::string type_name = in_type_name.empty() ? repodata_type_to_name(type) : in_type_name;
 
     std::string ext_fn;
 
@@ -360,6 +364,7 @@ void SolvRepo::load_repo_ext(RepodataType type, const std::string & in_type_name
             updateinfo_solvables_end = pool->nsolvables;
         }
 
+        loaded_ext_type_names.insert(type_name);
         return;
     }
 
@@ -398,6 +403,8 @@ void SolvRepo::load_repo_ext(RepodataType type, const std::string & in_type_name
             ext_fn,
             std::string(pool_errstr(*get_rpm_pool(base))));
     }
+
+    loaded_ext_type_names.insert(type_name);
 
     if (config.get_build_cache_option().get_value()) {
         if (type == RepodataType::COMPS) {

--- a/libdnf5/repo/solv_repo.hpp
+++ b/libdnf5/repo/solv_repo.hpp
@@ -32,6 +32,7 @@
 #include <solv/repo.h>
 
 #include <filesystem>
+#include <set>
 
 
 static const constexpr size_t CHKSUM_BYTES = 32;
@@ -158,6 +159,11 @@ private:
 
     /// List of system repo environmental groups without valid file with xml definition
     std::vector<std::string> environments_missing_xml;
+
+    /// Extension repodata names already loaded into the pool, so a later attempt
+    /// for the same type (e.g. after metadata was downloaded on demand)
+    /// doesn't load it twice.
+    std::set<std::string> loaded_ext_type_names;
 
 public:
     ::Repo * repo{nullptr};  // libsolv pool retains ownership

--- a/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-1-1.spec
+++ b/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-1-1.spec
@@ -1,0 +1,21 @@
+Name:           consumer
+Epoch:          0
+Version:        1
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A dummy package requiring a file only resolvable via filelists metadata
+Requires:       /opt/dnf5-test/tool
+BuildArch:      noarch
+
+%description
+A dummy package with a file-based dependency that can only be resolved once filelists
+metadata (not loaded by default) is loaded, since the required path isn't one createrepo_c
+promotes into primary.xml (see provider-1-1.spec).
+
+%files
+
+%changelog

--- a/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-missing-1-1.spec
+++ b/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-missing-1-1.spec
@@ -1,0 +1,21 @@
+Name:           consumer-missing
+Epoch:          0
+Version:        1
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A dummy package requiring a file no package in either repo provides
+Requires:       /opt/dnf5-test/does-not-exist
+BuildArch:      noarch
+
+%description
+A dummy package with a file-based dependency that no package provides, used to verify the
+automatic filelists retry gives up cleanly (a single attempt, no loop) when loading
+filelists doesn't actually resolve the problem.
+
+%files
+
+%changelog

--- a/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-nobest-1-1.spec
+++ b/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-nobest-1-1.spec
@@ -1,0 +1,20 @@
+Name:           consumer-nobest
+Epoch:          0
+Version:        1
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A dummy package with no requires, installable even without filelists
+BuildArch:      noarch
+
+%description
+The older, always-installable version of a package that also exists in a newer version
+(see consumer-nobest-2-1.spec) whose only difference is a file-based Requires - used to
+exercise the --no-best silent-skip trigger for the automatic filelists retry.
+
+%files
+
+%changelog

--- a/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-nobest-2-1.spec
+++ b/test/data/repos-rpm/rpm-repo-filedep-consumer/consumer-nobest-2-1.spec
@@ -1,0 +1,23 @@
+Name:           consumer-nobest
+Epoch:          0
+Version:        2
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A newer version requiring a file only resolvable via filelists metadata
+Requires:       /opt/dnf5-test/tool
+BuildArch:      noarch
+
+%description
+The newer version of a package that would normally be preferred, but has a file-based
+Requires that's unresolvable without filelists metadata (see provider-1-1.spec). With
+best=false, the solver silently falls back to the older, requires-free version
+(consumer-nobest-1-1.spec) instead of erroring - used to exercise the --no-best
+silent-skip trigger for the automatic filelists retry.
+
+%files
+
+%changelog

--- a/test/data/repos-rpm/rpm-repo-filedep-provider/provider-1-1.spec
+++ b/test/data/repos-rpm/rpm-repo-filedep-provider/provider-1-1.spec
@@ -1,0 +1,26 @@
+Name:           provider
+Epoch:          0
+Version:        1
+Release:        1
+Vendor:         dnf5-test
+
+License:        Public Domain
+URL:            http://example.com/
+
+Summary:        A dummy package that owns a file outside the standard filtered directories
+BuildArch:      noarch
+
+%description
+A dummy package that owns a file outside the paths createrepo_c treats as "primary"
+(cr_is_primary() in createrepo_c promotes any path containing "bin/", "/etc/", or
+"/usr/lib/sendmail" into primary.xml - this path deliberately avoids all of those), so
+the file only shows up in filelists.xml and not in primary.xml.
+
+%install
+mkdir -p %{buildroot}/opt/dnf5-test
+touch %{buildroot}/opt/dnf5-test/tool
+
+%files
+/opt/dnf5-test/tool
+
+%changelog

--- a/test/libdnf5/base/test_transaction.cpp
+++ b/test/libdnf5/base/test_transaction.cpp
@@ -55,3 +55,92 @@ void BaseTransactionTest::test_check_gpg_signatures_fail() {
     CPPUNIT_ASSERT(!transaction.check_gpg_signatures());
     CPPUNIT_ASSERT(!transaction.get_gpg_signature_problems().empty());
 }
+
+void BaseTransactionTest::test_auto_load_filelists_on_file_dependency() {
+    base.get_config().get_optional_metadata_types_option().set(std::set<std::string>{});
+    add_repo_rpm("rpm-repo-filedep-provider", false);
+    add_repo_rpm("rpm-repo-filedep-consumer");
+
+    libdnf5::Goal goal(base);
+    goal.add_rpm_install("consumer");
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT_EQUAL((size_t)2, transaction.get_transaction_packages_count());
+    CPPUNIT_ASSERT(transaction.get_filelists_auto_loaded());
+}
+
+void BaseTransactionTest::test_auto_load_filelists_not_needed_when_already_loaded() {
+    // Filelists already loaded (the BaseTestCase default) - the dependency resolves on the
+    // first try, no automatic retry should be needed.
+    add_repo_rpm("rpm-repo-filedep-provider", false);
+    add_repo_rpm("rpm-repo-filedep-consumer");
+
+    libdnf5::Goal goal(base);
+    goal.add_rpm_install("consumer");
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT_EQUAL((size_t)2, transaction.get_transaction_packages_count());
+    CPPUNIT_ASSERT(!transaction.get_filelists_auto_loaded());
+}
+
+void BaseTransactionTest::test_auto_load_filelists_gives_up_when_still_unresolved() {
+    base.get_config().get_optional_metadata_types_option().set(std::set<std::string>{});
+    add_repo_rpm("rpm-repo-filedep-provider", false);
+    add_repo_rpm("rpm-repo-filedep-consumer");
+
+    // "consumer-missing" requires a path no package provides, so loading filelists doesn't
+    // help - resolution should still fail with a normal solver error, with no repeated
+    // download attempts.
+    libdnf5::Goal goal(base);
+    goal.add_rpm_install("consumer-missing");
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT(transaction.get_filelists_auto_loaded());
+    CPPUNIT_ASSERT(
+        (transaction.get_problems() & libdnf5::GoalProblem::SOLVER_ERROR) == libdnf5::GoalProblem::SOLVER_ERROR);
+}
+
+void BaseTransactionTest::test_auto_load_filelists_on_no_best_skip() {
+    // With best=false, a file-based dependency that filelists could resolve doesn't cause a
+    // hard failure - the solver just silently settles for a lesser candidate. This is only
+    // detected by the strict-mode shadow-resolve in Transaction::Impl::set_transaction()
+    // (see SOLVER_PROBLEM_STRICT_RESOLVEMENT), not by the normal solve's problems. Verify the
+    // automatic retry is triggered by that case too, and that it recovers the actually-best
+    // candidate rather than leaving the silently-downgraded transaction in place.
+    base.get_config().get_optional_metadata_types_option().set(std::set<std::string>{});
+    base.get_config().get_best_option().set(false);
+    add_repo_rpm("rpm-repo-filedep-provider", false);
+    add_repo_rpm("rpm-repo-filedep-consumer");
+
+    libdnf5::Goal goal(base);
+    goal.add_rpm_install("consumer-nobest");
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT(transaction.get_filelists_auto_loaded());
+    CPPUNIT_ASSERT_EQUAL((size_t)2, transaction.get_transaction_packages_count());
+    bool found_v2 = false;
+    for (const auto & tspkg : transaction.get_transaction_packages()) {
+        if (tspkg.get_package().get_name() == "consumer-nobest") {
+            CPPUNIT_ASSERT_EQUAL(std::string("2"), tspkg.get_package().get_version());
+            found_v2 = true;
+        }
+    }
+    CPPUNIT_ASSERT(found_v2);
+}
+
+void BaseTransactionTest::test_auto_load_filelists_disabled_by_config() {
+    base.get_config().get_optional_metadata_types_option().set(std::set<std::string>{});
+    base.get_config().get_filelists_auto_load_option().set(false);
+    add_repo_rpm("rpm-repo-filedep-provider", false);
+    add_repo_rpm("rpm-repo-filedep-consumer");
+
+    // The file dependency would be resolvable via an automatic retry, but filelists_auto_load
+    // is disabled, so resolution should fail with the original solver error and no retry.
+    libdnf5::Goal goal(base);
+    goal.add_rpm_install("consumer");
+    auto transaction = goal.resolve();
+
+    CPPUNIT_ASSERT(!transaction.get_filelists_auto_loaded());
+    CPPUNIT_ASSERT(
+        (transaction.get_problems() & libdnf5::GoalProblem::SOLVER_ERROR) == libdnf5::GoalProblem::SOLVER_ERROR);
+}

--- a/test/libdnf5/base/test_transaction.hpp
+++ b/test/libdnf5/base/test_transaction.hpp
@@ -33,6 +33,11 @@ class BaseTransactionTest : public BaseTestCase {
 #ifndef WITH_PERFORMANCE_TESTS
     CPPUNIT_TEST(test_check_gpg_signatures_no_gpgcheck);
     CPPUNIT_TEST(test_check_gpg_signatures_fail);
+    CPPUNIT_TEST(test_auto_load_filelists_on_file_dependency);
+    CPPUNIT_TEST(test_auto_load_filelists_not_needed_when_already_loaded);
+    CPPUNIT_TEST(test_auto_load_filelists_gives_up_when_still_unresolved);
+    CPPUNIT_TEST(test_auto_load_filelists_on_no_best_skip);
+    CPPUNIT_TEST(test_auto_load_filelists_disabled_by_config);
 #endif
 
 #ifdef WITH_PERFORMANCE_TESTS
@@ -43,6 +48,11 @@ class BaseTransactionTest : public BaseTestCase {
 public:
     void test_check_gpg_signatures_no_gpgcheck();
     void test_check_gpg_signatures_fail();
+    void test_auto_load_filelists_on_file_dependency();
+    void test_auto_load_filelists_not_needed_when_already_loaded();
+    void test_auto_load_filelists_gives_up_when_still_unresolved();
+    void test_auto_load_filelists_on_no_best_skip();
+    void test_auto_load_filelists_disabled_by_config();
 };
 
 


### PR DESCRIPTION
Filelists metadata is excluded from `optional_metadata_types` by default because it's expensive to download. This means a plain `dnf5 upgrade` or `dnf5 install foo` that actually needs a file-based `Requires:` (e.g. `Requires: /usr/lib/foo`) can fail outright, or (with `--no-best`) silently skip the correct candidate with no error at all.

This PR makes `Goal::resolve()` detect that case and, when `filelists_auto_load` is enabled and filelists metadata isn't already requested, automatically download and load filelists for all enabled available repos and retry resolution once more before reporting the original problem.

Fixes rpm-software-management/dnf5#1053
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1941

I've also considered alternative approach - libsolv-native lazy loading.

Following a Fedora discussion on this issue (see https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/BRX7BAAFUS4HCRDN4J243FFBSECEFNTV/), Michael Schroder (libsolv upstream) suggested wiring filelists loading into libsolv's own lazy-loading mechanism (`pool_setloadcallback` + `REPODATA_STUB`) rather than retrying at the dnf5 level. This was prototyped in a separate worktree/PoC to evaluate feasibility (see https://github.com/m-blaha/dnf5/tree/worktree-filelists-libsolv-lazy-poc branch). (Warning - the Claude Code was heavily used to create this PoC, the code was not properly reviewed).

Unfortunately it doesn't hold up in practice: the solver evaluates all dependencies of every package that solver considers on each solve, not just dependencies touched by the current transaction. Any installed package with an unusual file-based dependency is therefore enough to trigger filelists loading on every single solve — and once triggered, libsolv searches for providers across all repos. For example, having `x264-libs` package (from `rpmfusion-free`) installed, with its `Recommends: /usr/lib64/libOpenCL.so.1`, causes filelists to be downloaded for every repo on every transaction, even something as unrelated as `dnf install acpi`.