### PR TITLE
libdnf5: Add `repo_gpgcheck_auto_import_keys` option

### DIFF
--- a/doc/dnf5.conf.5.rst
+++ b/doc/dnf5.conf.5.rst
@@ -1292,6 +1292,35 @@ configuration.
        already imported for package signature verification and this option is turned on, it may be needed
        to import it again for the repository.
 
+       To import these keys without asking for confirmation, see
+       :ref:`repo_gpgcheck_auto_import_keys <repo_gpgcheck_auto_import_keys_options-label>`.
+
+    Default: ``False``.
+
+.. _repo_gpgcheck_auto_import_keys_options-label:
+
+``repo_gpgcheck_auto_import_keys``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF5 imports the OpenPGP keys configured in ``gpgkey`` for this repository's
+    metadata signature check without asking for confirmation. The signature check itself is not
+    affected.
+
+    The keys for this check are stored per repository and keyed by the resolved repository URL,
+    so the confirmation is otherwise requested again whenever the repository URL changes, for
+    example after a ``$releasever`` change. In non-interactive runs a declined confirmation makes
+    loading the repository fail, or the repository is skipped when ``skip_if_unavailable`` is
+    enabled.
+
+    Only keys from local (``file://``) ``gpgkey`` URLs are imported automatically, for example a
+    key file installed by a package. Keys fetched from a remote URL always ask for confirmation
+    so the fingerprint can be verified before the key is trusted.
+    :ref:`assumeno <assumeno_options-label>` takes precedence over this option: the import is
+    declined as usual and nothing is imported. The option does not affect importing keys into
+    the RPM database for package signature verification.
+
+    Only applies when :ref:`repo_gpgcheck <repo_gpgcheck_options-label>` is enabled.
+
     Default: ``False``.
 
 .. _skip_if_unavailable_options-label:

--- a/include/libdnf5/conf/config_main.hpp
+++ b/include/libdnf5/conf/config_main.hpp
@@ -286,6 +286,9 @@ public:
     const OptionBool & get_pkg_gpgcheck_option() const;
     OptionBool & get_repo_gpgcheck_option();
     const OptionBool & get_repo_gpgcheck_option() const;
+    /// Auto-import applies only to keys from local (file://) gpgkey URLs.
+    OptionBool & get_repo_gpgcheck_auto_import_keys_option();
+    const OptionBool & get_repo_gpgcheck_auto_import_keys_option() const;
     OptionEnum & get_gpgcheck_policy_option();
     const OptionEnum & get_gpgcheck_policy_option() const;
     /// @deprecated Use ConfigRepo::get_enabled_option()

--- a/include/libdnf5/repo/config_repo.hpp
+++ b/include/libdnf5/repo/config_repo.hpp
@@ -92,6 +92,9 @@ public:
     const OptionChild<OptionBool> & get_pkg_gpgcheck_option() const;
     OptionChild<OptionBool> & get_repo_gpgcheck_option();
     const OptionChild<OptionBool> & get_repo_gpgcheck_option() const;
+    /// Auto-import applies only to keys from local (file://) gpgkey URLs.
+    OptionChild<OptionBool> & get_repo_gpgcheck_auto_import_keys_option();
+    const OptionChild<OptionBool> & get_repo_gpgcheck_auto_import_keys_option() const;
     OptionChild<OptionBool> & get_enablegroups_option();
     const OptionChild<OptionBool> & get_enablegroups_option() const;
     /// @deprecated The option does nothing

--- a/integration-tests/dnf-behave-tests/dnf/repo-gpgcheck.feature
+++ b/integration-tests/dnf-behave-tests/dnf/repo-gpgcheck.feature
@@ -51,3 +51,30 @@ Scenario: Remote gpg key is imported for already cached repo
         | Action        | Package                       |
         | reinstall     | labirinto-0:1.0-1.fc29.x86_64 |
     And stderr contains "The key was successfully imported."
+
+
+Scenario: Local key is imported without confirmation when repo_gpgcheck_auto_import_keys is enabled
+  Given I do not assume yes
+    And I use repository "simple-base" with configuration
+        | key                            | value                                                                   |
+        | pkg_gpgcheck                   | 0                                                                       |
+        | repo_gpgcheck                  | 1                                                                       |
+        | repo_gpgcheck_auto_import_keys | 1                                                                       |
+        | gpgkey                         | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public |
+   When I execute dnf with args "makecache"
+   Then the exit code is 0
+    And stderr contains "The key was successfully imported."
+    And stderr does not contain "Is this ok"
+
+
+Scenario: Remote key still asks for confirmation when repo_gpgcheck_auto_import_keys is enabled
+  Given I do not assume yes
+    And I use repository "simple-base" with configuration
+        | key                            | value                                                              |
+        | pkg_gpgcheck                   | 0                                                                  |
+        | repo_gpgcheck                  | 1                                                                  |
+        | repo_gpgcheck_auto_import_keys | 1                                                                  |
+        | gpgkey                         | http://localhost:{context.dnf.ports[key_server]}/dnf-ci-gpg-public |
+   When I execute dnf with args "makecache"
+   Then the exit code is 1
+    And stderr contains "Importing OpenPGP key"

--- a/libdnf5/conf/config_main.cpp
+++ b/libdnf5/conf/config_main.cpp
@@ -262,6 +262,7 @@ class ConfigMain::Impl {
     OptionEnum gpgcheck_policy{"legacy", {"legacy", "full", "all"}};
     OptionBool pkg_gpgcheck{false};
     OptionBool repo_gpgcheck{false};
+    OptionBool repo_gpgcheck_auto_import_keys{false};
     OptionBool enabled{true};
     OptionBool enablegroups{true};
     OptionNumber<std::uint32_t> bandwidth{0, str_to_bytes};
@@ -462,6 +463,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("gpgcheck_policy", gpgcheck_policy);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
+    owner.opt_binds().add("repo_gpgcheck_auto_import_keys", repo_gpgcheck_auto_import_keys);
     owner.opt_binds().add("enabled", enabled);
     owner.opt_binds().add("enablegroups", enablegroups);
     owner.opt_binds().add("bandwidth", bandwidth);
@@ -1235,6 +1237,13 @@ const OptionBool & ConfigMain::get_repo_gpgcheck_option() const {
     return p_impl->repo_gpgcheck;
 }
 
+OptionBool & ConfigMain::get_repo_gpgcheck_auto_import_keys_option() {
+    return p_impl->repo_gpgcheck_auto_import_keys;
+}
+const OptionBool & ConfigMain::get_repo_gpgcheck_auto_import_keys_option() const {
+    return p_impl->repo_gpgcheck_auto_import_keys;
+}
+
 OptionEnum & ConfigMain::get_gpgcheck_policy_option() {
     return p_impl->gpgcheck_policy;
 }
@@ -1556,6 +1565,7 @@ void ConfigMain::Impl::load_from_config(const ConfigMain::Impl & other) {
     load_option(gpgcheck_policy, other.gpgcheck_policy);
     load_option(pkg_gpgcheck, other.pkg_gpgcheck);
     load_option(repo_gpgcheck, other.repo_gpgcheck);
+    load_option(repo_gpgcheck_auto_import_keys, other.repo_gpgcheck_auto_import_keys);
     load_option(enabled, other.enabled);
     load_option(enablegroups, other.enablegroups);
     load_option(bandwidth, other.bandwidth);

--- a/libdnf5/repo/config_repo.cpp
+++ b/libdnf5/repo/config_repo.cpp
@@ -61,6 +61,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionStringAppendList> protected_packages{main_config.get_protected_packages_option()};
     OptionChild<OptionBool> pkg_gpgcheck{main_config.get_pkg_gpgcheck_option()};
     OptionChild<OptionBool> repo_gpgcheck{main_config.get_repo_gpgcheck_option()};
+    OptionChild<OptionBool> repo_gpgcheck_auto_import_keys{main_config.get_repo_gpgcheck_auto_import_keys_option()};
     OptionChild<OptionBool> enablegroups{main_config.get_enablegroups_option()};
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -156,6 +157,7 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::stri
     // Compatibility alias for pkg_gpgcheck
     owner.opt_binds().add("gpgcheck", pkg_gpgcheck);
     owner.opt_binds().add("repo_gpgcheck", repo_gpgcheck);
+    owner.opt_binds().add("repo_gpgcheck_auto_import_keys", repo_gpgcheck_auto_import_keys);
     owner.opt_binds().add("enablegroups", enablegroups);
     owner.opt_binds().add("retries", retries);
     owner.opt_binds().add("bandwidth", bandwidth);
@@ -356,6 +358,13 @@ OptionChild<OptionBool> & ConfigRepo::get_repo_gpgcheck_option() {
 }
 const OptionChild<OptionBool> & ConfigRepo::get_repo_gpgcheck_option() const {
     return p_impl->repo_gpgcheck;
+}
+
+OptionChild<OptionBool> & ConfigRepo::get_repo_gpgcheck_auto_import_keys_option() {
+    return p_impl->repo_gpgcheck_auto_import_keys;
+}
+const OptionChild<OptionBool> & ConfigRepo::get_repo_gpgcheck_auto_import_keys_option() const {
+    return p_impl->repo_gpgcheck_auto_import_keys;
 }
 
 OptionChild<OptionBool> & ConfigRepo::get_enablegroups_option() {

--- a/libdnf5/repo/repo_pgp.cpp
+++ b/libdnf5/repo/repo_pgp.cpp
@@ -122,6 +122,15 @@ void RepoPgp::import_key(int fd, const std::string & url) {
 
     auto key_infos = rawkey2infos(fd, url);
 
+    // With repo_gpgcheck_auto_import_keys enabled, keys from local (file://)
+    // gpgkey URLs are imported without a confirmation. Remote keys still go
+    // through the callback so the fingerprint can be verified before the key
+    // is trusted. assumeno takes precedence: the callback shows the key
+    // details and declines the import as usual.
+    const bool auto_import = config.get_repo_gpgcheck_auto_import_keys_option().get_value() &&
+                             !config.get_main_config().get_assumeno_option().get_value();
+    const bool key_is_local = url.starts_with("file://");
+
     auto known_keys = load_keys_ids_from_keyring();
     for (auto & key_info : key_infos) {
         if (std::find(known_keys.begin(), known_keys.end(), key_info.get_key_id()) != known_keys.end()) {
@@ -130,8 +139,23 @@ void RepoPgp::import_key(int fd, const std::string & url) {
             continue;
         }
 
-        if (callbacks && !callbacks->repokey_import(key_info)) {
-            continue;
+        if (auto_import && key_is_local) {
+            logger.info(
+                "Automatically importing OpenPGP key 0x{} (fingerprint {}) from {} for repository {}.",
+                key_info.get_key_id(),
+                key_info.get_fingerprint(),
+                key_info.get_url(),
+                config.get_id());
+        } else if (callbacks) {
+            if (auto_import && !key_is_local) {
+                logger.info(
+                    "repo_gpgcheck_auto_import_keys ignored for key from {}: only local (file://) gpgkey URLs are "
+                    "auto-imported.",
+                    url);
+            }
+            if (!callbacks->repokey_import(key_info)) {
+                continue;
+            }
         }
 
         auto keyring_dir = get_keyring_dir();

--- a/test/libdnf5/conf/test_conf.cpp
+++ b/test/libdnf5/conf/test_conf.cpp
@@ -72,6 +72,30 @@ void ConfTest::test_config_pkg_gpgcheck() {
 #pragma GCC diagnostic pop
 }
 
+void ConfTest::test_config_repo_gpgcheck_auto_import_keys() {
+    // The option is an opt-in and must default to false.
+    CPPUNIT_ASSERT_EQUAL(false, config.get_repo_gpgcheck_auto_import_keys_option().get_value());
+
+    repo::ConfigRepo config_repo(config, "test-repo");
+    CPPUNIT_ASSERT_EQUAL(false, config_repo.get_repo_gpgcheck_auto_import_keys_option().get_value());
+
+    // The repository option inherits the value set in [main].
+    config.get_repo_gpgcheck_auto_import_keys_option().set(Option::Priority::MAINCONFIG, true);
+    CPPUNIT_ASSERT_EQUAL(true, config_repo.get_repo_gpgcheck_auto_import_keys_option().get_value());
+
+    // A per-repository value overrides the inherited one.
+    config_repo.get_repo_gpgcheck_auto_import_keys_option().set(Option::Priority::REPOCONFIG, false);
+    CPPUNIT_ASSERT_EQUAL(false, config_repo.get_repo_gpgcheck_auto_import_keys_option().get_value());
+
+    // The option is registered under its name on both the main and the
+    // repository configuration, so it can be set from configuration files
+    // and --setopt.
+    config.opt_binds().at("repo_gpgcheck_auto_import_keys").new_string(Option::Priority::RUNTIME, "0");
+    CPPUNIT_ASSERT_EQUAL(false, config.get_repo_gpgcheck_auto_import_keys_option().get_value());
+    config_repo.opt_binds().at("repo_gpgcheck_auto_import_keys").new_string(Option::Priority::RUNTIME, "1");
+    CPPUNIT_ASSERT_EQUAL(true, config_repo.get_repo_gpgcheck_auto_import_keys_option().get_value());
+}
+
 void ConfTest::test_gpgcheck_policy_legacy() {
     ConfigMain cfg;
     ConfigParser parser;

--- a/test/libdnf5/conf/test_conf.hpp
+++ b/test/libdnf5/conf/test_conf.hpp
@@ -33,6 +33,7 @@ class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST(test_config_main);
     CPPUNIT_TEST(test_config_repo);
     CPPUNIT_TEST(test_config_pkg_gpgcheck);
+    CPPUNIT_TEST(test_config_repo_gpgcheck_auto_import_keys);
     CPPUNIT_TEST(test_config_load_from_config);
     CPPUNIT_TEST(test_gpgcheck_policy_legacy);
     CPPUNIT_TEST(test_gpgcheck_policy_full);
@@ -48,6 +49,7 @@ public:
     void test_config_main();
     void test_config_repo();
     void test_config_pkg_gpgcheck();
+    void test_config_repo_gpgcheck_auto_import_keys();
     void test_config_load_from_config();
     void test_gpgcheck_policy_legacy();
     void test_gpgcheck_policy_full();

--- a/test/libdnf5/repo/test_repo.cpp
+++ b/test/libdnf5/repo/test_repo.cpp
@@ -100,8 +100,11 @@ public:
         return accept_key_import;
     }
 
+    void repokey_imported([[maybe_unused]] const libdnf5::rpm::KeyInfo & key_info) override { ++repokey_imported_cnt; }
+
     bool accept_key_import{true};
     int repokey_import_cnt = 0;
+    int repokey_imported_cnt = 0;
 };
 
 }  // namespace
@@ -278,4 +281,69 @@ void RepoTest::test_load_repo_gpgcheck_refused_key_shows_error() {
         "Download callback should report 'Signing key not found' error exactly once (second pass only)",
         1,
         signing_key_error_cnt);
+}
+
+void RepoTest::test_load_repo_gpgcheck_auto_import_keys() {
+    std::string repoid("repomd-repo1-gpg");
+    std::filesystem::path repo_path = PROJECT_SOURCE_DIR "/test/data/repos-repomd";
+    repo_path /= repoid;
+    auto repo = repo_sack->create_repo(repoid);
+    repo->get_config().get_baseurl_option().set("file://" + repo_path.string());
+    repo->get_config().get_repo_gpgcheck_option().set(true);
+    repo->get_config().get_repo_gpgcheck_auto_import_keys_option().set(true);
+    repo->get_config().get_gpgkey_option().set(
+        std::vector<std::string>{"file://" + std::string(PROJECT_SOURCE_DIR) + "/test/data/keys/repo-gpg-key.pub"});
+
+    auto dl_callbacks = std::make_unique<DownloadCallbacks>();
+    auto dl_callbacks_ptr = dl_callbacks.get();
+    base.set_download_callbacks(std::move(dl_callbacks));
+
+    // The callback would refuse the import. With auto import enabled it must
+    // not be asked at all.
+    auto callbacks = std::make_unique<RepoCallbacks>();
+    auto cbs = callbacks.get();
+    cbs->accept_key_import = false;
+    repo->set_callbacks(std::move(callbacks));
+
+    repo_sack->load_repos(libdnf5::repo::Repo::Type::AVAILABLE);
+
+    // The key was imported without asking the callback, and the imported
+    // notification still fired.
+    CPPUNIT_ASSERT_EQUAL(0, cbs->repokey_import_cnt);
+    CPPUNIT_ASSERT_EQUAL(1, cbs->repokey_imported_cnt);
+
+    // The repository loaded without any download error, so the metadata
+    // signature verification passed with the auto-imported key.
+    CPPUNIT_ASSERT_MESSAGE("Expected no download errors", dl_callbacks_ptr->end_error_messages.empty());
+}
+
+void RepoTest::test_load_repo_gpgcheck_auto_import_keys_assumeno() {
+    std::string repoid("repomd-repo1-gpg");
+    std::filesystem::path repo_path = PROJECT_SOURCE_DIR "/test/data/repos-repomd";
+    repo_path /= repoid;
+    auto repo = repo_sack->create_repo(repoid);
+    repo->get_config().get_baseurl_option().set("file://" + repo_path.string());
+    repo->get_config().get_repo_gpgcheck_option().set(true);
+    repo->get_config().get_repo_gpgcheck_auto_import_keys_option().set(true);
+    repo->get_config().get_gpgkey_option().set(
+        std::vector<std::string>{"file://" + std::string(PROJECT_SOURCE_DIR) + "/test/data/keys/repo-gpg-key.pub"});
+    repo->get_config().get_skip_if_unavailable_option().set(true);
+
+    // assumeno takes precedence over the option: the import goes through the
+    // callback, which declines it.
+    base.get_config().get_assumeno_option().set(true);
+
+    auto dl_callbacks = std::make_unique<DownloadCallbacks>();
+    base.set_download_callbacks(std::move(dl_callbacks));
+
+    auto callbacks = std::make_unique<RepoCallbacks>();
+    auto cbs = callbacks.get();
+    cbs->accept_key_import = false;
+    repo->set_callbacks(std::move(callbacks));
+
+    repo_sack->load_repos(libdnf5::repo::Repo::Type::AVAILABLE);
+
+    // The callback was consulted and nothing was imported.
+    CPPUNIT_ASSERT_EQUAL(1, cbs->repokey_import_cnt);
+    CPPUNIT_ASSERT_EQUAL(0, cbs->repokey_imported_cnt);
 }

--- a/test/libdnf5/repo/test_repo.hpp
+++ b/test/libdnf5/repo/test_repo.hpp
@@ -36,6 +36,8 @@ class RepoTest : public BaseTestCase {
     CPPUNIT_TEST(test_load_repos_load_available_system);
     CPPUNIT_TEST(test_load_repo_gpgcheck_no_keyring_error);
     CPPUNIT_TEST(test_load_repo_gpgcheck_refused_key_shows_error);
+    CPPUNIT_TEST(test_load_repo_gpgcheck_auto_import_keys);
+    CPPUNIT_TEST(test_load_repo_gpgcheck_auto_import_keys_assumeno);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -48,6 +50,8 @@ public:
     void test_load_repos_load_available_system();
     void test_load_repo_gpgcheck_no_keyring_error();
     void test_load_repo_gpgcheck_refused_key_shows_error();
+    void test_load_repo_gpgcheck_auto_import_keys();
+    void test_load_repo_gpgcheck_auto_import_keys_assumeno();
 };
 
 #endif


### PR DESCRIPTION
### Summary

Add a boolean option `repo_gpgcheck_auto_import_keys` (default `false`). With `repo_gpgcheck=1`, OpenPGP keys from local `file://` `gpgkey` URLs are imported into the per-repository metadata keyring without the confirmation prompt. Keys fetched from remote URLs always keep the prompt so the fingerprint can be verified, and `assumeno` takes precedence: the import goes through the confirmation callback and is declined, so `assumeno` never changes the system. Signature verification itself is unchanged.

Closes #2923. The same option for dnf4 is proposed in rpm-software-management/libdnf#1778 with docs in rpm-software-management/dnf#2338; per that discussion, implementing in dnf5 first was preferred, and this PR follows the design settled there (the local-only restriction and the `assumeno` precedence).

### Motivation

The metadata keyring is per repository and keyed by the resolved URL, so the import confirmation is requested again whenever the repository URL changes, for example after a `$releasever` change, and a declined confirmation in unattended runs drops the repo (with `skip_if_unavailable=True`, at exit 0). Details and reproduction in #2923. The standing workaround is `-y` on every metadata-fetching command, including read-only ones, which auto-accepts every other prompt as well. The pain is not niche: #2354 reports that even a key shipped on disk by a distribution package (`file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-x86_64`) triggers the prompt.

### Design notes

- This does not change any default and does not add trust "by default": it is an explicit per-repo opt-in, limited to keys the administrator already placed on disk, and `assumeno` still declines. libdnf5's own API default (`RepoCallbacks::repokey_import` returns `true`) already imports configured keys without confirmation; this exposes the same behavior to the CLI, narrowed to local key files.
- The local-only rule follows the libdnf#1778 review: a remote `gpgkey` must show the fingerprint before the key is trusted, so remote URLs always prompt, and the skipped auto-import is logged.
- Complementary to, not competing with, the longer-term directions discussed in #838: keying the keyring by repository identity and verifying against the RPM keyring would both still prompt on the first import (fresh installs, images, cleared caches), which is the case this option covers.
- The gate lives in `RepoPgp::import_key`, the single import path for the metadata keyring. Importing keys into the RPM database for package signature verification is not affected.
- dnf5daemon: the option is deliberately not in `ALLOWED_MAIN_CONF_OVERRIDES`, so an unprivileged D-Bus client cannot enable it.
- Every auto-import is logged at INFO with the key id, fingerprint, source URL, and repository id; the CLI still prints `The key was successfully imported.` through `repokey_imported`.
- A `gpgkey` spelled with a single slash (`file:/...`) falls back to the prompt; the predicate matches the dnf4 patch in libdnf#1778.

### Testing

- Unit, configuration: default `false` on both `ConfigMain` and `ConfigRepo`, `[main]` inheritance, per-repo override, and name registration on both configs so the option parses from configuration files and `--setopt`.
- Unit, behavior: with the option enabled and a callback that would refuse, loading a `repo_gpgcheck` repository with a local key imports without consulting the callback and delivers `repokey_imported` exactly once, with no download errors; with `assumeno`, the callback is consulted and nothing is imported.
- Integration: two scenarios in `repo-gpgcheck.feature`: with the option enabled and no `assumeyes`, a local key imports without a prompt and `makecache` exits 0, while a remote key still asks for confirmation.
- ABI: abidiff of `libdnf5.so` before and after reports no removed or changed symbols, only the four new getters; `libdnf5-cli` is unchanged.

### Notes for reviewers

Open to a different option name. If the preferred direction is instead to surface the declined import in the exit code (direction 1 in #2923), I am happy to work on that as a follow-up; the two are independent.