### PR TITLE
needs-restarting: Restore DNF 4 restart-safety semantics for --services

### DIFF
--- a/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
+++ b/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp
@@ -29,6 +29,7 @@
 #include <libdnf5/rpm/package.hpp>
 #include <libdnf5/rpm/package_query.hpp>
 #include <libdnf5/sdbus_compat.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
 #include <unistd.h>
 #include <utils/string.hpp>
@@ -405,22 +406,22 @@ std::vector<NeedsRestartingCommand::SystemdService> NeedsRestartingCommand::get_
     for (const auto & unit : units) {
         // See ListUnits here:
         // https://www.freedesktop.org/wiki/Software/systemd/dbus/
-        const auto unit_name = std::get<0>(unit);
+        const auto & unit_name = std::get<0>(unit);
 
         // Only consider service units. Skip timers, targets, etc.
         if (!libdnf5::utils::string::ends_with(unit_name, ".service")) {
             continue;
         }
 
-        const auto unit_object_path = std::get<6>(unit);
-        auto unit_proxy = sdbus::createProxy(connection, SYSTEMD_DESTINATION_NAME, unit_object_path);
-
-        // Only consider active (running) services
-        std::string active_state =
-            unit_proxy->getProperty("ActiveState").onInterface(SYSTEMD_UNIT_INTERFACE).get<std::string>();
-        if (active_state != "active") {
+        // Only consider services with running processes.
+        const auto & active_state = std::get<3>(unit);
+        const auto & sub_state = std::get<4>(unit);
+        if (active_state != "active" || sub_state != "running") {
             continue;
         }
+
+        const auto & unit_object_path = std::get<6>(unit);
+        auto unit_proxy = sdbus::createProxy(connection, SYSTEMD_DESTINATION_NAME, unit_object_path);
 
         // FragmentPath is the path to the unit file that defines the service
         std::string fragment_path =
@@ -448,7 +449,16 @@ void NeedsRestartingCommand::services_need_restarting(Context & ctx) {
     libdnf5::rpm::PackageQuery installed{ctx.get_base()};
     installed.filter_installed();
 
+    libdnf5::rpm::PackageQuery reboot_suggested{ctx.get_base()};
+    reboot_suggested.filter_installed();
+    reboot_suggested.filter_reboot_suggested();
+    std::unordered_set<std::string> reboot_suggested_names;
+    for (const auto & pkg : reboot_suggested) {
+        reboot_suggested_names.insert(pkg.get_name());
+    }
+
     std::vector<std::string> service_names;
+    std::vector<std::string> reboot_service_names;
     for (const auto & package : installed) {
         for (const auto & file : package.get_files()) {
             const auto & service_pair = unit_file_to_service.find(file);
@@ -465,7 +475,11 @@ void NeedsRestartingCommand::services_need_restarting(Context & ctx) {
                     // of that service
                     const uint64_t install_timestamp_us = 1000L * 1000L * dep.get_install_time();
                     if (install_timestamp_us > service.start_timestamp_us) {
-                        service_names.emplace_back(service.name);
+                        if (reboot_suggested_names.count(package.get_name()) > 0) {
+                            reboot_service_names.emplace_back(service.name);
+                        } else {
+                            service_names.emplace_back(service.name);
+                        }
                         break;
                     }
                 }
@@ -475,6 +489,14 @@ void NeedsRestartingCommand::services_need_restarting(Context & ctx) {
     }
 
     std::sort(service_names.begin(), service_names.end());
+    std::sort(reboot_service_names.begin(), reboot_service_names.end());
+
+    if (!reboot_service_names.empty()) {
+        std::cerr << _("Warning: The following services should not be restarted but require a reboot:") << std::endl;
+        for (const auto & service_name : reboot_service_names) {
+            std::cerr << "  " << service_name << std::endl;
+        }
+    }
 
     if (ctx.get_json_output_requested()) {
         print_services_json(service_names);

--- a/doc/dnf5_plugins/needs_restarting.8.rst
+++ b/doc/dnf5_plugins/needs_restarting.8.rst
@@ -48,7 +48,7 @@ Options
     | Used with the ``-p, --processes`` option and will filter out any processes that are handled by systemd services.
 
 ``-s, --services``
-    | List systemd services that need restarting. If the package that provides the service, or any of its dependencies, have been updated since the service started, then restarting the service will be recommended. Note that this approach is quite aggressive to recommend a restart when one may not be strictly necessary.
+    | List systemd services that need restarting. If the package that provides the service, or any of its dependencies, have been updated since the service started, then restarting the service will be recommended. Note that this approach is quite aggressive to recommend a restart when one may not be strictly necessary. Services defined by core packages whose update requires a reboot (the same set the reboot hint checks) are not recommended for restart; they are listed on standard error with a warning instead.
 
 ``-r, --reboothint``
     | Has no effect, kept for compatibility with DNF 4. "dnf4 needs-restarting -r" provides the same functionality as "dnf5 needs-restarting".


### PR DESCRIPTION
# needs-restarting: Restore DNF 4 restart-safety semantics for --services

## Problem

`needs-restarting --services` reports every `.service` unit with `ActiveState`
`"active"` whose owning package (or any of its recursive dependencies) was
updated after the unit's `ActiveEnterTimestamp`. Compared to DNF 4's
process-based implementation, this loses two safety properties, and both
losses break consumers that pipe the output into `systemctl restart`.

### 1. Completed oneshot services are reported

`ActiveState` `"active"` also matches units in **`active (exited)`** state -
`Type=oneshot` services with `RemainAfterExit=yes` that already ran to
completion. Those have no processes left that could be running with outdated
dependencies, so reporting them is wrong on both ends:

- there is nothing a restart would fix, and
- "restarting" a oneshot **re-executes its one-time action** rather than
  reloading stale code.

For example, after a glibc update the output includes boot-time oneshots such
as `cloud-config.service`, `kmod-static-nodes.service` and
`dracut-shutdown.service`. Re-running `cloud-config.service` deadlocks under
cloud-init >= 25.3's single process architecture: the config stage waits on a
freshly restarted `cloud-init-main` that in turn waits for boot stages that
never re-run. This wedges the `systemctl` call - and, when driven from a
libdnf5 actions plugin hook, the whole parent dnf transaction.

DNF 4 could never report such units: it derives services from running
processes with stale mapped files, and an `active (exited)` unit has no
process. The code's own comment already states the intended behavior
[("Only consider active (running) services")](https://github.com/rpm-software-management/dnf5/blob/main/dnf5-plugins/needs_restarting_plugin/needs_restarting.cpp#L418), but the check only tests
`ActiveState`. 

### 2. Reboot-class services are recommended for restart

DNF 4 refuses to recommend restarting services defined by reboot-class
packages: units whose unit file belongs to a package providing one of the
`NEED_REBOOT` names (kernel, glibc, systemd, dbus, dbus-broker, ...) are
withheld from the restart list and printed to stderr under:

```
Warning: The following services should not be restarted but require a reboot:
```

DNF 5 dropped this guard entirely. Blindly restarting e.g.
`dbus-broker.service` mid-transaction can sever the session that drives the
update.

## Fix

- Require `SubState` `"running"` in addition to `ActiveState` `"active"`, so
  only services with live processes are reported - matching the code comment
  and DNF 4's semantics.
- Read both states from the `ListUnits` reply, which already carries them
  (field 4 `ActiveState`, field 5 `SubState`), instead of fetching
  `ActiveState` via a per-unit property call. This also moves the state
  filtering ahead of the proxy creation, so proxies and property calls are
  only made for the few units that qualify instead of every service unit on
  the system.
- Restore the reboot-class split: services whose unit file is owned by a
  package in the reboot-suggested set (`filter_reboot_suggested()`, the same
  set the reboot hint uses - the core package list plus `reboot_suggested`
  advisories) are excluded from the restart recommendations and from the
  exit-code decision, and reported on stderr in DNF 4's warning format.
- Document both behaviors for the `--services` option.
