### PR TITLE
VendorChangeManager: Allow empty vendor policies in compact format, unit tests included

### DIFF
--- a/libdnf5/solv/vendor_change_manager.cpp
+++ b/libdnf5/solv/vendor_change_manager.cpp
@@ -909,8 +909,9 @@ VendorChangeManager::VendorChangePolicy VendorChangePolicyCompactFormat::parse()
     pos = 0;
 
     skip_white_spaces();
+
     if (at_end()) {
-        throw_error(Error(M_("Empty vendor policy string")));
+        return policy;
     }
 
     if (peek() != '@') {
@@ -941,10 +942,6 @@ VendorChangeManager::VendorChangePolicy VendorChangePolicyCompactFormat::parse()
 
     if (!at_end()) {
         throw_error(Error(M_("Unexpected character '{}'"), peek()));
-    }
-
-    if (policy.vendor_entries.empty() && policy.outgoing_packages.empty() && policy.incoming_packages.empty()) {
-        throw_error(Error(M_("Empty policy: no vendor definitions or package filters specified")));
     }
 
     return policy;

--- a/test/libdnf5/base/test_vendor_change_manager.cpp
+++ b/test/libdnf5/base/test_vendor_change_manager.cpp
@@ -65,6 +65,9 @@ const std::string POLICY_TOML_TEST_2 =
     "  { filter = 'version', value = \"2.0\", comparator = 'GTE' }\n"
     "]\n";
 
+
+const std::string POLICY_TOML_EMPTY = "version = '1.2'\n";
+
 }  // namespace
 
 
@@ -98,6 +101,14 @@ void VendorChangeManagerTest::test_load_policy_from_compact() {
     CPPUNIT_ASSERT_EQUAL(std::string("text:test"), vcm->get_loaded_policy_source(0));
     CPPUNIT_ASSERT_EQUAL(POLICY_COMPACT_TEST_1, vcm->get_loaded_policy_as_compact(0));
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, vcm->get_loaded_policy_as_toml(0));
+
+    // Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+    vcm->load_policy_from_compact("", "text:empty1");
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), vcm->get_loaded_policies_count());
+
+    // Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+    vcm->load_policy_from_compact(" \n \t ", "text:empty2");
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), vcm->get_loaded_policies_count());
 }
 
 
@@ -113,6 +124,11 @@ void VendorChangeManagerTest::test_load_policy_from_toml_content() {
     CPPUNIT_ASSERT_EQUAL(std::string("text:test"), vcm->get_loaded_policy_source(0));
     CPPUNIT_ASSERT_EQUAL(POLICY_COMPACT_TEST_1, vcm->get_loaded_policy_as_compact(0));
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, vcm->get_loaded_policy_as_toml(0));
+
+    // Loading an empty policy (only version is present) from TOML string succeeds,
+    // but no policy is added to VendorChangeManager.
+    vcm->load_policy_from_toml(POLICY_TOML_EMPTY, "text:toml_only_version");
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), vcm->get_loaded_policies_count());
 }
 
 
@@ -128,13 +144,22 @@ void VendorChangeManagerTest::test_load_policy_from_toml_file() {
         libdnf5::utils::fs::File(path, "w").write(POLICY_TOML_TEST_1);
     }
 
-    vcm->load_policy_from_toml(std::filesystem::path(path));
+    vcm->load_policy_from_toml(path);
 
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), vcm->get_loaded_policies_count());
     std::string source = vcm->get_loaded_policy_source(0);
     CPPUNIT_ASSERT_EQUAL("file://" + path.string(), source);
     CPPUNIT_ASSERT_EQUAL(POLICY_COMPACT_TEST_1, vcm->get_loaded_policy_as_compact(0));
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_1, vcm->get_loaded_policy_as_toml(0));
+
+    // Loading an empty policy (only version is present) from TOML file succeeds,
+    // but no policy is added to VendorChangeManager.
+    const auto path_empty = installroot / "tmp" / "empty_policy.conf";
+    {
+        libdnf5::utils::fs::File(path_empty, "w").write(POLICY_TOML_EMPTY);
+    }
+    vcm->load_policy_from_toml(path_empty);
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), vcm->get_loaded_policies_count());
 }
 
 
@@ -152,6 +177,9 @@ void VendorChangeManagerTest::test_convert_toml_to_compact() {
 
     compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(POLICY_TOML_TEST_2, "text:test");
     CPPUNIT_ASSERT_EQUAL(POLICY_COMPACT_TEST_2, compact);
+
+    compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(POLICY_TOML_EMPTY, "text:test");
+    CPPUNIT_ASSERT_EQUAL(std::string(""), compact);
 }
 
 
@@ -167,6 +195,14 @@ void VendorChangeManagerTest::test_convert_toml_file_to_compact() {
 
     std::string compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(path);
     CPPUNIT_ASSERT_EQUAL(POLICY_COMPACT_TEST_1, compact);
+
+    // Create a TOML file with an empty policy (only version is present)
+    const auto path_empty = installroot / "tmp" / "empty_policy.conf";
+    {
+        libdnf5::utils::fs::File(path_empty, "w").write(POLICY_TOML_EMPTY);
+    }
+    compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(path_empty);
+    CPPUNIT_ASSERT_EQUAL(std::string(""), compact);
 }
 
 
@@ -184,6 +220,9 @@ void VendorChangeManagerTest::test_convert_compact_to_toml() {
 
     toml = libdnf5::base::VendorChangeManager::convert_policy_compact_to_toml(POLICY_COMPACT_TEST_2, "text:test");
     CPPUNIT_ASSERT_EQUAL(POLICY_TOML_TEST_2, toml);
+
+    toml = libdnf5::base::VendorChangeManager::convert_policy_compact_to_toml("", "text:test");
+    CPPUNIT_ASSERT_EQUAL(POLICY_TOML_EMPTY, toml);
 }
 
 

--- a/test/perl5/libdnf5/base/test_vendor_change_manager.t
+++ b/test/perl5/libdnf5/base/test_vendor_change_manager.t
@@ -79,6 +79,8 @@ filters = [
 ]
 EOF
 
+my $POLICY_TOML_EMPTY = "version = '1.2'\n";
+
 
 sub setup_test_base {
     my $base = new libdnf5::base::Base();
@@ -136,6 +138,14 @@ sub read_file {
     is($vcm->get_loaded_policy_source(0), "text:test", "Policy source is correct");
     is($vcm->get_loaded_policy_as_compact(0), $POLICY_COMPACT_TEST_1, "Policy as compact matches");
     is($vcm->get_loaded_policy_as_toml(0), $POLICY_TOML_TEST_1, "Policy as TOML matches");
+
+    # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+    $vcm->load_policy_from_compact("", "text:empty1");
+    is($vcm->get_loaded_policies_count(), 1, "Empty compact policy not added");
+
+    # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+    $vcm->load_policy_from_compact(" \n \t ", "text:empty2");
+    is($vcm->get_loaded_policies_count(), 1, "Whitespace-only compact policy not added");
 }
 
 # Test: load_policy_from_toml_content
@@ -150,6 +160,11 @@ sub read_file {
     is($vcm->get_loaded_policy_source(0), "text:test", "Policy source is correct");
     is($vcm->get_loaded_policy_as_compact(0), $POLICY_COMPACT_TEST_1, "Policy as compact matches");
     is($vcm->get_loaded_policy_as_toml(0), $POLICY_TOML_TEST_1, "Policy as TOML matches");
+
+    # Loading an empty policy (only version is present) from TOML string succeeds,
+    # but no policy is added to VendorChangeManager.
+    $vcm->load_policy_from_toml($POLICY_TOML_EMPTY, "text:toml_only_version");
+    is($vcm->get_loaded_policies_count(), 1, "Empty TOML policy not added");
 }
 
 # Test: load_policy_from_toml_file
@@ -170,6 +185,13 @@ sub read_file {
     is($source, "file://" . $path, "Policy source is file URI");
     is($vcm->get_loaded_policy_as_compact(0), $POLICY_COMPACT_TEST_1, "Policy as compact matches");
     is($vcm->get_loaded_policy_as_toml(0), $POLICY_TOML_TEST_1, "Policy as TOML matches");
+
+    # Loading an empty policy (only version is present) from TOML file succeeds,
+    # but no policy is added to VendorChangeManager.
+    my $path_empty = "$installroot/tmp/empty_policy.conf";
+    write_file($path_empty, $POLICY_TOML_EMPTY);
+    $vcm->load_policy_from_toml($path_empty);
+    is($vcm->get_loaded_policies_count(), 1, "Empty TOML file policy not added");
 }
 
 # Test: convert_toml_to_compact
@@ -189,6 +211,10 @@ sub read_file {
     $compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(
         $POLICY_TOML_TEST_2, "text:test");
     is($compact, $POLICY_COMPACT_TEST_2, "TOML to compact conversion (test_2)");
+
+    $compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact(
+        $POLICY_TOML_EMPTY, "text:test");
+    is($compact, "", "Empty TOML to compact conversion");
 }
 
 # Test: convert_toml_file_to_compact
@@ -202,6 +228,12 @@ sub read_file {
 
     my $compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact($path);
     is($compact, $POLICY_COMPACT_TEST_1, "TOML file to compact conversion");
+
+    # Create a TOML file with an empty policy (only version is present)
+    my $path_empty = "$installroot/tmp/empty_policy.conf";
+    write_file($path_empty, $POLICY_TOML_EMPTY);
+    $compact = libdnf5::base::VendorChangeManager::convert_policy_toml_to_compact($path_empty);
+    is($compact, "", "Empty TOML file to compact conversion");
 }
 
 # Test: convert_compact_to_toml
@@ -221,6 +253,9 @@ sub read_file {
     $toml = libdnf5::base::VendorChangeManager::convert_policy_compact_to_toml(
         $POLICY_COMPACT_TEST_2, "text:test");
     is($toml, $POLICY_TOML_TEST_2, "Compact to TOML conversion (test_2)");
+
+    $toml = libdnf5::base::VendorChangeManager::convert_policy_compact_to_toml("", "text:test");
+    is($toml, $POLICY_TOML_EMPTY, "Empty compact to TOML conversion");
 }
 
 # Test: unload_policies

--- a/test/python3/libdnf5/base/test_vendor_change_manager.py
+++ b/test/python3/libdnf5/base/test_vendor_change_manager.py
@@ -63,6 +63,8 @@ filters = [
 ]
 '''
 
+POLICY_TOML_EMPTY = "version = '1.2'\n"
+
 
 class TestVendorChangeManager(unittest.TestCase):
     """Test VendorChangeManager API"""
@@ -108,6 +110,14 @@ class TestVendorChangeManager(unittest.TestCase):
         self.assertEqual(vcm.get_loaded_policy_as_compact(0), POLICY_COMPACT_TEST_1)
         self.assertEqual(vcm.get_loaded_policy_as_toml(0), POLICY_TOML_TEST_1)
 
+        # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+        vcm.load_policy_from_compact("", "text:empty1")
+        self.assertEqual(vcm.get_loaded_policies_count(), 1)
+
+        # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+        vcm.load_policy_from_compact(" \n \t ", "text:empty2")
+        self.assertEqual(vcm.get_loaded_policies_count(), 1)
+
     def test_load_policy_from_toml_content(self):
         """Test loading vendor policy from TOML content string"""
         self.base.setup()
@@ -119,6 +129,11 @@ class TestVendorChangeManager(unittest.TestCase):
         self.assertEqual(vcm.get_loaded_policy_source(0), "text:test")
         self.assertEqual(vcm.get_loaded_policy_as_compact(0), POLICY_COMPACT_TEST_1)
         self.assertEqual(vcm.get_loaded_policy_as_toml(0), POLICY_TOML_TEST_1)
+
+        # Loading an empty policy (only version is present) from TOML string succeeds,
+        # but no policy is added to VendorChangeManager.
+        vcm.load_policy_from_toml(POLICY_TOML_EMPTY, "text:toml_only_version")
+        self.assertEqual(vcm.get_loaded_policies_count(), 1)
 
     def test_load_policy_from_toml_file(self):
         """Test loading vendor policy from TOML file"""
@@ -139,6 +154,14 @@ class TestVendorChangeManager(unittest.TestCase):
         self.assertEqual(vcm.get_loaded_policy_as_compact(0), POLICY_COMPACT_TEST_1)
         self.assertEqual(vcm.get_loaded_policy_as_toml(0), POLICY_TOML_TEST_1)
 
+        # Loading an empty policy (only version is present) from TOML file succeeds,
+        # but no policy is added to VendorChangeManager.
+        path_empty = os.path.join(installroot, "tmp", "empty_policy.conf")
+        with open(path_empty, 'w') as f:
+            f.write(POLICY_TOML_EMPTY)
+        vcm.load_policy_from_toml(path_empty)
+        self.assertEqual(vcm.get_loaded_policies_count(), 1)
+
     def test_convert_toml_to_compact(self):
         """Test converting TOML to compact format"""
         compact = libdnf5.base.VendorChangeManager.convert_policy_toml_to_compact(
@@ -157,6 +180,10 @@ class TestVendorChangeManager(unittest.TestCase):
             POLICY_TOML_TEST_2, "text:test")
         self.assertEqual(compact, POLICY_COMPACT_TEST_2)
 
+        compact = libdnf5.base.VendorChangeManager.convert_policy_toml_to_compact(
+            POLICY_TOML_EMPTY, "text:test")
+        self.assertEqual(compact, "")
+
     def test_convert_toml_file_to_compact(self):
         """Test converting TOML file to compact format"""
         installroot = self.base.get_config().installroot
@@ -167,6 +194,13 @@ class TestVendorChangeManager(unittest.TestCase):
 
         compact = libdnf5.base.VendorChangeManager.convert_policy_toml_to_compact(path)
         self.assertEqual(compact, POLICY_COMPACT_TEST_1)
+
+        # Create a TOML file with an empty policy (only version is present)
+        path_empty = os.path.join(installroot, "tmp", "empty_policy.conf")
+        with open(path_empty, 'w') as f:
+            f.write(POLICY_TOML_EMPTY)
+        compact = libdnf5.base.VendorChangeManager.convert_policy_toml_to_compact(path_empty)
+        self.assertEqual(compact, "")
 
     def test_convert_compact_to_toml(self):
         """Test converting compact format to TOML"""
@@ -185,6 +219,9 @@ class TestVendorChangeManager(unittest.TestCase):
         toml = libdnf5.base.VendorChangeManager.convert_policy_compact_to_toml(
             POLICY_COMPACT_TEST_2, "text:test")
         self.assertEqual(toml, POLICY_TOML_TEST_2)
+
+        toml = libdnf5.base.VendorChangeManager.convert_policy_compact_to_toml("", "text:test")
+        self.assertEqual(toml, POLICY_TOML_EMPTY)
 
     def test_unload_policies(self):
         """Test unload all vendor change policies from memory"""

--- a/test/ruby/libdnf5/base/test_vendor_change_manager.rb
+++ b/test/ruby/libdnf5/base/test_vendor_change_manager.rb
@@ -71,6 +71,8 @@ filters = [
 ]
 EOF
 
+POLICY_TOML_EMPTY = "version = '1.2'\n"
+
 
 class TestVendorChangeManager < Test::Unit::TestCase
     def setup
@@ -110,6 +112,14 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_equal("text:test", vcm.get_loaded_policy_source(0))
         assert_equal(POLICY_COMPACT_TEST_1, vcm.get_loaded_policy_as_compact(0))
         assert_equal(POLICY_TOML_TEST_1, vcm.get_loaded_policy_as_toml(0))
+
+        # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+        vcm.load_policy_from_compact("", "text:empty1")
+        assert_equal(1, vcm.get_loaded_policies_count())
+
+        # Loading an empty compact format succeeds, but no policy is added to VendorChangeManager
+        vcm.load_policy_from_compact(" \n \t ", "text:empty2")
+        assert_equal(1, vcm.get_loaded_policies_count())
     end
 
     def test_load_policy_from_toml_content
@@ -122,6 +132,11 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_equal("text:test", vcm.get_loaded_policy_source(0))
         assert_equal(POLICY_COMPACT_TEST_1, vcm.get_loaded_policy_as_compact(0))
         assert_equal(POLICY_TOML_TEST_1, vcm.get_loaded_policy_as_toml(0))
+
+        # Loading an empty policy (only version is present) from TOML string succeeds,
+        # but no policy is added to VendorChangeManager.
+        vcm.load_policy_from_toml(POLICY_TOML_EMPTY, "text:toml_only_version")
+        assert_equal(1, vcm.get_loaded_policies_count())
     end
 
     def test_load_policy_from_toml_file
@@ -140,6 +155,13 @@ class TestVendorChangeManager < Test::Unit::TestCase
         assert_equal("file://" + path, source)
         assert_equal(POLICY_COMPACT_TEST_1, vcm.get_loaded_policy_as_compact(0))
         assert_equal(POLICY_TOML_TEST_1, vcm.get_loaded_policy_as_toml(0))
+
+        # Loading an empty policy (only version is present) from TOML file succeeds,
+        # but no policy is added to VendorChangeManager.
+        path_empty = File.join(installroot, "tmp", "empty_policy.conf")
+        File.write(path_empty, POLICY_TOML_EMPTY)
+        vcm.load_policy_from_toml(path_empty)
+        assert_equal(1, vcm.get_loaded_policies_count())
     end
 
     def test_convert_toml_to_compact
@@ -158,6 +180,10 @@ class TestVendorChangeManager < Test::Unit::TestCase
         compact = Libdnf5::Base::VendorChangeManager.convert_policy_toml_to_compact(
             POLICY_TOML_TEST_2, "text:test")
         assert_equal(POLICY_COMPACT_TEST_2, compact)
+
+        compact = Libdnf5::Base::VendorChangeManager.convert_policy_toml_to_compact(
+            POLICY_TOML_EMPTY, "text:test")
+        assert_equal("", compact)
     end
 
     def test_convert_toml_file_to_compact
@@ -168,6 +194,12 @@ class TestVendorChangeManager < Test::Unit::TestCase
 
         compact = Libdnf5::Base::VendorChangeManager.convert_policy_toml_to_compact(path)
         assert_equal(POLICY_COMPACT_TEST_1, compact)
+
+        # Create a TOML file with an empty policy (only version is present)
+        path_empty = File.join(installroot, "tmp", "empty_policy.conf")
+        File.write(path_empty, POLICY_TOML_EMPTY)
+        compact = Libdnf5::Base::VendorChangeManager.convert_policy_toml_to_compact(path_empty)
+        assert_equal("", compact)
     end
 
     def test_convert_compact_to_toml
@@ -186,6 +218,9 @@ class TestVendorChangeManager < Test::Unit::TestCase
         toml = Libdnf5::Base::VendorChangeManager.convert_policy_compact_to_toml(
             POLICY_COMPACT_TEST_2, "text:test")
         assert_equal(POLICY_TOML_TEST_2, toml)
+
+        toml = Libdnf5::Base::VendorChangeManager.convert_policy_compact_to_toml("", "text:test")
+        assert_equal(POLICY_TOML_EMPTY, toml)
     end
 
     def test_unload_policies


### PR DESCRIPTION
Users need to mask (disable) distribution vendor policies located in `/usr/share/dnf5/vendors.d/` by creating a file with the same name in `/etc/dnf/vendors.d/`, but without adding any actual vendor change rules. Empty policies make this possible.
