### PR TITLE
doc: Document "repoquery --unsatisfied" as dropped

### DIFF
--- a/doc/changes_from_dnf4.7.rst
+++ b/doc/changes_from_dnf4.7.rst
@@ -456,7 +456,8 @@ Changes to individual commands
 
 ``repoquery``
   * Dropped: ``-a/--all``, ``--alldeps``, ``--nevra`` options. Their behavior is and has been the default for both DNF4 and DNF5, so the options are no longer needed.
-  * Dropped: ``--envra``, ``--nvr``, ``--unsatisfied`` options. They are no longer supported.
+  * Dropped: ``--envra`` and ``--nvr`` options. They are no longer supported.
+  * Dropped: ``--unsatisfied`` option. Users are ecouraged to use ``dnf check --dependencies`` instead.
   * Dropped: ``repoquery-n``, ``repoquery-na`` and ``repoquery-nevra`` command variants.
   * Dropped: ``--archlist`` alias for ``--arch``.
   * Dropped: ``-f`` alias for ``--file``. Also, the arguments to ``--file`` are separated by commas instead of spaces.


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/910