### PR TITLE
VendorChangeManager: Extend save_policy_from_* methods API

### DIFF
--- a/include/libdnf5/base/vendor_change_manager.hpp
+++ b/include/libdnf5/base/vendor_change_manager.hpp
@@ -140,10 +140,17 @@ public:
     /// @param source Origin of the policy (for error messages and validation).
     /// @param base_filename Base filename without extension or path (e.g., ``"my-policy"``).
     ///                      Must not contain path components. The ``.conf`` extension is added automatically.
+    /// @param allow_replace If ``true``, allows overwriting an existing policy file.
+    ///                        If ``false``, throws if the file already exists.
+    /// @return Path to the created policy file.
     /// @throws VendorChangeManagerError if validation or file write fails,
-    ///                                  or if base_filename contains path components.
-    void save_policy_from_toml(
-        std::string_view toml_content, std::string_view source, const std::filesystem::path & base_filename);
+    ///                                  if base_filename contains path components,
+    ///                                  or if file exists and allow_replace is false.
+    std::filesystem::path save_policy_from_toml(
+        std::string_view toml_content,
+        std::string_view source,
+        const std::filesystem::path & base_filename,
+        bool allow_replace);
 
     /// Save a vendor change policy from a TOML file to a configuration file
     /// in the vendor directory (``/etc/dnf/vendors.d/`` or installroot equivalent).
@@ -151,9 +158,14 @@ public:
     /// @param path Path to the TOML file containing the policy.
     /// @param base_filename Base filename without extension or path (e.g., ``"my-policy"``).
     ///                      Must not contain path components. The ``.conf`` extension is added automatically.
+    /// @param allow_replace If ``true``, allows overwriting an existing policy file.
+    ///                        If ``false``, throws if the file already exists.
+    /// @return Path to the created policy file.
     /// @throws VendorChangeManagerError if file read, validation, or write fails,
-    ///                                  or if base_filename contains path components.
-    void save_policy_from_toml(const std::filesystem::path & path, const std::filesystem::path & base_filename);
+    ///                                  if base_filename contains path components,
+    ///                                  or if file exists and allow_replace is false.
+    std::filesystem::path save_policy_from_toml(
+        const std::filesystem::path & path, const std::filesystem::path & base_filename, bool allow_replace);
 
     /// Save a vendor change policy from compact format to a configuration file
     /// in the vendor directory (``/etc/dnf/vendors.d/`` or installroot equivalent).
@@ -162,10 +174,17 @@ public:
     /// @param source Origin of the policy (for error messages).
     /// @param base_filename Base filename without extension or path (e.g., ``"my-policy"``).
     ///                      Must not contain path components. The ``.conf`` extension is added automatically.
+    /// @param allow_replace If ``true``, allows overwriting an existing policy file.
+    ///                        If ``false``, throws if the file already exists.
+    /// @return Path to the created policy file.
     /// @throws VendorChangeManagerError if conversion or file write fails,
-    ///                                  or if base_filename contains path components.
-    void save_policy_from_compact(
-        std::string_view policy_str, std::string_view source, const std::filesystem::path & base_filename);
+    ///                                  if base_filename contains path components,
+    ///                                  or if file exists and allow_replace is false.
+    std::filesystem::path save_policy_from_compact(
+        std::string_view policy_str,
+        std::string_view source,
+        const std::filesystem::path & base_filename,
+        bool allow_replace);
 
     /// Remove a vendor change policy configuration file.
     /// Removes the file from the vendor configuration directory (``/etc/dnf/vendors.d/`` or installroot equivalent).

--- a/libdnf5/base/vendor_change_manager.cpp
+++ b/libdnf5/base/vendor_change_manager.cpp
@@ -52,13 +52,20 @@ public:
 
     std::string get_loaded_policy_as_compact(std::size_t index) const { return vcm.get_policy_as_compact(index); }
 
-    void save_policy_from_toml(
-        std::string_view toml_content, std::string_view source, const std::filesystem::path & base_filename);
+    std::filesystem::path save_policy_from_toml(
+        std::string_view toml_content,
+        std::string_view source,
+        const std::filesystem::path & base_filename,
+        bool allow_replace);
 
-    void save_policy_from_toml(const std::filesystem::path & path, const std::filesystem::path & base_filename);
+    std::filesystem::path save_policy_from_toml(
+        const std::filesystem::path & path, const std::filesystem::path & base_filename, bool allow_replace);
 
-    void save_policy_from_compact(
-        std::string_view policy_str, std::string_view source, const std::filesystem::path & base_filename);
+    std::filesystem::path save_policy_from_compact(
+        std::string_view policy_str,
+        std::string_view source,
+        const std::filesystem::path & base_filename,
+        bool allow_replace);
 
     void remove_policy_file(const std::filesystem::path & base_filename);
 
@@ -73,8 +80,11 @@ public:
     WeakPtrGuard<VendorChangeManager, false> guard;
 
 private:
-    void save_policy_file(
-        std::string_view toml_content, const std::filesystem::path & base_filename, const char * caller_name);
+    std::filesystem::path save_policy_file(
+        std::string_view toml_content,
+        const std::filesystem::path & base_filename,
+        bool allow_replace,
+        const char * caller_name);
 
     std::filesystem::path get_vendor_conf_dir_path() const;
     std::filesystem::path get_distribution_vendor_conf_dir_path() const;
@@ -92,28 +102,34 @@ void VendorChangeManager::Impl::load_policies() {
 }
 
 
-void VendorChangeManager::Impl::save_policy_from_toml(
-    std::string_view toml_content, std::string_view source, const std::filesystem::path & base_filename) {
+std::filesystem::path VendorChangeManager::Impl::save_policy_from_toml(
+    std::string_view toml_content,
+    std::string_view source,
+    const std::filesystem::path & base_filename,
+    bool allow_replace) {
     // Validate TOML by parsing it
     solv::VendorChangeManager::convert_policy_toml_to_compact(toml_content, source);
-    save_policy_file(toml_content, base_filename, __func__);
+    return save_policy_file(toml_content, base_filename, allow_replace, __func__);
 }
 
 
-void VendorChangeManager::Impl::save_policy_from_toml(
-    const std::filesystem::path & path, const std::filesystem::path & base_filename) {
+std::filesystem::path VendorChangeManager::Impl::save_policy_from_toml(
+    const std::filesystem::path & path, const std::filesystem::path & base_filename, bool allow_replace) {
     // Read TOML content from file
     const std::string toml_content = utils::fs::File(path, "rb").read();
     // Validate TOML by parsing it
     solv::VendorChangeManager::convert_policy_toml_to_compact(toml_content, "file://" + path.string());
-    save_policy_file(toml_content, base_filename, __func__);
+    return save_policy_file(toml_content, base_filename, allow_replace, __func__);
 }
 
 
-void VendorChangeManager::Impl::save_policy_from_compact(
-    std::string_view policy_str, std::string_view source, const std::filesystem::path & base_filename) {
+std::filesystem::path VendorChangeManager::Impl::save_policy_from_compact(
+    std::string_view policy_str,
+    std::string_view source,
+    const std::filesystem::path & base_filename,
+    bool allow_replace) {
     const auto toml_content = solv::VendorChangeManager::convert_policy_compact_to_toml(policy_str, source);
-    save_policy_file(toml_content, base_filename, __func__);
+    return save_policy_file(toml_content, base_filename, allow_replace, __func__);
 }
 
 
@@ -203,13 +219,29 @@ std::filesystem::path VendorChangeManager::Impl::find_policy_file(const std::fil
 }
 
 
-void VendorChangeManager::Impl::save_policy_file(
-    std::string_view toml_content, const std::filesystem::path & base_filename, const char * caller_name) {
+std::filesystem::path VendorChangeManager::Impl::save_policy_file(
+    std::string_view toml_content,
+    const std::filesystem::path & base_filename,
+    bool allow_replace,
+    const char * caller_name) {
     namespace fs = std::filesystem;
 
     fs::path file_path = get_vendor_conf_dir_path() / make_policy_filename(base_filename);
 
-    // Use "wx" mode to fail if file already exists
+    // If allow_replace=true, remove existing file first to avoid following symlinks
+    if (allow_replace) {
+        try {
+            // Returns true if removed, false if didn't exist - both are OK
+            fs::remove(file_path);
+        } catch (...) {
+            libdnf5::throw_with_nested(VendorChangeManagerError(
+                M_("{func}(): Cannot remove existing policy file: {path}"),
+                NamedErrorArg("func", caller_name),
+                NamedErrorArg("path", file_path.string())));
+        }
+    }
+
+    // Always use "wxb" mode to fail if file exists
     utils::fs::File file;
     try {
         file.open(file_path, "wxb");
@@ -236,6 +268,8 @@ void VendorChangeManager::Impl::save_policy_file(
             NamedErrorArg("func", caller_name),
             NamedErrorArg("path", file_path.string())));
     }
+
+    return file_path;
 }
 
 
@@ -361,21 +395,27 @@ std::string VendorChangeManager::convert_policy_compact_to_toml(std::string_view
 }
 
 
-void VendorChangeManager::save_policy_from_toml(
-    std::string_view toml_content, std::string_view source, const std::filesystem::path & base_filename) {
-    p_impl->save_policy_from_toml(toml_content, source, base_filename);
+std::filesystem::path VendorChangeManager::save_policy_from_toml(
+    std::string_view toml_content,
+    std::string_view source,
+    const std::filesystem::path & base_filename,
+    bool allow_replace) {
+    return p_impl->save_policy_from_toml(toml_content, source, base_filename, allow_replace);
 }
 
 
-void VendorChangeManager::save_policy_from_toml(
-    const std::filesystem::path & path, const std::filesystem::path & base_filename) {
-    p_impl->save_policy_from_toml(path, base_filename);
+std::filesystem::path VendorChangeManager::save_policy_from_toml(
+    const std::filesystem::path & path, const std::filesystem::path & base_filename, bool allow_replace) {
+    return p_impl->save_policy_from_toml(path, base_filename, allow_replace);
 }
 
 
-void VendorChangeManager::save_policy_from_compact(
-    std::string_view policy_str, std::string_view source, const std::filesystem::path & base_filename) {
-    p_impl->save_policy_from_compact(policy_str, source, base_filename);
+std::filesystem::path VendorChangeManager::save_policy_from_compact(
+    std::string_view policy_str,
+    std::string_view source,
+    const std::filesystem::path & base_filename,
+    bool allow_replace) {
+    return p_impl->save_policy_from_compact(policy_str, source, base_filename, allow_replace);
 }
 
 

--- a/test/libdnf5/base/test_vendor_change_manager.cpp
+++ b/test/libdnf5/base/test_vendor_change_manager.cpp
@@ -364,15 +364,15 @@ void VendorChangeManagerTest::test_work_with_files() {
     CPPUNIT_ASSERT_EQUAL(distr_allow_fedora, files[1]);
 
     // Test save configuration file from string in compact format
-    vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora");
+    vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false);
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_2, libdnf5::utils::fs::File(allow_fedora, "rb").read());
     // fail - file already exists
     CPPUNIT_ASSERT_THROW(
-        vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora"),
+        vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false),
         libdnf5::base::VendorChangeManagerError);
 
     // Test save configuration file from string in TOML format
-    vcm->save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1");
+    vcm->save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false);
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, libdnf5::utils::fs::File(test1, "rb").read());
 
     // Test save configuration file from TOML file
@@ -381,7 +381,7 @@ void VendorChangeManagerTest::test_work_with_files() {
     {
         libdnf5::utils::fs::File(path, "w").write(POLICY_TOML_TEST_1);
     }
-    vcm->save_policy_from_toml(path, "from_toml_file");
+    vcm->save_policy_from_toml(path, "from_toml_file", false);
     CPPUNIT_ASSERT_EQUAL(
         POLICY_TOML_TEST_1, libdnf5::utils::fs::File(system_vendor_cfg_dir / "from_toml_file.conf", "rb").read());
 

--- a/test/libdnf5/base/test_vendor_change_manager.cpp
+++ b/test/libdnf5/base/test_vendor_change_manager.cpp
@@ -364,16 +364,25 @@ void VendorChangeManagerTest::test_work_with_files() {
     CPPUNIT_ASSERT_EQUAL(distr_allow_fedora, files[1]);
 
     // Test save configuration file from string in compact format
-    vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false);
+    auto saved_path = vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false);
+    CPPUNIT_ASSERT_EQUAL(allow_fedora, saved_path);
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_2, libdnf5::utils::fs::File(allow_fedora, "rb").read());
-    // fail - file already exists
+    // fail - file already exists when allow_replace=false
     CPPUNIT_ASSERT_THROW(
         vcm->save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false),
         libdnf5::base::VendorChangeManagerError);
+    // succeed - file can be replaced when allow_replace=true
+    saved_path = vcm->save_policy_from_compact(POLICY_COMPACT_TEST_1, "test:code", "allow_fedora", true);
+    CPPUNIT_ASSERT_EQUAL(allow_fedora, saved_path);
+    CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, libdnf5::utils::fs::File(allow_fedora, "rb").read());
 
     // Test save configuration file from string in TOML format
-    vcm->save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false);
+    saved_path = vcm->save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false);
+    CPPUNIT_ASSERT_EQUAL(test1, saved_path);
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, libdnf5::utils::fs::File(test1, "rb").read());
+    // Test replace with allow_replace=true
+    saved_path = vcm->save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", true);
+    CPPUNIT_ASSERT_EQUAL(test1, saved_path);
 
     // Test save configuration file from TOML file
     const std::filesystem::path installroot = base->get_config().get_installroot_option().get_value();
@@ -381,9 +390,17 @@ void VendorChangeManagerTest::test_work_with_files() {
     {
         libdnf5::utils::fs::File(path, "w").write(POLICY_TOML_TEST_1);
     }
-    vcm->save_policy_from_toml(path, "from_toml_file", false);
+    // It must work with allow_replace=true even if the target file does not exist.
+    saved_path = vcm->save_policy_from_toml(path, "from_toml_file", true);
+    CPPUNIT_ASSERT_EQUAL(system_vendor_cfg_dir / "from_toml_file.conf", saved_path);
     CPPUNIT_ASSERT_EQUAL(
         POLICY_TOML_TEST_1, libdnf5::utils::fs::File(system_vendor_cfg_dir / "from_toml_file.conf", "rb").read());
+    // fail - file already exists when allow_replace=false
+    CPPUNIT_ASSERT_THROW(
+        vcm->save_policy_from_toml(path, "from_toml_file", false), libdnf5::base::VendorChangeManagerError);
+    // Test replace with allow_replace=true
+    saved_path = vcm->save_policy_from_toml(path, "from_toml_file", true);
+    CPPUNIT_ASSERT_EQUAL(system_vendor_cfg_dir / "from_toml_file.conf", saved_path);
 
     files = vcm->get_policy_files();
     CPPUNIT_ASSERT_EQUAL(4U, static_cast<unsigned int>(files.size()));

--- a/test/perl5/libdnf5/base/test_vendor_change_manager.t
+++ b/test/perl5/libdnf5/base/test_vendor_change_manager.t
@@ -360,17 +360,26 @@ sub read_file {
     is($files[1], $distr_allow_fedora, "File 1 is distr_allow_fedora");
 
     # Test save_policy_from_compact
-    $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", 0);
+    my $saved_path = $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", 0);
+    is($saved_path, $allow_fedora, "save_policy_from_compact returned correct path");
     is(read_file($allow_fedora), $POLICY_TOML_TEST_2, "save_policy_from_compact wrote correct content");
 
-    # fail - file already exists
+    # fail - file already exists when allow_replace=0
     throws_ok {
         $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", 0);
     } qr//, "save_policy_from_compact throws on existing file";
+    # succeed - file can be replaced when allow_replace=1
+    $saved_path = $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_1, "test:code", "allow_fedora", 1);
+    is($saved_path, $allow_fedora, "save_policy_from_compact with replace returned correct path");
+    is(read_file($allow_fedora), $POLICY_TOML_TEST_1, "save_policy_from_compact with replace wrote correct content");
 
     # Test save_policy_from_toml with TOML content string
-    $vcm->save_policy_from_toml($POLICY_TOML_TEST_1, "test:code", "test1", 0);
+    $saved_path = $vcm->save_policy_from_toml($POLICY_TOML_TEST_1, "test:code", "test1", 0);
+    is($saved_path, $test1, "save_policy_from_toml(content) returned correct path");
     is(read_file($test1), $POLICY_TOML_TEST_1, "save_policy_from_toml(content) wrote correct content");
+    # Test overwrite with allow_replace=1
+    $saved_path = $vcm->save_policy_from_toml($POLICY_TOML_TEST_1, "test:code", "test1", 1);
+    is($saved_path, $test1, "save_policy_from_toml(content) with overwrite returned correct path");
 
     # Test save_policy_from_toml with TOML file
     my $installroot = $base->get_config()->get_installroot_option()->get_value();
@@ -378,9 +387,18 @@ sub read_file {
     my $path = "$installroot/tmp/toml_test1.conf";
     write_file($path, $POLICY_TOML_TEST_1);
 
-    $vcm->save_policy_from_toml($path, "from_toml_file", 0);
+    # It must work with allow_replace=1 even if the target file does not exist.
+    $saved_path = $vcm->save_policy_from_toml($path, "from_toml_file", 1);
     my $from_toml_file = "$system_vendor_cfg_dir/from_toml_file.conf";
+    is($saved_path, $from_toml_file, "save_policy_from_toml(path) returned correct path");
     is(read_file($from_toml_file), $POLICY_TOML_TEST_1, "save_policy_from_toml(path) wrote correct content");
+    # fail - file already exists when allow_replace=0
+    throws_ok {
+        $vcm->save_policy_from_toml($path, "from_toml_file", 0);
+    } qr//, "save_policy_from_toml throws on existing file";
+    # Test replace with allow_replace=1
+    $saved_path = $vcm->save_policy_from_toml($path, "from_toml_file", 1);
+    is($saved_path, $from_toml_file, "save_policy_from_toml(path) with replace returned correct path");
 
     $files = $vcm->get_policy_files();
     @files = @$files;

--- a/test/perl5/libdnf5/base/test_vendor_change_manager.t
+++ b/test/perl5/libdnf5/base/test_vendor_change_manager.t
@@ -360,16 +360,16 @@ sub read_file {
     is($files[1], $distr_allow_fedora, "File 1 is distr_allow_fedora");
 
     # Test save_policy_from_compact
-    $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora");
+    $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", 0);
     is(read_file($allow_fedora), $POLICY_TOML_TEST_2, "save_policy_from_compact wrote correct content");
 
     # fail - file already exists
     throws_ok {
-        $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora");
+        $vcm->save_policy_from_compact($POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", 0);
     } qr//, "save_policy_from_compact throws on existing file";
 
     # Test save_policy_from_toml with TOML content string
-    $vcm->save_policy_from_toml($POLICY_TOML_TEST_1, "test:code", "test1");
+    $vcm->save_policy_from_toml($POLICY_TOML_TEST_1, "test:code", "test1", 0);
     is(read_file($test1), $POLICY_TOML_TEST_1, "save_policy_from_toml(content) wrote correct content");
 
     # Test save_policy_from_toml with TOML file
@@ -378,7 +378,7 @@ sub read_file {
     my $path = "$installroot/tmp/toml_test1.conf";
     write_file($path, $POLICY_TOML_TEST_1);
 
-    $vcm->save_policy_from_toml($path, "from_toml_file");
+    $vcm->save_policy_from_toml($path, "from_toml_file", 0);
     my $from_toml_file = "$system_vendor_cfg_dir/from_toml_file.conf";
     is(read_file($from_toml_file), $POLICY_TOML_TEST_1, "save_policy_from_toml(path) wrote correct content");
 

--- a/test/python3/libdnf5/base/test_vendor_change_manager.py
+++ b/test/python3/libdnf5/base/test_vendor_change_manager.py
@@ -313,18 +313,28 @@ class TestVendorChangeManager(unittest.TestCase):
         self.assertEqual(files[1], distr_allow_fedora)
 
         # Test save_policy_from_compact
-        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", False)
+        saved_path = vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", False)
+        self.assertEqual(saved_path, allow_fedora)
         with open(allow_fedora, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_2)
 
-        # fail - file already exists
+        # fail - file already exists when allow_replace=False
         with self.assertRaises(libdnf5.exception.BaseVendorChangeManagerError):
             vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", False)
+        # succeed - file can be replaced when allow_replace=True
+        saved_path = vcm.save_policy_from_compact(POLICY_COMPACT_TEST_1, "test:code", "allow_fedora", True)
+        self.assertEqual(saved_path, allow_fedora)
+        with open(allow_fedora, 'r') as f:
+            self.assertEqual(f.read(), POLICY_TOML_TEST_1)
 
         # Test save_policy_from_toml with TOML content string
-        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", False)
+        saved_path = vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", False)
+        self.assertEqual(saved_path, test1)
         with open(test1, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_1)
+        # Test overwrite with allow_replace=True
+        saved_path = vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", True)
+        self.assertEqual(saved_path, test1)
 
         # Test save_policy_from_toml with TOML file
         installroot = self.base.get_config().installroot
@@ -332,10 +342,18 @@ class TestVendorChangeManager(unittest.TestCase):
         with open(path, 'w') as f:
             f.write(POLICY_TOML_TEST_1)
 
-        vcm.save_policy_from_toml(path, "from_toml_file", False)
+        # It must work with allow_replace=True even if the target file does not exist.
+        saved_path = vcm.save_policy_from_toml(path, "from_toml_file", True)
         from_toml_file = os.path.join(self.system_vendor_cfg_dir, "from_toml_file.conf")
+        self.assertEqual(saved_path, from_toml_file)
         with open(from_toml_file, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_1)
+        # fail - file already exists when allow_replace=False
+        with self.assertRaises(libdnf5.exception.BaseVendorChangeManagerError):
+            vcm.save_policy_from_toml(path, "from_toml_file", False)
+        # Test replace with allow_replace=True
+        saved_path = vcm.save_policy_from_toml(path, "from_toml_file", True)
+        self.assertEqual(saved_path, from_toml_file)
 
         files = vcm.get_policy_files()
         self.assertEqual(len(files), 4)

--- a/test/python3/libdnf5/base/test_vendor_change_manager.py
+++ b/test/python3/libdnf5/base/test_vendor_change_manager.py
@@ -313,16 +313,16 @@ class TestVendorChangeManager(unittest.TestCase):
         self.assertEqual(files[1], distr_allow_fedora)
 
         # Test save_policy_from_compact
-        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora")
+        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", False)
         with open(allow_fedora, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_2)
 
         # fail - file already exists
         with self.assertRaises(libdnf5.exception.BaseVendorChangeManagerError):
-            vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora")
+            vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", False)
 
         # Test save_policy_from_toml with TOML content string
-        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1")
+        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", False)
         with open(test1, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_1)
 
@@ -332,7 +332,7 @@ class TestVendorChangeManager(unittest.TestCase):
         with open(path, 'w') as f:
             f.write(POLICY_TOML_TEST_1)
 
-        vcm.save_policy_from_toml(path, "from_toml_file")
+        vcm.save_policy_from_toml(path, "from_toml_file", False)
         from_toml_file = os.path.join(self.system_vendor_cfg_dir, "from_toml_file.conf")
         with open(from_toml_file, 'r') as f:
             self.assertEqual(f.read(), POLICY_TOML_TEST_1)

--- a/test/ruby/libdnf5/base/test_vendor_change_manager.rb
+++ b/test/ruby/libdnf5/base/test_vendor_change_manager.rb
@@ -312,16 +312,16 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_equal(distr_allow_fedora, files[1])
 
         # Test save_policy_from_compact
-        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora")
+        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false)
         assert_equal(POLICY_TOML_TEST_2, File.read(allow_fedora))
 
         # fail - file already exists
         assert_raise do
-            vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora")
+            vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false)
         end
 
         # Test save_policy_from_toml with TOML content string
-        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1")
+        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false)
         assert_equal(POLICY_TOML_TEST_1, File.read(test1))
 
         # Test save_policy_from_toml with TOML file
@@ -329,7 +329,7 @@ class TestVendorChangeManager < Test::Unit::TestCase
         path = File.join(installroot, "tmp", "toml_test1.conf")
         File.write(path, POLICY_TOML_TEST_1)
 
-        vcm.save_policy_from_toml(path, "from_toml_file")
+        vcm.save_policy_from_toml(path, "from_toml_file", false)
         from_toml_file = File.join(@system_vendor_cfg_dir, "from_toml_file.conf")
         assert_equal(POLICY_TOML_TEST_1, File.read(from_toml_file))
 

--- a/test/ruby/libdnf5/base/test_vendor_change_manager.rb
+++ b/test/ruby/libdnf5/base/test_vendor_change_manager.rb
@@ -312,26 +312,44 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_equal(distr_allow_fedora, files[1])
 
         # Test save_policy_from_compact
-        vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false)
+        saved_path = vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false)
+        assert_equal(allow_fedora, saved_path)
         assert_equal(POLICY_TOML_TEST_2, File.read(allow_fedora))
 
-        # fail - file already exists
+        # fail - file already exists when allow_replace=false
         assert_raise do
             vcm.save_policy_from_compact(POLICY_COMPACT_TEST_2, "test:code", "allow_fedora", false)
         end
+        # succeed - file can be replaced when allow_replace=true
+        saved_path = vcm.save_policy_from_compact(POLICY_COMPACT_TEST_1, "test:code", "allow_fedora", true)
+        assert_equal(allow_fedora, saved_path)
+        assert_equal(POLICY_TOML_TEST_1, File.read(allow_fedora))
 
         # Test save_policy_from_toml with TOML content string
-        vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false)
+        saved_path = vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", false)
+        assert_equal(test1, saved_path)
         assert_equal(POLICY_TOML_TEST_1, File.read(test1))
+        # Test overwrite with allow_replace=true
+        saved_path = vcm.save_policy_from_toml(POLICY_TOML_TEST_1, "test:code", "test1", true)
+        assert_equal(test1, saved_path)
 
         # Test save_policy_from_toml with TOML file
         installroot = @base.get_config().get_installroot_option().get_value()
         path = File.join(installroot, "tmp", "toml_test1.conf")
         File.write(path, POLICY_TOML_TEST_1)
 
-        vcm.save_policy_from_toml(path, "from_toml_file", false)
+        # It must work with allow_replace=true even if the target file does not exist.
+        saved_path = vcm.save_policy_from_toml(path, "from_toml_file", true)
         from_toml_file = File.join(@system_vendor_cfg_dir, "from_toml_file.conf")
+        assert_equal(from_toml_file, saved_path)
         assert_equal(POLICY_TOML_TEST_1, File.read(from_toml_file))
+        # fail - file already exists when allow_replace=false
+        assert_raise do
+            vcm.save_policy_from_toml(path, "from_toml_file", false)
+        end
+        # Test replace with allow_replace=true
+        saved_path = vcm.save_policy_from_toml(path, "from_toml_file", true)
+        assert_equal(from_toml_file, saved_path)
 
         files = vcm.get_policy_files()
         assert_equal(4, files.size())


### PR DESCRIPTION
This PR extends the `VendorChangeManager` API's `save_policy_from_*` methods with improved control over file handling.
  
**API Extensions:**
- Added `allow_replace` parameter to `save_policy_from_*` methods
- Changed return type from `void` to `std::filesystem::path` to return the created file path
  
**Behavior:**
- `allow_replace=false`: Throws `VendorChangeManagerError` if the policy file already exists
- `allow_replace=true`: Replaces existing policy file without error
- Return value: Path to the created or overwritten policy file

**Testing:** 
- Updated unit tests for all language bindings (C++, Python, Perl, Ruby) to:
  - Pass the new required `allow_replace` parameter
  - Verify the returned file path
  - Test both `allow_replace=false` and `allow_replace=true` scenarios

These changes simplifies the upcoming `dnf5 config-manager` vendor policy management commands.
