### PR TITLE
transaction: Do not execute empty transactions

### DIFF
--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -389,64 +389,66 @@ bool is_transaction_trusted(libdnf5::base::Transaction * transaction) {
 sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
     transaction_resolved_assert();
     auto * transaction = session.get_transaction();
-    // read options from dbus call
-    dnfdaemon::KeyValueMap options;
-    call >> options;
-    bool interactive = dnfdaemon::key_value_map_get<bool>(options, "interactive", true);
-    bool downloadonly = dnfdaemon::key_value_map_get<bool>(options, "downloadonly", false);
-    if (!downloadonly && !session.check_authorization(
-                             is_transaction_trusted(transaction) ? dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION
-                                                                 : dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION,
-                             call.getSender(),
-                             interactive)) {
-        throw std::runtime_error("Not authorized");
-    }
+    if (!transaction->empty()) {
+        // read options from dbus call
+        dnfdaemon::KeyValueMap options;
+        call >> options;
+        bool interactive = dnfdaemon::key_value_map_get<bool>(options, "interactive", true);
+        bool downloadonly = dnfdaemon::key_value_map_get<bool>(options, "downloadonly", false);
+        if (!downloadonly && !session.check_authorization(
+                                 is_transaction_trusted(transaction) ? dnfdaemon::POLKIT_EXECUTE_RPM_TRUSTED_TRANSACTION
+                                                                     : dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION,
+                                 call.getSender(),
+                                 interactive)) {
+            throw std::runtime_error("Not authorized");
+        }
 
-    auto & transaction_mutex = session.get_transaction_mutex();
-    if (!transaction_mutex.try_lock()) {
-        //TODO(mblaha): use specialized exception class
-        throw std::runtime_error("Cannot acquire transaction lock (another transaction is running).");
-    }
-    std::lock_guard<std::mutex> transaction_lock(transaction_mutex, std::adopt_lock);
+        auto & transaction_mutex = session.get_transaction_mutex();
+        if (!transaction_mutex.try_lock()) {
+            //TODO(mblaha): use specialized exception class
+            throw std::runtime_error("Cannot acquire transaction lock (another transaction is running).");
+        }
+        std::lock_guard<std::mutex> transaction_lock(transaction_mutex, std::adopt_lock);
 
-    session.set_cancel_download(Session::CancelDownload::NOT_REQUESTED);
+        session.set_cancel_download(Session::CancelDownload::NOT_REQUESTED);
 
-    bool offline = dnfdaemon::key_value_map_get<bool>(options, "offline", false);
+        bool offline = dnfdaemon::key_value_map_get<bool>(options, "offline", false);
 
-    if (offline) {
-        session.store_transaction_offline(downloadonly);
-        // TODO(mblaha): signalize reboot?
-    } else {
-        session.download_transaction_packages();
-        session.set_cancel_download(Session::CancelDownload::NOT_ALLOWED);
-        if (!downloadonly) {
-            std::string comment;
-            if (options.find("comment") != options.end()) {
-                comment = dnfdaemon::key_value_map_get<std::string>(options, "comment");
+        if (offline) {
+            session.store_transaction_offline(downloadonly);
+            // TODO(mblaha): signalize reboot?
+        } else {
+            session.download_transaction_packages();
+            session.set_cancel_download(Session::CancelDownload::NOT_ALLOWED);
+            if (!downloadonly) {
+                std::string comment;
+                if (options.find("comment") != options.end()) {
+                    comment = dnfdaemon::key_value_map_get<std::string>(options, "comment");
+                }
+
+                transaction->set_callbacks(std::make_unique<dnf5daemon::DbusTransactionCB>(session));
+                transaction->set_description("dnf5daemon-server");
+                transaction->set_comment(comment);
+
+                auto rpm_result = transaction->run();
+                if (rpm_result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
+                    throw sdbus::Error(
+                        dnfdaemon::ERROR_TRANSACTION,
+                        fmt::format(
+                            "rpm transaction failed with code {}.",
+                            static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
+                                rpm_result)));
+                }
+
+                auto * base = session.get_base();
+                auto state = libdnf5::offline::OfflineTransactionState::from_base(*base);
+                if (state.is_pending()) {
+                    state.invalidate();
+                    base->get_logger()->info("Pending offline transaction has been invalidated.");
+                }
+
+                // TODO(mblaha): clean up downloaded packages after successful transaction
             }
-
-            transaction->set_callbacks(std::make_unique<dnf5daemon::DbusTransactionCB>(session));
-            transaction->set_description("dnf5daemon-server");
-            transaction->set_comment(comment);
-
-            auto rpm_result = transaction->run();
-            if (rpm_result != libdnf5::base::Transaction::TransactionRunResult::SUCCESS) {
-                throw sdbus::Error(
-                    dnfdaemon::ERROR_TRANSACTION,
-                    fmt::format(
-                        "rpm transaction failed with code {}.",
-                        static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
-                            rpm_result)));
-            }
-
-            auto * base = session.get_base();
-            auto state = libdnf5::offline::OfflineTransactionState::from_base(*base);
-            if (state.is_pending()) {
-                state.invalidate();
-                base->get_logger()->info("Pending offline transaction has been invalidated.");
-            }
-
-            // TODO(mblaha): clean up downloaded packages after successful transaction
         }
     }
 

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -1082,6 +1082,11 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
         return TransactionRunResult::ERROR_RESOLVE;
     }
 
+    // nothing to do, no reason to continue
+    if (transaction->empty()) {
+        return TransactionRunResult::SUCCESS;
+    }
+
     if (!check_gpg_signatures()) {
         return TransactionRunResult::ERROR_GPG_CHECK;
     }


### PR DESCRIPTION
Short-circuit an empty transaction in two places:

1. in Transaction::Impl::_run()
2. in Goal::do_transaction() D-Bus method

There is no need to polute the history database with bogus empty records. The dnf5 CLI never hit this, it already skips transaction.run() when the transaction is empty.