### PR TITLE
offline: acquire delay lock before triggering reboot

### DIFF
--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -42,6 +42,7 @@
 #include <systemd/sd-journal.h>
 #endif
 
+#include <csignal>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -290,7 +291,29 @@ void reboot(bool poweroff = false) {
         throw libdnf5::cli::CommandExitError(1, M_("Couldn't connect to D-Bus: {}"), error_message);
     }
     if (connection != nullptr) {
+        // Ignore SIGTERM/SIGINT so systemd's teardown signals cannot invoke our
+        // _exit(1) signal handlers
+        std::signal(SIGTERM, SIG_IGN);
+        std::signal(SIGINT, SIG_IGN);
+
         auto proxy = sdbus::createProxy(*connection, LOGIND_DESTINATION_NAME, LOGIND_OBJECT_PATH);
+
+        // Try to acquire inhibit delay lock to prevent systemd from starting
+        // the shutdown process while our destructors execute.
+        try {
+            sdbus::UnixFd fd;
+            proxy->callMethod("Inhibit")
+                .onInterface(LOGIND_MANAGER_INTERFACE)
+                .withArguments("shutdown", "dnf5", "Finalizing offline transaction", "delay")
+                .storeResultsTo(fd);
+            // Transfer ownership of the raw file descriptor out of sdbus::UnixFd
+            // so sdbus::UnixFd's destructor won't close it.
+            // The kernel will automatically close leaked_fd when the process terminates.
+            [[maybe_unused]] int leaked_fd = fd.release();
+        } catch (const sdbus::Error &) {
+        }
+
+        // Fire reboot/poweroff request.
         if (poweroff) {
             proxy->callMethod("PowerOff").onInterface(LOGIND_MANAGER_INTERFACE).withArguments(true);
         } else {

--- a/dnf5/commands/offline/offline.cpp
+++ b/dnf5/commands/offline/offline.cpp
@@ -291,12 +291,39 @@ void reboot(bool poweroff = false) {
         throw libdnf5::cli::CommandExitError(1, M_("Couldn't connect to D-Bus: {}"), error_message);
     }
     if (connection != nullptr) {
+        auto proxy = sdbus::createProxy(*connection, LOGIND_DESTINATION_NAME, LOGIND_OBJECT_PATH);
+
+        // Busy-wait for other processes blocking the shutdown to release their locks.
+        // Otherwise, the Reboot() call will fail with a D-Bus error if an active
+        // block lock is held (e.g., by akmods building kernel modules).
+        using InhibitorTuple = sdbus::Struct<std::string, std::string, std::string, std::string, uint32_t, uint32_t>;
+        const auto timeout = std::chrono::minutes(5);
+        const auto start_time = std::chrono::steady_clock::now();
+        const uint32_t my_pid = static_cast<uint32_t>(::getpid());
+        while (true) {
+            bool is_blocked = false;
+            try {
+                std::vector<InhibitorTuple> inhibitors;
+                proxy->callMethod("ListInhibitors").onInterface(LOGIND_MANAGER_INTERFACE).storeResultsTo(inhibitors);
+                for (const auto & [what, who, why, mode, uid, pid] : inhibitors) {
+                    if (mode == "block" && what.find("shutdown") != std::string::npos && pid != my_pid) {
+                        is_blocked = true;
+                        break;
+                    }
+                }
+            } catch (const sdbus::Error &) {
+                // On D-Bus error treat as not blocked
+            }
+            if (!is_blocked || (std::chrono::steady_clock::now() - start_time > timeout)) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+
         // Ignore SIGTERM/SIGINT so systemd's teardown signals cannot invoke our
         // _exit(1) signal handlers
         std::signal(SIGTERM, SIG_IGN);
         std::signal(SIGINT, SIG_IGN);
-
-        auto proxy = sdbus::createProxy(*connection, LOGIND_DESTINATION_NAME, LOGIND_OBJECT_PATH);
 
         // Try to acquire inhibit delay lock to prevent systemd from starting
         // the shutdown process while our destructors execute.


### PR DESCRIPTION
In offline transactions, triggering Reboot() or PowerOff() over D-Bus causes logind to immediately initiate system teardown and send SIGTERM to the dnf5 service. This introduces a race condition with our SIGTERM signal handler calling _exit(1), terminating the process mid-destructor and causing dnf5 to exit with status 1 instead of 0.

To resolve this race condition:
1. Mask SIGTERM and SIGINT before starting reboot so systemd's teardown signals cannot invoke our signal handlers. This serves as a fallback solution if delay lock acquisition fails.
2. Acquire a logind "shutdown" inhibit delay lock to hold off system teardown while C++ destructors execute. Keep the lock file descriptor open until the kernel closes it on process termination.

Resolves: https://github.com/rpm-software-management/dnf5/issues/2896
Resolves: https://github.com/rpm-software-management/dnf5/issues/2327