### PR TITLE
Rate limit progress bar redraw to save ~34MB of terminal output for a reposync

### DIFF
--- a/dnf5-plugins/manifest_plugin/download_callbacks.cpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.cpp
@@ -45,6 +45,7 @@ void * DownloadCallbacks::add_new_download(
     ppb->set_number_widget_visible(number_widget_visible);
     ppb->set_auto_finish(false);
     multi_progress_bar->add_bar(std::move(progress_bar));
+    ++num_of_downloads;
     return ppb;
 }
 
@@ -87,7 +88,21 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
-    print();
+    ++num_of_ended_downloads;
+    // Rate limit the repaint the same way progress() does. Repainting once per
+    // completed download is what makes downloading many small packages (a
+    // reposync of a whole repository, for example) expensive: every repaint
+    // re-renders each bar and rewrites the whole block of lines, so the cost
+    // grows with the number of packages rather than with the time spent.
+    //
+    // Nothing is lost by waiting - a repaint prints every bar that has finished
+    // since the previous one, in order - and the last download always repaints,
+    // so the final state of every bar reaches the terminal. libdnf5 guarantees
+    // exactly one end() call per add_new_download(), including for downloads
+    // that were interrupted, so the counters cannot drift.
+    if (all_downloads_ended() || is_time_to_print()) {
+        print();
+    }
     return ReturnCode::OK;
 }
 
@@ -98,31 +113,38 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
         message = message + " - " + metadata;
     }
     multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, message);
-    print();
+    // The message is attached to the bar, so it is printed by the next repaint.
+    // A failing mirror is always followed by an end() call for the same target,
+    // which repaints if this one didn't.
+    if (is_time_to_print()) {
+        print();
+    }
     return ReturnCode::OK;
 }
 
 void DownloadCallbacks::reset_progress_bar() {
     multi_progress_bar.reset();
+    num_of_downloads = 0;
+    num_of_ended_downloads = 0;
     if (printed) {
         printed = false;
     }
 }
 
-bool DownloadCallbacks::is_time_to_print() {
-    auto now = std::chrono::steady_clock::now();
-    auto delta = now - prev_print_time;
+bool DownloadCallbacks::all_downloads_ended() const noexcept {
+    return num_of_ended_downloads >= num_of_downloads;
+}
+
+bool DownloadCallbacks::is_time_to_print() const noexcept {
+    auto delta = std::chrono::steady_clock::now() - prev_print_time;
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-    if (ms > 100) {
-        // 100ms equals to 10 FPS and that seems to be smooth enough
-        prev_print_time = now;
-        return true;
-    }
-    return false;
+    // 100ms equals to 10 FPS and that seems to be smooth enough
+    return ms > 100;
 }
 
 void DownloadCallbacks::print() {
     multi_progress_bar->print();
+    prev_print_time = std::chrono::steady_clock::now();
     printed = true;
 }
 

--- a/dnf5-plugins/manifest_plugin/download_callbacks.cpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.cpp
@@ -138,8 +138,9 @@ bool DownloadCallbacks::all_downloads_ended() const noexcept {
 bool DownloadCallbacks::is_time_to_print() const noexcept {
     auto delta = std::chrono::steady_clock::now() - prev_print_time;
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-    // 100ms equals to 10 FPS and that seems to be smooth enough
-    return ms > 100;
+    // 200ms equals to 5 FPS. Still reads as live movement, and halves the output
+    // of a long download compared to 10 FPS.
+    return ms > 200;
 }
 
 void DownloadCallbacks::print() {

--- a/dnf5-plugins/manifest_plugin/download_callbacks.hpp
+++ b/dnf5-plugins/manifest_plugin/download_callbacks.hpp
@@ -44,11 +44,15 @@ private:
 
     int mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) override;
 
-    bool is_time_to_print();
+    /// @return `true` when every download registered so far has reported its result.
+    bool all_downloads_ended() const noexcept;
+    bool is_time_to_print() const noexcept;
     void print();
 
     std::unique_ptr<libdnf5::cli::progressbar::MultiProgressBar> multi_progress_bar;
     std::chrono::time_point<std::chrono::steady_clock> prev_print_time{std::chrono::steady_clock::now()};
+    std::size_t num_of_downloads{0};
+    std::size_t num_of_ended_downloads{0};
     bool printed{false};
 
     bool number_widget_visible{false};

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -45,6 +45,7 @@ void * DownloadCallbacks::add_new_download(
     ppb->set_number_widget_visible(number_widget_visible);
     ppb->set_auto_finish(false);
     multi_progress_bar->add_bar(std::move(progress_bar));
+    ++num_of_downloads;
     return ppb;
 }
 
@@ -87,7 +88,21 @@ int DownloadCallbacks::end(void * user_cb_data, TransferStatus status, const cha
             multi_progress_bar->bar_set_state(progress_bar, libdnf5::cli::progressbar::ProgressBarState::ERROR);
             break;
     }
-    print();
+    ++num_of_ended_downloads;
+    // Rate limit the repaint the same way progress() does. Repainting once per
+    // completed download is what makes downloading many small packages (a
+    // reposync of a whole repository, for example) expensive: every repaint
+    // re-renders each bar and rewrites the whole block of lines, so the cost
+    // grows with the number of packages rather than with the time spent.
+    //
+    // Nothing is lost by waiting - a repaint prints every bar that has finished
+    // since the previous one, in order - and the last download always repaints,
+    // so the final state of every bar reaches the terminal. libdnf5 guarantees
+    // exactly one end() call per add_new_download(), including for downloads
+    // that were interrupted, so the counters cannot drift.
+    if (all_downloads_ended() || is_time_to_print()) {
+        print();
+    }
     return ReturnCode::OK;
 }
 
@@ -98,31 +113,38 @@ int DownloadCallbacks::mirror_failure(void * user_cb_data, const char * msg, con
         message = message + " - " + metadata;
     }
     multi_progress_bar->bar_add_message(progress_bar, libdnf5::cli::progressbar::MessageType::ERROR, message);
-    print();
+    // The message is attached to the bar, so it is printed by the next repaint.
+    // A failing mirror is always followed by an end() call for the same target,
+    // which repaints if this one didn't.
+    if (is_time_to_print()) {
+        print();
+    }
     return ReturnCode::OK;
 }
 
 void DownloadCallbacks::reset_progress_bar() {
     multi_progress_bar.reset();
+    num_of_downloads = 0;
+    num_of_ended_downloads = 0;
     if (printed) {
         printed = false;
     }
 }
 
-bool DownloadCallbacks::is_time_to_print() {
-    auto now = std::chrono::steady_clock::now();
-    auto delta = now - prev_print_time;
+bool DownloadCallbacks::all_downloads_ended() const noexcept {
+    return num_of_ended_downloads >= num_of_downloads;
+}
+
+bool DownloadCallbacks::is_time_to_print() const noexcept {
+    auto delta = std::chrono::steady_clock::now() - prev_print_time;
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-    if (ms > 100) {
-        // 100ms equals to 10 FPS and that seems to be smooth enough
-        prev_print_time = now;
-        return true;
-    }
-    return false;
+    // 100ms equals to 10 FPS and that seems to be smooth enough
+    return ms > 100;
 }
 
 void DownloadCallbacks::print() {
     multi_progress_bar->print();
+    prev_print_time = std::chrono::steady_clock::now();
     printed = true;
 }
 

--- a/dnf5/download_callbacks.cpp
+++ b/dnf5/download_callbacks.cpp
@@ -138,8 +138,9 @@ bool DownloadCallbacks::all_downloads_ended() const noexcept {
 bool DownloadCallbacks::is_time_to_print() const noexcept {
     auto delta = std::chrono::steady_clock::now() - prev_print_time;
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-    // 100ms equals to 10 FPS and that seems to be smooth enough
-    return ms > 100;
+    // 200ms equals to 5 FPS. Still reads as live movement, and halves the output
+    // of a long download compared to 10 FPS.
+    return ms > 200;
 }
 
 void DownloadCallbacks::print() {

--- a/dnf5/download_callbacks.hpp
+++ b/dnf5/download_callbacks.hpp
@@ -44,11 +44,15 @@ private:
 
     int mirror_failure(void * user_cb_data, const char * msg, const char * url, const char * metadata) override;
 
-    bool is_time_to_print();
+    /// @return `true` when every download registered so far has reported its result.
+    bool all_downloads_ended() const noexcept;
+    bool is_time_to_print() const noexcept;
     void print();
 
     std::unique_ptr<libdnf5::cli::progressbar::MultiProgressBar> multi_progress_bar;
     std::chrono::time_point<std::chrono::steady_clock> prev_print_time{std::chrono::steady_clock::now()};
+    std::size_t num_of_downloads{0};
+    std::size_t num_of_ended_downloads{0};
     bool printed{false};
 
     bool number_widget_visible{false};

--- a/libdnf5-cli/tty.cpp
+++ b/libdnf5-cli/tty.cpp
@@ -24,10 +24,34 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
 
 
 namespace libdnf5::cli::tty {
+
+namespace {
+
+// get_width() and is_interactive() sit on the progress bar rendering path, which
+// asks for both several times for every bar it draws. Answering each of those
+// from a syscall is what made drawing a screenful of bars cost hundreds of
+// syscalls, so the syscall results are cached below.
+//
+// The environment overrides are deliberately left uncached: they are read on
+// every call, so tests (which set and unset them repeatedly within one process)
+// keep seeing the current value.
+
+/// Terminal width as last reported by the kernel, 0 when not queried yet.
+std::atomic<int> cached_width{0};
+/// steady_clock tick count at which cached_width was refreshed.
+std::atomic<std::chrono::steady_clock::rep> cached_width_time{0};
+
+/// How long a queried terminal width is reused before asking the kernel again.
+/// Bounds the ioctl() rate while still following a terminal resize promptly.
+constexpr auto WIDTH_CACHE_LIFETIME = std::chrono::milliseconds(100);
+
+}  // namespace
 
 
 int get_width() {
@@ -44,13 +68,26 @@ int get_width() {
         }
     }
 
+    const auto now = std::chrono::steady_clock::now().time_since_epoch();
+    const auto cached = cached_width.load(std::memory_order_relaxed);
+    if (cached > 0) {
+        const auto age = now - std::chrono::steady_clock::duration(cached_width_time.load(std::memory_order_relaxed));
+        if (age < WIDTH_CACHE_LIFETIME) {
+            return cached;
+        }
+    }
+
+    int width = 80;
     struct winsize size;
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0) {
         if (size.ws_col > 0)
-            return size.ws_col;
+            width = size.ws_col;
     }
 
-    return 80;
+    cached_width_time.store(now.count(), std::memory_order_relaxed);
+    cached_width.store(width, std::memory_order_relaxed);
+
+    return width;
 }
 
 
@@ -67,7 +104,10 @@ bool is_interactive() {
         } catch (std::out_of_range & ex) {
         }
     }
-    return isatty(fileno(stdout)) == 1;
+    // Whether stdout refers to a terminal cannot change for the lifetime of the
+    // process, so this only ever needs to be asked once.
+    static const bool interactive = isatty(fileno(stdout)) == 1;
+    return interactive;
 }
 
 static ColoringEnabled coloring = ColoringEnabled::AUTO;


### PR DESCRIPTION
While looking at how long a `reposync` of the entire AL2023 dnf repo for a single architecture took, I noticed that `dnf5` was outputting around 37MB of text to the console. While the progress bar updates were already rate limited to every 100ms, it did *not* rate limit around the event of finishing downloading a package. When you end up with a lot of packages you can download very quickly, this *really* adds up fast.

This PR reduces that from ~37MB to ~3MB and (at least to my eyes) it *looks* smoother in my terminal.

There's not really a hugely measurable CPU usage reduction here on the (high end) CPU cores I'm running on, but could be a lot more impactful on smaller systems.