### PR TITLE
spec: Build-require perl(lib) for tests

### DIFF
--- a/dnf5.spec
+++ b/dnf5.spec
@@ -260,6 +260,7 @@ BuildRequires:  swig >= %{swig_version}
 BuildRequires:  perl-devel
 BuildRequires:  perl-generators
 %if %{with tests}
+BuildRequires:  perl(lib)
 BuildRequires:  perl(strict)
 BuildRequires:  perl(Test::More)
 BuildRequires:  perl(Test::Exception)


### PR DESCRIPTION
A new test/perl5/libdnf5/base/test_interaction_callbacks.t file added in eaae68a4f450bb90f89fb389f3aaa00b657cfe78 commit ("tests: add unit tests for InteractionCallbacks") uses "lib" Perl module, but the spec file does not declare the dependecny.

This patch fixes it.