### PR TITLE
Fixes and improvements for top-level Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+integration-tests export-ignore

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SRPM_DIR = integration-tests/.srpm
 STAMPS_DIR = integration-tests/.stamps
 VERSION = $(shell rpmspec -q --queryformat '%{VERSION}\n' dnf5.spec | head -n1)
 MOCK_CONFIG ?= fedora-rawhide-x86_64
+CI_BASE_IMAGE ?= registry.fedoraproject.org/fedora:rawhide
 CONTAINER_TEST = ./integration-tests/container-test
 
 .PHONY: build test test-unit test-integration test-integration-build \
@@ -105,7 +106,7 @@ test-integration-build:
 	stamp="$$tree-$$rpms_stamp"; \
 	if [ ! -f $(STAMPS_DIR)/container-$$stamp ]; then \
 		echo "==> Container out of date, rebuilding..."; \
-		$(CONTAINER_TEST) build; \
+		$(CONTAINER_TEST) build --base=$(CI_BASE_IMAGE); \
 		rm -f $(STAMPS_DIR)/container-*; \
 		touch $(STAMPS_DIR)/container-$$stamp; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RPMS_DIR = integration-tests/rpms
 SRPM_DIR = integration-tests/.srpm
 STAMPS_DIR = integration-tests/.stamps
 VERSION = $(shell rpmspec -q --queryformat '%{VERSION}\n' dnf5.spec | head -n1)
-MOCK_CONFIG ?= fedora-43-x86_64
+MOCK_CONFIG ?= fedora-rawhide-x86_64
 CONTAINER_TEST = ./integration-tests/container-test
 
 .PHONY: build test test-unit test-integration test-integration-build \

--- a/Makefile
+++ b/Makefile
@@ -1,126 +1,163 @@
 BUILD_DIR ?= build
+SHELL := bash
 CMAKE_ARGS ?=
 CTEST_ARGS ?=
 NPROC ?= $(shell nproc)
-RPMS_DIR = integration-tests/rpms
-SRPM_DIR = integration-tests/.srpm
-STAMPS_DIR = integration-tests/.stamps
-VERSION = $(shell rpmspec -q --queryformat '%{VERSION}\n' dnf5.spec | head -n1)
+RPMS_DIR = integration-tests/build/rpms
+SOURCE_TARBALL_DIR = integration-tests/build/source
+SRPM_DIR = integration-tests/build/srpm
+STAMPS_DIR = integration-tests/build/stamps
+RPM_BUILDDIR = integration-tests/build/builddir
+VERSION := $(shell rpmspec -q --queryformat '%{VERSION}\n' dnf5.spec | head -n1)
+SOURCE_TARBALL_PREFIX := dnf5-$(VERSION)
+SOURCE_TARBALL_NAME := $(SOURCE_TARBALL_PREFIX).tar.gz
+SOURCE_TARBALL_PATH := $(SOURCE_TARBALL_DIR)/$(SOURCE_TARBALL_NAME)
 MOCK_CONFIG ?= fedora-rawhide-x86_64
 CI_BASE_IMAGE ?= registry.fedoraproject.org/fedora:rawhide
 CONTAINER_TEST = ./integration-tests/container-test
 
-.PHONY: build test test-unit test-integration test-integration-build \
-        test-integration-run rpms rpms-mock srpm clean help check-clean-tree
+.ONESHELL:
 
+FORCE:
+
+.PHONY: help
 help:
 	@echo "Unit tests:"
-	@echo "  make build              - Configure and build the project"
-	@echo "  make test-unit          - Run C++ unit tests (builds first)"
-	@echo "  make test               - Alias for test-unit"
-	@echo ""
-	@echo "Integration tests:"
-	@echo "  make test-integration        - Build RPMs (if needed), container (if needed), and run tests"
-	@echo "  make test-integration-build  - Build RPMs and the test container (with change detection)"
-	@echo "  make test-integration-run    - Run tests (container must be built)"
-	@echo "  make rpms                    - Build RPMs from local source (rpmbuild, no change detection)"
-	@echo "  make rpms-mock               - Build RPMs using Mock (no change detection)"
-	@echo "  make srpm                    - Build SRPM from local source"
-	@echo ""
-	@echo "  All integration targets pass extra args to container-test via ARGS=, e.g.:"
-	@echo "    make test-integration ARGS='--command dnf5 --tags dnf5 config.feature'"
-	@echo "    make test-integration-run ARGS='--no-destructive --command dnf5'"
-	@echo "    make test-integration-run ARGS='-r --command dnf5 install.feature'"
-	@echo ""
-	@echo "Other:"
-	@echo "  make clean              - Remove build directory, local RPMs, and stamps"
-	@echo ""
-	@echo "Variables:"
-	@echo "  BUILD_DIR=build         - Build directory (default: build)"
-	@echo "  CMAKE_ARGS=             - Extra cmake configure arguments"
-	@echo "  CTEST_ARGS=             - Extra ctest arguments (e.g. -R libdnf5)"
-	@echo "  NPROC=$$(nproc)           - Parallel build jobs"
-	@echo "  MOCK_CONFIG=fedora-rawhide-x86_64  - Mock config for rpms-mock"
+	echo "  make build     - Configure and build the project"
+	echo "  make test-unit - Run C++ unit tests (builds first)"
+	echo "  make test      - Alias for test-unit"
+	echo ""
+	echo "Integration tests:"
+	echo "  make test-integration       - Build RPMs (if needed), container (if needed), and run tests"
+	echo "  make test-integration-build - Build RPMs and the test container (with change detection)"
+	echo "  make rpms                   - Build RPMs from local source"
+	echo "  make rpms-mock              - Build RPMs using Mock"
+	echo "  make srpm                   - Build SRPM from local source"
+	echo ""
+	echo "  The test-integration target passes extra args to container-test via ARGS=, e.g.:"
+	echo "    make test-integration ARGS='--command dnf5 --tags dnf5 config.feature'"
+	echo "    make test-integration ARGS='--no-destructive --command dnf5'"
+	echo "    make test-integration ARGS='-r --command dnf5 install.feature'"
+	echo ""
+	echo "Other:"
+	echo "  make clean - Remove build directory, local RPMs, and stamps"
+	echo ""
+	echo "Variables:"
+	echo "  BUILD_DIR=build                                         - Build directory (default: build)"
+	echo "  CMAKE_ARGS=                                             - Extra cmake configure arguments"
+	echo "  CTEST_ARGS=                                             - Extra ctest arguments (e.g. -R libdnf5)"
+	echo "  NPROC=$$(nproc)                                         - Parallel build jobs"
+	echo "  MOCK_CONFIG=fedora-rawhide-x86_64                       - Mock config for rpms-mock"
+	echo "  CI_BASE_IMAGE=registry.fedoraproject.org/fedora:rawhide - Base image for test container"
 
+.PHONY: build
 build:
-	cmake -B $(BUILD_DIR) -DWITH_TESTS=ON $(CMAKE_ARGS)
-	cmake --build $(BUILD_DIR) -j$(NPROC)
+	cmake -B "$(BUILD_DIR)" -DWITH_TESTS=ON $(CMAKE_ARGS)
+	cmake --build "$(BUILD_DIR)" -j"$(NPROC)"
 
+.PHONY: test-unit
 test-unit: build
-	cd $(BUILD_DIR) && ctest --output-on-failure $(CTEST_ARGS)
+	cd "$(BUILD_DIR)" && ctest --output-on-failure $(CTEST_ARGS)
 
+.PHONY: test
 test: test-unit
 
-check-clean-tree:
-	@if [ -n "$$(git status --untracked-files=no --porcelain)" ]; then \
-		echo "Error: Working directory is not clean. Commit or stash your changes first."; \
-		echo "       git archive does not include uncommitted changes."; \
-		git status --short; \
-		exit 1; \
+$(STAMPS_DIR)/MOCK_CONFIG: FORCE
+	@mkdir -p "$(STAMPS_DIR)"
+	echo -n "$(MOCK_CONFIG)" | cmp -s "$@" || echo -n "$(MOCK_CONFIG)" > "$@"
+
+$(STAMPS_DIR)/CI_BASE_IMAGE: FORCE
+	@mkdir -p "$(STAMPS_DIR)"
+	echo -n "$(CI_BASE_IMAGE)" | cmp -s "$@" || echo -n "$(CI_BASE_IMAGE)" > "$@"
+
+$(SOURCE_TARBALL_PATH): FORCE
+	@set -e
+	mkdir -p "$(SOURCE_TARBALL_DIR)"
+	# Disregard changes in integration-tests.
+	if git status --untracked-files=no --porcelain | cut -c 4- | grep -v '^integration-tests/' | grep -q .; then
+		echo "Error: Working directory is not clean. Commit or stash your changes first."
+		echo "       git archive does not include uncommitted changes."
+		git status --short --untracked-files=no
+		exit 1
 	fi
+	git archive --mtime="1970-01-01T00:00:00" --format=tar --prefix="$(SOURCE_TARBALL_PREFIX)/" HEAD | gzip -n > "$@.tmp"
+	cmp -s "$@.tmp" "$@" || mv "$@.tmp" "$@"
+	rm -f "$@.tmp"
 
-srpm: check-clean-tree
-	@mkdir -p $(SRPM_DIR)
-	git archive --format=tar.gz --prefix=dnf5-$(VERSION)/ HEAD -o $(SRPM_DIR)/dnf5-$(VERSION).tar.gz
-
-rpms: srpm
-	@mkdir -p $(RPMS_DIR)
-	rm -f $(RPMS_DIR)/*.rpm
+$(STAMPS_DIR)/rpms: $(SOURCE_TARBALL_PATH)
+	set -e
+	mkdir -p "$(RPMS_DIR)" "$(RPM_BUILDDIR)" "$(SRPM_DIR)" "$(STAMPS_DIR)"
+	rm -rf "$(RPMS_DIR)"/*
+	rm -rf "$(SRPM_DIR)"/*
+	rm -rf "$(RPM_BUILDDIR)"/*
 	rpmbuild -bb dnf5.spec \
-		--define "_sourcedir $(CURDIR)/$(SRPM_DIR)" \
+		--define "_sourcedir $(CURDIR)/$(SOURCE_TARBALL_DIR)" \
 		--define "_rpmdir $(CURDIR)/$(RPMS_DIR)" \
 		--define "_srcrpmdir $(CURDIR)/$(SRPM_DIR)" \
-		--define "_builddir /tmp/dnf5-rpmbuild" \
+		--define "_builddir $(CURDIR)/$(RPM_BUILDDIR)" \
 		-D "version $(VERSION)"
-	find $(RPMS_DIR) -mindepth 2 -name '*.rpm' -exec mv {} $(RPMS_DIR)/ \;
-	rm -rf $(RPMS_DIR)/*/
+	touch "$(STAMPS_DIR)/rpms"
 
-rpms-mock: srpm
-	@mkdir -p $(RPMS_DIR)
-	rm -f $(RPMS_DIR)/*.rpm
+.PHONY: rpms
+rpms: $(STAMPS_DIR)/rpms
+
+$(STAMPS_DIR)/srpm: $(SOURCE_TARBALL_PATH)
+	set -e
+	mkdir -p "$(SRPM_DIR)" "$(STAMPS_DIR)"
+	rm -rf "$(SRPM_DIR)"/*
 	rpmbuild -bs dnf5.spec \
-		--define "_sourcedir $(CURDIR)/$(SRPM_DIR)" \
+		--define "_sourcedir $(CURDIR)/$(SOURCE_TARBALL_DIR)" \
 		--define "_srcrpmdir $(CURDIR)/$(SRPM_DIR)" \
 		-D "version $(VERSION)"
-	mock -r $(MOCK_CONFIG) --rebuild $(SRPM_DIR)/dnf5-$(VERSION)*.src.rpm \
-		--resultdir=$(CURDIR)/$(RPMS_DIR) --no-cleanup-after
-	rm -f $(RPMS_DIR)/*.src.rpm $(RPMS_DIR)/*.log $(RPMS_DIR)/installed_pkgs \
-		$(RPMS_DIR)/root.log $(RPMS_DIR)/build.log $(RPMS_DIR)/state.log \
-		$(RPMS_DIR)/hw_info.log $(RPMS_DIR)/available_pkgs
+	touch "$(STAMPS_DIR)/srpm"
 
-test-integration-build:
-	@mkdir -p $(STAMPS_DIR)
-	@set -e; \
-	commit=$$(git rev-parse HEAD); \
-	if [ ! -f $(STAMPS_DIR)/rpms-$$commit ]; then \
-		echo "==> RPMs out of date (commit $$commit), rebuilding with mock..."; \
-		$(MAKE) rpms-mock; \
-		rm -f $(STAMPS_DIR)/rpms-*; \
-		touch $(STAMPS_DIR)/rpms-$$commit; \
-	else \
-		echo "==> RPMs up to date for commit $$commit, skipping rebuild."; \
-	fi
-	@set -e; \
-	tree=$$(git rev-parse HEAD:integration-tests); \
-	rpms_stamp=$$(ls $(STAMPS_DIR)/rpms-* 2>/dev/null | head -1 | xargs basename 2>/dev/null); \
-	stamp="$$tree-$$rpms_stamp"; \
-	if [ ! -f $(STAMPS_DIR)/container-$$stamp ]; then \
-		echo "==> Container out of date, rebuilding..."; \
-		$(CONTAINER_TEST) build --base=$(CI_BASE_IMAGE); \
-		rm -f $(STAMPS_DIR)/container-*; \
-		touch $(STAMPS_DIR)/container-$$stamp; \
-	else \
-		echo "==> Container up to date, skipping rebuild."; \
-	fi
+.PHONY: srpm
+srpm: $(STAMPS_DIR)/srpm
 
-test-integration-run:
+$(STAMPS_DIR)/rpms-mock: $(SOURCE_TARBALL_PATH) $(STAMPS_DIR)/MOCK_CONFIG
+	set -e
+	mkdir -p "$(RPMS_DIR)" "$(SRPM_DIR)" "$(STAMPS_DIR)"
+	rm -rf "$(RPMS_DIR)"/*
+	rm -rf "$(SRPM_DIR)"/*
+	rpmbuild -bs dnf5.spec \
+		--define "_sourcedir $(CURDIR)/$(SOURCE_TARBALL_DIR)" \
+		--define "_srcrpmdir $(CURDIR)/$(SRPM_DIR)" \
+		-D "version $(VERSION)"
+	mock -r "$(MOCK_CONFIG)" --rebuild "$(SRPM_DIR)/dnf5-$(VERSION)"*.src.rpm \
+		--resultdir="$(CURDIR)/$(RPMS_DIR)" --no-cleanup-after
+	rm -rf integration-tests/rpms/*
+	while IFS= read -r rpm; do
+		ln -f "$$rpm" integration-tests/rpms/
+	done < <(find "$(RPMS_DIR)" -maxdepth 1 -name '*.rpm' ! -name '*.src.rpm')
+	touch "$(STAMPS_DIR)/rpms-mock"
+
+.PHONY: rpms-mock
+rpms-mock: $(STAMPS_DIR)/rpms-mock
+
+$(STAMPS_DIR)/integration-tests: FORCE
+	set -e
+	mkdir -p "$(STAMPS_DIR)"
+	stamp="$$(git ls-files -z integration-tests ':!integration-tests/dnf-behave-tests' | xargs -0 sha256sum | sha256sum)"
+	echo -n "$$stamp" | cmp -s "$@" || echo -n "$$stamp" > "$@"
+
+$(STAMPS_DIR)/test-integration-build: $(STAMPS_DIR)/rpms-mock $(STAMPS_DIR)/CI_BASE_IMAGE $(STAMPS_DIR)/integration-tests
+	mkdir -p "$(STAMPS_DIR)"
+	"$(CONTAINER_TEST)" build --base="$(CI_BASE_IMAGE)"
+	touch "$(STAMPS_DIR)/test-integration-build"
+
+.PHONY: test-integration-build
+test-integration-build: $(STAMPS_DIR)/test-integration-build
+
+.PHONY: test-integration
+test-integration: $(STAMPS_DIR)/test-integration-build
 	$(CONTAINER_TEST) -d run $(ARGS)
 
-test-integration: test-integration-build
-	$(CONTAINER_TEST) -d run $(ARGS)
-
+.PHONY: clean
 clean:
-	rm -rf $(BUILD_DIR)
-	rm -f $(RPMS_DIR)/*.rpm
-	rm -rf $(SRPM_DIR)
-	rm -rf $(STAMPS_DIR)
+	rm -rf "$(BUILD_DIR)"
+	rm -rf "$(RPMS_DIR)"
+	rm -rf "$(SRPM_DIR)"
+	rm -rf "$(RPM_BUILDDIR)"
+	rm -rf "$(STAMPS_DIR)"
+	rm -rf "$(SOURCE_TARBALL_DIR)"
+	rm -rf integration-tests/rpms/*

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ rpms-mock: srpm
 
 test-integration-build:
 	@mkdir -p $(STAMPS_DIR)
-	@commit=$$(git rev-parse HEAD); \
+	@set -e; \
+	commit=$$(git rev-parse HEAD); \
 	if [ ! -f $(STAMPS_DIR)/rpms-$$commit ]; then \
 		echo "==> RPMs out of date (commit $$commit), rebuilding with mock..."; \
 		$(MAKE) rpms-mock; \
@@ -98,7 +99,8 @@ test-integration-build:
 	else \
 		echo "==> RPMs up to date for commit $$commit, skipping rebuild."; \
 	fi
-	@tree=$$(git rev-parse HEAD:integration-tests); \
+	@set -e; \
+	tree=$$(git rev-parse HEAD:integration-tests); \
 	rpms_stamp=$$(ls $(STAMPS_DIR)/rpms-* 2>/dev/null | head -1 | xargs basename 2>/dev/null); \
 	stamp="$$tree-$$rpms_stamp"; \
 	if [ ! -f $(STAMPS_DIR)/container-$$stamp ]; then \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-unit: build
 test: test-unit
 
 check-clean-tree:
-	@if [ -n "$$(git status --porcelain)" ]; then \
+	@if [ -n "$$(git status --untracked-files=no --porcelain)" ]; then \
 		echo "Error: Working directory is not clean. Commit or stash your changes first."; \
 		echo "       git archive does not include uncommitted changes."; \
 		git status --short; \

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,2 +1,1 @@
-.srpm/
-.stamps/
+build/

--- a/integration-tests/Dockerfile.integration-tests
+++ b/integration-tests/Dockerfile.integration-tests
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
 
-ARG BASE=fedora:43
+ARG BASE=registry.fedoraproject.org/fedora:rawhide
 FROM $BASE
 
 ENV LANG C.UTF-8

--- a/integration-tests/Dockerfile.integration-tests
+++ b/integration-tests/Dockerfile.integration-tests
@@ -31,8 +31,10 @@ RUN set -x && \
     dnf -y install systemd --allowerasing; \
     dnf -y install dnf5 dnf5-plugins; \
     dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
-    dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-    dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
+    if [ "$TYPE" == "nightly" ]; then \
+        dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+        dnf5 --setopt=allow_vendor_change=true -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'; \
+    fi
 
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \


### PR DESCRIPTION
This is a follow-up to https://github.com/rpm-software-management/dnf5/pull/2834 which added the convenience Makefile for building dnf5 and running integration tests. See commit messages.

My main goal here was to get `make test-integration` to do as little rebuilding as possible while always automatically rebuilding what is necessary to rebuild.

I also swapped the integration tests to use fedora:rawhide by default, mainly to avoid having a hardcoded version number that we have to bump. `registry.fedoraproject.org/fedora:latest` could have also worked, IIUC this always refers to latest stable Fedora. However, I don't believe there is an equivalent Mock config that always means "latest stable".