### PR TITLE
Check rpm db changes before transaction, dnf5daemon lock system repo for transactions

### DIFF
--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -28,6 +28,7 @@
 #include "utils.hpp"
 
 #include <fmt/format.h>
+#include <libdnf5/base/transaction.hpp>
 #include <libdnf5/transaction/offline.hpp>
 #include <libdnf5/transaction/transaction_item.hpp>
 #include <libdnf5/transaction/transaction_item_action.hpp>
@@ -435,9 +436,8 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
                     throw sdbus::Error(
                         dnfdaemon::ERROR_TRANSACTION,
                         fmt::format(
-                            "rpm transaction failed with code {}.",
-                            static_cast<std::underlying_type_t<libdnf5::base::Transaction::TransactionRunResult>>(
-                                rpm_result)));
+                            "Transaction failed: {}.",
+                            libdnf5::base::Transaction::transaction_result_to_string(rpm_result)));
                 }
 
                 auto * base = session.get_base();

--- a/dnf5daemon-server/services/goal/goal.cpp
+++ b/dnf5daemon-server/services/goal/goal.cpp
@@ -60,6 +60,27 @@ static std::string dbus_transaction_item_type_to_string(dnfdaemon::DbusTransacti
     return "";
 }
 
+/// The class template OnScopeExit is a general-purpose scope guard
+/// intended to call its exit function when a scope is exited.
+template <typename TExitFunction>
+    requires requires(TExitFunction f) {
+        { f() } noexcept;
+    }
+class OnScopeExit {
+public:
+    OnScopeExit(TExitFunction && function) noexcept : exit_function{std::move(function)} {}
+
+    ~OnScopeExit() noexcept { exit_function(); }
+
+    OnScopeExit(const OnScopeExit &) = delete;
+    OnScopeExit(OnScopeExit &&) = delete;
+    OnScopeExit & operator=(const OnScopeExit &) = delete;
+    OnScopeExit & operator=(OnScopeExit &&) = delete;
+
+private:
+    TExitFunction exit_function;
+};
+
 void Goal::dbus_register() {
     auto dbus_object = session.get_dbus_object();
 #ifdef SDBUS_CPP_VERSION_2
@@ -411,6 +432,13 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
         }
         std::lock_guard<std::mutex> transaction_lock(transaction_mutex, std::adopt_lock);
 
+        auto * base = session.get_base();
+        if (!base->lock_system_repo(libdnf5::utils::LockAccess::WRITE, libdnf5::utils::LockBlocking::NON_BLOCKING)) {
+            //TODO(mblaha): use specialized exception class
+            throw std::runtime_error("Cannot acquire system repository lock (another process is accessing it.");
+        }
+        OnScopeExit unlock([base]() noexcept { base->unlock_system_repo(); });
+
         session.set_cancel_download(Session::CancelDownload::NOT_REQUESTED);
 
         bool offline = dnfdaemon::key_value_map_get<bool>(options, "offline", false);
@@ -440,7 +468,6 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
                             libdnf5::base::Transaction::transaction_result_to_string(rpm_result)));
                 }
 
-                auto * base = session.get_base();
                 auto state = libdnf5::offline::OfflineTransactionState::from_base(*base);
                 if (state.is_pending()) {
                     state.invalidate();

--- a/include/libdnf5/base/transaction.hpp
+++ b/include/libdnf5/base/transaction.hpp
@@ -60,6 +60,7 @@ public:
         ERROR_CHECK,
         ERROR_RPM_RUN,
         ERROR_GPG_CHECK,
+        ERROR_SYSTEM_CHANGED,
     };
 
     Transaction(const Transaction & transaction);

--- a/include/libdnf5/repo/repo.hpp
+++ b/include/libdnf5/repo/repo.hpp
@@ -326,6 +326,7 @@ private:
     friend class PackageDownloader;
     friend class RepoDownloader;
     friend class solv::Pool;
+    friend class base::Transaction;
 
     /// Loads the repository objects into sacks.
     ///
@@ -350,6 +351,7 @@ private:
 
     LIBDNF_LOCAL void load_available_repo();
     LIBDNF_LOCAL void load_system_repo();
+    LIBDNF_LOCAL bool is_system_repo_up_to_date();
 
     LIBDNF_LOCAL void internalize();
 

--- a/libdnf5/base/goal.cpp
+++ b/libdnf5/base/goal.cpp
@@ -29,6 +29,7 @@
 #include "rpm/package_sack_impl.hpp"
 #include "rpm/package_set_impl.hpp"
 #include "rpm/solv/goal_private.hpp"
+#include "rpm/transaction.hpp"
 #include "solv/id_queue.hpp"
 #include "solv/pool.hpp"
 #include "solver_problems_internal.hpp"

--- a/libdnf5/base/transaction.cpp
+++ b/libdnf5/base/transaction.cpp
@@ -92,6 +92,8 @@ const std::map<base::Transaction::TransactionRunResult, BgettextMessage> TRANSAC
      M_("Failed to obtain rpm transaction lock. Another transaction is in progress.")},
     {base::Transaction::TransactionRunResult::ERROR_RPM_RUN, M_("Rpm transaction failed.")},
     {base::Transaction::TransactionRunResult::ERROR_GPG_CHECK, M_("Signature verification failed.")},
+    {base::Transaction::TransactionRunResult::ERROR_SYSTEM_CHANGED,
+     M_("This transaction is no longer valid because the system repository has changed since it was loaded.")},
 };
 
 const std::map<base::ImportRepoKeysResult, BgettextMessage> IMPORT_REPO_KEYS_RESULT_DICT = {
@@ -439,6 +441,7 @@ std::string Transaction::transaction_result_to_string(const TransactionRunResult
         case TransactionRunResult::ERROR_LOCK:
         case TransactionRunResult::ERROR_RPM_RUN:
         case TransactionRunResult::ERROR_GPG_CHECK:
+        case TransactionRunResult::ERROR_SYSTEM_CHANGED:
             return TM_(TRANSACTION_RUN_RESULT_DICT.at(result), 1);
     }
     return {};
@@ -1070,6 +1073,11 @@ Transaction::TransactionRunResult Transaction::Impl::_run(
     const std::optional<uint32_t> user_id,
     const std::string & comment,
     const bool test_only) {
+    auto system_repo = base->get_repo_sack()->get_system_repo();
+    if (system_repo->is_loaded() && !system_repo->is_system_repo_up_to_date()) {
+        return TransactionRunResult::ERROR_SYSTEM_CHANGED;
+    }
+
     concurrent_transaction.reset();
 
     // do not allow running a transaction multiple times

--- a/libdnf5/repo/repo.cpp
+++ b/libdnf5/repo/repo.cpp
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "rpm/transaction.hpp"
+
 #include "libdnf5/repo/repo_errors.hpp"
 constexpr const char * REPOID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.:";
 
@@ -499,6 +501,19 @@ void Repo::load_available_repo() {
 void Repo::load_system_repo() {
     p_impl->solv_repo->load_system_repo();
     p_impl->solv_repo->load_system_repo_ext(RepodataType::COMPS);
+}
+
+
+bool Repo::is_system_repo_up_to_date() {
+    libdnf_user_assert(
+        get_type() == Type::SYSTEM, "Checking if the system was modified is supported only on system repo");
+
+    rpm::Transaction rpm_ts(p_impl->base);
+    if (p_impl->solv_repo->rpm_db_cookie == rpm_ts.get_db_cookie()) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 void Repo::add_xml_comps(const std::string & path) {

--- a/libdnf5/repo/solv_repo.cpp
+++ b/libdnf5/repo/solv_repo.cpp
@@ -22,6 +22,7 @@
 #include "base/base_impl.hpp"
 #include "repo_cache_private.hpp"
 #include "repo_downloader.hpp"
+#include "rpm/transaction.hpp"
 #include "solv/pool.hpp"
 
 #include "libdnf5/base/base.hpp"
@@ -444,6 +445,9 @@ void SolvRepo::load_system_repo(const std::string & rootdir) {
     main_solvables_end = pool->nsolvables;
     main_repodata_start = repodata_start;
     main_repodata_end = repo->nrepodata;
+
+    rpm::Transaction rpm_ts(base);
+    rpm_db_cookie = rpm_ts.get_db_cookie();
 }
 
 

--- a/libdnf5/repo/solv_repo.hpp
+++ b/libdnf5/repo/solv_repo.hpp
@@ -121,6 +121,12 @@ public:
     /// @return      True if the group was successfully read.
     bool read_group_solvable_from_xml(const std::string & path);
 
+    // Cookie when the system repo was loaded.
+    // Replace this with system repo cookie once it is implemented:
+    // https://github.com/rpm-software-management/dnf5/issues/2794
+    // The rpm db cookie doesn't track changes in reasons, groups,... (lidnf5 system state)
+    std::string rpm_db_cookie;
+
 private:
     // "type_name == nullptr" means load "primary" cache (.solv file)
     bool load_solv_cache(solv::Pool & pool, const char * type_name, int flags);


### PR DESCRIPTION
Required for: https://github.com/rpm-software-management/dnf5/pull/2785

Originally I wanted to add the check for rpm db cookie only to dnf5daemon however I believe it makes sense for any API user.

The dnf5daemon should perhaps also do READ lock when loading the system repo but I would prefer to file a separate issue for that as I am not exactly sure how it should look like.