### PR TITLE
aliases: add command_flag type for dnf4 flags that select commands

### DIFF
--- a/dnf5/cmdline_aliases.cpp
+++ b/dnf5/cmdline_aliases.cpp
@@ -22,13 +22,18 @@
 #include "utils/string.hpp"
 
 #include <libdnf5/common/preserve_order_map.hpp>
+#include <libdnf5/utils/bgettext/bgettext-lib.h>
 #include <libdnf5/utils/bgettext/bgettext-mark-domain.h>
+#include <libdnf5/utils/format.hpp>
 #include <libdnf5/utils/format_locale.hpp>
 #include <toml.hpp>
 
+#include <algorithm>
 #include <array>
 #include <iostream>
+#include <limits>
 #include <optional>
+#include <set>
 #include <type_traits>
 #include <vector>
 
@@ -38,7 +43,7 @@ namespace dnf5 {
 
 namespace {
 
-constexpr std::array<const char *, 2> CONF_FILE_SUPPORTED_VERSIONS = {"1.0", "1.1"};
+constexpr std::array<const char *, 3> CONF_FILE_SUPPORTED_VERSIONS = {"1.0", "1.1", "1.2"};
 
 using ArgParser = libdnf5::cli::ArgumentParser;
 
@@ -70,11 +75,16 @@ inline std::string location_lines(const toml::source_location & location) {
 #endif  // #ifdef TOML11_COMPAT
 
 
-// If the `arg` is of type `std::array<const char*, 2>`, it joins the elements with a `delimiter` string;
+// If the `arg` is of type `std::array<const char *, N>`, it joins the elements with a `delimiter` string;
 // otherwise, it returns the original value.
 template <typename T>
+struct is_const_char_ptr_array : std::false_type {};
+template <std::size_t N>
+struct is_const_char_ptr_array<std::array<const char *, N>> : std::true_type {};
+
+template <typename T>
 auto join_if_array(const T & arg, const char * delimiter) {
-    if constexpr (std::is_same_v<T, std::array<const char *, 2>>) {
+    if constexpr (is_const_char_ptr_array<std::decay_t<T>>::value) {
         return libdnf5::utils::string::join(arg, delimiter);
     } else {
         return arg;
@@ -180,7 +190,10 @@ bool attach_named_args(
 }
 
 void load_aliases_from_toml_file(
-    Context & context, const fs::path & config_file_path, const std::string & locale_name) {
+    Context & context,
+    const fs::path & config_file_path,
+    const std::string & locale_name,
+    CommandFlagAliasTable & command_flag_aliases) {
     auto & arg_parser = context.get_argument_parser();
     auto logger = context.get_base().get_logger();
 
@@ -262,6 +275,244 @@ void load_aliases_from_toml_file(
             const std::string element_parent_id_path =
                 element_id_pos == 0 ? "" : element_id_path.substr(0, element_id_pos - 1);
 
+            // dnf4 compatibility: 'command_flag' entries are handled before
+            // parent-command resolution - the parent may be a command alias
+            // (like updateinfo), and the table only needs the names.
+            {
+                bool is_command_flag = false;
+                std::optional<toml::source_location> type_location;
+                try {
+#ifdef TOML11_COMPAT
+                    const auto el_type = toml::find(element_options, "type");
+#else
+                    const auto el_type = toml::find<toml::ordered_value>(element_options, "type");
+#endif  // #ifdef TOML11_COMPAT
+                    is_command_flag = (std::string(el_type.as_string()) == "command_flag");
+                    type_location = el_type.location();
+                } catch (const std::out_of_range &) {
+                } catch (const toml::type_error &) {
+                }
+                if (is_command_flag) {
+                    if (version == "1.0" || version == "1.1") {
+                        print_and_log_error(
+                            *logger,
+                            M_("Used config file version \"{}\" for alias type \"command_flag\" of element \"{}\" "
+                               "in file \"{}\" on line {}: {}"),
+                            version,
+                            element_id_path,
+                            config_file_path.native(),
+                            location_first_line_num(*type_location),
+                            location_lines(*type_location));
+                        continue;
+                    }
+                    if (element_parent_id_path.empty() || element_parent_id_path.find('.') != std::string::npos) {
+                        print_and_log_warning(
+                            *logger,
+                            M_("Command flag alias \"{}\" must be named \"<command>.<flag>\" in file \"{}\" "
+                               "on line {}: {}"),
+                            element_id_path,
+                            config_file_path.native(),
+                            location_first_line_num(*type_location),
+                            location_lines(*type_location));
+                        continue;
+                    }
+                    const auto alias_key =
+                        std::pair<std::string, std::string>{element_parent_id_path, "--" + element_id};
+                    if (command_flag_aliases.count(alias_key) > 0) {
+                        print_and_log_error(
+                            *logger,
+                            M_("Command flag alias \"{}\" already registered. Requested in file \"{}\" on line {}: {}"),
+                            element_id_path,
+                            config_file_path.native(),
+                            location_first_line_num(*type_location),
+                            location_lines(*type_location));
+                        continue;
+                    }
+                    CommandFlagAlias alias;
+                    bool defined = false;
+                    bool broken = false;
+                    try {
+                        for (auto & [key, value] : element_options.as_table()) {
+                            if (key == "type") {
+                                continue;
+                            } else if (key == "reject_message") {
+                                alias.reject_message = value.as_string();
+                                if (alias.reject_message.empty()) {
+                                    const auto location = value.location();
+                                    print_and_log_error(
+                                        *logger,
+                                        M_("Bad value \"\" of attribute \"reject_message\" for element \"{}\" "
+                                           "in file \"{}\" on line {}: {}"),
+                                        element_id_path,
+                                        config_file_path.native(),
+                                        location_first_line_num(location),
+                                        location_lines(location));
+                                    broken = true;
+                                } else {
+                                    defined = true;
+                                }
+                            } else if (key == "attached_command") {
+                                const std::string attached{value.as_string()};
+                                alias.words = libdnf5::utils::string::split(attached, ".");
+                                bool bad_path = alias.words.empty();
+                                for (const auto & word : alias.words) {
+                                    if (word.empty()) {
+                                        bad_path = true;
+                                    }
+                                }
+                                if (bad_path) {
+                                    const auto location = value.location();
+                                    print_and_log_error(
+                                        *logger,
+                                        M_("Bad value \"{}\" of attribute \"attached_command\" for element \"{}\" "
+                                           "in file \"{}\" on line {}: {}"),
+                                        attached,
+                                        element_id_path,
+                                        config_file_path.native(),
+                                        location_first_line_num(location),
+                                        location_lines(location));
+                                    broken = true;
+                                } else {
+                                    defined = true;
+                                }
+                            } else if (key == "attached_flags") {
+                                for (const auto & flag : value.as_array()) {
+                                    alias.attached_flags.emplace_back(flag.as_string());
+                                    if (alias.attached_flags.back().empty()) {
+                                        const auto location = value.location();
+                                        print_and_log_error(
+                                            *logger,
+                                            M_("Bad value \"\" of attribute \"attached_flags\" for element \"{}\" "
+                                               "in file \"{}\" on line {}: {}"),
+                                            element_id_path,
+                                            config_file_path.native(),
+                                            location_first_line_num(location),
+                                            location_lines(location));
+                                        broken = true;
+                                        break;
+                                    }
+                                }
+                            } else if (key == "positional_template") {
+                                alias.positional_template = value.as_string();
+                            } else if (key == "token_prefix_maps") {
+                                for (const auto & map_entry : value.as_array()) {
+                                    std::optional<std::string> prefix;
+                                    std::optional<std::string> map_template;
+                                    for (auto & [map_key, map_value] : map_entry.as_table()) {
+                                        if (map_key == "prefix") {
+                                            prefix = std::string(map_value.as_string());
+                                        } else if (map_key == "template") {
+                                            map_template = std::string(map_value.as_string());
+                                        } else {
+                                            const auto location = map_value.location();
+                                            print_and_log_warning(
+                                                *logger,
+                                                M_("Unknown attribute \"{}\" of \"token_prefix_maps\" for element "
+                                                   "\"{}\" in file \"{}\" on line {}: {}"),
+                                                map_key,
+                                                element_id_path,
+                                                config_file_path.native(),
+                                                location_first_line_num(location),
+                                                location_lines(location));
+                                        }
+                                    }
+                                    if (prefix && prefix->empty()) {
+                                        const auto location = value.location();
+                                        print_and_log_error(
+                                            *logger,
+                                            M_("Bad value \"\" of attribute \"prefix\" in \"token_prefix_maps\" "
+                                               "for element \"{}\" in file \"{}\" on line {}: {}"),
+                                            element_id_path,
+                                            config_file_path.native(),
+                                            location_first_line_num(location),
+                                            location_lines(location));
+                                        broken = true;
+                                        break;
+                                    }
+                                    if (!prefix || !map_template) {
+                                        const auto location = value.location();
+                                        print_and_log_error(
+                                            *logger,
+                                            M_("Missing attribute \"prefix\" or \"template\" in \"token_prefix_maps\" "
+                                               "for element \"{}\" in file \"{}\" on line {}: {}"),
+                                            element_id_path,
+                                            config_file_path.native(),
+                                            location_first_line_num(location),
+                                            location_lines(location));
+                                        broken = true;
+                                        break;
+                                    }
+                                    alias.token_prefix_maps.emplace_back(std::move(*prefix), std::move(*map_template));
+                                }
+                            } else if (key == "companion_flag") {
+                                alias.companion_flag = value.as_string();
+                            } else if (key == "precedence") {
+                                const auto precedence = value.as_integer();
+                                if (precedence < std::numeric_limits<int>::min() ||
+                                    precedence > std::numeric_limits<int>::max()) {
+                                    const auto location = value.location();
+                                    print_and_log_error(
+                                        *logger,
+                                        M_("Bad value \"{}\" of attribute \"precedence\" for element \"{}\" "
+                                           "in file \"{}\" on line {}: {}"),
+                                        std::to_string(precedence),
+                                        element_id_path,
+                                        config_file_path.native(),
+                                        location_first_line_num(location),
+                                        location_lines(location));
+                                    broken = true;
+                                } else {
+                                    alias.precedence = static_cast<int>(precedence);
+                                }
+                            } else if (key == "drop_bare_positionals") {
+                                alias.drop_bare_positionals = value.as_boolean();
+                            } else if (key == "dropped_note") {
+                                alias.dropped_note = value.as_string();
+                            } else if (key == "leading_positionals") {
+                                alias.leading_positionals = value.as_boolean();
+                            } else if (key == "positional_suffix_gate") {
+                                alias.positional_suffix_gate = value.as_string();
+                            } else if (key == "gate_reject_message") {
+                                alias.gate_reject_message = value.as_string();
+                            } else {
+                                const auto location = value.location();
+                                print_and_log_warning(
+                                    *logger,
+                                    M_("Unknown attribute \"{}\" of command flag alias \"{}\" in file \"{}\" "
+                                       "on line {}: {}"),
+                                    key,
+                                    element_id_path,
+                                    config_file_path.native(),
+                                    location_first_line_num(location),
+                                    location_lines(location));
+                            }
+                        }
+                    } catch (const toml::type_error & e) {
+                        auto location = e.location();
+                        print_and_log_error(
+                            *logger,
+                            M_("Bad value type in file \"{}\" on line {}: {}"),
+                            config_file_path.native(),
+                            location_first_line_num(location),
+                            location_lines(location));
+                        continue;
+                    }
+                    if (broken) {
+                        continue;
+                    }
+                    if (!defined) {
+                        print_and_log_error(
+                            *logger,
+                            M_("Missing attribute \"attached_command\" or \"reject_message\" for element \"{}\" in "
+                               "file \"{}\""),
+                            element_id_path,
+                            config_file_path.native());
+                        continue;
+                    }
+                    command_flag_aliases.emplace(alias_key, std::move(alias));
+                    continue;
+                }
+            }
             ArgParser::Command * element_parent_cmd;
             try {
                 element_parent_cmd = &arg_parser.get_command(element_parent_id_path);
@@ -818,7 +1069,10 @@ void load_aliases_from_toml_file(
 }  // namespace
 
 void load_cmdline_aliases(
-    Context & context, const std::filesystem::path & config_dir_path, const std::string & locale) {
+    Context & context,
+    const std::filesystem::path & config_dir_path,
+    const std::string & locale,
+    CommandFlagAliasTable & command_flag_aliases) {
     auto logger = context.get_base().get_logger();
 
     std::vector<fs::path> config_paths;
@@ -832,8 +1086,348 @@ void load_cmdline_aliases(
 
     const std::string locale_name = locale.substr(0, locale.find('.'));  // Strip encoding (e.g. ".UTF-8") from locale
     for (const auto & path : config_paths) {
-        load_aliases_from_toml_file(context, path, locale_name);
+        load_aliases_from_toml_file(context, path, locale_name, command_flag_aliases);
     }
+}
+
+
+namespace {
+
+/// Collects the value-taking named arguments visible to the rewrite: global
+/// options on the root command, options of the given command word, and
+/// options of every resolvable prefix of the attached command path.
+std::vector<libdnf5::cli::ArgumentParser::NamedArg *> collect_value_args(
+    libdnf5::cli::ArgumentParser & arg_parser, const std::string & cmd_word, const std::vector<std::string> & words) {
+    std::vector<libdnf5::cli::ArgumentParser::NamedArg *> value_args;
+    auto add_from = [&value_args, &arg_parser](const std::string & path) {
+        try {
+            for (auto * named_arg : arg_parser.get_command(path).get_named_args()) {
+                if (named_arg->get_has_value()) {
+                    value_args.push_back(named_arg);
+                }
+            }
+        } catch (const libdnf5::cli::ArgumentParserNotFoundError &) {
+        }
+    };
+    add_from("");
+    if (!cmd_word.empty()) {
+        add_from(cmd_word);
+    }
+    std::string path;
+    for (const auto & word : words) {
+        path = path.empty() ? word : path + "." + word;
+        add_from(path);
+    }
+    return value_args;
+}
+
+/// Whether the token is an option that takes its value as the next argument.
+bool takes_separate_value(
+    const std::vector<libdnf5::cli::ArgumentParser::NamedArg *> & value_args, const std::string & token) {
+    if (token.rfind("-", 0) != 0 || token.find('=') != std::string::npos) {
+        return false;
+    }
+    for (auto * named_arg : value_args) {
+        if (token.rfind("--", 0) == 0) {
+            if (!named_arg->get_long_name().empty() && token.substr(2) == named_arg->get_long_name()) {
+                return true;
+            }
+        } else if (token.size() == 2 && named_arg->get_short_name() == token[1]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+std::optional<RewrittenArgv> apply_command_flag_aliases(
+    Context & context, const CommandFlagAliasTable & command_flag_aliases, int argc, const char * const * argv) {
+    if (command_flag_aliases.empty()) {
+        return std::nullopt;
+    }
+    auto & arg_parser = context.get_argument_parser();
+    auto & logger = *context.get_base().get_logger();
+
+    // The command word is the first argument that is not an option and not
+    // the value of a preceding value-taking global option.
+    const auto root_value_args = collect_value_args(arg_parser, "", {});
+    int cmd_i = -1;
+    for (int i = 1; i < argc; ++i) {
+        if (argv[i][0] != '-') {
+            cmd_i = i;
+            break;
+        }
+        if (takes_separate_value(root_value_args, argv[i])) {
+            ++i;  // the next token is the option's value, not the command
+        }
+    }
+    if (cmd_i <= 0) {
+        return std::nullopt;
+    }
+    const std::string cmd_word = argv[cmd_i];
+
+    // Select the entry to execute before executing anything: a dnf4 line can
+    // carry several matching flags in any order ('updateinfo --all --list').
+    // The highest-precedence match executes; ties go to the leftmost token.
+    // A trigger that names an existing option of the command would change
+    // the meaning of a working command line; such entries are ignored.
+    auto is_existing_option = [&arg_parser, &cmd_word](const std::string & flag_name) {
+        for (const auto & path : {std::string(), cmd_word}) {
+            try {
+                for (auto * named_arg : arg_parser.get_command(path).get_named_args()) {
+                    if (named_arg->get_long_name() == flag_name) {
+                        return true;
+                    }
+                }
+            } catch (const libdnf5::cli::ArgumentParserNotFoundError &) {
+            }
+        }
+        return false;
+    };
+
+    auto best_it = command_flag_aliases.end();
+    int best_i = -1;
+    std::set<std::string> shadow_warned;
+    // The scan must know the value-taking options of every candidate
+    // attached command too: their values must not be read as triggers.
+    auto scan_value_args = collect_value_args(arg_parser, cmd_word, {});
+    for (const auto & [alias_key, alias_entry] : command_flag_aliases) {
+        if (alias_key.first != cmd_word || alias_entry.words.empty()) {
+            continue;
+        }
+        for (auto * named_arg : collect_value_args(arg_parser, "", alias_entry.words)) {
+            if (std::find(scan_value_args.begin(), scan_value_args.end(), named_arg) == scan_value_args.end()) {
+                scan_value_args.push_back(named_arg);
+            }
+        }
+    }
+    for (int i = cmd_i + 1; i < argc; ++i) {
+        std::string token = argv[i];
+        if (takes_separate_value(scan_value_args, token)) {
+            ++i;  // the next token is the option's value, not a trigger
+            continue;
+        }
+        const auto eq = token.find('=');
+        if (token.rfind("--", 0) == 0 && eq != std::string::npos) {
+            token = token.substr(0, eq);
+        }
+        const auto entry = command_flag_aliases.find({cmd_word, token});
+        if (entry == command_flag_aliases.end()) {
+            continue;
+        }
+        if (is_existing_option(entry->first.second.substr(2))) {
+            if (shadow_warned.insert(entry->first.second).second) {
+                print_and_log_warning(
+                    logger,
+                    M_("Command flag alias \"{}.{}\" matches an existing option of the command, ignored"),
+                    cmd_word,
+                    entry->first.second.substr(2));
+            }
+            continue;
+        }
+        if (best_it == command_flag_aliases.end() || entry->second.precedence > best_it->second.precedence) {
+            best_it = entry;
+            best_i = i;
+        }
+    }
+    if (best_it == command_flag_aliases.end()) {
+        return std::nullopt;
+    }
+    // Everything after a bare "--" is an operand by parser contract; the
+    // rewrite cannot preserve that boundary, so leave such lines untouched.
+    for (int i = 1; i < argc; ++i) {
+        if (std::string_view{argv[i]} == "--") {
+            return std::nullopt;
+        }
+    }
+    const auto & alias = best_it->second;
+
+    if (!alias.reject_message.empty()) {
+        // Print the guidance and leave the arguments untouched so the parser
+        // produces its normal error.
+        std::cerr << alias.reject_message << std::endl;
+        logger.warning("Command flag alias for \"{} {}\": {}", cmd_word, argv[best_i], alias.reject_message);
+        return std::nullopt;
+    }
+
+    // Validate the attached command before rewriting so a broken alias entry
+    // produces a clear error instead of a confusing parse error.
+    std::string attached_path;
+    for (const auto & word : alias.words) {
+        attached_path = attached_path.empty() ? word : attached_path + "." + word;
+    }
+    try {
+        arg_parser.get_command(attached_path);
+    } catch (const libdnf5::cli::ArgumentParserNotFoundError &) {
+        print_and_log_error(
+            logger,
+            M_("Attached command \"{}\" of command flag alias \"{}{}\" not found"),
+            attached_path,
+            cmd_word + ".",
+            best_it->first.second.substr(2));
+        return std::nullopt;
+    }
+
+    std::string eq_value;
+    bool has_eq = false;
+    {
+        const std::string token = argv[best_i];
+        const auto eq = token.find('=');
+        if (token.rfind("--", 0) == 0 && eq != std::string::npos) {
+            has_eq = true;
+            eq_value = token.substr(eq + 1);
+        }
+    }
+    // A value given in the --flag=VALUE form is only meaningful with a
+    // template, and an empty value is only meaningful to reject. Otherwise
+    // print a note and leave the arguments untouched so the parser error
+    // stands instead of the value being silently discarded.
+    if (has_eq && (alias.positional_template.empty() || eq_value.empty())) {
+        const auto note =
+            alias.positional_template.empty()
+                ? libdnf5::utils::sformat(
+                      _("Command flag alias \"{}.{}\" does not accept a value"),
+                      cmd_word,
+                      best_it->first.second.substr(2))
+                : libdnf5::utils::sformat(
+                      _("Command flag alias \"{}.{}\" requires a value"), cmd_word, best_it->first.second.substr(2));
+        std::cerr << note << std::endl;
+        logger.warning("{}", note);
+        return std::nullopt;
+    }
+
+    const auto value_args = collect_value_args(arg_parser, cmd_word, alias.words);
+
+    if (!alias.positional_suffix_gate.empty()) {
+        bool gate_ok = true;
+        const auto & suffix = alias.positional_suffix_gate;
+        auto ends_with = [&suffix](const std::string & value) {
+            return value.size() >= suffix.size() &&
+                   value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+        };
+        if (!eq_value.empty() && !ends_with(eq_value)) {
+            gate_ok = false;
+        }
+        bool skip_value = false;
+        const int gate_from = alias.leading_positionals ? cmd_i + 1 : best_i + 1;
+        for (int j = gate_from; gate_ok && j < argc; ++j) {
+            if (j == best_i) {
+                continue;
+            }
+            const std::string value = argv[j];
+            if (skip_value) {
+                skip_value = false;
+                continue;
+            }
+            if (takes_separate_value(value_args, value)) {
+                skip_value = true;
+                continue;
+            }
+            if (value.rfind("-", 0) != 0 && !ends_with(value)) {
+                gate_ok = false;
+            }
+        }
+        if (!gate_ok) {
+            // Value shape does not match; print the guidance and leave the
+            // arguments untouched (the normal parser error stands).
+            if (!alias.gate_reject_message.empty()) {
+                std::cerr << alias.gate_reject_message << std::endl;
+                logger.warning(
+                    "Command flag alias for \"{} {}\": {}", cmd_word, argv[best_i], alias.gate_reject_message);
+            }
+            return std::nullopt;
+        }
+    }
+
+    auto apply_template = [](const std::string & template_string, const std::string & value) {
+        std::string out = template_string;
+        const auto placeholder = out.find("${}");
+        if (placeholder != std::string::npos) {
+            out.replace(placeholder, 3, value);
+        }
+        return out;
+    };
+
+    RewrittenArgv rewritten;
+    bool copy_value_verbatim = false;
+    for (int j = 0; j < argc; ++j) {
+        if (j == cmd_i) {
+            for (const auto & word : alias.words) {
+                rewritten.storage.emplace_back(word);
+            }
+            for (const auto & flag : alias.attached_flags) {
+                rewritten.storage.emplace_back(flag);
+            }
+            if (!eq_value.empty()) {
+                rewritten.storage.emplace_back(apply_template(alias.positional_template, eq_value));
+            }
+            continue;
+        }
+        if (j == best_i) {
+            continue;
+        }
+        std::string current = argv[j];
+        if (copy_value_verbatim) {
+            // The value of the preceding value-taking option, not an operand.
+            copy_value_verbatim = false;
+            rewritten.storage.emplace_back(std::move(current));
+            continue;
+        }
+        if (j > cmd_i && !alias.companion_flag.empty() && current == alias.companion_flag) {
+            continue;  // consumed together with the trigger flag
+        }
+        // dnf4 grammars marked leading_positionals accepted operands before
+        // the flag too; tokens before the command word stay untouched.
+        const bool operand_scope = j > best_i || (alias.leading_positionals && j > cmd_i && j < best_i);
+        if (j > cmd_i && takes_separate_value(value_args, current)) {
+            // The next token is this option's value wherever the option
+            // stands, so the value slot is protected in the whole line.
+            copy_value_verbatim = true;
+            rewritten.storage.emplace_back(std::move(current));
+            continue;
+        }
+        if (operand_scope && current.rfind("-", 0) != 0 && alias.drop_bare_positionals &&
+            current.find('=') == std::string::npos) {
+            // dnf4 allowed redundant bare arguments here; dnf5's target
+            // grammar has no place for them. Drop, loudly.
+            if (!alias.dropped_note.empty()) {
+                const auto note =
+                    libdnf5::utils::sformat(_("{}: ignoring argument \"{}\""), alias.dropped_note, current);
+                std::cerr << note << std::endl;
+                logger.warning("{}", note);
+            }
+            continue;
+        }
+        if (operand_scope && current.rfind("-", 0) != 0 && !alias.positional_template.empty()) {
+            rewritten.storage.emplace_back(apply_template(alias.positional_template, current));
+            continue;
+        }
+        if (operand_scope && current.rfind("-", 0) == 0) {
+            bool mapped = false;
+            for (const auto & [prefix, map_template] : alias.token_prefix_maps) {
+                if (current.rfind(prefix, 0) == 0) {
+                    rewritten.storage.emplace_back(apply_template(map_template, current.substr(prefix.size())));
+                    mapped = true;
+                    break;
+                }
+            }
+            if (mapped) {
+                continue;
+            }
+        }
+        rewritten.storage.emplace_back(std::move(current));
+    }
+    rewritten.argv.reserve(rewritten.storage.size());
+    for (const auto & piece : rewritten.storage) {
+        rewritten.argv.push_back(piece.c_str());
+    }
+    logger.debug(
+        "Command flag alias \"{}.{}\" rewrote the command line to: {}",
+        cmd_word,
+        best_it->first.second.substr(2),
+        libdnf5::utils::string::join(rewritten.storage, " "));
+    return rewritten;
 }
 
 }  // namespace dnf5

--- a/dnf5/cmdline_aliases.hpp
+++ b/dnf5/cmdline_aliases.hpp
@@ -23,12 +23,72 @@
 #include "dnf5/context.hpp"
 
 #include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace dnf5 {
 
-/// Creates groups and aliases of command line arguments as defined in configuration files
+/// dnf4 compatibility: one 'command_flag' alias entry. The key of the table
+/// is (command id path, flag including the leading dashes). Entries are
+/// filled by the alias loader and applied by apply_command_flag_aliases().
+struct CommandFlagAlias {
+    /// words of the attached command path; empty when reject_message is set
+    std::vector<std::string> words;
+    /// options always passed after the attached command
+    std::vector<std::string> attached_flags;
+    /// template applied to each following positional; ${} is the value
+    std::string positional_template;
+    /// prefix rewrite map for following dashed tokens: prefix -> template
+    std::vector<std::pair<std::string, std::string>> token_prefix_maps;
+    /// when the flag appears together with this companion flag, the
+    /// companion is consumed too
+    std::string companion_flag;
+    /// when true: following bare positionals are dropped instead of copied;
+    /// dropped_note is printed per drop
+    bool drop_bare_positionals = false;
+    std::string dropped_note;
+    /// when true: the value handling also covers tokens between the command
+    /// word and the trigger flag
+    bool leading_positionals = false;
+    /// when set: the rewrite only applies if every following value ends with
+    /// this suffix; otherwise gate_reject_message is printed if set and the
+    /// arguments are left untouched
+    std::string positional_suffix_gate;
+    std::string gate_reject_message;
+    /// when set: matching prints this message and no rewrite happens
+    std::string reject_message;
+    /// when several tokens on one line match entries, the highest precedence
+    /// executes; ties go to the leftmost token
+    int precedence = 0;
+};
+
+using CommandFlagAliasTable = std::map<std::pair<std::string, std::string>, CommandFlagAlias>;
+
+/// Command line rewritten by a 'command_flag' alias. The argv pointers point
+/// into storage, so the object must outlive the parsing.
+struct RewrittenArgv {
+    std::vector<std::string> storage;
+    std::vector<const char *> argv;
+};
+
+/// Creates groups and aliases of command line arguments as defined in configuration files.
+/// 'command_flag' alias entries are recorded into the given table instead of
+/// being registered with the argument parser.
 void load_cmdline_aliases(
-    Context & context, const std::filesystem::path & config_dir_path, const std::string & locale_name);
+    Context & context,
+    const std::filesystem::path & config_dir_path,
+    const std::string & locale_name,
+    CommandFlagAliasTable & command_flag_aliases);
+
+/// Applies 'command_flag' aliases: a dnf4 flag that selects a dnf5 subcommand
+/// is translated, with optional rewriting of the values that follow it,
+/// before parsing. Returns std::nullopt when no entry matched or the matched
+/// entry declined the rewrite; parse the original arguments in that case.
+std::optional<RewrittenArgv> apply_command_flag_aliases(
+    Context & context, const CommandFlagAliasTable & command_flag_aliases, int argc, const char * const * argv);
 
 }  // namespace dnf5
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -813,11 +813,12 @@ static void load_plugins(Context & context) {
     }
 }
 
-static void load_cmdline_aliases(Context & context) {
+static void load_cmdline_aliases(Context & context, CommandFlagAliasTable & command_flag_aliases) {
     std::string locale_name = setlocale(LC_MESSAGES, NULL);
-    load_cmdline_aliases(context, INSTALL_PREFIX "/share/dnf5/aliases.d", locale_name);
-    load_cmdline_aliases(context, SYSCONFIG_DIR "/dnf/dnf5-aliases.d", locale_name);
-    load_cmdline_aliases(context, libdnf5::xdg::get_user_config_dir() / "dnf5/aliases.d", locale_name);
+    load_cmdline_aliases(context, INSTALL_PREFIX "/share/dnf5/aliases.d", locale_name, command_flag_aliases);
+    load_cmdline_aliases(context, SYSCONFIG_DIR "/dnf/dnf5-aliases.d", locale_name, command_flag_aliases);
+    load_cmdline_aliases(
+        context, libdnf5::xdg::get_user_config_dir() / "dnf5/aliases.d", locale_name, command_flag_aliases);
 }
 
 static void print_versions(Context & context) {
@@ -1333,7 +1334,8 @@ int main(int argc, char * argv[]) try {
 
         dnf5::add_commands(context);
         dnf5::load_plugins(context);
-        dnf5::load_cmdline_aliases(context);
+        dnf5::CommandFlagAliasTable command_flag_aliases;
+        dnf5::load_cmdline_aliases(context, command_flag_aliases);
 
         // Argument completion handler
         // If the argument at position 1 is "--complete=<index>[,add_description=1/0]", this is a request to complete
@@ -1369,11 +1371,23 @@ int main(int argc, char * argv[]) try {
             return 0;
         }
 
+        // dnf4 compatibility: apply 'command_flag' aliases ("updateinfo
+        // --list" -> "advisory list") before parsing. Logs and history keep
+        // the command line as the user typed it, and command lines that
+        // match no entry are not touched.
+        const auto rewritten_args = dnf5::apply_command_flag_aliases(context, command_flag_aliases, argc, argv);
+        int parse_argc = argc;
+        const char * const * parse_argv = argv;
+        if (rewritten_args) {
+            parse_argc = static_cast<int>(rewritten_args->argv.size());
+            parse_argv = rewritten_args->argv.data();
+        }
+
         // Parse command line arguments
         {
             auto & arg_parser = context.get_argument_parser();
             try {
-                arg_parser.parse(argc, argv);
+                arg_parser.parse(parse_argc, parse_argv);
             } catch (libdnf5::cli::ArgumentParserError & ex) {
                 // Error during parsing arguments. Try to find "--help"/"-h".
                 bool help_printed{false};

--- a/doc/misc/aliases.7.rst
+++ b/doc/misc/aliases.7.rst
@@ -66,6 +66,7 @@ There are the following types of aliases:
     - :ref:`command <aliases_misc_command_ref-label>`
     - :ref:`cloned_named_arg <aliases_misc_cloned_named_arg_ref-label>`
     - :ref:`named_arg <aliases_misc_named_arg_ref-label>`
+    - :ref:`command_flag <aliases_misc_command_flag_ref-label>`
     - :ref:`group <aliases_misc_group_ref-label>`
 
 
@@ -269,6 +270,75 @@ Examples:
         attached_named_args = [
          { id_path = 'setopt', value = 'tsflags=${}' }
         ]
+
+
+.. _aliases_misc_command_flag_ref-label:
+
+Type: command_flag
+------------------
+
+The ``command_flag`` alias maps an option to a command and can rewrite the values that follow it. It serves
+compatibility with grammars where an option selected what is a separate command now, for example DNF4's
+``updateinfo --list``. When the named command and the option both appear on the command line, the arguments
+are translated before parsing: the command word is replaced by the attached command and the option is
+consumed. Command lines that match no entry are not touched, and logs and history keep the command line
+as the user typed it. Added in config file version 1.2.
+
+The element name has the ``<command>.<option name without dashes>`` form. The entry matches the long
+option ``--<option name>`` of ``<command>``; short options cannot be triggers. Command lines that contain the ``--`` separator are never rewritten. An entry whose
+option already exists for the command is ignored with a warning.
+
+Keys:
+    - ``type`` - Must have value ``command_flag``.
+    - ``attached_command`` - Path to the command that the option selects.
+    - ``attached_flags`` - Array of options that are always passed with the attached command.
+    - ``positional_template`` - Template applied to each following positional argument; ``${}`` is replaced
+      by the value. Also applied to a value given in the ``--option=value`` form.
+    - ``token_prefix_maps`` - Array of tables with ``prefix`` and ``template`` keys. A following option that
+      starts with ``prefix`` is replaced by ``template``, with ``${}`` replaced by the rest of the option.
+    - ``companion_flag`` - An option consumed together with the trigger option.
+    - ``leading_positionals`` - When true, the value handling also covers positional arguments between the
+      command and the trigger option. Default is false.
+    - ``drop_bare_positionals`` - When true, following positional arguments are dropped instead of copied.
+      Default is false.
+    - ``dropped_note`` - Message printed to standard error for each dropped argument.
+    - ``positional_suffix_gate`` - When set, the translation applies only if every following value ends with
+      this suffix; otherwise the arguments are left unchanged and ``gate_reject_message``, if set, is printed
+      to standard error.
+    - ``gate_reject_message`` - Message printed when the suffix gate does not match.
+    - ``reject_message`` - When set, matching prints this message to standard error and no translation
+      happens. Use it to give guidance for grammars with no equivalent; the normal parser error follows.
+    - ``precedence`` - When several options on one command line match entries, the entry with the highest
+      precedence is used; ties go to the leftmost option. Default is 0.
+
+The required keys are ``type``, and either ``attached_command`` or ``reject_message``.
+
+Examples:
+  - DNF4's ``updateinfo --list`` runs ``advisory list``:
+
+    .. code-block:: TOML
+
+        ['updateinfo.list']
+        type = 'command_flag'
+        attached_command = 'advisory.list'
+
+  - An option that selects a subcommand and always adds an option to it:
+
+    .. code-block:: TOML
+
+        ['updateinfo.summary']
+        type = 'command_flag'
+        attached_command = 'advisory.summary'
+        attached_flags = ['--with-cve']
+
+  - DNF4's ``config-manager --set-enabled repo1 repo2`` runs ``config-manager setopt repo1.enabled=1 repo2.enabled=1``:
+
+    .. code-block:: TOML
+
+        ['config-manager.set-enabled']
+        type = 'command_flag'
+        attached_command = 'config-manager.setopt'
+        positional_template = '${}.enabled=1'
 
 
 .. _aliases_misc_group_ref-label:

--- a/integration-tests/dnf-behave-tests/dnf/aliases.feature
+++ b/integration-tests/dnf-behave-tests/dnf/aliases.feature
@@ -165,3 +165,228 @@ Test Query Aliases:
   ls                            Alias for 'repo list'
   if                            Alias for 'repo info'
 """
+
+
+Scenario: command_flag alias maps a dnf4 flag to a subcommand
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+"""
+ When I execute dnf with args "updateinfo --list"
+ Then the exit code is 0
+
+
+Scenario: command_flag alias rewrites following values through a template
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.whatneeds']
+type = 'command_flag'
+attached_command = 'repoquery'
+positional_template = '--whatrequires=${}'
+"""
+ When I execute dnf with args "repoquery --whatneeds labirinto"
+ Then the exit code is 0
+  And stdout contains "vagare"
+
+
+Scenario: command_flag alias requires config file version 1.2
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.1'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+"""
+ When I execute dnf with args "updateinfo --list"
+ Then the exit code is 2
+  And stderr contains "Used config file version \"1.1\" for alias type \"command_flag\""
+
+
+Scenario: command_flag alias with reject_message prints guidance and keeps the parser error
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.nogo']
+type = 'command_flag'
+reject_message = 'The nogo option has no equivalent'
+"""
+ When I execute dnf with args "repoquery --nogo"
+ Then the exit code is 2
+  And stderr contains "The nogo option has no equivalent"
+  And stderr contains "Unknown argument \"--nogo\""
+
+
+Scenario: command_flag alias with precedence picks the right entry when several flags match
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+precedence = 10
+
+['updateinfo.all']
+type = 'command_flag'
+attached_command = 'advisory.list'
+"""
+ When I execute dnf with args "updateinfo --all --list"
+ Then the exit code is 0
+
+
+Scenario: command_flag alias rewrites dashed tokens through a prefix map
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.needsmap']
+type = 'command_flag'
+attached_command = 'repoquery'
+token_prefix_maps = [{ prefix = '--need-', template = '--whatrequires=${}' }]
+"""
+ When I execute dnf with args "repoquery --needsmap --need-labirinto"
+ Then the exit code is 0
+  And stdout contains "vagare"
+
+
+Scenario: command_flag alias leaves a value of a following option untouched
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.whatneeds']
+type = 'command_flag'
+attached_command = 'repoquery'
+positional_template = '--whatrequires=${}'
+"""
+ When I execute dnf with args "repoquery --whatneeds labirinto --exclude foo"
+ Then the exit code is 0
+  And stdout contains "vagare"
+
+
+Scenario: command lines that match no command_flag alias are not touched
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+"""
+ When I execute dnf with args "repoquery --no-such-option"
+ Then the exit code is 2
+  And stderr contains "Unknown argument \"--no-such-option\""
+
+
+Scenario: command_flag alias drops redundant bare operands with a note
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.dropper']
+type = 'command_flag'
+attached_command = 'repoquery'
+drop_bare_positionals = true
+dropped_note = 'The dropper option takes no arguments'
+"""
+ When I execute dnf with args "repoquery --dropper labirinto"
+ Then the exit code is 0
+  And stderr contains "The dropper option takes no arguments: ignoring argument \"labirinto\""
+
+
+Scenario: command_flag alias with a value gate prints guidance when values do not match
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.gatedneeds']
+type = 'command_flag'
+attached_command = 'repoquery'
+positional_template = '--whatrequires=${}'
+positional_suffix_gate = '.rpm'
+gate_reject_message = 'The gatedneeds option only translates .rpm values'
+"""
+ When I execute dnf with args "repoquery --gatedneeds labirinto"
+ Then the exit code is 2
+  And stderr contains "The gatedneeds option only translates .rpm values"
+
+
+Scenario: command_flag alias naming an existing option is ignored and other entries still fire
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['repoquery.available']
+type = 'command_flag'
+attached_command = 'repoquery'
+
+['repoquery.whatneeds']
+type = 'command_flag'
+attached_command = 'repoquery'
+positional_template = '--whatrequires=${}'
+"""
+ When I execute dnf with args "repoquery --available --whatneeds labirinto"
+ Then the exit code is 0
+  And stdout contains "vagare"
+  And stderr contains "Command flag alias \"repoquery.available\" matches an existing option of the command, ignored"
+
+
+Scenario: command_flag alias keeps the typed command line in the log
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+"""
+ When I execute dnf with args "updateinfo --list"
+ Then the exit code is 0
+  And file "/var/log/dnf5.log" contains lines
+"""
+DNF5 launched with arguments: ".*updateinfo --list"
+rewrote the command line to: .*advisory list
+"""
+  And file "/var/log/dnf5.log" does not contain lines
+"""
+DNF5 launched with arguments: ".*advisory list"
+"""
+
+
+Scenario: command_flag alias does not read a value of an attached command option as a trigger
+Given I create directory "//etc/dnf/dnf5-aliases.d"
+  And I create file "//etc/dnf/dnf5-aliases.d/TEST_ALIASES.conf" with
+"""
+version = '1.2'
+
+['updateinfo.list']
+type = 'command_flag'
+attached_command = 'advisory.list'
+
+['updateinfo.all']
+type = 'command_flag'
+attached_command = 'advisory.info'
+precedence = 50
+"""
+ When I execute dnf with args "updateinfo --list --contains-pkgs --all"
+ Then the exit code is 0


### PR DESCRIPTION
Closes #2925.

Adds a `command_flag` alias type to aliases.d, gated behind a new config file version 1.2. An entry names a command, a flag, and the command it selects. When both appear on the command line, the arguments are translated before parsing, so `updateinfo --list` runs `advisory list`.

Optional keys cover the dnf4 grammars where the flag also changed how the following values were read: `positional_template` rewrites following positionals and `--flag=value` forms, `token_prefix_maps` rewrites dashed tokens by prefix, `attached_flags` passes fixed options with the selected command, `companion_flag` consumes a second flag together with the trigger, `precedence` picks one entry when several flags on one line match, `leading_positionals` extends value handling to operands before the flag, `drop_bare_positionals` with `dropped_note` drops redundant operands loudly, `positional_suffix_gate` with `gate_reject_message` limits the rewrite to values of the expected shape, and `reject_message` prints guidance while the normal parser error stands.

Design notes:

- Version gating follows the existing pattern: files declaring 1.0 or 1.1 report the same style of error as other version-gated attributes, so older dnf5 releases refuse the new type cleanly.
- The rewrite never guesses. It declines and leaves the arguments untouched whenever it cannot translate faithfully: a `--flag=value` form without a template, an empty `=` value, a command line containing the `--` separator, values that fail the suffix gate, or an attached command that does not resolve. In each case the user sees a note plus the parser's normal error.
- Values of value-taking options are protected on the whole line: they are never treated as triggers, never templated, never dropped, and never consumed as companion flags.
- The rewrite runs after the `--complete=` handler and after the command line is captured for logs and history, so completion input and history keep the command line as the user typed it. The rewritten form is logged at debug level.
- The loader reports wrong value types, unknown attributes, duplicate entries, and unusable element names with the same diagnostics as the existing alias types. Entries are recorded in a table owned by `main()`; nothing is stored in globals.
- No library or API changes: the whole change lives in the `dnf5` binary sources, its man page, and the behave tests.

Testing:

- 10 new behave scenarios cover the rewrite, the value template, prefix maps, precedence, values of following options, the drop note, the gate guidance, the version gate, the reject path, and that non-matching command lines are untouched. All pass against the built binary, along with the pre-existing aliases scenarios.
- Manual verification against a live repository confirmed rewritten queries produce byte-identical output to typing the target command directly, including the `--flag=value` form and flags supplied through `attached_flags`.
- The binary was also exercised under AddressSanitizer and UndefinedBehaviorSanitizer across the full option matrix with no findings.