### PR TITLE
Enable focusnew on rhel, the flag has proven to be good on Fedora 

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -19,12 +19,7 @@
 %bcond_without modulemd
 %endif
 %bcond_without systemd
-# Disable SOLVER_FLAG_FOCUS_NEW only for RHEL
-%if 0%{?rhel} && 0%{?rhel} < 11
-%bcond_with    focus_new
-%else
 %bcond_without focus_new
-%endif
 
 # Main components
 %bcond_without dnf5


### PR DESCRIPTION
Fedora has been using the flag for a while now and there were basically
no problems with it.
We want to have unified behavior between Fedora and rhel as much as
possible plus the new behavior (the flag provides) was mostly requested
on rhel anyway since it keeps more old package versions.

Requires: https://github.com/rpm-software-management/dnf5/pull/2883