### PR TITLE
Makefile: Add .DEFAULT_GOAL = build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ MOCK_CONFIG ?= fedora-rawhide-x86_64
 CI_BASE_IMAGE ?= registry.fedoraproject.org/fedora:rawhide
 CONTAINER_TEST = ./integration-tests/container-test
 
+.DEFAULT_GOAL = build
+
 .ONESHELL:
 
 FORCE:


### PR DESCRIPTION
Currently `make` tries to run the dummy `FORCE` target.