### PR TITLE
build: Specify a time zone for "git archive" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(SOURCE_TARBALL_PATH): FORCE
 		git status --short --untracked-files=no
 		exit 1
 	fi
-	git archive --mtime="1970-01-01T00:00:00" --format=tar --prefix="$(SOURCE_TARBALL_PREFIX)/" HEAD | gzip -n > "$@.tmp"
+	git archive --mtime="1970-01-01T00:00:00+00:00" --format=tar --prefix="$(SOURCE_TARBALL_PREFIX)/" HEAD | gzip -n > "$@.tmp"
 	cmp -s "$@.tmp" "$@" || mv "$@.tmp" "$@"
 	rm -f "$@.tmp"
 


### PR DESCRIPTION
"make rpms" failed for me because the build script complained that a source file has a time stamp in the future:

    + /usr/bin/rpmuncompress -x /home/test/dnf5/integration-tests/build/source/dnf5-5.4.4.0.tar.gz
    /usr/bin/tar: Extended header mtime=18446744073709544416 is out of range -9223372036854775808..9223372036854775807
    [...]
    /usr/bin/tar: dnf5-5.4.4.0: time stamp 2242-03-16 13:56:31 is 6801672615.13816569 s in the future
    /usr/bin/tar: Exiting with failure status due to previous errors

I tracked it down the "git archive --mtime="1970-01-01T00:00:00" command (git-core-2.55.0-2.fc45) which unfortunatelly interepreted the --mtime value relative to the current time zone, which is UTC+01:00 me, leading to an integer underflow in the git tool, producing a tar archive with time stamps far in the future.

This patch works around it by setting the time zone offset to UTC+00:00.