### PR TITLE
manifest: Print transaction table on resolve

### DIFF
--- a/dnf5-plugins/manifest_plugin/manifest.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest.cpp
@@ -6,6 +6,8 @@
 #include "download_callbacks.hpp"
 
 #include <dnf5/context.hpp>
+#include <libdnf5-cli/output/adapters/transaction.hpp>
+#include <libdnf5-cli/output/transaction_table.hpp>
 #include <libdnf5-cli/utils/userconfirm.hpp>
 #include <libdnf5/logger/logger.hpp>
 #include <libdnf5/repo/repo_errors.hpp>
@@ -301,6 +303,8 @@ std::vector<libdnf5::rpm::Package> ManifestSubcommand::resolve_goal(
     libdnf5::Goal & goal, libdnf5::Base & base, const bool include_srpms) {
     auto & ctx = get_context();
 
+    ctx.print_info(libdnf5::utils::sformat(_("Resolving transaction for arch {}"), base.get_vars()->get_value("arch")));
+
     // Resolve the goal
     auto transaction = goal.resolve();
     if (transaction.get_problems() != libdnf5::GoalProblem::NO_PROBLEM) {
@@ -344,6 +348,9 @@ std::vector<libdnf5::rpm::Package> ManifestSubcommand::resolve_goal(
         }
         resolved_pkgs_set.insert(source_pkgs.begin(), source_pkgs.end());
     }
+
+    libdnf5::cli::output::TransactionAdapter cli_output_transaction{transaction};
+    libdnf5::cli::output::print_transaction_table(cli_output_transaction);
 
     std::vector<libdnf5::rpm::Package> resolved_pkgs{resolved_pkgs_set.begin(), resolved_pkgs_set.end()};
     return sort_pkgs(std::move(resolved_pkgs));

--- a/dnf5-plugins/manifest_plugin/manifest_new.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_new.cpp
@@ -126,6 +126,8 @@ void ManifestNewCommand::populate_manifest(
 }
 
 void ManifestNewCommand::run() {
+    auto & ctx = get_context();
+
     libpkgmanifest::manifest::Serializer serializer;
     if (per_arch_option->get_value()) {
         for (const auto & arch : arches) {
@@ -135,13 +137,16 @@ void ManifestNewCommand::run() {
             std::string path{manifest_path_option->get_value()};
             path = std::regex_replace(path, std::regex("\\.yaml$"), fmt::format(".{}.yaml", arch));
             serializer.serialize(manifest, path);
+            ctx.print_info(libdnf5::utils::sformat(_("Wrote {}"), path));
         }
     } else {
         libpkgmanifest::manifest::Manifest manifest;
         for (const auto & arch : arches) {
             populate_manifest(manifest, arch, arches.size() > 1);
         }
-        serializer.serialize(manifest, manifest_path_option->get_value());
+        const auto & path = manifest_path_option->get_value();
+        serializer.serialize(manifest, path);
+        ctx.print_info(libdnf5::utils::sformat(_("Wrote {}"), path));
     }
 }
 

--- a/dnf5-plugins/manifest_plugin/manifest_resolve.cpp
+++ b/dnf5-plugins/manifest_plugin/manifest_resolve.cpp
@@ -122,6 +122,7 @@ void ManifestResolveCommand::populate_manifest(
 }
 
 void ManifestResolveCommand::run() {
+    auto & ctx = get_context();
     libpkgmanifest::manifest::Serializer serializer;
     if (per_arch_option->get_value()) {
         for (const auto & arch : arches) {
@@ -131,13 +132,16 @@ void ManifestResolveCommand::run() {
             std::string path{manifest_path_option->get_value()};
             path = std::regex_replace(path, std::regex("\\.yaml$"), fmt::format(".{}.yaml", arch));
             serializer.serialize(manifest, path);
+            ctx.print_info(libdnf5::utils::sformat(_("Wrote {}"), path));
         }
     } else {
         libpkgmanifest::manifest::Manifest manifest;
         for (const auto & arch : arches) {
             populate_manifest(manifest, arch, arches.size() > 1);
         }
-        serializer.serialize(manifest, manifest_path_option->get_value());
+        const auto & path = manifest_path_option->get_value();
+        serializer.serialize(manifest, path);
+        ctx.print_info(libdnf5::utils::sformat(_("Wrote {}"), path));
     }
 }
 


### PR DESCRIPTION
Adds transaction tables to the output of `manifest new` and `manifest resolve`. If the infile contains multiple architectures, one transaction for each architecture will be resolved, so a transaction table for each architecture will be printed.

Also adds a couple info messages to indicate which architecture the transaction table is for, and what manifest files were written.

Before:

```
# dnf5 manifest resolve --use-host-repos
Updating and loading repositories for arch x86_64:
Repositories loaded.
Updating and loading repositories for arch aarch64:
Repositories loaded.
```

<details>

<summary>After</summary>

```
# dnf5 manifest resolve --use-host-repos
Updating and loading repositories for arch x86_64:
Repositories loaded.
Resolving transaction for arch x86_64
Package                                        Arch        Version                                        Repository                     Size
Installing:
 bash                                          x86_64      0:5.3.9-3.fc44                                 fedora                      8.5 MiB
Installing dependencies:
 fedora-gpg-keys                               noarch      0:44-2                                         updates                   257.6 KiB
 fedora-release                                noarch      0:44-18                                        updates                     0.0   B
 fedora-release-common                         noarch      0:44-18                                        updates                    20.6 KiB
 fedora-release-identity-basic                 noarch      0:44-18                                        updates                   629.0   B
 fedora-repos                                  noarch      0:44-2                                         updates                     4.9 KiB
 filesystem                                    x86_64      0:3.18-52.fc44                                 fedora                    112.0   B
 glibc                                         x86_64      0:2.43-8.fc44                                  updates                     6.9 MiB
 glibc-common                                  x86_64      0:2.43-8.fc44                                  updates                     1.0 MiB
 glibc-minimal-langpack                        x86_64      0:2.43-8.fc44                                  updates                     0.0   B
 libgcc                                        x86_64      0:16.2.1-2.fc44                                updates                   270.6 KiB
 ncurses-base                                  noarch      0:6.6-1.fc44                                   fedora                    329.7 KiB
 ncurses-libs                                  x86_64      0:6.6-1.fc44                                   fedora                    968.9 KiB
 setup                                         noarch      0:2.15.0-28.fc44                               fedora                    724.9 KiB
Installing weak dependencies:
 glibc-gconv-extra                             x86_64      0:2.43-8.fc44                                  updates                     7.4 MiB
 tzdata                                        noarch      0:2026c-1.fc44                                 updates                     1.2 MiB

Transaction Summary:
 Installing:        16 packages

Updating and loading repositories for arch aarch64:
Repositories loaded.
Resolving transaction for arch aarch64
Package                                        Arch         Version                                        Repository                    Size
Installing:
 bash                                          aarch64      0:5.3.9-3.fc44                                 fedora                     8.4 MiB
Installing dependencies:
 fedora-gpg-keys                               noarch       0:44-2                                         updates                  257.6 KiB
 fedora-release                                noarch       0:44-18                                        updates                    0.0   B
 fedora-release-common                         noarch       0:44-18                                        updates                   20.6 KiB
 fedora-release-identity-basic                 noarch       0:44-18                                        updates                  629.0   B
 fedora-repos                                  noarch       0:44-2                                         updates                    4.9 KiB
 filesystem                                    aarch64      0:3.18-52.fc44                                 fedora                   112.0   B
 glibc                                         aarch64      0:2.43-8.fc44                                  updates                    6.4 MiB
 glibc-common                                  aarch64      0:2.43-8.fc44                                  updates                    1.3 MiB
 glibc-minimal-langpack                        aarch64      0:2.43-8.fc44                                  updates                    0.0   B
 libgcc                                        aarch64      0:16.2.1-2.fc44                                updates                  222.3 KiB
 ncurses-base                                  noarch       0:6.6-1.fc44                                   fedora                   329.7 KiB
 ncurses-libs                                  aarch64      0:6.6-1.fc44                                   fedora                     1.2 MiB
 setup                                         noarch       0:2.15.0-28.fc44                               fedora                   724.9 KiB
Installing weak dependencies:
 glibc-gconv-extra                             aarch64      0:2.43-8.fc44                                  updates                   18.5 MiB
 tzdata                                        noarch       0:2026c-1.fc44                                 updates                    1.2 MiB

Transaction Summary:
 Installing:        16 packages

Wrote packages.manifest.yaml
```

</details>

I did not add the typical `DNF transaction is following` steps in the integration tests since we'd be duplicating checks with the manifest files themselves.

Resolves https://github.com/rpm-software-management/dnf5/issues/2877