### PR TITLE
manifest: Check checksum of packages to be installed

### DIFF
--- a/dnf5-plugins/manifest_plugin/CMakeLists.txt
+++ b/dnf5-plugins/manifest_plugin/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(manifest_cmd_plugin MODULE ${MANIFEST_SOURCES})
 
 set_target_properties(manifest_cmd_plugin PROPERTIES PREFIX "")
 
-pkg_check_modules(LIBPKGMANIFEST REQUIRED libpkgmanifest)
+pkg_check_modules(LIBPKGMANIFEST REQUIRED libpkgmanifest>=0.5.10)
 target_link_directories(manifest_cmd_plugin PRIVATE ${LIBPKGMANIFEST_LIBRARY_DIRS})
 target_link_libraries(manifest_cmd_plugin PRIVATE pkgmanifest)
 

--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -422,13 +422,15 @@ void ManifestSubcommand::add_pkgs_to_manifest(
         }
 
         auto dnf_checksum = dnf_pkg.get_checksum();
-        if (is_from_system_repo && dnf_checksum.get_checksum().empty()) {
-            dnf_checksum = dnf_pkg.get_hdr_checksum();
-        }
+        if (!dnf_checksum.get_checksum().empty()) {
+            manifest_pkg.get_checksum().set_method(checksum_method_rpm_to_manifest(dnf_checksum));
+            manifest_pkg.get_checksum().set_digest(dnf_checksum.get_checksum());
 
-        const auto & manifest_checksum_method = checksum_method_rpm_to_manifest(dnf_checksum);
-        manifest_pkg.get_checksum().set_method(manifest_checksum_method);
-        manifest_pkg.get_checksum().set_digest(dnf_checksum.get_checksum());
+        } else if (is_from_system_repo) {
+            auto dnf_hdr_checksum = dnf_pkg.get_hdr_checksum();
+            manifest_pkg.get_hdr_checksum().set_method(checksum_method_rpm_to_manifest(dnf_hdr_checksum));
+            manifest_pkg.get_hdr_checksum().set_digest(dnf_hdr_checksum.get_checksum());
+        }
 
         if (multiarch) {
             manifest.get_packages().add(manifest_pkg, arch);

--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -148,6 +148,44 @@ void load_host_repos(dnf5::Context & ctx, libdnf5::Base & base) {
     repo_sack->create_repos_from_paths(repos_from_path, libdnf5::Option::Priority::COMMANDLINE);
 }
 
+std::pair<libdnf5::rpm::PackageSet, std::vector<std::string>> get_packages_from_manifest(
+    libdnf5::Base & base, libpkgmanifest::manifest::Manifest & manifest, bool with_srpm) {
+    const auto & arch = base.get_vars()->get_value("arch");
+    libdnf5::rpm::PackageSet packages(base);
+    std::vector<std::string> errors;
+    for (auto & manifest_pkg : manifest.get_packages().get(arch, with_srpm)) {
+        libdnf5::rpm::PackageQuery query{base};
+        query.filter_repo_id(manifest_pkg.get_repo_id());
+        const auto & nevra = nevra_manifest_to_dnf(manifest_pkg.get_nevra());
+        query.filter_nevra(nevra);
+        if (query.empty()) {
+            errors.push_back(libdnf5::utils::sformat(_("No package {} available."), to_nevra_string(nevra)));
+            continue;
+        }
+        const auto & checksum = manifest_pkg.get_checksum();
+        const auto & checksum_digest = checksum.get_digest();
+        if (!checksum_digest.empty()) {
+            libdnf5::rpm::Checksum::Type checksum_type;
+            try {
+                checksum_type = checksum_method_manifest_to_dnf(checksum.get_method());
+            } catch (const libdnf5::RuntimeError & ex) {
+                errors.push_back(libdnf5::utils::sformat(
+                    _("Package {} has checksum with unsupported method: {}"), to_nevra_string(nevra), ex.what()));
+                continue;
+            }
+            query.filter_checksum(checksum_digest, checksum_type);
+            if (query.empty()) {
+                errors.push_back(libdnf5::utils::sformat(
+                    _("No package {} with checksum {} available."), to_nevra_string(nevra), checksum_digest));
+                continue;
+            }
+        }
+        packages.add(*query.begin());
+    }
+
+    return {packages, errors};
+}
+
 class KeyImportRepoCB : public libdnf5::repo::RepoCallbacks2_1 {
 public:
     explicit KeyImportRepoCB(libdnf5::ConfigMain & config) : config(&config) {}

--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -54,6 +54,28 @@ libpkgmanifest::manifest::ChecksumMethod checksum_method_rpm_to_manifest(libdnf5
     }
 }
 
+libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method) {
+    switch (method) {
+        case libpkgmanifest::manifest::ChecksumMethod::SHA1:
+            return libdnf5::rpm::Checksum::Type::SHA1;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA224:
+            return libdnf5::rpm::Checksum::Type::SHA224;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA256:
+            return libdnf5::rpm::Checksum::Type::SHA256;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA384:
+            return libdnf5::rpm::Checksum::Type::SHA384;
+        case libpkgmanifest::manifest::ChecksumMethod::SHA512:
+            return libdnf5::rpm::Checksum::Type::SHA512;
+        case libpkgmanifest::manifest::ChecksumMethod::MD5:
+            return libdnf5::rpm::Checksum::Type::MD5;
+        case libpkgmanifest::manifest::ChecksumMethod::CRC32:
+        case libpkgmanifest::manifest::ChecksumMethod::CRC64:
+            throw libdnf5::RuntimeError(M_("Manifest checksum method (CRC) is not supported for RPM package lookup"));
+        default:
+            throw libdnf5::RuntimeError(M_("Unsupported manifest checksum method for RPM package lookup"));
+    }
+}
+
 std::string get_pkg_location(libdnf5::Base & base, const libdnf5::rpm::Package & dnf_pkg) {
     std::optional<std::string> system_repo_id;
     if (base.get_repo_sack()->has_system_repo()) {

--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -421,7 +421,10 @@ void ManifestSubcommand::add_pkgs_to_manifest(
             manifest_pkg.set_location(get_pkg_location(base, dnf_pkg));
         }
 
-        const auto & dnf_checksum = is_from_system_repo ? dnf_pkg.get_hdr_checksum() : dnf_pkg.get_checksum();
+        auto dnf_checksum = dnf_pkg.get_checksum();
+        if (is_from_system_repo && dnf_checksum.get_checksum().empty()) {
+            dnf_checksum = dnf_pkg.get_hdr_checksum();
+        }
 
         const auto & manifest_checksum_method = checksum_method_rpm_to_manifest(dnf_checksum);
         manifest_pkg.get_checksum().set_method(manifest_checksum_method);

--- a/dnf5-plugins/manifest_plugin/manifest.hpp
+++ b/dnf5-plugins/manifest_plugin/manifest.hpp
@@ -21,6 +21,8 @@ std::vector<libdnf5::rpm::Package> sort_pkgs(std::vector<libdnf5::rpm::Package> 
 
 libdnf5::rpm::Nevra nevra_manifest_to_dnf(const libpkgmanifest::manifest::Nevra & manifest_nevra);
 
+libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method);
+
 std::filesystem::path get_manifest_path(libdnf5::OptionPath & option, const std::string & arch);
 
 void set_repo_callbacks(libdnf5::Base & base);

--- a/dnf5-plugins/manifest_plugin/manifest.hpp
+++ b/dnf5-plugins/manifest_plugin/manifest.hpp
@@ -29,6 +29,9 @@ void set_repo_callbacks(libdnf5::Base & base);
 
 void load_host_repos(dnf5::Context & ctx, libdnf5::Base & base);
 
+std::pair<libdnf5::rpm::PackageSet, std::vector<std::string>> get_packages_from_manifest(
+    libdnf5::Base & base, libpkgmanifest::manifest::Manifest & manifest, bool with_srpm = false);
+
 namespace dnf5 {
 
 class ManifestCommand : public Command {

--- a/dnf5-plugins/manifest_plugin/manifest_download.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_download.cpp
@@ -20,33 +20,6 @@
 using namespace libdnf5::cli;
 
 
-namespace {
-
-libdnf5::rpm::Checksum::Type checksum_method_manifest_to_dnf(libpkgmanifest::manifest::ChecksumMethod method) {
-    switch (method) {
-        case libpkgmanifest::manifest::ChecksumMethod::SHA1:
-            return libdnf5::rpm::Checksum::Type::SHA1;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA224:
-            return libdnf5::rpm::Checksum::Type::SHA224;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA256:
-            return libdnf5::rpm::Checksum::Type::SHA256;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA384:
-            return libdnf5::rpm::Checksum::Type::SHA384;
-        case libpkgmanifest::manifest::ChecksumMethod::SHA512:
-            return libdnf5::rpm::Checksum::Type::SHA512;
-        case libpkgmanifest::manifest::ChecksumMethod::MD5:
-            return libdnf5::rpm::Checksum::Type::MD5;
-        case libpkgmanifest::manifest::ChecksumMethod::CRC32:
-        case libpkgmanifest::manifest::ChecksumMethod::CRC64:
-            throw libdnf5::RuntimeError(M_("Manifest checksum method (CRC) is not supported for RPM package lookup"));
-        default:
-            throw libdnf5::RuntimeError(M_("Unsupported manifest checksum method for RPM package lookup"));
-    }
-}
-
-}  // namespace
-
-
 namespace dnf5 {
 
 void ManifestDownloadCommand::set_argument_parser() {

--- a/dnf5-plugins/manifest_plugin/manifest_download.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_download.cpp
@@ -109,24 +109,18 @@ void ManifestDownloadCommand::download_packages(
     libdnf5::repo::PackageDownloader downloader{*base};
     downloader.force_keep_packages(true);
 
-    for (auto & manifest_pkg : manifest.get_packages().get(arch, srpm_option->get_value())) {
-        libdnf5::rpm::PackageQuery query{*base};
-        query.filter_repo_id(manifest_pkg.get_repo_id());
-        const auto & nevra = nevra_manifest_to_dnf(manifest_pkg.get_nevra());
-        query.filter_nevra(nevra);
-        if (query.empty()) {
-            throw libdnf5::cli::CommandExitError(1, M_("No package {} available."), to_nevra_string(nevra));
+    const auto result = get_packages_from_manifest(*base, manifest, srpm_option->get_value());
+    const auto & packages = result.first;
+    const auto & errors = result.second;
+
+    if (!errors.empty()) {
+        for (const auto & error : errors) {
+            ctx.print_error(error);
         }
-        const auto & checksum = manifest_pkg.get_checksum();
-        const auto & checksum_digest = checksum.get_digest();
-        if (!checksum_digest.empty()) {
-            query.filter_checksum(checksum_digest, checksum_method_manifest_to_dnf(checksum.get_method()));
-            if (query.empty()) {
-                throw libdnf5::cli::CommandExitError(
-                    1, M_("No package {} with checksum {} available."), to_nevra_string(nevra), checksum_digest);
-            }
-        }
-        const auto & pkg = *query.begin();
+        throw libdnf5::cli::CommandExitError(1, M_("Some packages from the manifest were not found."));
+    }
+
+    for (const auto & pkg : packages) {
         const auto & pkg_arch = pkg.get_arch();
         // If split per arch, download noarch/src packages into separate subdirectories.
         if (per_arch_option->get_value()) {

--- a/dnf5-plugins/manifest_plugin/manifest_install.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_install.cpp
@@ -57,12 +57,19 @@ void ManifestInstallCommand::run() {
     auto & ctx = get_context();
     auto & base = ctx.get_base();
 
-    auto * goal = ctx.get_goal();
-    const auto & arch = base.get_vars()->get_value("arch");
-    for (auto & manifest_pkg : manifest.get_packages().get(arch)) {
-        libdnf5::GoalJobSettings settings;
-        settings.set_to_repo_ids({manifest_pkg.get_repo_id()});
-        goal->add_install(manifest_pkg.get_nevra().to_string(), settings);
+    const auto result = get_packages_from_manifest(base, manifest);
+    const auto & packages = result.first;
+    const auto & errors = result.second;
+
+    if (!errors.empty()) {
+        for (const auto & error : errors) {
+            ctx.print_error(error);
+        }
+        throw libdnf5::cli::CommandExitError(1, M_("Some packages from the manifest were not found."));
+    }
+
+    for (const auto & pkg : packages) {
+        ctx.get_goal()->add_rpm_install(pkg);
     }
 }
 

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -147,6 +147,7 @@ Provides:       dnf5-command(versionlock) = %{version}-%{release}
 
 # ========== versions of dependencies ==========
 
+%global libpkgmanifest_version 0.5.10
 %if %{with modulemd}
 %global libmodulemd_version 2.5.0
 %endif
@@ -228,7 +229,7 @@ BuildRequires:  pkgconfig(smartcols)
 %if %{with dnf5_plugins}
 BuildRequires:  libcurl-devel >= 7.62.0
 %if %{with plugin_manifest}
-BuildRequires:  pkgconfig(libpkgmanifest)
+BuildRequires:  pkgconfig(libpkgmanifest) >= %{libpkgmanifest_version}
 %endif
 %endif
 
@@ -1036,6 +1037,7 @@ License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+Requires:       libpkgmanifest%{?_isa} >= %{libpkgmanifest_version}
 Provides:       dnf5-command(manifest) = %{version}-%{release}
 
 %description plugin-manifest

--- a/doc/dnf5_plugins/manifest.8.rst
+++ b/doc/dnf5_plugins/manifest.8.rst
@@ -39,7 +39,9 @@ For working with RPM package manifest files using the `libpkgmanifest <https://g
     resolved and pinned in the manifest file.
 
     If a list of packages is not given, all installed packages on the system
-    will be pinned in the manifest file.
+    will be pinned in the manifest file. In this case, package checksums may
+    not be available which will make checksum verification impossible for
+    download and instalation.
 
 ``resolve``
     Create a manifest file from a provided input file.

--- a/doc/dnf5_plugins/manifest.8.rst
+++ b/doc/dnf5_plugins/manifest.8.rst
@@ -52,8 +52,8 @@ For working with RPM package manifest files using the `libpkgmanifest <https://g
 ``download``
     Download all packages specified in the manifest file to disk.
 
-    If checksums are specified, download only the packages that match both the
-    NEVRAs and checksums, otherwise, match only the NEVRAs.
+    If package checksums are specified, download only the packages that match
+    both the NEVRAs and package checksums, otherwise, match only the NEVRAs.
 
     By default, packages are downloaded to a subfolder named after the
     manifest file. You can also use the ``--destdir`` option to
@@ -66,6 +66,9 @@ For working with RPM package manifest files using the `libpkgmanifest <https://g
 
 ``install``
     Install all packages specified in the manifest file.
+
+    If package checksums are specified, install only the packages that match
+    both the NEVRAs and package checksums, otherwise, match only the NEVRAs.
 
 ---------
 Arguments

--- a/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
+++ b/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
@@ -640,7 +640,7 @@ Scenario: Download multiarch packages from per-arch manifests
         | {context.dnf.tempdir}/packages.manifest.ppc64/waldo-1.0-1.noarch.rpm        | file://{context.dnf.fixturesdir}/repos/manifest-multiarch/noarch/waldo-1.0-1.noarch.rpm         |
 
 
-Scenario: Download packages from the manifest when a checksum is incorrect
+Scenario: Download packages from the manifest when a checksum is incorrect or package is unavailable
   Given I create and substitute file "/{context.dnf.tempdir}/packages.manifest.yaml" with
     """
     document: rpm-package-manifest
@@ -657,10 +657,17 @@ Scenario: Download packages from the manifest when a checksum is incorrect
             checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
             size: 1
             evr: 2.4.0-1.fc29
+          - name: non-existent
+            repo_id: dnf-ci-fedora
+            location: x86_64/non-existent-1.0-1.fc29.x86_64.rpm
+            checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            size: 1
+            evr: 1.0-1.fc29
     """
    When I execute dnf with args "manifest download"
    Then the exit code is 1
     And stderr contains "No package http-parser-2.4.0-1.fc29.x86_64 with checksum 1111111111111111111111111111111111111111111111111111111111111111 available."
+    And stderr contains "No package non-existent-1.0-1.fc29.x86_64 available."
 
 
 Scenario: Install packages from the manifest
@@ -674,7 +681,7 @@ Scenario: Install packages from the manifest
         | install       | wget-0:1.19.5-5.fc29.x86_64       |
 
 
-Scenario: Install packages from the manifest when a checksum is incorrect
+Scenario: Install packages from the manifest when a checksum is incorrect or package is unavailable
   Given I create and substitute file "/{context.dnf.tempdir}/packages.manifest.yaml" with
     """
     document: rpm-package-manifest
@@ -691,7 +698,14 @@ Scenario: Install packages from the manifest when a checksum is incorrect
             checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
             size: 1
             evr: 2.4.0-1.fc29
+          - name: non-existent
+            repo_id: dnf-ci-fedora
+            location: x86_64/non-existent-1.0-1.fc29.x86_64.rpm
+            checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            size: 1
+            evr: 1.0-1.fc29
     """
    When I execute dnf with args "manifest install"
    Then the exit code is 1
     And stderr contains "No package http-parser-2.4.0-1.fc29.x86_64 with checksum 1111111111111111111111111111111111111111111111111111111111111111 available."
+    And stderr contains "No package non-existent-1.0-1.fc29.x86_64 available."

--- a/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
+++ b/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
@@ -672,3 +672,26 @@ Scenario: Install packages from the manifest
         | install       | abcde-0:2.9.2-1.fc29.noarch       |
         | install       | http-parser-0:2.4.0-1.fc29.x86_64 |
         | install       | wget-0:1.19.5-5.fc29.x86_64       |
+
+
+Scenario: Install packages from the manifest when a checksum is incorrect
+  Given I create and substitute file "/{context.dnf.tempdir}/packages.manifest.yaml" with
+    """
+    document: rpm-package-manifest
+    version: 0.2.2
+    data:
+      repositories:
+        - id: dnf-ci-fedora
+          baseurl: file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora
+      packages:
+        x86_64:
+          - name: http-parser
+            repo_id: dnf-ci-fedora
+            location: x86_64/http-parser-2.4.0-1.fc29.x86_64.rpm
+            checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            size: 1
+            evr: 2.4.0-1.fc29
+    """
+   When I execute dnf with args "manifest install"
+   Then the exit code is 1
+    And stderr contains "No package http-parser-2.4.0-1.fc29.x86_64 with checksum 1111111111111111111111111111111111111111111111111111111111111111 available."

--- a/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
+++ b/integration-tests/dnf-behave-tests/dnf/plugins-core/manifest.feature
@@ -670,6 +670,23 @@ Scenario: Download packages from the manifest when a checksum is incorrect or pa
     And stderr contains "No package non-existent-1.0-1.fc29.x86_64 available."
 
 
+@force_installroot
+Scenario: Download packages from the manifest created from system
+  Given I successfully execute dnf with args "manifest new"
+    And I successfully execute dnf with args "remove basesystem glibc flac"
+   When I execute dnf with args "manifest download"
+   Then the exit code is 0
+    And file sha256 checksums are following
+        | Path                                                                               | sha256                                                                                                 |
+        | {context.dnf.tempdir}/packages.manifest/basesystem-11-6.fc29.noarch.rpm            | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm            |
+        | {context.dnf.tempdir}/packages.manifest/filesystem-3.9-2.fc29.x86_64.rpm           | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm           |
+        | {context.dnf.tempdir}/packages.manifest/flac-1.3.2-8.fc29.x86_64.rpm               | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/flac-1.3.2-8.fc29.x86_64.rpm               |
+        | {context.dnf.tempdir}/packages.manifest/glibc-2.28-9.fc29.x86_64.rpm               | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/glibc-2.28-9.fc29.x86_64.rpm               |
+        | {context.dnf.tempdir}/packages.manifest/glibc-all-langpacks-2.28-9.fc29.x86_64.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/glibc-all-langpacks-2.28-9.fc29.x86_64.rpm |
+        | {context.dnf.tempdir}/packages.manifest/glibc-all-langpacks-2.28-9.fc29.x86_64.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/glibc-all-langpacks-2.28-9.fc29.x86_64.rpm |
+        | {context.dnf.tempdir}/packages.manifest/setup-2.12.1-1.fc29.noarch.rpm             | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm             |
+
+
 Scenario: Install packages from the manifest
   Given I successfully execute dnf with args "manifest new abcde http-parser"
    When I execute dnf with args "manifest install"
@@ -709,3 +726,20 @@ Scenario: Install packages from the manifest when a checksum is incorrect or pac
    Then the exit code is 1
     And stderr contains "No package http-parser-2.4.0-1.fc29.x86_64 with checksum 1111111111111111111111111111111111111111111111111111111111111111 available."
     And stderr contains "No package non-existent-1.0-1.fc29.x86_64 available."
+
+
+@force_installroot
+Scenario: Install packages from the manifest created from system
+  Given I successfully execute dnf with args "manifest new"
+    And I successfully execute dnf with args "remove basesystem glibc flac"
+   When I execute dnf with args "manifest install"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                  |
+        | install       | basesystem-0:11-6.fc29.noarch            |
+        | install       | filesystem-0:3.9-2.fc29.x86_64           |
+        | install       | flac-0:1.3.2-8.fc29.x86_64               |
+        | install       | glibc-0:2.28-9.fc29.x86_64               |
+        | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64 |
+        | install       | glibc-common-0:2.28-9.fc29.x86_64        |
+        | install       | setup-0:2.12.1-1.fc29.noarch             |


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/SWM-8370

This grew a bit since the originally intended fix, mainly due to the new command recording header checksums for packages installed on the system, instead of package checksums. The first commit ([manifest: Store checksum even for installed packages when available](https://github.com/rpm-software-management/dnf5/commit/bfe61eb24328b98a2cc5309d725413d332004959)) is a preparation for when we can use package checksums from rpmdb. It won't work without https://github.com/openSUSE/libsolv/pull/630, but it won't break without it either.

The next commits implement downloading by checksum also for the install command (previously just for download) when there is a match + ci tests. This is not great without the checksum verification after download in cases where there were multiple candidates, but I think it's better to resolve this to unite the behavior of download and install commands and leave the checksum verification for a follow-up PR.