### PR TITLE
Automatic install service

### DIFF
--- a/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf-automatic-install.service
+++ b/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf-automatic-install.service
@@ -1,0 +1,1 @@
+dnf5-automatic-install.service

--- a/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf-automatic-install.timer
+++ b/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf-automatic-install.timer
@@ -1,0 +1,1 @@
+dnf5-automatic-install.timer

--- a/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf5-automatic-install.service
+++ b/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf5-automatic-install.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=dnf5 automatic install
+ConditionPathExists=!/run/ostree-booted
+After=network-online.target
+
+[Service]
+Type=oneshot
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+ExecStart=/usr/bin/dnf5 automatic --installupdates --timer

--- a/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf5-automatic-install.timer
+++ b/dnf5-plugins/automatic_plugin/config/usr/lib/systemd/system/dnf5-automatic-install.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=dnf-automatic install timer
+ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
+
+[Timer]
+OnCalendar=*-*-* 6:00
+RandomizedDelaySec=60m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -1020,6 +1020,10 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %{_unitdir}/dnf5-automatic.timer
 %{_unitdir}/dnf-automatic.service
 %{_unitdir}/dnf-automatic.timer
+%{_unitdir}/dnf5-automatic-install.service
+%{_unitdir}/dnf5-automatic-install.timer
+%{_unitdir}/dnf-automatic-install.service
+%{_unitdir}/dnf-automatic-install.timer
 %if %{with dnf5_obsoletes_dnf}
 %{_bindir}/dnf-automatic
 %else

--- a/dnf5.spec
+++ b/dnf5.spec
@@ -1030,6 +1030,34 @@ automatically and regularly from systemd timers, cron jobs or similar.
 %exclude %{_bindir}/dnf-automatic
 %endif
 
+%post plugin-automatic
+%if %{with dnf5_obsoletes_dnf}
+%systemd_post dnf-automatic.timer
+%systemd_post dnf-automatic-install.timer
+%else
+%systemd_post dnf5-automatic.timer
+%systemd_post dnf5-automatic-install.timer
+%endif
+
+%preun plugin-automatic
+%if %{with dnf5_obsoletes_dnf}
+%systemd_preun dnf-automatic.timer
+%systemd_preun dnf-automatic-install.timer
+%else
+%systemd_preun dnf5-automatic.timer
+%systemd_preun dnf5-automatic-install.timer
+%endif
+
+%postun plugin-automatic
+%if %{with dnf5_obsoletes_dnf}
+%systemd_postun_with_restart dnf-automatic.timer
+%systemd_postun_with_restart dnf-automatic-install.timer
+%else
+%systemd_postun_with_restart dnf5-automatic.timer
+%systemd_postun_with_restart dnf5-automatic-install.timer
+%endif
+
+
 # ========== dnf5-manifest plugin ==========
 
 %if %{with plugin_manifest}


### PR DESCRIPTION
Fixes: https://github.com/rpm-software-management/dnf5/issues/2875

This adds timer units for ensuring updates are installed via a timer as well as adding the relevant snippets to the RPM spec to enable via a preset.