### PR TITLE
Remove DNF5_FORCE_COLUMNS fallback to FORCE_COLUMNS enviroment variable

### DIFF
--- a/integration-tests/dnf-behave-tests/dnf/repo-sync.feature
+++ b/integration-tests/dnf-behave-tests/dnf/repo-sync.feature
@@ -5,7 +5,7 @@ Background: Force column width
 # Some of the curl errors can be quite long and since they are
 # truncated: https://github.com/rpm-software-management/dnf5/issues/1829
 # we need to force the width to see them in full.
-Given I set environment variable "FORCE_COLUMNS" to "500"
+Given I set environment variable "DNF5_FORCE_COLUMNS" to "500"
 
 
 @bz1763663

--- a/integration-tests/dnf-behave-tests/dnf/scriptlets.feature
+++ b/integration-tests/dnf-behave-tests/dnf/scriptlets.feature
@@ -6,7 +6,7 @@ Background: Enable repository
     # Some of the rpm scriptlet outputs can be quite long and since they are
     # truncated: https://github.com/rpm-software-management/dnf5/issues/1829
     # we need to force the width to see it in full.
-    And I set environment variable "FORCE_COLUMNS" to "400"
+    And I set environment variable "DNF5_FORCE_COLUMNS" to "400"
 
 
 # Disable on older fedoras and rhels because they don't contain rpm-6.0.91

--- a/libdnf5-cli/tty.cpp
+++ b/libdnf5-cli/tty.cpp
@@ -34,11 +34,6 @@ int get_width() {
     // Use a custom "DNF5_FORCE_COLUMNS" variable for testing purposes.
     // "COLUMNS" is overwritten in a sub-shell and that makes testing more difficult
     char * columns = std::getenv("DNF5_FORCE_COLUMNS");
-    if (!columns) {
-        // TODO: Remove this private, obsolete variable once CI tests migrate
-        // to DNF5_FORCE_COLUMNS variable.
-        columns = std::getenv("FORCE_COLUMNS");
-    }
     if (columns != nullptr) {
         try {
             auto value = std::stoi(columns);


### PR DESCRIPTION
DNF5 made FORCE_COLUMNS variable public under DNF5_FORCE_COLUMNS name (commit 2aaf62bc811c3c13cc5edcfc6c832b945f896018,
<https://github.com/rpm-software-management/dnf5/pull/2844>).

This patch migrates CI stack to the new name and removes the now unneeded fallback to the FORCE_COLUMNS name in libdnf5.