### PR TITLE
Makefile: Add FEDORA_VERSION to unify defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,15 @@ To build RPMs using Mock for a more reproducible build (or to target a
 different Fedora version):
 ```
 make rpms-mock
-make rpms-mock MOCK_CONFIG=fedora-43-x86_64
+make rpms-mock FEDORA_VERSION=43
+```
+
+`FEDORA_VERSION` also sets the default base image used to build the
+integration test container. To use a non-Fedora Mock root (e.g. rhel or epel)
+or a different container image, override `MOCK_CONFIG` and `CI_BASE_IMAGE`
+directly instead, independently of `FEDORA_VERSION`:
+```
+make rpms-mock MOCK_CONFIG=epel-10-x86_64
 ```
 
 If the container is already built, you can skip the RPM build and container

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ VERSION := $(shell rpmspec -q --queryformat '%{VERSION}\n' dnf5.spec | head -n1)
 SOURCE_TARBALL_PREFIX := dnf5-$(VERSION)
 SOURCE_TARBALL_NAME := $(SOURCE_TARBALL_PREFIX).tar.gz
 SOURCE_TARBALL_PATH := $(SOURCE_TARBALL_DIR)/$(SOURCE_TARBALL_NAME)
-MOCK_CONFIG ?= fedora-rawhide-x86_64
-CI_BASE_IMAGE ?= registry.fedoraproject.org/fedora:rawhide
+FEDORA_VERSION ?= rawhide
+MOCK_CONFIG ?= fedora-$(FEDORA_VERSION)-x86_64
+CI_BASE_IMAGE ?= registry.fedoraproject.org/fedora:$(FEDORA_VERSION)
 CONTAINER_TEST = ./integration-tests/container-test
 
 .DEFAULT_GOAL = build
@@ -49,8 +50,7 @@ help:
 	echo "  CMAKE_ARGS=                                             - Extra cmake configure arguments"
 	echo "  CTEST_ARGS=                                             - Extra ctest arguments (e.g. -R libdnf5)"
 	echo "  NPROC=$$(nproc)                                         - Parallel build jobs"
-	echo "  MOCK_CONFIG=fedora-rawhide-x86_64                       - Mock config for rpms-mock"
-	echo "  CI_BASE_IMAGE=registry.fedoraproject.org/fedora:rawhide - Base image for test container"
+	echo "  FEDORA_VERSION=$(FEDORA_VERSION)                                  - Fedora version for rpms-mock and the test container"
 
 .PHONY: build
 build:


### PR DESCRIPTION
MOCK_CONFIG and CI_BASE_IMAGE both encoded a Fedora version independently, with no guarantee they'd stay in sync. Introduce FEDORA_VERSION as the single default knob for both, while keeping MOCK_CONFIG and CI_BASE_IMAGE independently overridable for non-Fedora Mock roots (rhel, epel, ...) or custom container images.

Example:

make test-integration FEDORA_VERSION=43