### PR TITLE
VendorChangeManager: Make remove_policy_file return removed file path

### DIFF
--- a/include/libdnf5/base/vendor_change_manager.hpp
+++ b/include/libdnf5/base/vendor_change_manager.hpp
@@ -190,8 +190,9 @@ public:
     /// Removes the file from the vendor configuration directory (``/etc/dnf/vendors.d/`` or installroot equivalent).
     /// @param base_filename Base filename without extension or path (e.g., ``"my-policy"``).
     ///                      Must not contain path components. The ``.conf`` extension is added automatically.
+    /// @return Path to the removed policy file.
     /// @throws VendorChangeManagerError if base_filename contains path components or file removal fails.
-    void remove_policy_file(const std::filesystem::path & base_filename);
+    std::filesystem::path remove_policy_file(const std::filesystem::path & base_filename);
 
     /// Get a list of all vendor change policy configuration files.
     /// Returns paths to all ``.conf`` files from both vendor configuration directories

--- a/libdnf5/base/vendor_change_manager.cpp
+++ b/libdnf5/base/vendor_change_manager.cpp
@@ -67,7 +67,7 @@ public:
         const std::filesystem::path & base_filename,
         bool allow_replace);
 
-    void remove_policy_file(const std::filesystem::path & base_filename);
+    std::filesystem::path remove_policy_file(const std::filesystem::path & base_filename);
 
     std::vector<std::filesystem::path> get_policy_files() const;
 
@@ -133,7 +133,7 @@ std::filesystem::path VendorChangeManager::Impl::save_policy_from_compact(
 }
 
 
-void VendorChangeManager::Impl::remove_policy_file(const std::filesystem::path & base_filename) {
+std::filesystem::path VendorChangeManager::Impl::remove_policy_file(const std::filesystem::path & base_filename) {
     namespace fs = std::filesystem;
 
     fs::path file_path = get_vendor_conf_dir_path() / make_policy_filename(base_filename);
@@ -153,6 +153,8 @@ void VendorChangeManager::Impl::remove_policy_file(const std::filesystem::path &
                 NamedErrorArg("path", file_path.string()));
         }
     }
+
+    return file_path;
 }
 
 
@@ -419,8 +421,8 @@ std::filesystem::path VendorChangeManager::save_policy_from_compact(
 }
 
 
-void VendorChangeManager::remove_policy_file(const std::filesystem::path & base_filename) {
-    p_impl->remove_policy_file(base_filename);
+std::filesystem::path VendorChangeManager::remove_policy_file(const std::filesystem::path & base_filename) {
+    return p_impl->remove_policy_file(base_filename);
 }
 
 

--- a/test/libdnf5/base/test_vendor_change_manager.cpp
+++ b/test/libdnf5/base/test_vendor_change_manager.cpp
@@ -355,8 +355,10 @@ void VendorChangeManagerTest::test_work_with_files() {
 
     // Test remove_policy_file
     CPPUNIT_ASSERT_THROW(vcm->remove_policy_file(distr_allow_cmdline), libdnf5::base::VendorChangeManagerError);
-    vcm->remove_policy_file("allow_fedora");
-    vcm->remove_policy_file("test1");
+    auto removed_path = vcm->remove_policy_file("allow_fedora");
+    CPPUNIT_ASSERT_EQUAL(allow_fedora, removed_path);
+    removed_path = vcm->remove_policy_file("test1");
+    CPPUNIT_ASSERT_EQUAL(test1, removed_path);
 
     files = vcm->get_policy_files();
     CPPUNIT_ASSERT_EQUAL(2U, static_cast<unsigned int>(files.size()));

--- a/test/perl5/libdnf5/base/test_vendor_change_manager.t
+++ b/test/perl5/libdnf5/base/test_vendor_change_manager.t
@@ -350,8 +350,10 @@ sub read_file {
         $vcm->remove_policy_file($distr_allow_cmdline);
     } qr//, "remove_policy_file throws on distribution file";
 
-    $vcm->remove_policy_file("allow_fedora");
-    $vcm->remove_policy_file("test1");
+    my $removed_path = $vcm->remove_policy_file("allow_fedora");
+    is($removed_path, $allow_fedora, "remove_policy_file returned correct path for allow_fedora");
+    $removed_path = $vcm->remove_policy_file("test1");
+    is($removed_path, $test1, "remove_policy_file returned correct path for test1");
 
     $files = $vcm->get_policy_files();
     @files = @$files;

--- a/test/python3/libdnf5/base/test_vendor_change_manager.py
+++ b/test/python3/libdnf5/base/test_vendor_change_manager.py
@@ -304,8 +304,10 @@ class TestVendorChangeManager(unittest.TestCase):
         # Test remove_policy_file
         with self.assertRaises(libdnf5.exception.BaseVendorChangeManagerError):
             vcm.remove_policy_file(distr_allow_cmdline)
-        vcm.remove_policy_file("allow_fedora")
-        vcm.remove_policy_file("test1")
+        removed_path = vcm.remove_policy_file("allow_fedora")
+        self.assertEqual(removed_path, allow_fedora)
+        removed_path = vcm.remove_policy_file("test1")
+        self.assertEqual(removed_path, test1)
 
         files = vcm.get_policy_files()
         self.assertEqual(len(files), 2)

--- a/test/ruby/libdnf5/base/test_vendor_change_manager.rb
+++ b/test/ruby/libdnf5/base/test_vendor_change_manager.rb
@@ -303,8 +303,10 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_raise(Libdnf5::Exception::BaseVendorChangeManagerError) do
             vcm.remove_policy_file(distr_allow_cmdline)
         end
-        vcm.remove_policy_file("allow_fedora")
-        vcm.remove_policy_file("test1")
+        removed_path = vcm.remove_policy_file("allow_fedora")
+        assert_equal(allow_fedora, removed_path)
+        removed_path = vcm.remove_policy_file("test1")
+        assert_equal(test1, removed_path)
 
         files = vcm.get_policy_files()
         assert_equal(2, files.size())


### PR DESCRIPTION
Extend the `VendorChangeManager::remove_policy_file()` method to return the path to the removed policy file. This allows callers to confirm the removal and use the path for logging or user feedback.

Unit tests included.