### PR TITLE
readthedocs: switch to latest versions of ubuntu and python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,11 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: "ubuntu-lts-latest"
   apt_packages:
     - swig
   tools:
-    python: "3.11"
+    python: latest
   jobs:
     pre_build:
       - python doc/rtd_build.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2026/05/ubuntu-26-04/ 
https://about.readthedocs.com/blog/2024/02/introducing-latest-aliases/

It has newer version of swig which we require since https://github.com/rpm-software-management/dnf5/pull/2870

Build from my branch passed: https://app.readthedocs.org/projects/amatej-dnf5/builds/34357554/ 