### PR TITLE
tests: Allow vendor change in the Dockerfile

### DIFF
--- a/integration-tests/Dockerfile.integration-tests
+++ b/integration-tests/Dockerfile.integration-tests
@@ -39,7 +39,7 @@ RUN set -x && \
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \
        dnf5 -y copr enable $COPR; \
-       dnf5 -y install $COPR_RPMS; \
+       dnf5 --setopt=allow_vendor_change=true -y install $COPR_RPMS; \
     fi
 
 # install local RPMs if available
@@ -47,7 +47,7 @@ COPY ./rpms/ /opt/ci/rpms/
 RUN set -x && \
     rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
     if [ -n "$(find /opt/ci/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
-        dnf5 -y install /opt/ci/rpms/*.rpm --disableplugin=local && \
+        dnf5 --setopt=allow_vendor_change=true -y install /opt/ci/rpms/*.rpm --disableplugin=local && \
         dnf5 -y versionlock add $(rpm -qp --queryformat '%{NAME}\n' /opt/ci/rpms/*.rpm | sort | uniq); \
     fi
 
@@ -57,7 +57,8 @@ COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests
 # install test suite dependencies
 # Temporarily exclude new libfaketime because it doesn't work: https://bugzilla.redhat.com/show_bug.cgi?id=2381595
 RUN set -x && \
-    dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* && \
+    dnf5 --setopt=allow_vendor_change=true -y \
+        builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* && \
     pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt
 
 # create directory for dbus daemon socket


### PR DESCRIPTION
This adds --setopt=allow_vendor_change=true option to DNF5 invocations as forgotten to port from these ci-dnf-stack commits:

6aa8ccbaaa4c6d5705c59132fece4ca6b9f7a202 "Allow vendor change in the Dockerfile" 223fc40b736aabef6312aed80cdbdc7024f16922 "Allow vendor change for testing pull requests"