### PR TITLE
DNF5 CLI global option "--dump-vendor-policies"

### DIFF
--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -733,6 +733,14 @@ bool Context::get_dump_variables() const {
     return p_impl->get_dump_variables();
 }
 
+void Context::set_dump_vendor_policies(bool enable) {
+    p_impl->set_dump_vendor_policies(enable);
+}
+
+bool Context::get_dump_vendor_policies() const {
+    return p_impl->get_dump_vendor_policies();
+}
+
 void Context::set_show_new_leaves(bool show_new_leaves) {
     p_impl->set_show_new_leaves(show_new_leaves);
 }

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -872,15 +872,31 @@ bool Context::get_clear_vendor_policies() const {
     return p_impl->get_clear_vendor_policies();
 }
 
+void Context::add_remove_vendor_policy_source(const std::string & source_pattern) {
+    p_impl->add_remove_vendor_policy_source(source_pattern);
+}
+
+std::vector<std::string> & Context::get_remove_vendor_policy_sources() {
+    return p_impl->get_remove_vendor_policy_sources();
+}
+
+const std::vector<std::string> & Context::get_remove_vendor_policy_sources() const {
+    return p_impl->get_remove_vendor_policy_sources();
+}
+
 void Context::apply_cmdline_vendor_policies() {
     const bool do_clear = p_impl->get_clear_vendor_policies();
+    const auto & remove_sources = p_impl->get_remove_vendor_policy_sources();
     const auto & policies = p_impl->get_cmdline_vendor_policies();
-    if (!do_clear && policies.empty()) {
+    if (!do_clear && remove_sources.empty() && policies.empty()) {
         return;
     }
     auto vcm = p_impl->get_base().get_vendor_change_manager();
     if (do_clear) {
         vcm->unload_policies();
+    }
+    for (const auto & source_pattern : remove_sources) {
+        vcm->unload_policies_matching_source(source_pattern);
     }
     for (const auto & policy_str : policies) {
         vcm->load_policy_from_compact(policy_str, "text:COMMAND LINE");

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -34,6 +34,7 @@
 #include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/base.hpp>
 #include <libdnf5/base/goal.hpp>
+#include <libdnf5/base/vendor_change_manager.hpp>
 #include <libdnf5/common/proc.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/rpm/package_query.hpp>
@@ -853,6 +854,37 @@ std::vector<std::pair<std::vector<std::string>, bool>> & Context::get_libdnf_plu
 
 const std::vector<std::pair<std::vector<std::string>, bool>> & Context::get_libdnf_plugins_enablement() const {
     return p_impl->get_libdnf_plugins_enablement();
+}
+
+std::vector<std::string> & Context::get_cmdline_vendor_policies() {
+    return p_impl->get_cmdline_vendor_policies();
+}
+
+const std::vector<std::string> & Context::get_cmdline_vendor_policies() const {
+    return p_impl->get_cmdline_vendor_policies();
+}
+
+void Context::set_clear_vendor_policies(bool value) {
+    p_impl->set_clear_vendor_policies(value);
+}
+
+bool Context::get_clear_vendor_policies() const {
+    return p_impl->get_clear_vendor_policies();
+}
+
+void Context::apply_cmdline_vendor_policies() {
+    const bool do_clear = p_impl->get_clear_vendor_policies();
+    const auto & policies = p_impl->get_cmdline_vendor_policies();
+    if (!do_clear && policies.empty()) {
+        return;
+    }
+    auto vcm = p_impl->get_base().get_vendor_change_manager();
+    if (do_clear) {
+        vcm->unload_policies();
+    }
+    for (const auto & policy_str : policies) {
+        vcm->load_policy_from_compact(policy_str, "text:COMMAND LINE");
+    }
 }
 
 

--- a/dnf5/context_impl.hpp
+++ b/dnf5/context_impl.hpp
@@ -128,6 +128,12 @@ public:
         return libdnf_plugins_enablement;
     }
 
+    std::vector<std::string> & get_cmdline_vendor_policies() { return cmdline_vendor_policies; }
+    const std::vector<std::string> & get_cmdline_vendor_policies() const { return cmdline_vendor_policies; }
+
+    void set_clear_vendor_policies(bool value) { clear_vendor_policies = value; }
+    bool get_clear_vendor_policies() const { return clear_vendor_policies; }
+
     void set_show_version(bool enable) { this->show_version = enable; }
     bool get_show_version() const { return this->show_version; }
 
@@ -144,6 +150,12 @@ private:
 
     /// list of lists of libdnf plugin names (global patterns) that we want to enable (true) or disable (false)
     std::vector<std::pair<std::vector<std::string>, bool>> libdnf_plugins_enablement;
+
+    /// vendor policy strings from --add-vendor-policy CLI arguments
+    std::vector<std::string> cmdline_vendor_policies;
+
+    /// when true, clear all vendor policies before applying CLI ones
+    bool clear_vendor_policies{false};
 
     std::string cmdline;
 

--- a/dnf5/context_impl.hpp
+++ b/dnf5/context_impl.hpp
@@ -69,6 +69,10 @@ public:
 
     bool get_dump_variables() const { return dump_variables; }
 
+    void set_dump_vendor_policies(bool enable) { this->dump_vendor_policies = enable; }
+
+    bool get_dump_vendor_policies() const { return dump_vendor_policies; }
+
     void set_show_new_leaves(bool show_new_leaves) { this->show_new_leaves = show_new_leaves; }
 
     bool get_show_new_leaves() const { return show_new_leaves; }
@@ -181,6 +185,7 @@ private:
     bool dump_main_config{false};
     std::vector<std::string> dump_repo_config_id_list;
     bool dump_variables{false};
+    bool dump_vendor_policies{false};
     bool show_new_leaves{false};
     std::string get_cmd_line();
 

--- a/dnf5/context_impl.hpp
+++ b/dnf5/context_impl.hpp
@@ -134,6 +134,12 @@ public:
     void set_clear_vendor_policies(bool value) { clear_vendor_policies = value; }
     bool get_clear_vendor_policies() const { return clear_vendor_policies; }
 
+    void add_remove_vendor_policy_source(const std::string & source_pattern) {
+        remove_vendor_policy_sources.push_back(source_pattern);
+    }
+    std::vector<std::string> & get_remove_vendor_policy_sources() { return remove_vendor_policy_sources; }
+    const std::vector<std::string> & get_remove_vendor_policy_sources() const { return remove_vendor_policy_sources; }
+
     void set_show_version(bool enable) { this->show_version = enable; }
     bool get_show_version() const { return this->show_version; }
 
@@ -156,6 +162,9 @@ private:
 
     /// when true, clear all vendor policies before applying CLI ones
     bool clear_vendor_policies{false};
+
+    /// source patterns from --remove-vendor-policy-source CLI arguments
+    std::vector<std::string> remove_vendor_policy_sources;
 
     std::string cmdline;
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -129,6 +129,11 @@ public:
 
     bool get_dump_variables() const;
 
+    /// Set to true to print loaded vendor change policies
+    void set_dump_vendor_policies(bool enable);
+
+    bool get_dump_vendor_policies() const;
+
     /// Set to true to show newly installed leaf packages and packages that became leaves after a transaction.
     void set_show_new_leaves(bool show_new_leaves);
 

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -66,6 +66,10 @@ public:
 
     void apply_repository_setopts();
 
+    /// Apply vendor change policies specified via --vendor-policy CLI arguments.
+    /// Must be called after base.setup().
+    void apply_cmdline_vendor_policies();
+
     /// Update required metadata types according to the provided `pkg_specs`.
     /// If a `pkg_spec` is a file pattern, the file lists need to be loaded.
     void update_repo_metadata_from_specs(const std::vector<std::string> & pkg_specs);
@@ -183,6 +187,12 @@ public:
 
     std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement();
     const std::vector<std::pair<std::vector<std::string>, bool>> & get_libdnf_plugins_enablement() const;
+
+    std::vector<std::string> & get_cmdline_vendor_policies();
+    const std::vector<std::string> & get_cmdline_vendor_policies() const;
+
+    void set_clear_vendor_policies(bool value);
+    bool get_clear_vendor_policies() const;
 
     /// Set to true to print version information
     void set_show_version(bool enable);

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -194,6 +194,10 @@ public:
     void set_clear_vendor_policies(bool value);
     bool get_clear_vendor_policies() const;
 
+    void add_remove_vendor_policy_source(const std::string & source_pattern);
+    std::vector<std::string> & get_remove_vendor_policy_sources();
+    const std::vector<std::string> & get_remove_vendor_policy_sources() const;
+
     /// Set to true to print version information
     void set_show_version(bool enable);
     bool get_show_version() const;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -389,6 +389,25 @@ void RootCommand::set_argument_parser() {
     }
 
     {
+        auto remove_vendor_policy_source = parser.add_new_named_arg("remove-vendor-policy-source");
+        remove_vendor_policy_source->set_long_name("remove-vendor-policy-source");
+        remove_vendor_policy_source->set_has_value(true);
+        remove_vendor_policy_source->set_arg_value_help("SOURCE");
+        remove_vendor_policy_source->set_description(
+            _("Remove vendor change policies whose source matches the specified pattern. "
+              "Supports globs, can be specified multiple times."));
+        remove_vendor_policy_source->set_parse_hook_func([&ctx](
+                                                             [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                                             [[maybe_unused]] const char * option,
+                                                             const char * value) {
+            ctx.add_remove_vendor_policy_source(value);
+            return true;
+        });
+        remove_vendor_policy_source->add_conflict_argument(*allow_vendor_change);
+        global_options_group->register_argument(remove_vendor_policy_source);
+    }
+
+    {
         auto no_docs = parser.add_new_named_arg("no-docs");
         no_docs->set_long_name("no-docs");
         no_docs->set_description(

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -75,6 +75,7 @@
 #include <libdnf5-cli/utils/units.hpp>
 #include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/base/base.hpp>
+#include <libdnf5/base/vendor_change_manager.hpp>
 #include <libdnf5/common/xdg.hpp>
 #include <libdnf5/conf/const.hpp>
 #include <libdnf5/logger/factory.hpp>
@@ -700,6 +701,20 @@ void RootCommand::set_argument_parser() {
     }
 
     {
+        auto dump_vendor_policies = parser.add_new_named_arg("dump-vendor-policies");
+        dump_vendor_policies->set_long_name("dump-vendor-policies");
+        dump_vendor_policies->set_description(_("Print loaded vendor change policies to stdout"));
+        dump_vendor_policies->set_parse_hook_func([&ctx](
+                                                      [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                                      [[maybe_unused]] const char * option,
+                                                      [[maybe_unused]] const char * value) {
+            ctx.set_dump_vendor_policies(true);
+            return true;
+        });
+        global_options_group->register_argument(dump_vendor_policies);
+    }
+
+    {
         auto version = parser.add_new_named_arg("version");
         version->set_long_name("version");
         version->set_description(_("Show DNF5 version and exit"));
@@ -789,6 +804,7 @@ void RootCommand::pre_configure() {
     if (arg_parser.get_named_arg("dump-variables", false).get_parse_count() > 0 ||
         arg_parser.get_named_arg("dump-main-config", false).get_parse_count() > 0 ||
         arg_parser.get_named_arg("dump-repo-config", false).get_parse_count() > 0 ||
+        arg_parser.get_named_arg("dump-vendor-policies", false).get_parse_count() > 0 ||
         arg_parser.get_named_arg("version", false).get_parse_count() > 0) {
         return;
     }
@@ -1066,6 +1082,22 @@ static void dump_variables(Context & context) {
     for (const auto & var : context.get_base().get_vars()->get_variables()) {
         const auto & val = var.second;
         context.print_output(fmt::format("{} = {}", var.first, val.value));
+    }
+}
+
+static void dump_vendor_policies(Context & context) {
+    context.print_output(_("======== Vendor Change Policies: ========"));
+    auto vcm = context.get_base().get_vendor_change_manager();
+    const auto count = vcm->get_loaded_policies_count();
+    for (std::size_t i = 0; i < count; ++i) {
+        context.print_output(libdnf5::utils::sformat(_("Policy #{}: source: {}"), i, vcm->get_loaded_policy_source(i)));
+        context.print_output("  " + vcm->get_loaded_policy_as_compact(i));
+    }
+    auto & config = context.get_base().get_config();
+    if (config.get_allow_vendor_change_option().get_value()) {
+        context.print_output(
+            _("allow_vendor_change is enabled. "
+              "Packages can be replaced by any vendor, and vendor change policies will be ignored."));
     }
 }
 
@@ -1623,6 +1655,10 @@ int main(int argc, char * argv[]) try {
 
             if (const auto & repo_id_list = context.get_dump_repo_config_id_list(); !repo_id_list.empty()) {
                 dump_repository_configuration(context, repo_id_list);
+            }
+
+            if (context.get_dump_vendor_policies()) {
+                dump_vendor_policies(context);
             }
 
             // std::nullopt == Unknown whether system is bootc

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -355,6 +355,40 @@ void RootCommand::set_argument_parser() {
     no_allow_vendor_change->add_conflict_argument(*allow_vendor_change);
 
     {
+        auto add_vendor_policy = parser.add_new_named_arg("add-vendor-policy");
+        add_vendor_policy->set_long_name("add-vendor-policy");
+        add_vendor_policy->set_has_value(true);
+        add_vendor_policy->set_arg_value_help("POLICY");
+        add_vendor_policy->set_description(
+            _("Add a vendor change policy for this run. Can be specified multiple times."));
+        add_vendor_policy->set_parse_hook_func([&ctx](
+                                                   [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                                   [[maybe_unused]] const char * option,
+                                                   const char * value) {
+            ctx.get_cmdline_vendor_policies().emplace_back(value);
+            return true;
+        });
+        global_options_group->register_argument(add_vendor_policy);
+    }
+
+    {
+        auto clear_vendor_policies = parser.add_new_named_arg("clear-vendor-policies");
+        clear_vendor_policies->set_long_name("clear-vendor-policies");
+        clear_vendor_policies->set_description(libdnf5::utils::sformat(
+            _("Remove all vendor change policies. Can be combined with {} to replace them."),
+            "--add-vendor-policy=POLICY"));
+        clear_vendor_policies->set_parse_hook_func([&ctx](
+                                                       [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                                       [[maybe_unused]] const char * option,
+                                                       [[maybe_unused]] const char * value) {
+            ctx.set_clear_vendor_policies(true);
+            return true;
+        });
+        clear_vendor_policies->add_conflict_argument(*allow_vendor_change);
+        global_options_group->register_argument(clear_vendor_policies);
+    }
+
+    {
         auto no_docs = parser.add_new_named_arg("no-docs");
         no_docs->set_long_name("no-docs");
         no_docs->set_description(
@@ -1555,6 +1589,8 @@ int main(int argc, char * argv[]) try {
 
                 context.apply_repository_setopts();
             }
+
+            context.apply_cmdline_vendor_policies();
 
             // Run selected command
             command->configure();

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -1259,8 +1259,9 @@ static void print_resolve_hints(dnf5::Context & context) {
     bool has_vendor_change_skipped =
         context.get_transaction() && !context.get_transaction()->get_vendor_change_skipped_packages().empty();
     if (!conf.get_allow_vendor_change_option().get_value() && (vendor_change || has_vendor_change_skipped)) {
-        const std::string_view arg{"--allow-vendor-change"};
-        hints.emplace_back(libdnf5::utils::sformat(_("{} to allow changing package vendors"), arg));
+        hints.emplace_back(
+            libdnf5::utils::sformat(_("{} to add specific vendor change rules"), "--add-vendor-policy=POLICY"));
+        hints.emplace_back(libdnf5::utils::sformat(_("{} to allow all vendor changes"), "--allow-vendor-change"));
     }
 
     if (hints.size() > 0) {

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -291,6 +291,15 @@ Following options are applicable in the general context for any ``dnf5`` command
     | Can be combined with ``--add-vendor-policy`` to replace existing policies with custom ones.
     | Cannot be combined with ``--allow-vendor-change``.
 
+.. _remove_vendor_policy_source_option_ref-label:
+
+``--remove-vendor-policy-source=SOURCE``
+    | Temporarily remove vendor change policies whose source matches the specified pattern for the purpose of the current ``DNF5`` command.
+    | This option can be specified multiple times.
+    | Accepted values are source strings, or a glob of source strings.
+    | Cannot be combined with ``--allow-vendor-change``.
+    | Example: ``--remove-vendor-policy-source="*/test.conf"``
+
 .. _no_best_option_ref-label:
 
 ``--no-best``

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -188,6 +188,13 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--assumeno``
     | Automatically answer no for all questions.
 
+.. _add_vendor_policy_option_ref-label:
+
+``--add-vendor-policy=POLICY``
+    | Add a vendor change policy for this run using the compact format.
+    | Can be specified multiple times. Each value defines one policy.
+    | :ref:`See <vendorpolicy_compact_format-label>` :manpage:`dnf5.conf-vendorpolicy-v1_1(5)` for format details.
+
 .. _allow_vendor_change_option_ref-label:
 
 ``--allow-vendor-change``
@@ -276,6 +283,13 @@ Following options are applicable in the general context for any ``dnf5`` command
     | Do not allow automatic package replacements from different vendors for RPM upgrades or downgrades.
     | The behavior of this option can be fine-tuned with vendor change policy configuration.
     | :ref:`See <vendorpolicy_conf-label>` :manpage:`dnf5.conf-vendorpolicy(5)` for more info.
+
+.. _clear_vendor_policies_option_ref-label:
+
+``--clear-vendor-policies``
+    | Temporarily remove all vendor change policies for the purpose of the current ``DNF5`` command.
+    | Can be combined with ``--add-vendor-policy`` to replace existing policies with custom ones.
+    | Cannot be combined with ``--allow-vendor-change``.
 
 .. _no_best_option_ref-label:
 

--- a/doc/dnf5.8.rst
+++ b/doc/dnf5.8.rst
@@ -253,6 +253,11 @@ Following options are applicable in the general context for any ``dnf5`` command
 ``--dump-variables``
     | Print variable values to stdout.
 
+``--dump-vendor-policies``
+    | Print loaded vendor change policies to stdout.
+    | For each policy, its index (numbered from 0), source, and compact format representation are displayed.
+    | Additionally, if ``allow_vendor_change`` is enabled, displays a message indicating that packages can be replaced by any vendor and policies are ignored.
+
 ``--enable-plugin=PLUGIN_NAME,...``
     | Enable specified libdnf5 library plugins for the purpose of the current ``DNF5`` command.
     | This is a list option which can be specified multiple times.

--- a/doc/dnf5.conf-vendorpolicy-v1_1.5.rst
+++ b/doc/dnf5.conf-vendorpolicy-v1_1.5.rst
@@ -47,7 +47,7 @@ Required Fields
    but it will not define any rules and will not affect vendor manager behavior.
 
 Vendor Mapping Definition
---------------------------
+-------------------------
 
 The following vendor lists can be used to define vendor mappings.
 All lists are optional and can be freely combined. All conditions are evaluated together.
@@ -255,6 +255,118 @@ Each entry in ``[[outgoing_packages]]`` or ``[[incoming_packages]]`` can contain
 
     Default: ``false``
 
+.. _vendorpolicy_compact_format-label:
+
+Compact Format
+==============
+
+Vendor change policies can also be specified using a compact string representation.
+This is useful for the ``--add-vendor-policy`` command-line option or the
+``VendorChangeManager::load_policy_from_compact()`` API method.
+
+Each compact string defines one policy (equivalent to one TOML configuration file).
+
+Syntax
+------
+
+A compact policy string has two sections separated by ``@``::
+
+    direction:eop"value",...@direction:e[filters],...
+
+Both sections are optional, but at least one must be present.
+
+**Vendor entries** (before ``@``) are comma-separated, each with a direction prefix::
+
+    direction:eop"value"
+
+- ``direction`` is ``in``, ``out``, or ``eq`` (incoming / outgoing / equivalent vendors)
+- ``e`` after ``:`` is optional and sets ``exclude = true``
+- ``op`` is a comparator operator (see below), omit for default ``EXACT``
+
+**Package filter entries** (after ``@``) are comma-separated, each enclosed in
+literal ``[...]``::
+
+    direction:e[field op "value",...]
+
+- ``direction`` is ``in`` or ``out`` (incoming / outgoing packages)
+- ``e`` before ``[`` is optional and sets ``exclude = true``
+- Multiple filters inside ``[...]`` are separated by ``,`` and combined with AND logic
+
+Operators
+~~~~~~~~~
+
+The operator syntax is ``!iOP`` where ``!`` negates and ``i`` makes it case-insensitive.
+Both ``!`` and ``i`` are optional. They must appear in this order and without spaces
+between them or the operator symbol.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 25 25
+
+   * - Operator
+     - TOML comparator
+     - With ``i`` prefix
+   * - ``=``
+     - ``EXACT``
+     - ``IEXACT``
+   * - ``^``
+     - ``STARTSWITH``
+     - ``ISTARTSWITH``
+   * - ``$``
+     - ``ENDSWITH``
+     - ``IENDSWITH``
+   * - ``*``
+     - ``CONTAINS``
+     - ``ICONTAINS``
+   * - ``=*``
+     - ``GLOB``
+     - ``IGLOB``
+   * - ``=~``
+     - ``REGEX``
+     - ``IREGEX``
+   * - ``>``
+     - ``GT``
+     -
+   * - ``>=``
+     - ``GTE``
+     -
+   * - ``<``
+     - ``LT``
+     -
+   * - ``<=``
+     - ``LTE``
+     -
+
+The ``!`` prefix adds negation (e.g., ``!=`` -> ``NOT_EXACT``, ``!i*`` -> ``NOT_ICONTAINS``).
+The ``!`` and ``i`` prefixes can only be used with string operators (``=``, ``^``, ``$``,
+``*``, ``=*``, ``=~``), not with relational operators (``>``, ``>=``, ``<``, ``<=``).
+Negation of relational operators is unnecessary -- use the complementary operator instead
+(e.g., ``<=`` instead of ``!>``).
+
+A bare quoted value without an operator (e.g., ``in:"Vendor"``) defaults to ``EXACT``.
+
+Values are enclosed in double quotes (``"..."``). A literal ``"`` inside a value
+is written as ``\"``, and a literal ``\`` as ``\\``.
+
+Whitespace
+~~~~~~~~~~
+
+Whitespace (spaces, tabs, newlines) is allowed between all elements of the compact
+format syntax.
+
+The operator forms a single element and must therefore be written as a single unit
+without whitespaces. The ``!`` and ``i`` modifiers are part of the operator, so
+``!i^`` is a single element and must not contain spaces. Similarly, two-character
+operators such as ``=*``, ``=~``, ``>=``, ``<=`` must not contain spaces.
+
+Whitespace inside quoted values ``"..."`` is preserved literally.
+
+This means the following are all equivalent::
+
+    eq:!i^"Fedora"
+    eq : !i^ "Fedora"
+    eq :  !i^  "Fedora"
+
 Examples
 ========
 
@@ -263,6 +375,8 @@ Example 1: Allow change from "VendorA" to "VendorB"
 
 This example shows the minimal required configuration, allowing a change from
 "VendorA" to "VendorB", but not the reverse.
+
+TOML:
 
 .. code-block:: toml
 
@@ -274,11 +388,17 @@ This example shows the minimal required configuration, allowing a change from
     [[incoming_vendors]]
     vendor = 'VendorB'
 
+Compact::
+
+    out:"VendorA",in:"VendorB"
+
 Example 2: Allow change from any vendor to "My Trusted Vendor"
 --------------------------------------------------------------
 
 This example shows allowing a change from any vendor to "My Trusted Vendor",
 but not the reverse. Missing ``outgoing_vendors`` means any vendor is allowed.
+
+TOML:
 
 .. code-block:: toml
 
@@ -287,11 +407,17 @@ but not the reverse. Missing ``outgoing_vendors`` means any vendor is allowed.
     [[incoming_vendors]]
     vendor = 'My Trusted Vendor'
 
+Compact::
+
+    in:"My Trusted Vendor"
+
 Example 3: Equivalent vendors
 -----------------------------
 
 This example shows vendors that are mutually equivalent, allowing changes
 in both directions.
+
+TOML:
 
 .. code-block:: toml
 
@@ -309,11 +435,17 @@ in both directions.
     vendor = 'CentOS'
     comparator = 'ISTARTSWITH'
 
+Compact::
+
+    eq:"Fedora Project",eq:i^"Red Hat",eq:i^"CentOS"
+
 Example 4: Equivalent vendors with an exclusion
 -----------------------------------------------
 
 This example shows a vendor policy for SUSE-related vendors with an exclusion
 for openSUSE Build Service.
+
+TOML:
 
 .. code-block:: toml
 
@@ -333,12 +465,18 @@ for openSUSE Build Service.
     vendor = 'openSUSE'
     comparator = 'ISTARTSWITH'
 
+Compact::
+
+    eq:ei^"openSUSE Build Service",eq:i^"SUSE",eq:i^"openSUSE"
+
 Example 5: Combining equivalent vendors with incoming vendors
 -------------------------------------------------------------
 
 This example demonstrates combining ``equivalent_vendors`` with ``incoming_vendors``,
 a feature introduced in version ``"1.1"``. "First Vendor" and "Second Vendor" are mutually
 equivalent, and both can change to "Third Vendor".
+
+TOML:
 
 .. code-block:: toml
 
@@ -353,11 +491,17 @@ equivalent, and both can change to "Third Vendor".
     [[incoming_vendors]]
     vendor = 'Third Vendor'
 
+Compact::
+
+    eq:"First Vendor",eq:"Second Vendor",in:"Third Vendor"
+
 Example 6: Allow command-line packages from any vendor
 ------------------------------------------------------
 
 This example allows installing packages from the command-line repository
 from any vendor, bypassing vendor restrictions.
+
+TOML:
 
 .. code-block:: toml
 
@@ -368,11 +512,17 @@ from any vendor, bypassing vendor restrictions.
       { filter = 'cmdline_repo', value = 'true' }
     ]
 
+Compact::
+
+    @in:[cmdline_repo="true"]
+
 Example 7: Command-line packages with exclusion
 -----------------------------------------------
 
 This example allows installing packages from the command-line repository
 from any vendor, except for packages whose names start with "mypackage".
+
+TOML:
 
 .. code-block:: toml
 
@@ -389,12 +539,18 @@ from any vendor, except for packages whose names start with "mypackage".
       { filter = 'cmdline_repo', value = 'true' }
     ]
 
+Compact::
+
+    @in:e[name ^"mypackage"],in:[cmdline_repo="true"]
+
 Example 8: Allow change from any vendor to specific one with package filtering
 ------------------------------------------------------------------------------
 
 This example allows a change from any vendor to "My Vendor", but
 only for incoming packages whose source package name is "mypackage" and
 version is greater than or equal to "2.0".
+
+TOML:
 
 .. code-block:: toml
 
@@ -408,6 +564,10 @@ version is greater than or equal to "2.0".
 
     [[incoming_vendors]]
     vendor = 'My Vendor'
+
+Compact::
+
+    in:"My Vendor"@in:[source_name="mypackage",version>="2.0"]
 
 See Also
 ========

--- a/doc/dnf5.conf-vendorpolicy.5.rst
+++ b/doc/dnf5.conf-vendorpolicy.5.rst
@@ -70,6 +70,9 @@ This is useful for adding policies for a single run without creating configurati
 The :ref:`--clear-vendor-policies <clear_vendor_policies_option_ref-label>` option
 can be used to remove all policies, optionally replacing them with command-line policies.
 
+The :ref:`--remove-vendor-policy-source <remove_vendor_policy_source_option_ref-label>` option
+can be used to remove policies from specific sources.
+
 For the compact format syntax and examples, see
 :ref:`Compact Format <vendorpolicy_compact_format-label>` in the v1.1 reference.
 

--- a/doc/dnf5.conf-vendorpolicy.5.rst
+++ b/doc/dnf5.conf-vendorpolicy.5.rst
@@ -60,6 +60,19 @@ If a file with the same name exists in both directories, the file from ``/etc/dn
 is used. This implies that the distribution configuration file can be simply overridden
 by creating a file with the same name in the ``/etc/dnf/vendors.d/`` directory.
 
+Command-Line Policies
+=====================
+
+Vendor change policies can also be specified directly on the command line using
+the :ref:`--add-vendor-policy <add_vendor_policy_option_ref-label>` option with a compact syntax.
+This is useful for adding policies for a single run without creating configuration files.
+
+The :ref:`--clear-vendor-policies <clear_vendor_policies_option_ref-label>` option
+can be used to remove all policies, optionally replacing them with command-line policies.
+
+For the compact format syntax and examples, see
+:ref:`Compact Format <vendorpolicy_compact_format-label>` in the v1.1 reference.
+
 See Also
 ========
 

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-default.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-default.feature
@@ -50,7 +50,8 @@ Scenario: Hint shown when vendor change blocked by default
        """
        Skipping 1 package due to vendor change restriction: "First Vendor" -> "Second Vendor".
        """
-   And stderr contains "--allow-vendor-change to allow changing package vendors"
+   And stderr contains "--add-vendor-policy=POLICY to add specific vendor change rules"
+   And stderr contains "--allow-vendor-change to allow all vendor changes"
 
 
 Scenario: Override default with --setopt=allow_vendor_change=true

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
@@ -43,6 +43,92 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
    And stdout contains "Vendor *: Second Vendor"
 
 
+Scenario: Upgrade with vendor policy - vendor change not allowed (policy from conf file cleared using --clear-vendor-policies)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--clear-vendor-policies upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.1-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: First Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second and Third Vendor (Third has newer version)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (policy from conf file cleared using --clear-vendor-policies)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--clear-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (conf file in /usr)
   Given I create file "/usr/share/dnf5/vendors.d/test-policy.conf" with
       """
@@ -76,7 +162,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
       vendor = 'First Vendor'
 
       [[incoming_vendors]]
-      vendor = 'Second Vendor'
+      vendor = 'Third Vendor'
       """
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
       """
@@ -86,7 +172,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
       vendor = 'First Vendor'
 
       [[incoming_vendors]]
-      vendor = 'Third Vendor'
+      vendor = 'Second Vendor'
       """
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
@@ -95,10 +181,10 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
-       | upgrade | vendor-1.3-1.x86_64 |
+       | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor *: Third Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed)
@@ -116,6 +202,20 @@ Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed, --add-vendor-policy, used optional '=')
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:=\"First\ Vendor\",eq:\"Second\ Vendor\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
@@ -174,6 +274,20 @@ Scenario: Upgrade with vendor policy - glob pattern matching
    And stdout contains "Vendor *: Third Vendor"
 
 
+Scenario: Upgrade with vendor policy - glob pattern matching (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:=*\"*Ve*or\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
+
+
 Scenario: Upgrade with vendor policy - case insensitive matching and starts with
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
       """
@@ -191,6 +305,20 @@ Scenario: Upgrade with vendor policy - case insensitive matching and starts with
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - case insensitive matching and starts with (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:i^\"first\",in:i=\"second\ vendor\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
@@ -219,6 +347,20 @@ Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:e\"Third\ Vendor\",eq:*\"\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
@@ -81,7 +81,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
    And stdout contains "Vendor *: Second Vendor"
 
 
-Scenario: Upgrade with vendor policy - allow change from First Vendor to Second and Third Vendor (Third has newer version)
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second (--add-vendor-policy) and Third Vendor (Third has newer version)
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
       """
       version = '1.0'
@@ -127,6 +127,108 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
    And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor and Third (in two config files, Third has newer version)
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-second.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (policy to Third is removed using --remove-vendor-policy-source)
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-second.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--remove-vendor-policy-source='*/allow-first-to-thirh.conf'  upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Third Vendor (policy to Second is removed using --remove-vendor-policy-source)
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-second.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--remove-vendor-policy-source='*/*second*'  upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (conf file in /usr)

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
@@ -33,14 +33,46 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/test-policy.conf\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #1:"
+   And stdout does not contain "vendor change policies will be ignored"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
    And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - any vendor change allowed using --allow-vendor-change, vendor change policies loaded but ignored
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--dump-vendor-policies --allow-vendor-change upgrade vendor"
+   Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/test-policy.conf\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout contains "allow_vendor_change is enabled. Packages can be replaced by any vendor, and vendor change policies will be ignored."
+   And stdout does not contain "Policy #1:"
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
 
 
 Scenario: Upgrade with vendor policy - vendor change not allowed (policy from conf file cleared using --clear-vendor-policies)
@@ -57,8 +89,10 @@ Scenario: Upgrade with vendor policy - vendor change not allowed (policy from co
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--clear-vendor-policies upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies --clear-vendor-policies upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout does not contain "Policy #0:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.1-1.x86_64 |
@@ -71,8 +105,11 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: text:COMMAND LINE\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #1:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.2-1.x86_64 |
@@ -95,8 +132,12 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/test-policy.conf\n  out:\"First Vendor\",in:\"Third Vendor\""
+   And stdout contains "Policy #1: source: text:COMMAND LINE\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #2:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.3-1.x86_64 |
@@ -119,8 +160,11 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--clear-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies --clear-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: text:COMMAND LINE\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #1:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.2-1.x86_64 |
@@ -130,7 +174,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor and Third (in two config files, Third has newer version)
-  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-third.conf" with
       """
       version = '1.0'
 
@@ -153,8 +197,12 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/allow-first-to-second.conf\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout contains "Policy #1: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/allow-first-to-third.conf\n  out:\"First Vendor\",in:\"Third Vendor\""
+   And stdout does not contain "Policy #2:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.3-1.x86_64 |
@@ -164,7 +212,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (policy to Third is removed using --remove-vendor-policy-source)
-  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-third.conf" with
       """
       version = '1.0'
 
@@ -187,7 +235,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--remove-vendor-policy-source='*/allow-first-to-thirh.conf'  upgrade vendor"
+   When I execute dnf with args "--remove-vendor-policy-source='*/allow-first-to-third.conf'  upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
@@ -198,7 +246,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Third Vendor (policy to Second is removed using --remove-vendor-policy-source)
-  Given I create file "/etc/dnf/vendors.d/allow-first-to-thirh.conf" with
+  Given I create file "/etc/dnf/vendors.d/allow-first-to-third.conf" with
       """
       version = '1.0'
 
@@ -221,8 +269,11 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Third V
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "--remove-vendor-policy-source='*/*second*'  upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies --remove-vendor-policy-source='*/*second*'  upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/allow-first-to-third.conf\n  out:\"First Vendor\",in:\"Third Vendor\""
+   And stdout does not contain "Policy #1:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.3-1.x86_64 |
@@ -245,8 +296,11 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/usr/share/dnf5/vendors.d/test-policy.conf\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #1:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.2-1.x86_64 |
@@ -279,8 +333,11 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
-   When I execute dnf with args "upgrade vendor"
+   When I execute dnf with args "--dump-vendor-policies upgrade vendor"
    Then the exit code is 0
+   And stdout contains "======== Vendor Change Policies: ========"
+   And stdout contains "Policy #0: source: file://{context.dnf.installroot}/etc/dnf/vendors.d/test-policy.conf\n  out:\"First Vendor\",in:\"Second Vendor\""
+   And stdout does not contain "Policy #1:"
    And Transaction is following
        | Action  | Package             |
        | upgrade | vendor-1.2-1.x86_64 |

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies1_1.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies1_1.feature
@@ -50,6 +50,23 @@ Scenario: Upgrade with vendor policy - equivalent vendors and incoming vendors t
     """
 
 
+Scenario: Upgrade with vendor policy - equivalent vendors and incoming vendors together (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:\"First\ Vendor\",eq:\"Second\ Vendor\",in:\"Third\ Vendor\" upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.3-1 : Third Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.8-1 : Third Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
 Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is allowed
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
     """
@@ -62,6 +79,24 @@ Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is a
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.10-1 : Second Vendor
+    vendordep-1.6-1 : First Vendor
+    vendordep2-1.1-1 : Second Vendor
+    vendordep3-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is allowed (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:\"Second\ Vendor\" upgrade '*'"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0
@@ -89,6 +124,23 @@ Scenario: Upgrade with vendor policy - Allow packages from the command-line repo
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.0-1 : First Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - Allow packages from the command-line repo from any vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=@in:[cmdline_repo=\"true\"] upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0
@@ -132,6 +184,22 @@ Scenario: Upgrade with vendor policy - Allow packages from the command-line repo
     """
 
 
+Scenario: Upgrade with vendor policy - Allow packages from the command-line repo from any vendor with exclusion packages whose name ends with "pkg" (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=@in:e[name$\"pkg\"],in:[cmdline_repo=\"1\"] upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.0-1 : First Vendor
+    vendordep-1.0-1 : First Vendor
+    """
+
+
 Scenario: Upgrade with vendor policy - all incoming packages whose source name starting "vend" and version is >= "1.8" to change vendor to "Third Vendor"
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
     """
@@ -150,6 +218,23 @@ Scenario: Upgrade with vendor policy - all incoming packages whose source name s
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.1-1 : First Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.8-1 : Third Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - all incoming packages whose source name starting "vend" and version is >= "1.8" to change vendor to "Third Vendor" (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:\"Third\ Vendor\"@in:[source_name^\"vend\",version\>=\"1.8\"] upgrade '*'"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies1_2.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor-policies1_2.feature
@@ -55,3 +55,32 @@ Examples:
     | ^t.ird.*  | NOT_REGEX       | vendor-1.3-1 : Third Vendor   |
     | ^t.ird.*  | NOT_IREGEX      | vendor-1.2-1 : Second Vendor  |
     | ^p.ird.*  | NOT_IREGEX      | vendor-1.3-1 : Third Vendor   |
+
+
+Scenario Outline: Upgrade with vendor policy - <comparator> (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:<comparator>\"<vendor>\" upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -i vendor"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    <stdout_line>
+    """
+
+Examples:
+    | vendor     | comparator | stdout_line                   |
+    | Third      | !^         | vendor-1.2-1 : Second Vendor  |
+    | third      | !^         | vendor-1.3-1 : Third Vendor   |
+    | third      | !i^        | vendor-1.2-1 : Second Vendor  |
+    | five       | !i^        | vendor-1.3-1 : Third Vendor   |
+    | rd\ Vendor | !$         | vendor-1.2-1 : Second Vendor  |
+    | rd\ vendor | !$         | vendor-1.3-1 : Third Vendor   |
+    | rd\ vendor | !i$        | vendor-1.2-1 : Second Vendor  |
+    | five       | !i$        | vendor-1.3-1 : Third Vendor   |
+    | ^T.ird.*   | !=~        | vendor-1.2-1 : Second Vendor  |
+    | ^t.ird.*   | !=~        | vendor-1.3-1 : Third Vendor   |
+    | ^t.ird.*   | !i=~       | vendor-1.2-1 : Second Vendor  |
+    | ^p.ird.*   | !i=~       | vendor-1.3-1 : Third Vendor   |

--- a/integration-tests/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/integration-tests/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -63,5 +63,6 @@ Scenario: Downgrade is unable to resolve transaction
          - conflicting requests
        You can try to add to command line:
          --skip-broken to skip uninstallable packages
-         --allow-vendor-change to allow changing package vendors
+         --add-vendor-policy=POLICY to add specific vendor change rules
+         --allow-vendor-change to allow all vendor changes
        """


### PR DESCRIPTION
Resolves: https://github.com/rpm-software-management/dnf5/issues/2876

**New dnf5 global CLI option `--dump-vendor-policies`:**
- Prints all loaded vendor change policies to stdout
- For each policy, displays its index (numbered from 0), source, and compact format representation
- If `allow_vendor_change` is enabled, displays an additional message indicating that packages can be replaced by
  any vendor and policies are ignored

Documentation and CI tests included.

This PR (included CI tests) extends the CI tests added in https://github.com/rpm-software-management/dnf5/pull/2888 . **Please review and merge first: https://github.com/rpm-software-management/dnf5/pull/2888.** Then I rebase this.

### Example output

With `allow_vendor_change` disabled:
```
======== Vendor Change Policies: ========
Policy #0: source: file:///usr/share/dnf5/vendors.d/allow-cmdline.conf
  @in:[cmdline_repo="1"]
```

With `allow_vendor_change` enabled:
```
======== Vendor Change Policies: ========
Policy #0: source: file:///usr/share/dnf5/vendors.d/allow-cmdline.conf
  @in:[cmdline_repo="1"]
allow_vendor_change is enabled. Packages can be replaced by any vendor, and vendor change policies will be ignored.
```
